### PR TITLE
fix(chat): preserve citation tags through chunking so every bubble ke…

### DIFF
--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -2418,14 +2418,11 @@ export const useChatAI = ({
                     }
                 }
             }
-            // Clean all quote tag variants from content
-            aiContent = aiContent.replace(QUOTE_CLEAN_DOUBLE, '').replace(QUOTE_CLEAN_SINGLE, '').replace(REPLY_CLEAN_CN, '').trim();
-
             // 8. Split and Stream (Simulate Typing)
             // Note: SEND_EMOJI tags are preserved through sanitize so splitResponse can interleave them with text
-
-            // Comprehensive AI output sanitization (strips name prefixes, headers, stray backticks, residual tags, etc.)
-            aiContent = ChatParser.sanitize(aiContent);
+            // Citation tags are preserved here so each chunk can detect its own reply target;
+            // they are stripped per-chunk below (and again via per-chunk sanitize for visible text).
+            aiContent = ChatParser.sanitize(aiContent, { keepCitations: true });
 
             // 意识流（innerState）现由副 API 的情绪评估管线产出并 setEvolvedNarrative；
             // 仍然兜底清理一次，防止老 prompt 缓存或模型残留标签泄漏到用户可见内容。
@@ -2548,7 +2545,7 @@ export const useChatAI = ({
                                 await new Promise(r => setTimeout(r, delay));
 
                                 let chunkReplyTarget: { id: number, content: string, name: string } | undefined;
-                                const chunkQuoteMatch = chunk.match(QUOTE_RE_DOUBLE) || chunk.match(QUOTE_RE_SINGLE);
+                                const chunkQuoteMatch = chunk.match(QUOTE_RE_DOUBLE) || chunk.match(QUOTE_RE_SINGLE) || chunk.match(REPLY_RE_CN);
                                 if (chunkQuoteMatch) {
                                     const quotedText = chunkQuoteMatch[1].trim();
                                     if (quotedText) {
@@ -2559,10 +2556,12 @@ export const useChatAI = ({
                                             chunkReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
                                         }
                                     }
-                                    chunk = chunk.replace(QUOTE_CLEAN_DOUBLE, '').replace(QUOTE_CLEAN_SINGLE, '').trim();
+                                    chunk = chunk.replace(QUOTE_CLEAN_DOUBLE, '').replace(QUOTE_CLEAN_SINGLE, '').replace(REPLY_CLEAN_CN, '').trim();
                                 }
 
-                                const replyData = chunkReplyTarget || (globalMsgIndex === 0 ? aiReplyTarget : undefined);
+                                // Per-chunk citation detection above handles every quote tag in the message,
+                                // so each bubble gets the citation that was actually inline in its own chunk.
+                                const replyData = chunkReplyTarget;
 
                                 if (ChatParser.hasDisplayContent(chunk)) {
                                     const cleanChunk = ChatParser.sanitize(chunk);

--- a/utils/chatParser.ts
+++ b/utils/chatParser.ts
@@ -201,9 +201,11 @@ export const ChatParser = {
      * Comprehensive sanitizer for AI output before saving to DB.
      * Removes AI-specific artifacts that should never appear in chat bubbles.
      * Safe to call multiple times (idempotent). Preserves %%BILINGUAL%% markers.
+     * Pass { keepCitations: true } to preserve [QUOTE:..]/[引用:..]/[回复 ".."] tags
+     * (used when downstream chunking needs to detect per-bubble citation targets).
      */
-    sanitize: (text: string): string => {
-        return text
+    sanitize: (text: string, options?: { keepCitations?: boolean }): string => {
+        let result = text
             // Convert literal \n (backslash + n) the AI sometimes outputs into real newlines
             .replace(/\\n/g, '\n')
             // Strip source tags [聊天]/[通话]/[约会] leaked from history context → newline to preserve splits
@@ -221,11 +223,15 @@ export const ChatParser = {
             .replace(/^#{1,6}\s+/gm, '')
             // Strip residual action/system tags that weren't caught earlier
             .replace(/\[\[(?:ACTION|RECALL|SEARCH|DIARY|READ_DIARY|FS_DIARY|FS_READ_DIARY|DIARY_START|DIARY_END|FS_DIARY_START|FS_DIARY_END|MUSIC_ACTION)[:\s][\s\S]*?\]\]/g, '')
-            .replace(/\[schedule_message[^\]]*\]/g, '')
-            .replace(/\[\[(?:QU[OA]TE|引用)[：:][\s\S]*?\]\]/g, '')
-            .replace(/\[(?:QU[OA]TE|引用)[：:][^\]]*\]/g, '')
-            // [回复 "content"]: format (AI mimics history context format)
-            .replace(/\[回复\s*[""\u201C][^""\u201D]*?[""\u201D](?:\.{0,3})\]\s*[：:]?\s*/g, '')
+            .replace(/\[schedule_message[^\]]*\]/g, '');
+        if (!options?.keepCitations) {
+            result = result
+                .replace(/\[\[(?:QU[OA]TE|引用)[：:][\s\S]*?\]\]/g, '')
+                .replace(/\[(?:QU[OA]TE|引用)[：:][^\]]*\]/g, '')
+                // [回复 "content"]: format (AI mimics history context format)
+                .replace(/\[回复\s*[""\u201C][^""\u201D]*?[""\u201D](?:\.{0,3})\]\s*[：:]?\s*/g, '');
+        }
+        return result
             // Strip backtick-wrapped action tags and empty backtick pairs
             .replace(/`(\[\[[\s\S]*?\]\])`/g, '$1')
             .replace(/``+/g, '')


### PR DESCRIPTION
…eps its reply target

Pre-chunk strip on line 2422 plus default-stripping inside ChatParser.sanitize removed every [QUOTE:..]/[引用:..]/[回复 ".."] tag before splitResponse/chunkText ran, which meant the per-chunk match fallback at the chunk loop was dead code. Result: only the first bubble of a reply could carry a citation (via the aiReplyTarget fallback gated on globalMsgIndex===0); any subsequent quotes the AI emitted in the same reply silently lost their formatting.

- Add { keepCitations } option to ChatParser.sanitize so callers that need to detect per-bubble citation targets can keep the tags through later passes.
- Drop the global pre-strip in useChatAI; let the global sanitize keep citations and rely on per-chunk match + per-chunk sanitize for cleanup.
- Extend the per-chunk match and strip to also cover REPLY_RE_CN/REPLY_CLEAN_CN (the [回复 "..."] variant), and drop the aiReplyTarget fallback in the non-bilingual path now that every chunk handles its own tag.