### PR TITLE
fix(SocialApp): show all characters in share modal

### DIFF
--- a/apps/SocialApp.tsx
+++ b/apps/SocialApp.tsx
@@ -850,7 +850,7 @@ ${identityMap}
 
             <Modal isOpen={showShareModal} title="分享帖子" onClose={() => setShowShareModal(false)}>
                 <div className="grid grid-cols-4 gap-4 p-2">
-                    {characters.slice(0, 8).map(c => (
+                    {characters.map(c => (
                         <button key={c.id} onClick={() => handleShare(c.id, false)} className="flex flex-col items-center gap-2 group">
                             <img src={c.avatar} className="w-12 h-12 rounded-full object-cover border border-slate-100 group-active:scale-90 transition-transform" />
                             <span className="text-[10px] text-slate-600 truncate w-full text-center">{c.name}</span>


### PR DESCRIPTION
Remove .slice(0, 8) limit so the share dialog displays every character. The Modal already has max-h-[60vh] overflow-y-auto, so the grid will scroll naturally when there are more than 8 entries.