### PR TITLE
Minimax: normalize headers, inject group_id, and retry upstream when proxy unavailable

### DIFF
--- a/utils/minimaxEndpoint.ts
+++ b/utils/minimaxEndpoint.ts
@@ -24,11 +24,46 @@ const PROXY_MAP: Record<string, string> = {
  * Return the actual URL to fetch for a given proxy path.
  */
 export function resolveMinimaxUrl(proxyPath: string): string {
-  if (isNative() && PROXY_MAP[proxyPath]) {
+  if (PROXY_MAP[proxyPath] && isNative()) {
     return PROXY_MAP[proxyPath];
   }
   return proxyPath;
 }
+
+const normalizeHeaders = (headers: Record<string, string> = {}): Record<string, string> => {
+  const normalized: Record<string, string> = {};
+  Object.entries(headers).forEach(([k, v]) => {
+    normalized[k.toLowerCase()] = v;
+  });
+  return normalized;
+};
+
+const buildUpstreamWebInit = (
+  init: { method?: string; headers?: Record<string, string>; body?: string },
+): { method?: string; headers?: Record<string, string>; body?: string } => {
+  const headers = normalizeHeaders(init.headers || {});
+  const groupId = (headers['x-minimax-group-id'] || '').trim();
+
+  // MiniMax upstream CORS doesn't allow x-minimax-api-key/x-minimax-group-id custom headers.
+  delete headers['x-minimax-api-key'];
+  delete headers['x-minimax-group-id'];
+
+  if (!groupId || !init.body) {
+    return { ...init, headers };
+  }
+
+  try {
+    const body = JSON.parse(init.body);
+    if (body && typeof body === 'object' && !body.group_id) {
+      body.group_id = groupId;
+      return { ...init, headers, body: JSON.stringify(body) };
+    }
+  } catch {
+    // Keep original body when it's not JSON.
+  }
+
+  return { ...init, headers };
+};
 
 /**
  * A fetch-like wrapper that uses CapacitorHttp on native platforms
@@ -44,6 +79,11 @@ export async function minimaxFetch(
 
   if (!isNative()) {
     const res = await fetch(url, init);
+    // Static deployments (e.g. GitHub Pages) don't support POST /api/* proxy.
+    // If proxy endpoint is unavailable, retry against MiniMax upstream directly.
+    if ((res.status === 404 || res.status === 405) && PROXY_MAP[proxyPath]) {
+      return fetch(PROXY_MAP[proxyPath], buildUpstreamWebInit(init));
+    }
     return res;
   }
 


### PR DESCRIPTION
### Motivation
- Ensure native Capacitor networking bypasses CORS while web deployments gracefully handle missing proxy endpoints and avoid upstream rejecting custom MiniMax headers, and permit passing `group_id` from a header into JSON request bodies.

### Description
- Reordered the `resolveMinimaxUrl` check to verify the proxy mapping before checking native platform with `isNative()`.
- Added `normalizeHeaders` and `buildUpstreamWebInit` helpers to lowercase header keys, strip `x-minimax-api-key` and `x-minimax-group-id` before forwarding, and inject `group_id` into the JSON body when `x-minimax-group-id` is present and the body lacks `group_id`.
- On web, if a proxied `fetch` returns `404` or `405` and a mapped upstream exists, retry the request directly against the upstream using `fetch(PROXY_MAP[proxyPath], buildUpstreamWebInit(init))`.
- Kept native behavior using `CapacitorHttp.request` and return a Response-like object with `.ok`, `.status`, and `.json()`.

### Testing
- Ran the project's automated test suite with `npm test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be703367f48330830cdd155f7285bb)