### PR TITLE
fix: 修复字体重置/小组件长按移除/全局播放器拖动

### DIFF
--- a/apps/Appearance.tsx
+++ b/apps/Appearance.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { useOS, DEFAULT_WALLPAPER } from '../context/OSContext';
 import { OSTheme, DesktopDecoration, AppearancePreset, Toast } from '../types';
 import { INSTALLED_APPS, Icons } from '../constants';
@@ -9,6 +9,67 @@ import { ChatAppearanceEditor as ModularChatAppearanceEditor } from '../componen
 import { Capacitor } from '@capacitor/core';
 import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Share } from '@capacitor/share';
+
+// Touch-friendly long-press wrapper. `onContextMenu` alone misses iOS Safari /
+// Capacitor WebView, so we also wire pointer/touch timers to fire after ~550ms.
+// When a long-press fires, the subsequent click is suppressed.
+const LongPressArea: React.FC<{
+    onLongPress: () => void;
+    onClick?: () => void;
+    delay?: number;
+    className?: string;
+    style?: React.CSSProperties;
+    children?: React.ReactNode;
+}> = ({ onLongPress, onClick, delay = 550, className, style, children }) => {
+    const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const fired = useRef(false);
+    const startPos = useRef<{ x: number; y: number } | null>(null);
+
+    const clear = useCallback(() => {
+        if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+        startPos.current = null;
+    }, []);
+
+    useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+
+    const start = (x: number, y: number) => {
+        fired.current = false;
+        startPos.current = { x, y };
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => {
+            fired.current = true;
+            onLongPress();
+        }, delay);
+    };
+    const move = (x: number, y: number) => {
+        const sp = startPos.current;
+        if (!sp) return;
+        if (Math.hypot(x - sp.x, y - sp.y) > 8) clear();
+    };
+
+    return (
+        <div
+            className={className}
+            style={style}
+            onContextMenu={(e) => { e.preventDefault(); onLongPress(); }}
+            onTouchStart={(e) => { const t = e.touches[0]; if (t) start(t.clientX, t.clientY); }}
+            onTouchMove={(e) => { const t = e.touches[0]; if (t) move(t.clientX, t.clientY); }}
+            onTouchEnd={clear}
+            onTouchCancel={clear}
+            onPointerDown={(e) => { if (e.pointerType !== 'touch') start(e.clientX, e.clientY); }}
+            onPointerMove={(e) => { if (e.pointerType !== 'touch') move(e.clientX, e.clientY); }}
+            onPointerUp={clear}
+            onPointerLeave={clear}
+            onPointerCancel={clear}
+            onClick={() => {
+                if (fired.current) { fired.current = false; return; }
+                onClick?.();
+            }}
+        >
+            {children}
+        </div>
+    );
+};
 
 const TwemojiImg: React.FC<{ code: string; alt?: string; className?: string }> = ({ code, alt, className = 'w-4 h-4 inline-block' }) => (
   <img src={`https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/${code}.png`} alt={alt || ''} className={className} draggable={false} />
@@ -850,11 +911,10 @@ const Appearance: React.FC = () => {
                 {/* Wallpaper Section */}
                 <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100">
                     <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-4">Wallpaper</h2>
-                    <div
+                    <LongPressArea
                         className="aspect-[9/16] w-1/2 mx-auto bg-slate-100 rounded-2xl overflow-hidden relative shadow-inner mb-4 group cursor-pointer"
                         onClick={() => wallpaperInputRef.current?.click()}
-                        onContextMenu={(e) => {
-                            e.preventDefault();
+                        onLongPress={() => {
                             if (theme.wallpaper === DEFAULT_WALLPAPER) {
                                 addToast('当前已是默认壁纸', 'info');
                                 return;
@@ -876,7 +936,7 @@ const Appearance: React.FC = () => {
                          <div className="absolute inset-0 bg-black/30 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
                              <span className="text-white text-xs font-bold bg-black/20 px-3 py-1 rounded-full backdrop-blur-md">更换壁纸</span>
                          </div>
-                    </div>
+                    </LongPressArea>
                     <input type="file" ref={wallpaperInputRef} className="hidden" accept="image/*" onChange={(e) => e.target.files?.[0] && handleWallpaperUpload(e.target.files[0])} />
                     <p className="text-center text-[10px] text-slate-400 mb-4">点击上传 / 长按恢复默认壁纸 (支持原画质)</p>
 
@@ -909,9 +969,16 @@ const Appearance: React.FC = () => {
                             const slot = 'dsq';
                             const img = (theme.launcherWidgets || {})[slot];
                             return (
-                                <div className={`w-40 aspect-square rounded-2xl overflow-hidden relative cursor-pointer transition-transform active:scale-95 ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
+                                <LongPressArea
+                                    className={`w-40 aspect-square rounded-2xl overflow-hidden relative cursor-pointer transition-transform active:scale-95 ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
                                     onClick={() => { setActiveWidgetSlot(slot); widgetInputRef.current?.click(); }}
-                                    onContextMenu={(e) => { e.preventDefault(); if (img) removeWidget(slot); }}>
+                                    onLongPress={() => {
+                                        if (img) {
+                                            removeWidget(slot);
+                                            addToast('已移除方图', 'success');
+                                        }
+                                    }}
+                                >
                                     {img ? (
                                         <>
                                             <img src={img} className="w-full h-full object-cover" />
@@ -925,7 +992,7 @@ const Appearance: React.FC = () => {
                                             <span className="text-[10px]">方图</span>
                                         </div>
                                     )}
-                                </div>
+                                </LongPressArea>
                             );
                         })()}
                     </div>
@@ -941,9 +1008,17 @@ const Appearance: React.FC = () => {
                             {['tl', 'tr'].map(slot => {
                                 const img = (theme.launcherWidgets || {})[slot];
                                 return (
-                                    <div key={slot} className={`flex-1 aspect-square rounded-xl overflow-hidden relative cursor-pointer transition-transform active:scale-95 ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
+                                    <LongPressArea
+                                        key={slot}
+                                        className={`flex-1 aspect-square rounded-xl overflow-hidden relative cursor-pointer transition-transform active:scale-95 ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
                                         onClick={() => { setActiveWidgetSlot(slot); widgetInputRef.current?.click(); }}
-                                        onContextMenu={(e) => { e.preventDefault(); if (img) removeWidget(slot); }}>
+                                        onLongPress={() => {
+                                            if (img) {
+                                                removeWidget(slot);
+                                                addToast('已移除小组件', 'success');
+                                            }
+                                        }}
+                                    >
                                         {img ? (
                                             <>
                                                 <img src={img} className="w-full h-full object-cover" />
@@ -957,7 +1032,7 @@ const Appearance: React.FC = () => {
                                                 <span className="text-[9px]">图片</span>
                                             </div>
                                         )}
-                                    </div>
+                                    </LongPressArea>
                                 );
                             })}
                         </div>
@@ -965,9 +1040,16 @@ const Appearance: React.FC = () => {
                             const slot = 'wide';
                             const img = (theme.launcherWidgets || {})[slot];
                             return (
-                                <div className={`w-full h-20 rounded-xl overflow-hidden relative cursor-pointer transition-transform active:scale-[0.98] ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
+                                <LongPressArea
+                                    className={`w-full h-20 rounded-xl overflow-hidden relative cursor-pointer transition-transform active:scale-[0.98] ${img ? 'shadow-sm' : 'border-2 border-dashed border-slate-200 bg-white flex items-center justify-center'}`}
                                     onClick={() => { setActiveWidgetSlot(slot); widgetInputRef.current?.click(); }}
-                                    onContextMenu={(e) => { e.preventDefault(); if (img) removeWidget(slot); }}>
+                                    onLongPress={() => {
+                                        if (img) {
+                                            removeWidget(slot);
+                                            addToast('已移除横幅', 'success');
+                                        }
+                                    }}
+                                >
                                     {img ? (
                                         <>
                                             <img src={img} className="w-full h-full object-cover" />
@@ -981,7 +1063,7 @@ const Appearance: React.FC = () => {
                                             <span className="text-[9px]">横幅</span>
                                         </div>
                                     )}
-                                </div>
+                                </LongPressArea>
                             );
                         })()}
                     </div>

--- a/components/os/GlobalMiniPlayer.tsx
+++ b/components/os/GlobalMiniPlayer.tsx
@@ -16,6 +16,7 @@ const BUBBLE_SIZE = 40;
 const EDGE_PAD = 8;
 const STORAGE_KEY = 'globalMiniPlayer.bubblePos.v1';
 const HIDDEN_KEY = 'globalMiniPlayer.hidden.v1';
+const EXPANDED_BOTTOM_KEY = 'globalMiniPlayer.expandedBottom.v1';
 const DRAG_THRESHOLD = 4; // 像素：超过这个位移算拖动，不触发点击
 
 type Pos = { x: number; y: number } | null;
@@ -30,15 +31,35 @@ const readPos = (): Pos => {
   return null;
 };
 
+const readExpandedBottom = (): number | null => {
+  try {
+    const raw = localStorage.getItem(EXPANDED_BOTTOM_KEY);
+    if (!raw) return null;
+    const n = parseFloat(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch { return null; }
+};
+
 const GlobalMiniPlayer: React.FC = () => {
   const { activeApp } = useOS();
   const { current, playing, togglePlay, nextSong, prevSong, progress, duration } = useMusic();
 
   const [expanded, setExpanded] = useState(false); // 默认折叠
   const [pos, setPos] = useState<Pos>(() => readPos()); // null = 默认右下
+  const [expandedBottom, setExpandedBottom] = useState<number | null>(() => readExpandedBottom()); // 展开态距底部像素
   const [hidden, setHidden] = useState<boolean>(() => {
     try { return sessionStorage.getItem(HIDDEN_KEY) === '1'; } catch { return false; }
   });
+
+  const expandedRef = useRef<HTMLDivElement | null>(null);
+  const expandedDragState = useRef<{
+    startY: number;
+    startBottom: number;
+    parentH: number;
+    selfH: number;
+    moved: boolean;
+    pointerId: number;
+  } | null>(null);
 
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const dragState = useRef<{
@@ -68,6 +89,53 @@ const GlobalMiniPlayer: React.FC = () => {
     if (!pos) return;
     try { localStorage.setItem(STORAGE_KEY, JSON.stringify(pos)); } catch {}
   }, [pos]);
+
+  useEffect(() => {
+    if (expandedBottom == null) return;
+    try { localStorage.setItem(EXPANDED_BOTTOM_KEY, String(expandedBottom)); } catch {}
+  }, [expandedBottom]);
+
+  // 展开态：拖把手垂直拖动；点击则收起
+  const onExpandedHandleDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const el = expandedRef.current;
+    if (!el) return;
+    const parent = el.parentElement as HTMLElement | null;
+    if (!parent) return;
+    const parentRect = parent.getBoundingClientRect();
+    const selfRect = el.getBoundingClientRect();
+    const currentBottom = parentRect.bottom - selfRect.bottom;
+    expandedDragState.current = {
+      startY: e.clientY,
+      startBottom: currentBottom,
+      parentH: parentRect.height,
+      selfH: selfRect.height,
+      moved: false,
+      pointerId: e.pointerId,
+    };
+    try { (e.currentTarget as any).setPointerCapture?.(e.pointerId); } catch {}
+  }, []);
+
+  const onExpandedHandleMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const ds = expandedDragState.current;
+    if (!ds) return;
+    const dy = e.clientY - ds.startY;
+    if (!ds.moved && Math.abs(dy) > DRAG_THRESHOLD) ds.moved = true;
+    if (!ds.moved) return;
+    let nextBottom = ds.startBottom - dy;
+    const maxBottom = Math.max(0, ds.parentH - ds.selfH - EDGE_PAD);
+    nextBottom = Math.max(EDGE_PAD, Math.min(maxBottom, nextBottom));
+    setExpandedBottom(nextBottom);
+  }, []);
+
+  const onExpandedHandleUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const ds = expandedDragState.current;
+    expandedDragState.current = null;
+    try { (e.currentTarget as any).releasePointerCapture?.(e.pointerId); } catch {}
+    if (ds && !ds.moved) {
+      // 当作"收起到小球"
+      setExpanded(false);
+    }
+  }, []);
 
   const hide = useCallback(() => {
     setHidden(true);
@@ -209,9 +277,13 @@ const GlobalMiniPlayer: React.FC = () => {
   // 刻意不给外层 wrapper 绑 onClick —— 在别的 App 里点它不应该跳到 Music App
   // （会把用户正在做的事情弄丢），只有里面的按钮生效。
   return (
-    <div className="absolute left-3 right-3 bottom-3 z-[55] pointer-events-none">
+    <div
+      ref={expandedRef}
+      className="absolute left-3 right-3 z-[55] pointer-events-none"
+      style={{ bottom: expandedBottom != null ? expandedBottom : 12 }}
+    >
       <div
-        className="pointer-events-auto flex items-center gap-2.5 rounded-2xl px-2.5 py-2 relative overflow-hidden animate-fade-in"
+        className="pointer-events-auto flex items-center gap-2.5 rounded-2xl pl-1.5 pr-2.5 py-2 relative overflow-hidden animate-fade-in"
         style={{
           background: 'rgba(20, 24, 35, 0.65)',
           backdropFilter: 'blur(24px) saturate(1.6)',
@@ -220,6 +292,19 @@ const GlobalMiniPlayer: React.FC = () => {
           boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
         }}
       >
+        {/* 拖动把手 — 垂直拖动整个条；点击则收起 */}
+        <div
+          onPointerDown={onExpandedHandleDown}
+          onPointerMove={onExpandedHandleMove}
+          onPointerUp={onExpandedHandleUp}
+          onPointerCancel={onExpandedHandleUp}
+          className="shrink-0 flex items-center justify-center px-1 cursor-grab active:cursor-grabbing touch-none select-none"
+          style={{ alignSelf: 'stretch' }}
+          aria-label="拖动调整位置（点击收起）"
+          title="上下拖动 · 点击收起"
+        >
+          <div className="w-1 h-7 rounded-full" style={{ background: 'rgba(255,255,255,0.25)' }} />
+        </div>
         {/* 封面 */}
         <img
           src={current.albumPic}

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1494,7 +1494,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     }
 
     // Logic for Font: Differentiate between Data URI (Blob) and URL (Web Font)
-    if (customFont !== undefined) {
+    // Use `in` check so an explicit `customFont: undefined` (user-initiated reset)
+    // still triggers the reset branch — `customFont !== undefined` would skip it.
+    if ('customFont' in updates) {
         if (customFont && customFont.startsWith('data:')) {
             // Blob: Save to DB, Apply
             await DB.saveAsset('custom_font_data', customFont);


### PR DESCRIPTION
- 字体: updateTheme 用 in 检测显式 undefined，恢复默认字体能真正清除自定义字体并刷新 CSS
- 桌面小组件 & 壁纸: 在外观定制里加触摸长按识别（onContextMenu 在 iOS WebView 不触发），长按可移除/恢复默认
- 全局 MiniPlayer 展开态: 加左侧把手，可上下拖动避开被裁切的位置，位置持久化