### PR TITLE
feat(appearance): 一键还原外观到初始状态

### DIFF
--- a/apps/Appearance.tsx
+++ b/apps/Appearance.tsx
@@ -230,16 +230,29 @@ interface PresetManagerProps {
     onRename: (id: string, name: string) => void;
     onExport: (id: string) => Promise<Blob>;
     onImport: (file: File) => Promise<void>;
+    onReset: () => Promise<void>;
     addToast: (msg: string, type?: Toast['type']) => void;
     currentTheme: OSTheme;
 }
 
-const PresetManager: React.FC<PresetManagerProps> = ({ presets, onSave, onApply, onDelete, onRename, onExport, onImport, addToast, currentTheme }) => {
+const PresetManager: React.FC<PresetManagerProps> = ({ presets, onSave, onApply, onDelete, onRename, onExport, onImport, onReset, addToast, currentTheme }) => {
     const [newName, setNewName] = useState('');
     const [editingId, setEditingId] = useState<string | null>(null);
     const [editName, setEditName] = useState('');
     const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+    const [confirmReset, setConfirmReset] = useState(false);
+    const [resetting, setResetting] = useState(false);
     const importRef = useRef<HTMLInputElement>(null);
+
+    const handleReset = async () => {
+        setResetting(true);
+        try {
+            await onReset();
+        } finally {
+            setResetting(false);
+            setConfirmReset(false);
+        }
+    };
 
     const handleSave = () => {
         const name = newName.trim() || `预设 ${new Date().toLocaleDateString('zh-CN')}`;
@@ -319,6 +332,35 @@ const PresetManager: React.FC<PresetManagerProps> = ({ presets, onSave, onApply,
 
     return (
         <div className="space-y-5">
+            {/* One-click Reset */}
+            <section className="bg-gradient-to-br from-rose-50 to-orange-50 rounded-3xl p-5 shadow-sm border border-rose-100">
+                <div className="flex items-center gap-2 mb-2">
+                    <h2 className="text-sm font-bold text-rose-500 uppercase tracking-widest">一键还原外观</h2>
+                </div>
+                <p className="text-[10px] text-slate-500 mb-3 leading-relaxed">
+                    把主题色、壁纸、字体、应用图标、桌面小组件、装饰贴纸全部还原成最初始状态。在不同版本之间反复导入预设导致图标错乱时使用。<br/>
+                    <span className="text-slate-400">已保存的外观预设不会被删除，随时还能切回去。</span>
+                </p>
+                {!confirmReset ? (
+                    <button onClick={() => setConfirmReset(true)}
+                        className="w-full py-2.5 bg-white text-rose-500 font-bold text-xs rounded-xl border border-rose-200 active:scale-95 transition-transform flex items-center justify-center gap-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-4 h-4"><path strokeLinecap="round" strokeLinejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" /></svg>
+                        还原为初始外观
+                    </button>
+                ) : (
+                    <div className="flex gap-2">
+                        <button onClick={handleReset} disabled={resetting}
+                            className="flex-1 py-2.5 bg-rose-500 text-white font-bold text-xs rounded-xl shadow-sm active:scale-95 transition-transform disabled:opacity-50">
+                            {resetting ? '正在还原...' : '确认还原'}
+                        </button>
+                        <button onClick={() => setConfirmReset(false)} disabled={resetting}
+                            className="flex-1 py-2.5 bg-white text-slate-500 font-bold text-xs rounded-xl border border-slate-200 active:scale-95 transition-transform disabled:opacity-50">
+                            取消
+                        </button>
+                    </div>
+                )}
+            </section>
+
             {/* Save Current */}
             <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100">
                 <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-3">保存当前外观</h2>
@@ -456,7 +498,7 @@ const PresetManager: React.FC<PresetManagerProps> = ({ presets, onSave, onApply,
 };
 
 const Appearance: React.FC = () => {
-  const { theme, updateTheme, closeApp, setCustomIcon, customIcons, addToast, appearancePresets, saveAppearancePreset, applyAppearancePreset, deleteAppearancePreset, renameAppearancePreset, exportAppearancePreset, importAppearancePreset } = useOS();
+  const { theme, updateTheme, closeApp, setCustomIcon, customIcons, addToast, appearancePresets, saveAppearancePreset, applyAppearancePreset, deleteAppearancePreset, renameAppearancePreset, exportAppearancePreset, importAppearancePreset, resetAppearance } = useOS();
   const [activeTab, setActiveTab] = useState<'theme' | 'icons' | 'presets' | 'chat'>('theme');
   const wallpaperInputRef = useRef<HTMLInputElement>(null);
   const [wallpaperUrl, setWallpaperUrl] = useState('');
@@ -1194,6 +1236,7 @@ const Appearance: React.FC = () => {
                 onRename={renameAppearancePreset}
                 onExport={exportAppearancePreset}
                 onImport={importAppearancePreset}
+                onReset={resetAppearance}
                 addToast={addToast}
                 currentTheme={theme}
             />

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -215,6 +215,9 @@ interface OSContextType {
   customIcons: Record<string, string>;
   setCustomIcon: (appId: string, iconUrl: string | undefined) => void;
 
+  // Appearance Reset
+  resetAppearance: () => Promise<void>;
+
   // Global Message Signal
   lastMsgTimestamp: number; // New: Signal for Chat to refresh
   unreadMessages: Record<string, number>; // New: Track unread counts per character
@@ -1913,6 +1916,48 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       addToast('预设已删除', 'info');
   };
 
+  // 一键还原外观：把主题、图标、壁纸、小组件、装饰、字体全部回到出厂状态。
+  // 用户在不同版本/不同备份之间反复导入时，customIcons 与 IndexedDB 里的 widget_/deco_/icon_
+  // 残留经常导致图标错乱，这里直接整体清空再写回 default。
+  // 已保存的外观预设不动，用户随时还能切回去。
+  const resetAppearance = async () => {
+      try {
+          setTheme(defaultTheme);
+          applyCustomFont(undefined);
+
+          const iconAppIds = Object.keys(customIcons);
+          setCustomIcons({});
+          for (const appId of iconAppIds) {
+              await DB.deleteAsset(`icon_${appId}`);
+          }
+
+          const allAssets = await DB.getAllAssets();
+          for (const asset of allAssets) {
+              const id = asset.id;
+              if (
+                  id === 'wallpaper' ||
+                  id === 'launcherWidgetImage' ||
+                  id === 'custom_font_data' ||
+                  id.startsWith('widget_') ||
+                  id.startsWith('deco_') ||
+                  id.startsWith('icon_')
+              ) {
+                  await DB.deleteAsset(id);
+              }
+          }
+
+          try {
+              localStorage.setItem('os_theme', JSON.stringify(defaultTheme));
+          } catch (e) {
+              console.warn('[resetAppearance] localStorage 写入失败', e);
+          }
+
+          addToast('外观已还原为初始状态', 'success');
+      } catch (e: any) {
+          addToast(e?.message || '还原失败', 'error');
+      }
+  };
+
   const renameAppearancePreset = async (id: string, name: string) => {
       setAppearancePresets(prev => prev.map(p => {
           if (p.id !== id) return p;
@@ -2832,6 +2877,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     addToast,
     customIcons,
     setCustomIcon,
+    resetAppearance,
     lastMsgTimestamp,
     unreadMessages,
     clearUnread,


### PR DESCRIPTION
在「外观定制 → 外观预设」加一个一键还原按钮，把主题、壁纸、字体、
应用图标、桌面小组件、装饰贴纸全部清回出厂默认。
不同版本的预设导来导去时图标错乱可以靠这个救回来。
已保存的外观预设不会被删除。

https://claude.ai/code/session_01Txd3adH2KQ1KtXpauuQjKj