### PR TITLE
minimaxEndpoint: normalize headers, inject group_id, and add web proxy bypass & fallback

### DIFF
--- a/utils/minimaxEndpoint.ts
+++ b/utils/minimaxEndpoint.ts
@@ -24,11 +24,53 @@ const PROXY_MAP: Record<string, string> = {
  * Return the actual URL to fetch for a given proxy path.
  */
 export function resolveMinimaxUrl(proxyPath: string): string {
-  if (isNative() && PROXY_MAP[proxyPath]) {
+  if (PROXY_MAP[proxyPath] && isNative()) {
     return PROXY_MAP[proxyPath];
   }
   return proxyPath;
 }
+
+const normalizeHeaders = (headers: Record<string, string> = {}): Record<string, string> => {
+  const normalized: Record<string, string> = {};
+  Object.entries(headers).forEach(([k, v]) => {
+    normalized[k.toLowerCase()] = v;
+  });
+  return normalized;
+};
+
+const buildUpstreamWebInit = (
+  init: { method?: string; headers?: Record<string, string>; body?: string },
+): { method?: string; headers?: Record<string, string>; body?: string } => {
+  const headers = normalizeHeaders(init.headers || {});
+  const groupId = (headers['x-minimax-group-id'] || '').trim();
+
+  // MiniMax upstream CORS doesn't allow x-minimax-api-key/x-minimax-group-id custom headers.
+  delete headers['x-minimax-api-key'];
+  delete headers['x-minimax-group-id'];
+
+  if (!groupId || !init.body) {
+    return { ...init, headers };
+  }
+
+  try {
+    const body = JSON.parse(init.body);
+    if (body && typeof body === 'object' && !body.group_id) {
+      body.group_id = groupId;
+      return { ...init, headers, body: JSON.stringify(body) };
+    }
+  } catch {
+    // Keep original body when it's not JSON.
+  }
+
+  return { ...init, headers };
+};
+
+const shouldBypassWebProxy = (proxyPath: string): boolean => {
+  if (!PROXY_MAP[proxyPath]) return false;
+  if (typeof window === 'undefined') return false;
+  const host = String(window.location.hostname || '').toLowerCase();
+  return host === 'github.io' || host.endsWith('.github.io');
+};
 
 /**
  * A fetch-like wrapper that uses CapacitorHttp on native platforms
@@ -43,7 +85,15 @@ export async function minimaxFetch(
   const url = resolveMinimaxUrl(proxyPath);
 
   if (!isNative()) {
+    if (shouldBypassWebProxy(proxyPath)) {
+      return fetch(PROXY_MAP[proxyPath], buildUpstreamWebInit(init));
+    }
     const res = await fetch(url, init);
+    // Static deployments (e.g. GitHub Pages) don't support POST /api/* proxy.
+    // If proxy endpoint is unavailable, retry against MiniMax upstream directly.
+    if ((res.status === 404 || res.status === 405) && PROXY_MAP[proxyPath]) {
+      return fetch(PROXY_MAP[proxyPath], buildUpstreamWebInit(init));
+    }
     return res;
   }
 


### PR DESCRIPTION
### Motivation

- Fix issues when running on static web hosts (e.g. GitHub Pages) where the local `/api/minimax/*` proxy is not available and MiniMax upstream must be called directly.
- Ensure MiniMax upstream receives `group_id` in the request body because upstream blocks custom headers like `x-minimax-group-id` and `x-minimax-api-key`.

### Description

- Added `normalizeHeaders` to canonicalize header keys to lowercase and `buildUpstreamWebInit` to strip disallowed headers and inject `group_id` into JSON bodies when present in headers.
- Added `shouldBypassWebProxy` to detect static deployments (hosts ending with `.github.io`) and bypass the local proxy by calling the upstream defined in `PROXY_MAP` for those cases.
- Updated `minimaxFetch` to retry against the upstream on web when the proxy returns `404` or `405`, and to use `buildUpstreamWebInit` for upstream requests; preserved native behavior using `CapacitorHttp` for native platforms.
- Minor reorder in `resolveMinimaxUrl` condition to check `PROXY_MAP` before `isNative` for clarity.

### Testing

- Ran TypeScript type-check (`tsc`) locally and it completed successfully.
- Ran the existing automated test suite (`npm test`) and all tests passed.
- Linting (`eslint`) completed with no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be703367f48330830cdd155f7285bb)