### PR TITLE
Fix MiniMax voice fetch fallback for static deployments

### DIFF
--- a/utils/minimaxEndpoint.ts
+++ b/utils/minimaxEndpoint.ts
@@ -24,7 +24,7 @@ const PROXY_MAP: Record<string, string> = {
  * Return the actual URL to fetch for a given proxy path.
  */
 export function resolveMinimaxUrl(proxyPath: string): string {
-  if (isNative() && PROXY_MAP[proxyPath]) {
+  if (PROXY_MAP[proxyPath] && isNative()) {
     return PROXY_MAP[proxyPath];
   }
   return proxyPath;
@@ -44,6 +44,11 @@ export async function minimaxFetch(
 
   if (!isNative()) {
     const res = await fetch(url, init);
+    // Static deployments (e.g. GitHub Pages) don't support POST /api/* proxy.
+    // If proxy endpoint is unavailable, retry against MiniMax upstream directly.
+    if ((res.status === 404 || res.status === 405) && PROXY_MAP[proxyPath]) {
+      return fetch(PROXY_MAP[proxyPath], init);
+    }
     return res;
   }
 


### PR DESCRIPTION
### Motivation
- Static hosts (GitHub Pages, etc.) can return `404`/`405` for client-side proxy paths like `/api/minimax/get-voice`, producing HTML that breaks JSON parsing and causes the MiniMax voice load to fail. 
- Add a small client-side fallback so web builds retry the official MiniMax upstream when the local proxy is not available while preserving native behavior.

### Description
- Update `resolveMinimaxUrl` to only substitute the upstream URL when a mapping exists and the platform is native. 
- Add a web-path fallback in `minimaxFetch` that detects `404` or `405` from the proxy and retries against the mapped MiniMax upstream (`PROXY_MAP[proxyPath]`).
- Keep native behavior unchanged by continuing to use `CapacitorHttp` and returning a Response-like object for native requests. 
- Change is localized to `utils/minimaxEndpoint.ts` only.

### Testing
- Ran `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be703367f48330830cdd155f7285bb)