### PR TITLE
feat(music): add download button for AI-generated songs

### DIFF
--- a/apps/MusicApp.tsx
+++ b/apps/MusicApp.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useOS } from '../context/OSContext';
 import { useMusic, musicApi, normalizeCookie, toHttps, Song } from '../context/MusicContext';
+import { DB } from '../utils/db';
 import { Gear, User as UserIcon, Crosshair, Play as PlayIcon, Pause as PauseIcon } from '@phosphor-icons/react';
 import {
   C, Sparkle, CrossStar, MizuHeader, SearchBar, SongRow, MiniPlayer,
@@ -37,6 +38,32 @@ const MusicApp: React.FC = () => {
   } = useMusic();
   const isCurrentRegenerating = !!current && current.id === regeneratingId;
   // 把对轴入口和单曲循环按钮移到 SubActions 里，避免散乱
+  // 下载本地生成的歌曲到本地文件系统
+  const downloadCurrentLocal = useCallback(async () => {
+    if (!current?.local || !current.localAssetKey) return;
+    try {
+      const entry = await DB.getAssetRaw(current.localAssetKey).catch(() => null) as
+        | { blob?: Blob; mimeType?: string }
+        | Blob
+        | null;
+      const blob: Blob | null = entry instanceof Blob
+        ? entry
+        : (entry?.blob instanceof Blob ? entry.blob : null);
+      if (!blob) { addToast('音频文件丢失', 'error'); return; }
+      const mime = current.localMimeType || (entry && !(entry instanceof Blob) ? entry.mimeType : '') || blob.type || 'audio/mpeg';
+      const ext = /wav/i.test(mime) ? 'wav' : /ogg/i.test(mime) ? 'ogg' : /flac/i.test(mime) ? 'flac' : /m4a|aac|mp4/i.test(mime) ? 'm4a' : 'mp3';
+      const safe = (current.name || 'song').replace(/[\\/:*?"<>|]+/g, '_').slice(0, 80);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = `${safe}.${ext}`;
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      addToast('已下载', 'success');
+    } catch {
+      addToast('下载失败', 'error');
+    }
+  }, [current, addToast]);
+
   const cyclePlayMode = useCallback(() => {
     const order: ('loop' | 'single' | 'shuffle')[] = ['loop', 'single', 'shuffle'];
     const next = order[(order.indexOf(playMode) + 1) % order.length];
@@ -404,6 +431,8 @@ const MusicApp: React.FC = () => {
                 setSyncDraft(lyric.map(l => l.t));
                 setShowLyricSync(true);
               }}
+              showDownload={!!(current.local && current.localAssetKey)}
+              onDownload={downloadCurrentLocal}
               playMode={playMode}
               onCyclePlayMode={cyclePlayMode}
             />

--- a/apps/music/MusicUI.tsx
+++ b/apps/music/MusicUI.tsx
@@ -479,10 +479,12 @@ export const SubActions: React.FC<{
   liked?: boolean;
   onSync?: () => void;             // 手动对轴 (仅本地歌显示)
   showSync?: boolean;
+  onDownload?: () => void;         // 下载本地生成的音频 (仅本地歌显示)
+  showDownload?: boolean;
   playMode?: SubPlayMode;
   onCyclePlayMode?: () => void;    // 循环模式切换
   onAdd?: () => void;
-}> = ({ onLike, liked, onSync, showSync, playMode = 'loop', onCyclePlayMode, onAdd }) => {
+}> = ({ onLike, liked, onSync, showSync, onDownload, showDownload, playMode = 'loop', onCyclePlayMode, onAdd }) => {
   const Item = ({ icon, label, onClick, active }: { icon: React.ReactNode; label: string; onClick?: () => void; active?: boolean }) => (
     <button onClick={onClick}
       className="flex flex-col items-center gap-1 transition-opacity active:scale-95"
@@ -533,6 +535,13 @@ export const SubActions: React.FC<{
       <path d="M3 6h13M3 12h13M3 18h9M17 15v6M14 18h6" />
     </svg>
   );
+  const downloadSvg = (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 4v12" />
+      <path d="M7 11l5 5 5-5" />
+      <path d="M5 20h14" />
+    </svg>
+  );
 
   const playModeLabel: Record<SubPlayMode, string> = { loop: 'Loop', single: 'One', shuffle: 'Mix' };
 
@@ -540,6 +549,7 @@ export const SubActions: React.FC<{
     <div className="flex items-end justify-around gap-4 max-w-[280px] mx-auto">
       <Item onClick={onLike} active={liked} label="Like" icon={heartSvg} />
       {showSync && onSync && <Item onClick={onSync} active label="Sync" icon={syncSvg} />}
+      {showDownload && onDownload && <Item onClick={onDownload} active label="Save" icon={downloadSvg} />}
       {onCyclePlayMode && <Item onClick={onCyclePlayMode} active={playMode !== 'loop'} label={playModeLabel[playMode]} icon={loopSvg} />}
       {onAdd && <Item onClick={onAdd} label="Add" icon={addSvg} />}
     </div>


### PR DESCRIPTION
Lets the user save the locally-generated audio (写歌 → 网易云) to a file. The button sits next to Sync in the SubActions row and only shows when the current track is a local blob-backed song.

https://claude.ai/code/session_019BTRJRYUMZUNUXL8troKGk