### PR TITLE
fix(call): 通话结束后立即刷新通话历史

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -640,6 +640,7 @@ const CallApp: React.FC = () => {
         content: `通话结束 · ${selectedChar.name}｜${formatDuration(elapsedSeconds)}｜${Math.max(1, userTurns)}轮对话`,
         metadata: { source: 'call-end-popup', callSessionId: currentSessionId, ...payload },
       });
+      await loadCallRecords(selectedChar.id);
     }
     clearSuspendedCall();
     resetCurrentCall();


### PR DESCRIPTION
之前 finishCall 写入数据库后没有重新加载 callRecords，
而加载只在 selectedCharId 变化时触发，导致用户挂断后
切到 history 视图仍然看到旧列表，需要切换角色或重进
才会出现新记录。