### PR TITLE
fix(chat): stop flashing "沉思" indicator on memory-palace skip paths

### DIFF
--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -2335,7 +2335,10 @@ export const useChatAI = ({
                 : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
             if (char.memoryPalaceEnabled && mpEmb?.baseUrl && mpEmb?.apiKey && mpLLM.baseUrl) {
                 const charName = char.name;
-                setMemoryPalaceStatus(`${charName}正在回味你们的对话…`);
+                // 不再预置"正在回味"状态：pipeline 会在水位线未到时立刻 skip，
+                // 预置状态会让"沉思"指示器一闪让用户误以为在干活。
+                // onProgress 在 pipeline 真正进入处理路径后（过完 hot_zone/threshold 检查）
+                // 才首次触发 setMemoryPalaceStatus，这样 skip 路径下指示器不会亮。
 
                 // 缓冲区处理（LLM提取 + Embedding向量化）
                 const recentMsgs = await DB.getRecentMessagesByCharId(char.id, 50);


### PR DESCRIPTION
用户反馈"隔一会就开始沉思"但副 API 实际没被调、palace 也不增长。
根因是 useChatAI.ts 在调 processNewMessages 之前就预置了
  setMemoryPalaceStatus(`${charName}正在回味你们的对话…`)
pipeline 进去后立刻命中 hot_zone/threshold skip 返回，状态在 finally 里被清掉——但指示器已经一闪，用户误以为"在干活"，跟实际 skip 形成巨大落差。

改成不预置状态，只靠 pipeline 内的 onProgress 回调设状态。
onProgress 的 4 个触发点都在 skip 检查之后（pipeline.ts:1089/1160/1213/1225）， 所以 skip 路径下 memoryPalaceStatus 一直是空串，"沉思"指示器不会亮。
真正进入处理流程后（过完水位线）指示器正常显示"正在整理 N 条对话…"。

https://claude.ai/code/session_011aHDTbTAuQtjvL3k7t2SSb