### PR TITLE
fix(character): scope backfill to emotion only, leave memory palace o…

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1662,12 +1662,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   const savePresets = (presets: ApiPreset[]) => { setApiPresets(presets); localStorage.setItem('os_api_presets', JSON.stringify(presets)); };
   const addCharacter = async () => {
     const name = 'New Character';
-    // 默认开启 emotionConfig.enabled 与 memoryPalaceEnabled，让新角色与老角色行为对齐：
-    // - 情绪标签由 (isScheduleFeatureOn && emotionConfig.enabled) 双闸门控制；schedule
-    //   未开时不会触发副 API，所以这里默认 true 是安全的，仅是把"用户开日程后情绪自然
-    //   跟着启用"这条隐含约定显式落到默认值上。
-    // - memoryPalaceEnabled 真正的 gate 还要全局 embedding/lightLLM 配好，没配的话
-    //   pipeline 会自然 skip；老用户 (历史角色) 已有此字段，新角色补齐即可。
+    // 默认开启 emotionConfig.enabled，让"开日程 = 开情绪"这条隐含约定对新角色也成立。
+    // 真正的闸门是 (isScheduleFeatureOn && emotionConfig.enabled)，schedule 没开
+    // 时副 API 不会触发，所以这里默认 true 安全。
+    // 注意：memoryPalaceEnabled 不在这里默认开 —— 那是用户在记忆宫殿 App 显式 opt-in
+    // 的功能，自动开会替用户决策。
     const newChar: CharacterProfile = {
       id: `char-${Date.now()}`,
       name,
@@ -1677,7 +1676,6 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       memories: [],
       contextLimit: 500,
       emotionConfig: { enabled: true },
-      memoryPalaceEnabled: true,
     };
     setCharacters(prev => [...prev, newChar]);
     setActiveCharacterId(newChar.id);

--- a/utils/impression.ts
+++ b/utils/impression.ts
@@ -99,19 +99,12 @@ export const normalizeCharacterImpression = (char: CharacterProfile): CharacterP
 };
 
 /**
- * 历史脏数据兜底：早期 addCharacter 没初始化情绪 / 记忆宫殿开关，导致一批"新角色"
- * 字段为 undefined，副 API 闸门 (useChatAI:761 / :2604) 永远过不去。
- * 此处只把 undefined 补成默认 true —— 用户显式关掉 (false) 的不动。
- * 在加载阶段调用即可，updateCharacter 自然会在下次保存时把补好的字段持久化。
+ * 历史脏数据兜底：早期 addCharacter 没初始化 emotionConfig，导致一批"新角色"该字段
+ * 为 undefined，情绪闸门 (useChatAI:761) 永远过不去。
+ * 此处只把 undefined 补成默认 enabled，用户显式关掉 (false) 的不动。
+ * memoryPalaceEnabled 是用户显式 opt-in 的功能，不在这里替用户开。
  */
 export const normalizeCharacterDefaults = (char: CharacterProfile): CharacterProfile => {
-    const patch: Partial<CharacterProfile> = {};
-    if (char.emotionConfig === undefined) {
-        patch.emotionConfig = { enabled: true };
-    }
-    if (char.memoryPalaceEnabled === undefined) {
-        patch.memoryPalaceEnabled = true;
-    }
-    if (Object.keys(patch).length === 0) return char;
-    return { ...char, ...patch };
+    if (char.emotionConfig !== undefined) return char;
+    return { ...char, emotionConfig: { enabled: true } };
 };


### PR DESCRIPTION
…pt-in

向量自动总结 (memoryPalaceEnabled) 实际是正常跑的 —— 用户报告里那句
"也没有正常启动"被误读了。把 addCharacter 里 memoryPalaceEnabled: true 的默认值和 normalizeCharacterDefaults 里的对应分支撤掉，避免替用户开
本来要 opt-in 的 palace 功能。emotion 那一支保留，那才是真 bug。