### PR TITLE
fix(api): 解耦记忆宫殿副 API 与情绪 API，避免改一处覆盖另一处

### DIFF
--- a/apps/MemoryPalaceApp.tsx
+++ b/apps/MemoryPalaceApp.tsx
@@ -394,7 +394,7 @@ const labelClass = "text-[10px] font-bold text-slate-400 uppercase tracking-wide
 // ─── 主组件 ───────────────────────────────────────────
 
 export default function MemoryPalaceApp() {
-    const { activeCharacterId, characters, updateCharacter, setActiveCharacterId, closeApp, apiPresets, userProfile, memoryPalaceConfig, updateMemoryPalaceConfig, syncEmotionApiToAllCharacters, remoteVectorConfig, updateRemoteVectorConfig, addToast } = useOS();
+    const { activeCharacterId, characters, updateCharacter, setActiveCharacterId, closeApp, apiPresets, userProfile, memoryPalaceConfig, updateMemoryPalaceConfig, remoteVectorConfig, updateRemoteVectorConfig, addToast } = useOS();
     const char = characters.find(c => c.id === activeCharacterId);
 
     const [view, setView] = useState<'picker' | 'palace' | 'room' | 'memory' | 'settings' | 'globalSettings' | 'all' | 'boxes'>('picker');
@@ -901,9 +901,8 @@ export default function MemoryPalaceApp() {
             apiKey: lightKey.trim(),
             model: lightModel.trim(),
         };
-        // 一次性写到全局 lightLLM + 所有角色的 emotionConfig.api
-        // （各角色 enabled 标志保持不变；记忆宫殿轻量 LLM 与情绪 API 共用一份配置）
-        syncEmotionApiToAllCharacters(api);
+        // 只写全局 lightLLM；与情绪 API（emotionConfig.api）完全独立，互不影响。
+        updateMemoryPalaceConfig({ lightLLM: api });
         setLightSaved(true);
         setTimeout(() => setLightSaved(false), 2000);
     };

--- a/apps/pixelHome/MemoryDiveMode.tsx
+++ b/apps/pixelHome/MemoryDiveMode.tsx
@@ -46,7 +46,6 @@ interface Props {
   homeState: PixelHomeState;
   assets: PixelAsset[];
   apiConfig: APIConfig;
-  memoryPalaceConfig?: { lightLLM?: { baseUrl: string; apiKey: string; model: string } };
   remoteVectorConfig?: RemoteVectorConfig;
   onExit: (result: DiveResult | null) => void;
 }
@@ -66,7 +65,7 @@ type PlaybackStep =
 
 const MemoryDiveMode: React.FC<Props> = ({
   charId, charName, charProfile, userProfile, charSprite, playerSprite,
-  userName, homeState, assets, apiConfig, memoryPalaceConfig, remoteVectorConfig, onExit,
+  userName, homeState, assets, apiConfig, remoteVectorConfig, onExit,
 }) => {
   const fullCharContext = useMemo(() =>
     ContextBuilder.buildCoreContext(charProfile, userProfile, true),
@@ -603,14 +602,11 @@ const MemoryDiveMode: React.FC<Props> = ({
 
     // 后台向角色发射情绪（若启用了 emotionConfig）——角色不记得发生了什么，
     // 但潜意识里会留一层情绪底色，与 chat app 的 buff 系统共用同一套机制
-    // 情绪 API 未单独配置时自动回退到主 apiConfig
+    // 情绪 API 未单独配置时回退到主 apiConfig（与记忆宫殿副 API 完全独立）
     if (charProfile.emotionConfig?.enabled) {
-      const lightLLM = memoryPalaceConfig?.lightLLM;
       const emotionApi = (charProfile.emotionConfig.api?.baseUrl)
         ? charProfile.emotionConfig.api
-        : (lightLLM && lightLLM.baseUrl)
-          ? { baseUrl: lightLLM.baseUrl, apiKey: lightLLM.apiKey, model: lightLLM.model }
-          : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
+        : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
       // fire-and-forget
       emitDiveEmotion({
         charProfile,

--- a/apps/pixelHome/PixelHomeView.tsx
+++ b/apps/pixelHome/PixelHomeView.tsx
@@ -38,7 +38,7 @@ interface Props {
 }
 
 const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName, onBack }) => {
-  const { addToast, apiConfig, characters, userProfile, remoteVectorConfig, memoryPalaceConfig } = useOS();
+  const { addToast, apiConfig, characters, userProfile, remoteVectorConfig } = useOS();
   const char = characters.find(c => c.id === charId);
   const [viewMode, setViewMode] = useState<PixelHomeViewMode>('map');
   const [homeState, setHomeState] = useState<PixelHomeState | null>(null);
@@ -328,7 +328,6 @@ const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName
             userName={userName}
             homeState={homeState} assets={assets}
             apiConfig={apiConfig}
-            memoryPalaceConfig={memoryPalaceConfig}
             remoteVectorConfig={remoteVectorConfig}
             onExit={handleDiveExit}
           />

--- a/apps/pixelHome/memoryDiveEngine.ts
+++ b/apps/pixelHome/memoryDiveEngine.ts
@@ -901,7 +901,7 @@ interface EmitDiveEmotionParams {
   diveBuffs: DiveBuffValues;
   /** 走过的房间，按顺序 */
   visitedRooms: MemoryRoom[];
-  /** 二级 API（复用 emotionConfig.api；会由外层传入，保证和 chat app 完全一致） */
+  /** 情绪 API（来自 emotionConfig.api，未配置时由调用方回退到主 apiConfig） */
   api: APIConfig;
 }
 

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1316,14 +1316,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               const fullMessages = [{ role: 'system', content: systemPrompt }, ...apiMessages];
 
               // 3c. 情绪评估 fire-and-forget — 与主 API 并行，沿用 useChatAI 的 API 选择逻辑：
-              //     角色专属情绪 API > 全局 lightLLM > 主 apiConfig
+              //     角色专属情绪 API > 主 apiConfig（与记忆宫殿副 API 完全独立）
               if (isScheduleFeatureOn(char) && char.emotionConfig?.enabled) {
-                  const lightLLM = memoryPalaceConfigRef.current?.lightLLM;
                   const emotionApi = (char.emotionConfig.api?.baseUrl)
                       ? char.emotionConfig.api
-                      : (lightLLM && lightLLM.baseUrl)
-                          ? { baseUrl: lightLLM.baseUrl, apiKey: lightLLM.apiKey, model: lightLLM.model }
-                          : { baseUrl: apiConfigRef.current.baseUrl, apiKey: apiConfigRef.current.apiKey, model: apiConfigRef.current.model };
+                      : { baseUrl: apiConfigRef.current.baseUrl, apiKey: apiConfigRef.current.apiKey, model: apiConfigRef.current.model };
                   if (emotionApi.baseUrl && currentUserProfile) {
                       evaluateEmotionBackground(char, currentUserProfile, systemPrompt, apiMessages, emotionApi)
                           .then((innerState) => {
@@ -1628,8 +1625,8 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   };
 
   // 情绪 API 同步到所有角色：API 字段（baseUrl/apiKey/model）所有角色共用，
-  // 各角色自身的 enabled 标志保持不变。同时把同一份值写到全局 lightLLM，
-  // 让记忆宫殿轻量 LLM 与情绪 API 保持一致（两者本来就指向同一个副 API 概念）。
+  // 各角色自身的 enabled 标志保持不变。
+  // 注意：与记忆宫殿副 API（memoryPalaceConfig.lightLLM）完全独立，两者各管各的。
   const syncEmotionApiToAllCharacters = (api: { baseUrl: string; apiKey: string; model: string } | undefined) => {
     setCharacters(prev => {
       const updated = prev.map(c => {
@@ -1644,15 +1641,6 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       });
       return updated;
     });
-    if (api && api.baseUrl) {
-      const newConfig: MemoryPalaceGlobalConfig = {
-        embedding: { ...memoryPalaceConfig.embedding },
-        lightLLM: { baseUrl: api.baseUrl, apiKey: api.apiKey, model: api.model },
-        rerank: { ...memoryPalaceConfig.rerank },
-      };
-      setMemoryPalaceConfig(newConfig);
-      localStorage.setItem('os_memory_palace_config', JSON.stringify(newConfig));
-    }
   };
   const updateRemoteVectorConfig = (updates: Partial<typeof defaultRemoteVectorConfig>) => {
     const newConfig = { ...remoteVectorConfig, ...updates };

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -782,14 +782,11 @@ export const useChatAI = ({
             // 3. Fire-and-forget emotion evaluation in parallel with main API call
             //    直接复用已 build 好的 systemPrompt 和 cleanedApiMessages，确保情绪评估和主 API 看到的上下文完全一致
             //    情绪评估同时产出 innerState（意识流独白），注入下一轮 system prompt
-            //    未单独配置情绪 API 时，自动回退到主 apiConfig
+            //    未单独配置情绪 API 时，回退到主 apiConfig（与记忆宫殿副 API 完全独立）
             if (isScheduleFeatureOn(char) && char.emotionConfig?.enabled) {
-                const lightLLM = memoryPalaceConfig?.lightLLM;
                 const emotionApi = (char.emotionConfig.api?.baseUrl)
                     ? char.emotionConfig.api
-                    : (lightLLM && lightLLM.baseUrl)
-                        ? { baseUrl: lightLLM.baseUrl, apiKey: lightLLM.apiKey, model: lightLLM.model }
-                        : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
+                    : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
                 setEmotionStatus('evaluating');
                 evaluateEmotionBackground(char, userProfile, systemPrompt, cleanedApiMessages, emotionApi)
                     .then((innerState) => {

--- a/utils/memoryPalace/pipeline.ts
+++ b/utils/memoryPalace/pipeline.ts
@@ -12,7 +12,8 @@
  * - 保留缓冲区尾部 15% 作为下次提取的上下文衔接
  *
  * LLM 调用策略：
- * - 记忆提取 → 用 LightLLMConfig（复用 emotionConfig.api 轻量副模型）
+ * - 记忆提取 → 用 LightLLMConfig（来自 memoryPalaceConfig.lightLLM 全局副 API，
+ *   与情绪 API emotionConfig.api 完全独立）
  * - 检索管线 → 纯计算，不调 LLM
  */
 
@@ -75,7 +76,7 @@ import { isMessageSemanticallyRelevant, formatMessageForPrompt } from '../messag
 
 /**
  * 轻量 LLM 配置，用于记忆提取等后台任务。
- * 复用 emotionConfig.api 的 { baseUrl, apiKey, model }。
+ * 来源是 memoryPalaceConfig.lightLLM（全局副 API），与情绪 API（emotionConfig.api）独立。
  * 这样可以用便宜快速的小模型（如 DeepSeek-V2-Lite、GLM-4-Flash）
  * 而不是主聊天模型。
  */


### PR DESCRIPTION
之前 syncEmotionApiToAllCharacters 同时写各角色 emotionConfig.api 和全局 memoryPalaceConfig.lightLLM，记忆宫殿"保存副 API"和聊天"情绪 API"两条保存 路径互相覆盖。情绪评估的 fallback 链也把 lightLLM 串了进来，用户换宫殿
副 API 会隐式影响情绪表现。

- syncEmotionApiToAllCharacters 只写 emotionConfig.api
- MemoryPalaceApp.handleSaveLightApi 改用 updateMemoryPalaceConfig
- 情绪评估 fallback 改为 emotionConfig.api > apiConfig（去掉 lightLLM 一节）
- MemoryDiveMode 移除不再需要的 memoryPalaceConfig prop
- 修订相关注释

https://claude.ai/code/session_01PnFmDNMf8zCrxrdsfEZro1