### PR TITLE
fix(character): backfill emotion/palace defaults for legacy new-roles…

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -6,7 +6,7 @@ import { ProactiveChat } from '../utils/proactiveChat';
 import { ChatPrompts } from '../utils/chatPrompts';
 import { ChatParser } from '../utils/chatParser';
 import { safeFetchJson } from '../utils/safeApi';
-import { normalizeCharacterImpression } from '../utils/impression';
+import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
 import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
@@ -923,7 +923,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
             }
         }
 
-        finalChars = finalChars.map(normalizeCharacterImpression);
+        finalChars = finalChars.map(c => normalizeCharacterDefaults(normalizeCharacterImpression(c)));
 
         if (finalChars.length > 0) {
           setCharacters(finalChars);
@@ -2716,7 +2716,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               setAppearancePresets(loadedPresets);
           }
 
-          if (chars.length > 0) setCharacters(chars.map(normalizeCharacterImpression));
+          if (chars.length > 0) setCharacters(chars.map(c => normalizeCharacterDefaults(normalizeCharacterImpression(c))));
           if (groupsList.length > 0) setGroups(groupsList);
           if (themes.length > 0) setCustomThemes(themes);
           if (user) setUserProfile(user);

--- a/utils/impression.ts
+++ b/utils/impression.ts
@@ -97,3 +97,21 @@ export const normalizeCharacterImpression = (char: CharacterProfile): CharacterP
         impression: normalizedImpression,
     };
 };
+
+/**
+ * 历史脏数据兜底：早期 addCharacter 没初始化情绪 / 记忆宫殿开关，导致一批"新角色"
+ * 字段为 undefined，副 API 闸门 (useChatAI:761 / :2604) 永远过不去。
+ * 此处只把 undefined 补成默认 true —— 用户显式关掉 (false) 的不动。
+ * 在加载阶段调用即可，updateCharacter 自然会在下次保存时把补好的字段持久化。
+ */
+export const normalizeCharacterDefaults = (char: CharacterProfile): CharacterProfile => {
+    const patch: Partial<CharacterProfile> = {};
+    if (char.emotionConfig === undefined) {
+        patch.emotionConfig = { enabled: true };
+    }
+    if (char.memoryPalaceEnabled === undefined) {
+        patch.memoryPalaceEnabled = true;
+    }
+    if (Object.keys(patch).length === 0) return char;
+    return { ...char, ...patch };
+};


### PR DESCRIPTION
… on load

新增 normalizeCharacterDefaults：加载角色时把 undefined 的 emotionConfig 补 { enabled: true }、undefined 的 memoryPalaceEnabled 补 true。只动 undefined，用户显式关掉的 false 不覆盖。这样上一版 addCharacter 漏初始 化遗留下来的脏角色不用进记忆宫殿手动重开，下次任意 updateCharacter 会
顺手把补好的字段写回 DB。