### PR TITLE
fix(mcd): 手打"麦请求"等价于点击麦克风按钮, 直接拉起麦当劳菜单

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -695,6 +695,19 @@ const Chat: React.FC = () => {
         const text = customContent || input.trim();
         const type = customType || 'text';
 
+        // 用户手打"麦请求"三个字 → 等价于点击麦克风按钮 (拉起麦当劳菜单)
+        // 不落库, 跟按钮点击行为完全一致, 避免出现"banner 在但菜单没拉起"的诡异状态
+        if (!customContent && type === 'text' && text === MCD_ACTIVATE_TRIGGER) {
+            setInput(''); localStorage.removeItem(draftKey);
+            if (!isMcdConfigured()) {
+                addToast('请先到设置 → 麦当劳 启用并填入 MCP Token', 'info');
+                return;
+            }
+            setMcdAppOpen(true);
+            setShowPanel('none');
+            return;
+        }
+
         if (!customContent) { setInput(''); localStorage.removeItem(draftKey); }
         
         if (type === 'image') {


### PR DESCRIPTION
部分用户习惯手打"麦请求"三个字而不是点击按钮, 之前只会落库 user 消息让
banner 出现, 但 McdMiniApp 不会被打开, 表现为"麦请求进行中"提示在但菜单
拉不起来的诡异状态。在 handleSendText 入口拦截这种纯文本激活, 走和按钮
点击同一条路径 (配置缺失则 toast, 已配置则 setMcdAppOpen(true)), 不落库 保持与按钮行为一致。