### PR TITLE
统一主动消息/正常聊天/emotion 三家的上下文构造，修浏览器通知不弹的 bug

### DIFF
--- a/context/MusicContext.tsx
+++ b/context/MusicContext.tsx
@@ -123,6 +123,21 @@ const loadCfg = (): MusicCfg => {
  */
 export const loadMusicCfgStandalone = (): MusicCfg => loadCfg();
 
+/**
+ * 实时播放快照 — 给 OSContext 主动消息流程读，避免 OSProvider 在 MusicProvider
+ * 外层导致拿不到 useMusic()。MusicProvider mount 后会持续把当前播放状态写到这里。
+ */
+export interface MusicPlaybackSnapshot {
+  current: Song | null;
+  playing: boolean;
+  lyric: LyricLine[];
+  activeLyricIdx: number;
+  listeningTogetherWith: string[];
+  cfg: MusicCfg;
+}
+let __musicPlaybackSnapshot: MusicPlaybackSnapshot | null = null;
+export const loadMusicPlaybackSnapshot = (): MusicPlaybackSnapshot | null => __musicPlaybackSnapshot;
+
 const saveCfg = (cfg: MusicCfg) => {
   try { localStorage.setItem(LS_CFG_KEY, JSON.stringify(cfg)); } catch {}
 };
@@ -763,6 +778,19 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     if (!('mediaSession' in navigator)) return;
     try { (navigator as any).mediaSession.playbackState = playing ? 'playing' : 'paused'; } catch {}
   }, [playing]);
+
+  // 把当前播放状态写到模块级快照，供非 React 调用者（OSContext.runProactive
+  // 等位于 MusicProvider 上层的代码）读取。useMusic() 在那一层用不了。
+  useEffect(() => {
+    __musicPlaybackSnapshot = {
+      current,
+      playing,
+      lyric,
+      activeLyricIdx,
+      listeningTogetherWith,
+      cfg,
+    };
+  }, [current, playing, lyric, activeLyricIdx, listeningTogetherWith, cfg]);
 
   const value: MusicContextType = {
     cfg, setCfg,

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -3,14 +3,13 @@ import React, { createContext, useContext, useEffect, useState, useRef, useCallb
 import { APIConfig, AppID, OSTheme, VirtualTime, CharacterProfile, ChatTheme, Toast, FullBackupData, UserProfile, ApiPreset, GroupProfile, SystemLog, Worldbook, NovelBook, SongSheet, Message, RealtimeConfig, AppearancePreset, CloudBackupConfig, CloudBackupFile } from '../types';
 import { DB } from '../utils/db';
 import { ProactiveChat } from '../utils/proactiveChat';
-import { ChatPrompts } from '../utils/chatPrompts';
-import { buildThinkingChainPrompt } from '../utils/thinkingChainPrompt';
 import { ChatParser } from '../utils/chatParser';
 import { safeFetchJson } from '../utils/safeApi';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
-import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
+import { buildChatRequestPayload } from '../utils/chatRequestPayload';
+import { loadMusicPlaybackSnapshot } from './MusicContext';
 import { setMinimaxRegion } from '../utils/minimaxEndpoint';
 import { LocalNotifications } from '@capacitor/local-notifications';
 import { Capacitor } from '@capacitor/core';
@@ -1101,17 +1100,20 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               const preview = (body || `${charName} sent a proactive message`).replace(/\s+/g, ' ').trim() || `${charName} sent a proactive message`;
               void sendProactiveNativeNotification(charId, charName, preview);
 
-              // Web Notification
-              if (!Capacitor.isNativePlatform() && window.Notification && Notification.permission === 'granted') {
+              // Web Notification —— 走 Service Worker 的 showNotification（和"测试推送"
+              // 同一条链路）。页面级 `new Notification(...)` 在标签后台 / PWA / 移动端会
+              // 静默失败，必须走 SW registration 才稳定。
+              if (!Capacitor.isNativePlatform() && 'serviceWorker' in navigator && window.Notification && Notification.permission === 'granted') {
                   const char = characters.find(c => c.id === charId);
-                  try {
-                      const notif = new Notification(charName, {
+                  navigator.serviceWorker.ready.then(reg => {
+                      reg.showNotification(charName, {
                           body: preview,
-                          icon: char?.avatar,
-                          silent: false
-                      });
-                      notif.onclick = () => { window.focus(); setActiveApp(AppID.Chat); setActiveCharacterId(charId); };
-                  } catch (e) { /* notification failed */ }
+                          icon: char?.avatar || './icons/icon-192.png',
+                          badge: './icons/icon-192.png',
+                          tag: `proactive-${charId}`,
+                          data: { charId, kind: 'proactive-1.0' },
+                      }).catch(() => { /* notification failed */ });
+                  }).catch(() => { /* SW not ready */ });
               }
           }
       };
@@ -1153,16 +1155,19 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               const preview = (body || `${charName} sent an active message`).replace(/\s+/g, ' ').trim() || `${charName} sent an active message`;
               void sendProactiveNativeNotification(charId, charName, preview);
 
-              if (!Capacitor.isNativePlatform() && window.Notification && Notification.permission === 'granted') {
+              // 同主动消息 1.0 — 必须走 SW registration.showNotification，页面级 Notification 在
+              // 后台 / PWA / 移动端会静默失败。
+              if (!Capacitor.isNativePlatform() && 'serviceWorker' in navigator && window.Notification && Notification.permission === 'granted') {
                   const char = characters.find(c => c.id === charId);
-                  try {
-                      const notif = new Notification(charName, {
+                  navigator.serviceWorker.ready.then(reg => {
+                      reg.showNotification(charName, {
                           body: preview,
-                          icon: char?.avatar,
-                          silent: false
-                      });
-                      notif.onclick = () => { window.focus(); setActiveApp(AppID.Chat); setActiveCharacterId(charId); };
-                  } catch (e) { /* notification failed */ }
+                          icon: char?.avatar || './icons/icon-192.png',
+                          badge: './icons/icon-192.png',
+                          tag: `proactive-${charId}`,
+                          data: { charId, kind: 'active-msg-2.0' },
+                      }).catch(() => { /* notification failed */ });
+                  }).catch(() => { /* SW not ready */ });
               }
           }
       };
@@ -1297,33 +1302,33 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   metadata: { proactiveHint: true, hidden: true }
               });
 
-              // 3. Build prompt & message history
+              // 3. Build prompt & message history — 走和 useChatAI / emotion eval 同一个 helper，
+              //    保证三家拿到的"材料"完全一致；区别只在前面追加的"现在主动找用户"那条 hint。
               const allMsgs = await DB.getRecentMessagesByCharId(charId, char.contextLimit || 500);
               const emojis = await DB.getEmojis();
               const categories = await DB.getEmojiCategories();
 
-              // 3a. 记忆宫殿向量召回 — 与 useChatAI 主流程一致，挂到 char.memoryPalaceInjection
-              //     buildSystemPrompt 内部 buildCoreContext 会自动读取并注入
-              await injectMemoryPalace(char, allMsgs, undefined, currentUserProfile?.name);
-
-              // 3b. 注入上一轮缓存的意识流独白（innerState），供日程/情绪上下文延续
+              // 上一轮缓存的意识流独白 —— 主路径用 React state，主动消息这里用 ref Map
               const cachedInnerState = proactiveInnerStateRef.current.get(charId) || undefined;
 
-              let systemPrompt = await ChatPrompts.buildSystemPrompt(
-                  char, currentUserProfile, currentGroups, emojis, categories, allMsgs,
-                  currentRealtimeConfig, cachedInnerState,
-              );
-              // 3b'. 思考链注入 — 与 useChatAI 主流程保持一致，主动消息也支持「心象」展示
-              if ((char as any).showThinkingChain) {
-                  const userNameForThinking = (currentUserProfile?.name && currentUserProfile.name.trim()) || '用户';
-                  systemPrompt += `\n\n${buildThinkingChainPrompt(char.name, userNameForThinking)}`;
-                  const extraThinking = ((char as any).thinkingChainCustomPrompt || '').trim();
-                  if (extraThinking) {
-                      systemPrompt += `\n\n## 用户对内心独白的额外要求\n${extraThinking}`;
-                  }
-              }
-              const { apiMessages } = ChatPrompts.buildMessageHistory(allMsgs, char.contextLimit || 500, char, currentUserProfile, emojis);
-              const fullMessages = [{ role: 'system', content: systemPrompt }, ...apiMessages];
+              const payload = await buildChatRequestPayload({
+                  char, userProfile: currentUserProfile!, groups: currentGroups,
+                  emojis, categories,
+                  historyMsgs: allMsgs,
+                  contextLimit: char.contextLimit || 500,
+                  realtimeConfig: currentRealtimeConfig,
+                  innerState: cachedInnerState,
+                  // 实时音乐播放状态 —— OSContext 在 MusicProvider 上层用不了 useMusic()，
+                  // 走 MusicContext 暴露的模块级快照（Provider mount 后会持续写入）
+                  musicSnapshot: loadMusicPlaybackSnapshot(),
+                  // translationConfig / mcdMiniSnap 是 chat-app 会话级 UI 状态，主动消息触发时
+                  // 不存在；保持 undefined 即可，与"用户当时根本没在 chat 界面"的语义一致
+                  htmlMode: { enabled: !!(char as any).htmlModeEnabled, customPrompt: (char as any).htmlModeCustomPrompt },
+                  thinkingChain: { enabled: !!(char as any).showThinkingChain, customPrompt: (char as any).thinkingChainCustomPrompt },
+              });
+              const systemPrompt = payload.systemPrompt;
+              const apiMessages = payload.cleanedApiMessages;
+              const fullMessages = payload.fullMessages;
 
               // 3c. 情绪评估 fire-and-forget — 与主 API 并行，沿用 useChatAI 的 API 选择逻辑：
               //     角色专属情绪 API > 主 apiConfig（与记忆宫殿副 API 完全独立）

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -10,9 +10,9 @@ import { safeFetchJson, safeResponseJson } from '../utils/safeApi';
 import { KeepAlive } from '../utils/keepAlive';
 import { ProactiveChat } from '../utils/proactiveChat';
 import { ContextBuilder } from '../utils/context';
-import { buildThinkingChainPrompt } from '../utils/thinkingChainPrompt';
+// 思考链 / HTML / MCD / memoryPalace 注入已下沉到 chatRequestPayload；这里不再直接调用
 import { useMusic } from '../context/MusicContext';
-import { injectMemoryPalace, processNewMessages, mergePalaceFragmentsIntoMemories } from '../utils/memoryPalace/pipeline';
+import { processNewMessages, mergePalaceFragmentsIntoMemories } from '../utils/memoryPalace/pipeline';
 import { incrementDigestRound, runCognitiveDigestion, detectPersonalityStyle } from '../utils/memoryPalace';
 // evolveFlowNarrative 保留为低频深刷新备用，日常意识流由副 API 的情绪评估同轮产出（innerState 字段）
 // import { evolveFlowNarrative } from '../utils/scheduleGenerator';
@@ -21,8 +21,9 @@ import type { DigestResult } from '../utils/memoryPalace';
 // 麦当劳: useChatAI 现在只读 McdMiniApp 当前快照注入 system prompt + 给 LLM 一个
 // UI 钩子工具 propose_cart_items。MCP 实际调用都在 McdMiniApp 组件内做, useChatAI
 // 不再 import callMcdTool / normalizeMcdToolName / isMcdConfigured / 旧 prompt。
-import { buildMcdMiniAppContextBlock, MCD_PROPOSE_TOOL, autoFixProposalCodesByName } from '../utils/mcdToolBridge';
-import { buildHtmlPrompt, extractHtmlBlocks } from '../utils/htmlPrompt';
+import { MCD_PROPOSE_TOOL, autoFixProposalCodesByName } from '../utils/mcdToolBridge';
+import { extractHtmlBlocks } from '../utils/htmlPrompt';
+import { buildChatRequestPayload } from '../utils/chatRequestPayload';
 
 // ─── 情绪评估（副API，fire & forget）───
 
@@ -626,157 +627,74 @@ export const useChatAI = ({
                 finally { perfStages[label] = Math.round(performance.now() - t0); }
             };
 
-            // 0.9 Memory Palace — 检索记忆，挂到 char.memoryPalaceInjection
-            //     buildCoreContext 会自动读取并注入到 System Prompt
-            //     此时已有"…"气泡，不额外显示状态提示
-            await stageT('memoryPalace', injectMemoryPalace(char, currentMsgs, undefined, userProfile?.name));
-
-            // 1. Build System Prompt (包含实时世界信息 + 记忆宫殿 + 音乐氛围)
-            // 构造 user 的"此刻在听"上下文 —— 前2当前后2共 ≤5 行
-            let userListeningContext: {
-                songName: string; artists: string; lyricWindow: string[]; activeIdx: number;
-            } | null = null;
-            if (music.current && music.playing && music.lyric.length > 0) {
-                const idx = music.activeLyricIdx;
-                if (idx >= 0) {
-                    const from = Math.max(0, idx - 2);
-                    const to = Math.min(music.lyric.length, idx + 2 + 1);
-                    const window = music.lyric.slice(from, to).map(l => l.text);
-                    const activeIdx = idx - from; // 在 window 里的下标
-                    userListeningContext = {
-                        songName: music.current.name,
-                        artists: music.current.artists,
-                        lyricWindow: window,
-                        activeIdx,
-                    };
-                }
-            } else if (music.current && music.playing) {
-                // 无歌词也给个基本提示，让 char 知道对方在听什么
-                userListeningContext = {
-                    songName: music.current.name,
-                    artists: music.current.artists,
-                    lyricWindow: [],
-                    activeIdx: -1,
-                };
-            }
-            // 只有 user 真的把 char 加进"一起听"名单，才算处于共听状态；
-            // 暂停 / 切歌 / 播放出错 / 用户显式踢出 都会让 char 从名单里掉出来。
-            const isListeningTogether = !!(
-                userListeningContext && music.listeningTogetherWith.includes(char.id)
-            );
-            // buildSystemPrompt 和 DB 消息加载彼此独立，并发跑节省 Math.max 以外的等待时间
+            // 0.9 历史消息加载（DB 取完整窗口，最多 contextLimit；React state 上限 200 条）
+            //     和 buildChatRequestPayload 并行跑，省一次 DB 来回的等待
             const limit = char.contextLimit || 500;
-            const systemPromptPromise = ChatPrompts.buildSystemPrompt(
-                char, userProfile, groups, emojis, categories, currentMsgs,
-                realtimeConfig, evolvedNarrative || undefined, userListeningContext,
-                isListeningTogether, music.cfg,
-            );
             const fullHistoryPromise: Promise<Message[] | null> = (limit > currentMsgs.length && char.id)
                 ? DB.getRecentMessagesByCharId(char.id, limit).catch(e => {
                     console.error('Failed to load full history from DB, using React state:', e);
                     return null;
                 })
                 : Promise.resolve(null);
-
-            let [systemPrompt, fullHistory] = await Promise.all([
-                stageT('systemPrompt', systemPromptPromise),
-                stageT('dbHistory', fullHistoryPromise),
-            ]);
-
-            // 1.5 Inject bilingual output instruction when translation is enabled
-            const bilingualActive = translationConfig?.enabled && translationConfig.sourceLang && translationConfig.targetLang;
-            if (bilingualActive) {
-                systemPrompt += `\n\n[CRITICAL: 双语输出模式 - 必须严格遵守]
-你的每句话都必须用以下XML标签格式输出双语内容：
-<翻译>
-<原文>${translationConfig.sourceLang}内容</原文>
-<译文>${translationConfig.targetLang}内容</译文>
-</翻译>
-
-规则：
-- 每句话单独包裹一个<翻译>标签
-- 多句话就输出多个<翻译>标签，一句一个
-- <翻译>标签外不要写任何文字
-- 表情包命令 [[SEND_EMOJI: ...]] 放在所有<翻译>标签外面
-
-示例（${translationConfig.sourceLang}→${translationConfig.targetLang}）：
-<翻译>
-<原文>こんにちは！</原文>
-<译文>你好！</译文>
-</翻译>
-<翻译>
-<原文>今日は何する？</原文>
-<译文>今天做什么？</译文>
-</翻译>`;
-            }
-
-            // 1.6 HTML 模块模式 — 注入内置 HTML 提示词 (+ 用户自定义追加)
-            //     开启后允许 AI 输出 [html]...[/html] 卡片, 客户端解析为 html_card 单独渲染。
-            if ((char as any).htmlModeEnabled) {
-                systemPrompt += `\n\n${buildHtmlPrompt((char as any).htmlModeCustomPrompt)}`;
-            }
-
-            // 1.7 思考过程展示 — 思考链会回灌给用户看，所以让模型用角色的语气和中文思考，
-            //     避免出现"作为 AI 我应该……"这种 OOC 元思考；prompt 同样作用于 thinking 阶段。
-            if ((char as any).showThinkingChain) {
-                const userName = (userProfile?.name && userProfile.name.trim()) || '用户';
-                systemPrompt += `\n\n${buildThinkingChainPrompt(char.name, userName)}`;
-                // 用户额外追加的思考要求（不替换原生提示词，只在末尾追加一段，避免覆盖代入感约束）
-                const extra = ((char as any).thinkingChainCustomPrompt || '').trim();
-                if (extra) {
-                    systemPrompt += `\n\n## 用户对内心独白的额外要求\n${extra}`;
-                }
-            }
-
-            // 2. Build Message History
-            // CRITICAL: Load full message history from DB up to contextLimit,
-            // not from React state which is capped at 200 for rendering performance
+            const fullHistory = await stageT('dbHistory', fullHistoryPromise);
             let contextMsgs = currentMsgs;
             if (fullHistory && fullHistory.length > currentMsgs.length) {
                 console.log(`📊 [Context] Loaded ${fullHistory.length} msgs from DB (React state had ${currentMsgs.length}, contextLimit=${limit})`);
                 contextMsgs = fullHistory;
             }
 
-            // Memory Palace 过滤已在 DB 层完成（getMessagesByCharId / getRecentMessagesByCharId 自动排除 hwm 之前的消息）
-
-            const { apiMessages, historySlice } = ChatPrompts.buildMessageHistory(contextMsgs, limit, char, userProfile, emojis);
-
-            // 2.5 Strip translation content from previous messages to save tokens
-            const cleanedApiMessages = apiMessages.map((msg: any) => {
-                if (typeof msg.content !== 'string') return msg;
-                let c = msg.content;
-                // Strip old %%BILINGUAL%% format
-                if (c.toLowerCase().includes('%%bilingual%%')) {
-                    const idx = c.toLowerCase().indexOf('%%bilingual%%');
-                    c = c.substring(0, idx).trim();
-                }
-                // Strip new XML tag format: keep only <原文> content
-                if (c.includes('<翻译>')) {
-                    c = c.replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, '$1').trim();
-                }
-                return { ...msg, content: c };
-            });
-
-            // 2.7 麦当劳 MCP — 若当前会话激活 (麦请求 vs 结束麦请求 谁更新听谁的) 且 token 已配置, 拉工具+追加 system 段
-            //     拉取失败则降级为纯聊天, 不阻断主流程
-            // 麦当劳: 小程序 (McdMiniApp) 打开时把当前 cart/菜单/营养表追加到 system,
-            // 给 LLM 唯一一个 UI 工具 propose_cart_items (在下面 baseReqBody 里挂)。
-            // 旧的"麦请求"文本路径已废弃 (legacy LLM-调-MCP-工具 链路太脆), 现在不再注入任何
-            // 残留 MCP 工具说明, 避免 char 困惑。
+            // 1. 构造完整 chat 请求载荷（memoryPalace 召回 + system prompt + 双语 / HTML / 思考链 / MCD + 历史）
+            //    — 主动消息和 emotion eval 走的是同一个 helper，保证三家拿到的"材料"完全一致。
             const mcdMiniSnap = mcdMiniAppRef?.current;
             const mcdMiniOpen = !!mcdMiniSnap?.open;
-            // 小程序模式下, 所有这一轮新落库的 assistant 消息都打 fromMcdMiniApp 标,
-            // 让 InAppChat 面板能 filter 出来显示 (否则用户看不到 char 的回复, 以为没触发 LLM)
             const mcdInheritMeta = mcdMiniOpen ? { fromMcdMiniApp: true } : undefined;
-            if (mcdMiniOpen) {
-                const block = buildMcdMiniAppContextBlock(mcdMiniSnap, userProfile?.name || '用户');
-                if (block) {
-                    systemPrompt += block;
-                    console.log(`🍔 [MCD-MiniApp] 注入协同点餐上下文 step=${mcdMiniSnap?.step} cartItems=${mcdMiniSnap?.cart?.length || 0} menuItems=${mcdMiniSnap?.menuMeals ? Object.keys(mcdMiniSnap.menuMeals).length : 0} nutrition=${mcdMiniSnap?.nutritionData ? mcdMiniSnap.nutritionData.length : 0}字`);
-                }
-            }
 
-            const fullMessages = [{ role: 'system', content: systemPrompt }, ...cleanedApiMessages];
+            const payload = await stageT('payload', buildChatRequestPayload({
+                char, userProfile, groups, emojis, categories,
+                historyMsgs: contextMsgs,
+                recentMsgsHint: currentMsgs,
+                contextLimit: limit,
+                realtimeConfig,
+                innerState: evolvedNarrative || undefined,
+                userListeningContext: (() => {
+                    if (music.current && music.playing && music.lyric.length > 0) {
+                        const idx = music.activeLyricIdx;
+                        if (idx >= 0) {
+                            const from = Math.max(0, idx - 2);
+                            const to = Math.min(music.lyric.length, idx + 2 + 1);
+                            const window = music.lyric.slice(from, to).map(l => l.text);
+                            return {
+                                songName: music.current.name,
+                                artists: music.current.artists,
+                                lyricWindow: window,
+                                activeIdx: idx - from,
+                            };
+                        }
+                    }
+                    if (music.current && music.playing) {
+                        return {
+                            songName: music.current.name,
+                            artists: music.current.artists,
+                            lyricWindow: [],
+                            activeIdx: -1,
+                        };
+                    }
+                    return null;
+                })(),
+                isListeningTogether: !!(music.current && music.playing && music.listeningTogetherWith.includes(char.id)),
+                musicCfg: music.cfg,
+                translationConfig,
+                htmlMode: { enabled: !!(char as any).htmlModeEnabled, customPrompt: (char as any).htmlModeCustomPrompt },
+                thinkingChain: { enabled: !!(char as any).showThinkingChain, customPrompt: (char as any).thinkingChainCustomPrompt },
+                mcdMiniSnap: mcdMiniOpen ? mcdMiniSnap : undefined,
+            }));
+            const systemPrompt = payload.systemPrompt;
+            const cleanedApiMessages = payload.cleanedApiMessages;
+            const fullMessages = payload.fullMessages;
+            if (payload.flags.mcdActive) {
+                console.log(`🍔 [MCD-MiniApp] 注入协同点餐上下文 step=${mcdMiniSnap?.step} cartItems=${mcdMiniSnap?.cart?.length || 0} menuItems=${mcdMiniSnap?.menuMeals ? Object.keys(mcdMiniSnap.menuMeals).length : 0} nutrition=${mcdMiniSnap?.nutritionData ? mcdMiniSnap.nutritionData.length : 0}字`);
+            }
+            const bilingualActive = payload.flags.bilingualActive;
 
             // Debug: Log context composition
             const systemPromptLength = systemPrompt.length;
@@ -786,11 +704,6 @@ export const useChatAI = ({
 
             // Save for dev debug viewer
             setLastSystemPrompt(systemPrompt);
-
-            // 2.6 Reinforce bilingual instruction at the end of messages for stronger compliance
-            if (bilingualActive) {
-                fullMessages.push({ role: 'system', content: `[Reminder: 每句话必须用 <翻译><原文>...</原文><译文>...</译文></翻译> 标签包裹。一句一个标签。绝对不能省略。]` });
-            }
 
             // 3. Fire-and-forget emotion evaluation in parallel with main API call
             //    直接复用已 build 好的 systemPrompt 和 cleanedApiMessages，确保情绪评估和主 API 看到的上下文完全一致
@@ -2496,8 +2409,8 @@ export const useChatAI = ({
                 const quotedText = firstQuoteMatch[1].trim();
                 if (quotedText) {
                     // Try exact include first, then fuzzy match (first 10 chars)
-                    const targetMsg = historySlice.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
-                        || (quotedText.length > 10 ? historySlice.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
+                    const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
+                        || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
                     if (targetMsg) {
                         const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
                         aiReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
@@ -2635,8 +2548,8 @@ export const useChatAI = ({
                                 if (chunkQuoteMatch) {
                                     const quotedText = chunkQuoteMatch[1].trim();
                                     if (quotedText) {
-                                        const targetMsg = historySlice.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
-                                            || (quotedText.length > 10 ? historySlice.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
+                                        const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
+                                            || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
                                         if (targetMsg) {
                                             const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
                                             chunkReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };

--- a/utils/chatRequestPayload.ts
+++ b/utils/chatRequestPayload.ts
@@ -1,0 +1,247 @@
+/**
+ * 聊天请求载荷统一构造器
+ *
+ * 设计目标：让"正常聊天"、"主动消息"、"emotion 副 API 评估"三条路径吃到的
+ * 上下文材料完全一致——区别只在末尾各自追加的"现在你要做什么"指令。
+ *
+ * 三条路径过去各拼一遍 system prompt + 消息历史，导致主动消息缺音乐共听 /
+ * HTML 模式 / 双语模式 / 麦当劳小程序等块；emotion eval 也容易跟主路径分叉。
+ * 现在统一从这里走，避免再分叉。
+ *
+ * 顺序严格对齐 useChatAI.ts 的现有实现（line 629–793），保证现有行为字节级
+ * 等价。新增 caller（runProactive）只是补齐了过去缺的字段。
+ */
+
+import type { CharacterProfile, UserProfile, GroupProfile, Emoji, EmojiCategory, Message, RealtimeConfig, TranslationConfig } from '../types';
+import { ChatPrompts } from './chatPrompts';
+import { injectMemoryPalace } from './memoryPalace/pipeline';
+import { buildHtmlPrompt } from './htmlPrompt';
+import { buildThinkingChainPrompt } from './thinkingChainPrompt';
+import { buildMcdMiniAppContextBlock } from './mcdToolBridge';
+import type { McdMiniAppSnapshot } from './mcdToolBridge';
+import type { MusicCfg, Song, LyricLine, MusicPlaybackSnapshot } from '../context/MusicContext';
+
+export interface UserListeningContext {
+    songName: string;
+    artists: string;
+    lyricWindow: string[];
+    activeIdx: number;
+}
+
+export interface BuildChatPayloadInput {
+    char: CharacterProfile;
+    userProfile: UserProfile;
+    groups: GroupProfile[];
+    emojis: Emoji[];
+    categories: EmojiCategory[];
+    /** 给 buildMessageHistory 用的完整历史（≤ contextLimit） */
+    historyMsgs: Message[];
+    /**
+     * 给 buildSystemPrompt + memoryPalace 召回用的"较短近窗"。不传则等于 historyMsgs。
+     * useChatAI 主路径里 React state 上限 200 条，DB 历史可能更长——保留这个区分。
+     */
+    recentMsgsHint?: Message[];
+    contextLimit: number;
+
+    // 实时世界 / 角色情绪
+    realtimeConfig?: RealtimeConfig;
+    /** 上一轮 emotion eval 产出的内心独白 */
+    innerState?: string;
+
+    // user 共听上下文（非 React 调用方可传 musicSnapshot 让 helper 自动算）
+    userListeningContext?: UserListeningContext | null;
+    isListeningTogether?: boolean;
+    musicCfg?: MusicCfg;
+    /** 备选：传一份原始播放快照，helper 内部按主路径同样的逻辑算 listening 三件套 */
+    musicSnapshot?: MusicPlaybackSnapshot | null;
+
+    // 模式开关
+    translationConfig?: TranslationConfig | { enabled: boolean; sourceLang: string; targetLang: string };
+    htmlMode?: { enabled: boolean; customPrompt?: string };
+    thinkingChain?: { enabled: boolean; customPrompt?: string };
+    mcdMiniSnap?: McdMiniAppSnapshot;
+}
+
+export interface BuildChatPayloadResult {
+    /** 完整 system prompt（含所有可选块） */
+    systemPrompt: string;
+    /** 已剥离双语标签的历史消息（emotion eval 也吃这份） */
+    cleanedApiMessages: Array<{ role: string; content: any }>;
+    /** [system, ...cleanedApiMessages, 末尾 bilingual reminder?] —— 主 API 直接发这个 */
+    fullMessages: Array<{ role: string; content: any }>;
+    /** 调试用：bilingual / mcd 是否实际注入 */
+    flags: { bilingualActive: boolean; mcdActive: boolean; htmlActive: boolean; thinkingActive: boolean };
+}
+
+/**
+ * 用 MusicPlaybackSnapshot 算 user 共听上下文 —— 与 useChatAI.ts:636–666 行为一致。
+ */
+function deriveListeningFromSnapshot(
+    snap: MusicPlaybackSnapshot | null | undefined,
+    charId: string,
+): { userListeningContext: UserListeningContext | null; isListeningTogether: boolean; musicCfg?: MusicCfg } {
+    if (!snap) return { userListeningContext: null, isListeningTogether: false };
+    const { current, playing, lyric, activeLyricIdx, listeningTogetherWith, cfg } = snap;
+    let userListeningContext: UserListeningContext | null = null;
+    if (current && playing && lyric.length > 0) {
+        const idx = activeLyricIdx;
+        if (idx >= 0) {
+            const from = Math.max(0, idx - 2);
+            const to = Math.min(lyric.length, idx + 2 + 1);
+            const window = lyric.slice(from, to).map((l: LyricLine) => l.text);
+            const activeIdx = idx - from;
+            userListeningContext = {
+                songName: current.name,
+                artists: current.artists,
+                lyricWindow: window,
+                activeIdx,
+            };
+        }
+    } else if (current && playing) {
+        userListeningContext = {
+            songName: current.name,
+            artists: current.artists,
+            lyricWindow: [],
+            activeIdx: -1,
+        };
+    }
+    const isListeningTogether = !!(userListeningContext && listeningTogetherWith.includes(charId));
+    return { userListeningContext, isListeningTogether, musicCfg: cfg };
+}
+
+/**
+ * 构造完整 chat 请求载荷。顺序严格对齐 useChatAI.ts 现有实现：
+ *
+ *   1. injectMemoryPalace（向量召回挂到 char.memoryPalaceInjection）
+ *   2. ChatPrompts.buildSystemPrompt（核心人设 + 实时 + 记忆 + 音乐 + 日程内心独白）
+ *   3. += 双语指令
+ *   4. += HTML 模式提示词
+ *   5. += 思考链提示词（+ 用户额外要求）
+ *   6. ChatPrompts.buildMessageHistory → apiMessages
+ *   7. 剥离 apiMessages 里旧的双语标签 → cleanedApiMessages
+ *   8. += 麦当劳小程序上下文（注意：在 6/7 之后追加到 systemPrompt）
+ *   9. fullMessages = [system, ...cleanedApiMessages]
+ *  10. fullMessages.push（末尾双语 reminder，不进 systemPrompt）
+ *
+ * emotion eval 应当吃 (systemPrompt, cleanedApiMessages) —— 与主 API 看到的完全一致。
+ */
+export async function buildChatRequestPayload(input: BuildChatPayloadInput): Promise<BuildChatPayloadResult> {
+    const {
+        char, userProfile, groups, emojis, categories, historyMsgs, contextLimit,
+        realtimeConfig, innerState,
+        translationConfig, htmlMode, thinkingChain, mcdMiniSnap,
+    } = input;
+    const recentMsgsHint = input.recentMsgsHint ?? historyMsgs;
+
+    // ── 1. Memory Palace 向量召回 ─────────────────────────
+    await injectMemoryPalace(char, recentMsgsHint, undefined, userProfile?.name);
+
+    // ── 2. 解析音乐共听（如果 caller 没显式给，就从 snapshot 推） ──
+    let userListeningContext = input.userListeningContext;
+    let isListeningTogether = input.isListeningTogether;
+    let musicCfg = input.musicCfg;
+    if (userListeningContext === undefined && input.musicSnapshot !== undefined) {
+        const derived = deriveListeningFromSnapshot(input.musicSnapshot, char.id);
+        userListeningContext = derived.userListeningContext;
+        isListeningTogether = derived.isListeningTogether;
+        musicCfg = derived.musicCfg ?? musicCfg;
+    }
+
+    // ── 3. buildSystemPrompt 核心 ─────────────────────────
+    let systemPrompt = await ChatPrompts.buildSystemPrompt(
+        char, userProfile, groups, emojis, categories, recentMsgsHint,
+        realtimeConfig, innerState || undefined,
+        userListeningContext ?? null,
+        !!isListeningTogether,
+        musicCfg,
+    );
+
+    // ── 4. 双语指令注入 ───────────────────────────────────
+    const bilingualActive = !!(translationConfig?.enabled && translationConfig.sourceLang && translationConfig.targetLang);
+    if (bilingualActive && translationConfig) {
+        systemPrompt += `\n\n[CRITICAL: 双语输出模式 - 必须严格遵守]
+你的每句话都必须用以下XML标签格式输出双语内容：
+<翻译>
+<原文>${translationConfig.sourceLang}内容</原文>
+<译文>${translationConfig.targetLang}内容</译文>
+</翻译>
+
+规则：
+- 每句话单独包裹一个<翻译>标签
+- 多句话就输出多个<翻译>标签，一句一个
+- <翻译>标签外不要写任何文字
+- 表情包命令 [[SEND_EMOJI: ...]] 放在所有<翻译>标签外面
+
+示例（${translationConfig.sourceLang}→${translationConfig.targetLang}）：
+<翻译>
+<原文>こんにちは！</原文>
+<译文>你好！</译文>
+</翻译>
+<翻译>
+<原文>今日は何する？</原文>
+<译文>今天做什么？</译文>
+</翻译>`;
+    }
+
+    // ── 5. HTML 卡片模式 ─────────────────────────────────
+    const htmlActive = !!htmlMode?.enabled;
+    if (htmlActive) {
+        systemPrompt += `\n\n${buildHtmlPrompt(htmlMode?.customPrompt)}`;
+    }
+
+    // ── 6. 思考链提示词 ───────────────────────────────────
+    const thinkingActive = !!thinkingChain?.enabled;
+    if (thinkingActive) {
+        const userName = (userProfile?.name && userProfile.name.trim()) || '用户';
+        systemPrompt += `\n\n${buildThinkingChainPrompt(char.name, userName)}`;
+        const extra = (thinkingChain?.customPrompt || '').trim();
+        if (extra) {
+            systemPrompt += `\n\n## 用户对内心独白的额外要求\n${extra}`;
+        }
+    }
+
+    // ── 7. 历史消息构造 ───────────────────────────────────
+    const { apiMessages } = ChatPrompts.buildMessageHistory(historyMsgs, contextLimit, char, userProfile, emojis);
+
+    // ── 8. 剥离历史里旧的双语标签 ─────────────────────────
+    const cleanedApiMessages = apiMessages.map((msg: any) => {
+        if (typeof msg.content !== 'string') return msg;
+        let c: string = msg.content;
+        if (c.toLowerCase().includes('%%bilingual%%')) {
+            const idx = c.toLowerCase().indexOf('%%bilingual%%');
+            c = c.substring(0, idx).trim();
+        }
+        if (c.includes('<翻译>')) {
+            c = c.replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, '$1').trim();
+        }
+        return { ...msg, content: c };
+    });
+
+    // ── 9. 麦当劳小程序上下文（在 cleanedApiMessages 之后追加到 systemPrompt） ──
+    const mcdActive = !!mcdMiniSnap?.open;
+    if (mcdActive) {
+        const block = buildMcdMiniAppContextBlock(mcdMiniSnap, userProfile?.name || '用户');
+        if (block) {
+            systemPrompt += block;
+        }
+    }
+
+    // ── 10. 组装 fullMessages + 末尾双语 reminder ─────────
+    const fullMessages: Array<{ role: string; content: any }> = [
+        { role: 'system', content: systemPrompt },
+        ...cleanedApiMessages,
+    ];
+    if (bilingualActive) {
+        fullMessages.push({
+            role: 'system',
+            content: `[Reminder: 每句话必须用 <翻译><原文>...</原文><译文>...</译文></翻译> 标签包裹。一句一个标签。绝对不能省略。]`,
+        });
+    }
+
+    return {
+        systemPrompt,
+        cleanedApiMessages,
+        fullMessages,
+        flags: { bilingualActive, mcdActive, htmlActive, thinkingActive },
+    };
+}


### PR DESCRIPTION
问题1：浏览器没收到主动消息推送
原因：runProactive 用页面级 new Notification(...)，在标签后台/PWA/移动端 会静默失败；测试推送走 SW.registration.showNotification 才稳。
修复：把 OSContext 里两条 web 通知路径都切到 navigator.serviceWorker.ready → reg.showNotification，和"测试推送"同一条链路；点击由 SW 的
notificationclick 路由回 chat。

问题2：主动消息和聊天的"材料"对不齐
原因：useChatAI 和 runProactive 各自拼一遍 system prompt + 消息历史， 主动消息缺音乐共听 / HTML 模式 / 双语 / 麦当劳小程序等块；emotion eval
也容易跟主路径分叉。
修复：抽 utils/chatRequestPayload.ts 做唯一的载荷构造器，按 useChatAI 现有顺序（memoryPalace → systemPrompt → bilingual → HTML → thinking → buildMessageHistory → strip 双语 → MCD → fullMessages → bilingual reminder） 逐字节复刻；useChatAI 和 runProactive 都改走它。三家拿到的
(systemPrompt, cleanedApiMessages) 完全一致，区别只在前面追加的"现在 你要做什么"指令。

附带：MusicContext 暴露模块级 loadMusicPlaybackSnapshot()，让位于 MusicProvider 上层的 OSContext 也能读到实时播放状态（useMusic 在那一层 用不了）。

https://claude.ai/code/session_01KeMQ44CQZD4x7TBh1jyHcf