### PR TITLE
fix(mcd): reject hallucinated productCodes before they reach calculat…

### DIFF
--- a/components/mcd/McdMiniApp.tsx
+++ b/components/mcd/McdMiniApp.tsx
@@ -1045,6 +1045,22 @@ const McdMiniApp: React.FC<McdMiniAppProps> = ({ open, onClose, char, userProfil
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
 
+    // 菜单加载/切换后, 把购物车里"当前菜单字典里没有的 code"清掉。
+    // 用户换了门店/取餐方式后, calculate-price 不会因为残留的旧店 code 一直空 list。
+    useEffect(() => {
+        const meals = menuData?.meals;
+        if (!meals || !Object.keys(meals).length) return;
+        setCart((prev: Map<string, CartLine>) => {
+            let dirty = false;
+            const next = new Map<string, CartLine>();
+            for (const [code, line] of prev) {
+                if (meals[code]) next.set(code, line);
+                else { dirty = true; console.warn(`🍔 [MCD-MiniApp] 购物车清掉新菜单里不存在的 code: ${code} (${line.name})`); }
+            }
+            return dirty ? next : prev;
+        });
+    }, [menuData]);
+
     // 每次状态变化推给父组件 → useChatAI 注入到 system prompt 末尾
     useEffect(() => {
         if (!onStateChange) return;
@@ -1098,23 +1114,31 @@ const McdMiniApp: React.FC<McdMiniAppProps> = ({ open, onClose, char, userProfil
     }, [messages]);
 
     // 提案卡片 + 加 / 全部加 按钮 → 往购物车里塞 (从菜单里拿真实价格)
+    // 严格模式: code 必须在当前门店菜单里存在, 否则拒绝加购 (calculate-price 也会拒)。
     // 客户端兜底再做一次名字匹配, 万一服务端 (useChatAI) 里那道修没生效也不至于把烂 code 塞进购物车。
     const handleAddFromProposal = (it: McdProposalItem) => {
         if (!it?.code && !it?.name) return;
-        let realCode: string | undefined = it.code;
-        let meal = realCode ? menuData?.meals?.[realCode] : undefined;
-        if (!meal && menuData?.meals) {
+        if (!menuData?.meals || !Object.keys(menuData.meals).length) {
+            console.warn('🍔 [MCD-MiniApp] 拒绝加购: 当前菜单还没加载, 不能从 proposal 加购');
+            return;
+        }
+        let realCode: string | undefined = menuData.meals[it.code || ''] ? it.code : undefined;
+        let meal = realCode ? menuData.meals[realCode] : undefined;
+        if (!meal) {
             // 服务端没修上 / propose 直接漏了 code 校准: 在这儿按 name 兜底
             const { fixed, fixes } = autoFixProposalCodesByName([it], menuData.meals);
-            if (fixes.length && fixed[0]?.code) {
+            if (fixes.length && fixed[0]?.code && menuData.meals[fixed[0].code]) {
                 realCode = fixed[0].code;
                 meal = menuData.meals[realCode];
                 console.log(`🍔 [MCD-MiniApp] 客户端兜底修 code: '${it.code}' → '${realCode}' (${fixes[0].name})`);
             }
         }
-        if (!realCode) return;
-        const price = meal?.currentPrice;
-        const name = meal?.name || it.name;
+        if (!realCode || !meal) {
+            console.warn(`🍔 [MCD-MiniApp] 拒绝加购: code='${it.code}' name='${it.name}' 在当前门店菜单里找不到匹配`);
+            return;
+        }
+        const price = meal.currentPrice;
+        const name = meal.name || it.name;
         for (let i = 0; i < (it.qty || 1); i++) {
             updateCart(realCode, 1, { name, price });
         }

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -838,19 +838,28 @@ export const useChatAI = ({
                             console.warn('🍔 [MCD-MiniApp] propose 参数解析失败:', e);
                         }
                         if (fname === 'propose_cart_items' && Array.isArray(args.items) && args.items.length) {
-                            // 第一步: 全局名字匹配自动修 code (char 经常把"板烧鸡腿堡"当 code 传)
+                            // 第一步: 菜单还没加载就直接拒, 不能让模型瞎编 code
+                            // 这是导致 calculate-price 返回空列表的根因之一: propose 在 pick 步骤被调用,
+                            // 此时 menuMeals 是空的, 旧版 menuKeys.length===0 会直接跳过校验, 烂 code 一路到 cart。
                             const menu = mcdMiniSnap?.menuMeals || {};
                             const menuKeys = Object.keys(menu);
+                            if (menuKeys.length === 0) {
+                                loopMessages.push({
+                                    role: 'tool',
+                                    tool_call_id: tc.id,
+                                    content: `菜单还没加载 (用户当前在选模式 / 选地址门店阶段, 还没进入菜单页)。请先用文字陪用户聊, 等用户在小程序里选完地址/门店、菜单加载出来后再调 propose_cart_items。所有 code 必须从加载后的"当前门店在售"清单里挑, 不能凭印象编。`,
+                                } as any);
+                                continue;
+                            }
+                            // 第二步: 全局名字匹配自动修 code (char 经常把"板烧鸡腿堡"当 code 传)
                             const { fixed, fixes } = autoFixProposalCodesByName(args.items, menu);
                             if (fixes.length) {
                                 console.log(`🍔 [MCD-MiniApp] propose 自动修 ${fixes.length} 个 code:`,
                                     fixes.map(f => `'${f.from}' → '${f.to}' (${f.name})`).join(', '));
                             }
                             args.items = fixed;
-                            // 第二步: 修完后还有非法的就退回 char 重提
-                            const invalidItems = menuKeys.length > 0
-                                ? args.items.filter((it: any) => !it?.code || !(menu as any)[it.code])
-                                : [];
+                            // 第三步: 修完后还有非法的就退回 char 重提 (严格模式: 任何不在 menu 字典里的 code 都拒)
+                            const invalidItems = args.items.filter((it: any) => !it?.code || !(menu as any)[it.code]);
                             if (invalidItems.length > 0) {
                                 const sample = menuKeys.slice(0, 20).map(k => `${k}=${(menu as any)[k]?.name || ''}`).join(', ');
                                 const bad = invalidItems.map((i: any) => `'${i.code}'(${i.name || '?'})`).join(', ');

--- a/utils/mcdToolBridge.ts
+++ b/utils/mcdToolBridge.ts
@@ -223,7 +223,7 @@ export const MCD_PROPOSE_TOOL = {
     type: 'function' as const,
     function: {
         name: 'propose_cart_items',
-        description: '当你想给用户推荐 1~N 件商品加进购物车时调用这工具。用户会在小程序聊天里看到一张"char 想加这些"小卡片, 每项带"+ 加进购物车"按钮自己决定。这不是真下单, 只是把推荐推到 UI; 你调完工具还可以继续用文字解释或聊天。',
+        description: '当你想给用户推荐 1~N 件商品加进购物车时调用这工具。用户会在小程序聊天里看到一张"char 想加这些"小卡片, 每项带"+ 加进购物车"按钮自己决定。这不是真下单, 只是把推荐推到 UI; 你调完工具还可以继续用文字解释或聊天。\n\n**前置硬条件**: 必须等到 system prompt 里出现"当前门店在售 (前 N 项...)"清单后再调; 用户还在选模式 / 选地址门店阶段时, 菜单没加载, 任何 code 都是凭印象编的, 你的 propose 会被服务端直接拒, 反而拖慢节奏。这种时候用文字陪聊就好 ("等你选完店我帮你看")。',
         parameters: {
             type: 'object',
             properties: {
@@ -233,7 +233,7 @@ export const MCD_PROPOSE_TOOL = {
                     items: {
                         type: 'object',
                         properties: {
-                            code: { type: 'string', description: '商品 productCode, 必须是"当前门店在售"列表里的 code key (数字字符串如 "9900010341", "920215"), 绝对不能用商品名 (e.g. "板烧鸡腿堡" 是错的, 那是名字不是 code)。优先选名字含套餐/单人餐/双人餐/全家桶/三/四件套 这种打包好的, 比单点划算。' },
+                            code: { type: 'string', description: '商品 productCode, **必须**是当前 system prompt 里"当前门店在售"清单 = 号左边那串纯数字 (如 "9900010341", "920215")。**绝对不能**: ① 用商品名当 code (e.g. "板烧鸡腿堡" 是错的, 那是名字); ② 用其它门店 / 印象中的 code (上一笔订单 / 别店看到的, 这家不一定有, 算价会空); ③ 在菜单还没加载时硬编。优先选名字含套餐/单人餐/双人餐/全家桶/三/四件套 这种打包好的, 比单点划算。' },
                             name: { type: 'string', description: '商品名 (跟菜单一致)' },
                             qty: { type: 'integer', description: '推荐数量', minimum: 1, maximum: 10 },
                             reason: { type: 'string', description: '一句话说为什么推这个 (热量/搭配/划算/口味), 30 字内' }
@@ -334,7 +334,13 @@ export const buildMcdMiniAppContextBlock = (snap?: McdMiniAppSnapshot, userName:
     }
     lines.push('');
 
-    if (snap.menuMeals && Object.keys(snap.menuMeals).length) {
+    const menuLoaded = !!(snap.menuMeals && Object.keys(snap.menuMeals).length);
+    if (!menuLoaded) {
+        lines.push(`# 当前菜单: ❌ 还没加载 (用户还在选模式 / 选地址门店阶段)`);
+        lines.push(`**这一阶段不要调 propose_cart_items**: 没有菜单字典, 你 propose 出去的任何 code 都会被服务端拒 (会回一条 tool error)。陪用户选地址 / 门店就好, 文字回应即可; 等小程序进入菜单页, system prompt 里出现"当前门店在售"清单后再说推荐。`);
+        lines.push('');
+    }
+    if (menuLoaded) {
         // 把套餐排前面 (人气热卖里的套餐 char 看着最先, 下意识更倾向推套餐)
         const COMBO_RE = /(套餐|单人餐|双人餐|全家桶|三件套|四件套|五件套|超值组合|节省组合)/;
         const allEntries = Object.entries(snap.menuMeals).filter(([, m]: any) => m?.name);


### PR DESCRIPTION
…e-price

Three defects let LLM-invented productCodes (codes that exist in some McDonald's stores but not the user's current store) leak into the cart, causing calculate-price to silently return an empty list:

1. Server-side propose validation in useChatAI.ts skipped entirely when menuMeals was empty (menuKeys.length===0 short-circuit). Triggered when propose_cart_items was called before the user reached the menu step.
2. Client-side handleAddFromProposal in McdMiniApp.tsx fell through to updateCart even when the code wasn't in the current menu and name-match also failed.
3. Cart wasn't purged when the menu reloaded for a different store, so stale codes from a previous store could persist.

Tighten all three: server now rejects propose with a tool error when menu isn't loaded, client refuses to add codes that aren't in the menu dict, and cart auto-prunes on menu reload. Also strengthen the propose tool description and the in-app context block so the model is told upfront not to propose before the menu loads.