### PR TITLE
Add GitHub Pages deployment workflow and make Vite base relative for Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAGES: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,3 +18,30 @@ View your app in AI Studio: https://ai.studio/apps/drive/1DiUqAZz4qIDr0G34xUSl5u
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## 部署到 GitHub Pages
+
+这个项目已经配置好 GitHub Actions 自动发布（`.github/workflows/deploy-pages.yml`）。
+
+### 一次性设置
+
+1. 把代码推送到 GitHub 仓库的 `main` 分支。
+2. 打开仓库 **Settings → Pages**。
+3. 在 **Build and deployment** 里选择 **Source: GitHub Actions**。
+
+### 之后怎么发布
+
+- 每次 push 到 `main` 都会自动执行构建并发布。
+- 你也可以在 **Actions** 页面手动运行 `Deploy to GitHub Pages`。
+
+### 本地先验证构建
+
+```bash
+npm install
+npm run build
+npm run preview
+```
+
+如果发布成功，页面地址通常是：
+
+`https://<你的GitHub用户名>.github.io/<仓库名>/`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
       },
     },
   ],
-  base: '/', // 使用绝对路径，避免 SPA 路由下资源路径解析错误
+  // GitHub Pages 发布时使用相对路径，避免仓库子路径导致资源 404
+  base: process.env.GITHUB_PAGES ? './' : '/',
   server: {
     proxy: {
       '/api/minimax/t2a': {


### PR DESCRIPTION
### Motivation

- Provide an automated way to publish the app to GitHub Pages on push to `main` or via manual trigger.  
- Fix static asset 404s when the site is served from a repository subpath by using a relative `base` during Pages builds.

### Description

- Add `.github/workflows/deploy-pages.yml` which builds the app (`npm ci` / `npm run build`), uploads `./dist` and deploys it via `actions/deploy-pages@v4` on push to `main` or on manual dispatch.  
- Update `vite.config.ts` to set `base: process.env.GITHUB_PAGES ? './' : '/'` so GitHub Pages builds use relative asset paths while local/dev keeps `/`.  
- Add a Chinese README section documenting one-time Pages setup (`Settings → Pages` → `Source: GitHub Actions`) and how to publish and locally validate with `npm install`, `npm run build`, and `npm run preview`.

### Testing

- Ran `npm install` which completed successfully.  
- Ran `npm run build` which completed successfully and produced the `dist/` output (build reported chunk-size warnings but finished successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be6a7412808330a7184ec385718976)