### PR TITLE
历史断点弹窗：长按跳到聊天原文，短按弹窗确认设隐藏点

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -37,6 +37,9 @@ const Chat: React.FC = () => {
     const [messages, setMessages] = useState<Message[]>([]);
     const [totalMsgCount, setTotalMsgCount] = useState(0);
     const [visibleCount, setVisibleCount] = useState(30);
+    const [windowedFocusMsgId, setWindowedFocusMsgId] = useState<number | null>(null);
+    const [flashMsgId, setFlashMsgId] = useState<number | null>(null);
+    const WINDOW_RADIUS = 25;
     const [input, setInput] = useState('');
     const [showPanel, setShowPanel] = useState<'none' | 'actions' | 'emojis' | 'chars'>('none');
     
@@ -506,6 +509,8 @@ const Chat: React.FC = () => {
             setSelectionMode(false);
             setSelectedMsgIds(new Set());
             setShowingTargetIds(new Set());
+            setWindowedFocusMsgId(null);
+            setFlashMsgId(null);
         }
     }, [activeCharacterId, reloadMessages]);
 
@@ -669,22 +674,25 @@ const Chat: React.FC = () => {
         if (!scrollRef.current || selectionMode) return;
         const currentLastId = messages.length > 0 ? messages[messages.length - 1].id : null;
         // Only auto-scroll when a new message is appended (ID changes),
-        // not when loading older history or updating existing messages in-place
+        // not when loading older history or updating existing messages in-place.
+        // windowed 模式下用户在翻旧消息，不要被新消息打断滚走。
         if (currentLastId !== lastMsgIdRef.current) {
-            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+            if (windowedFocusMsgId === null) {
+                scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+            }
             lastMsgIdRef.current = currentLastId;
         }
-    }, [messages, activeCharacterId, selectionMode]);
+    }, [messages, activeCharacterId, selectionMode, windowedFocusMsgId]);
 
     useEffect(() => {
-        if (isTyping && scrollRef.current && !selectionMode) {
+        if (isTyping && scrollRef.current && !selectionMode && windowedFocusMsgId === null) {
             const now = Date.now();
             if (now - scrollThrottleRef.current > 150) {
                 scrollThrottleRef.current = now;
                 scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
             }
         }
-    }, [messages, isTyping, recallStatus, searchStatus, diaryStatus, selectionMode]);
+    }, [messages, isTyping, recallStatus, searchStatus, diaryStatus, selectionMode, windowedFocusMsgId]);
 
     const formatTime = (ts: number) => {
         return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
@@ -696,6 +704,12 @@ const Chat: React.FC = () => {
         if (!char || (!input.trim() && !customContent)) return;
         const text = customContent || input.trim();
         const type = customType || 'text';
+
+        // 发消息隐含"回到当前聊天"——退出 windowed 旧消息浏览模式
+        if (windowedFocusMsgId !== null) {
+            setWindowedFocusMsgId(null);
+            setFlashMsgId(null);
+        }
 
         // 用户手打"麦请求"三个字 → 等价于点击麦克风按钮 (拉起麦当劳菜单)
         // 不落库, 跟按钮点击行为完全一致, 避免出现"banner 在但菜单没拉起"的诡异状态
@@ -1367,6 +1381,36 @@ const Chat: React.FC = () => {
         addToast(messageId ? '已隐藏历史消息' : '已恢复全部历史记录', 'success');
     };
 
+    // 跳转到旧消息：加载全量到 messages，再用 windowedFocusMsgId 把 displayMessages
+    // 收窄到目标周围 51 条。"回到当前聊天"会把 visibleCount 重置回 30。
+    const handleJumpToMessageInChat = async (messageId: number) => {
+        if (!activeCharacterId) return;
+        setModalType('none');
+        const LARGE = 999999;
+        visibleCountRef.current = LARGE;
+        setVisibleCount(LARGE);
+        await reloadMessages(LARGE);
+        setWindowedFocusMsgId(messageId);
+        setFlashMsgId(messageId);
+        // 等下一帧让目标节点挂上 DOM 再滚
+        requestAnimationFrame(() => {
+            const el = document.getElementById(`chat-msg-${messageId}`);
+            el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        });
+        window.setTimeout(() => setFlashMsgId(null), 2200);
+    };
+
+    const handleBackToCurrent = async () => {
+        setWindowedFocusMsgId(null);
+        setFlashMsgId(null);
+        visibleCountRef.current = 30;
+        setVisibleCount(30);
+        await reloadMessages(30);
+        requestAnimationFrame(() => {
+            scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+        });
+    };
+
     const handleFullArchive = async () => {
         if (!apiConfig.apiKey || !char) {
             addToast('请先配置 API Key', 'error');
@@ -1648,12 +1692,22 @@ const Chat: React.FC = () => {
 
     // hideBeforeMessageId 不在视觉层过滤：用户依旧能往上翻到旧消息，只是 LLM 拉不到。
     // 真正想从聊天记录里抹掉，应该走"删除"。
-    const displayMessages = useMemo(() => messages
-        .filter(m => m.metadata?.source !== 'date' && m.metadata?.source !== 'call')
-        .filter(m => !m.metadata?.proactiveHint) // Hide proactive system hints
-        .filter(m => { if (char?.hideSystemLogs && m.role === 'system' && m.type !== 'score_card') return false; return true; })
-        .slice(-visibleCount),
-        [messages, char?.id, char?.hideSystemLogs, visibleCount]);
+    // windowed 模式：定位到旧消息时只渲染目标周围 51 条，避免 DOM 卡爆。
+    const displayMessages = useMemo(() => {
+        const base = messages
+            .filter(m => m.metadata?.source !== 'date' && m.metadata?.source !== 'call')
+            .filter(m => !m.metadata?.proactiveHint)
+            .filter(m => { if (char?.hideSystemLogs && m.role === 'system' && m.type !== 'score_card') return false; return true; });
+        if (windowedFocusMsgId !== null) {
+            const idx = base.findIndex(m => m.id === windowedFocusMsgId);
+            if (idx >= 0) {
+                const start = Math.max(0, idx - WINDOW_RADIUS);
+                const end = Math.min(base.length, idx + WINDOW_RADIUS + 1);
+                return base.slice(start, end);
+            }
+        }
+        return base.slice(-visibleCount);
+    }, [messages, char?.id, char?.hideSystemLogs, visibleCount, windowedFocusMsgId]);
 
     const collapsedCount = Math.max(0, totalMsgCount - displayMessages.length);
 
@@ -1894,7 +1948,7 @@ const Chat: React.FC = () => {
                 onSaveSettings={saveSettings} onBgUpload={handleBgUpload} onRemoveBg={() => updateCharacter(char.id, { chatBackground: undefined })}
                 onClearHistory={handleClearHistory} onArchive={handleFullArchive}
                 onCreatePrompt={createNewPrompt} onEditPrompt={editSelectedPrompt} onSavePrompt={handleSavePrompt} onDeletePrompt={handleDeletePrompt}
-                onSetHistoryStart={handleSetHistoryStart} onEnterSelectionMode={handleEnterSelectionMode}
+                onSetHistoryStart={handleSetHistoryStart} onJumpToMessageInChat={handleJumpToMessageInChat} onEnterSelectionMode={handleEnterSelectionMode}
                 onReplyMessage={handleReplyMessage} onEditMessageStart={() => { if (selectedMessage) { setEditContent(selectedMessage.content); setModalType('edit-message'); } }}
                 onConfirmEditMessage={confirmEditMessage} onDeleteMessage={handleDeleteMessage} onCopyMessage={handleCopyMessage} onDeleteEmoji={handleDeleteEmoji} onDeleteCategory={handleDeleteCategory}
                 allCharacters={characters} onSaveCategoryVisibility={handleSaveCategoryVisibility}
@@ -2094,7 +2148,15 @@ const Chat: React.FC = () => {
             })()}
 
             <div ref={scrollRef} className="flex-1 overflow-y-auto overflow-x-hidden pt-6 pb-6 no-scrollbar" style={{ backgroundImage: activeTheme.type === 'custom' && activeTheme.user.backgroundImage ? 'none' : undefined }}>
-                {collapsedCount > 0 && (
+                {windowedFocusMsgId !== null && (
+                    <div className="sticky top-0 z-20 flex justify-center pb-2 pointer-events-none">
+                        <button onClick={handleBackToCurrent} className="pointer-events-auto px-4 py-2 bg-primary text-white rounded-full text-xs font-bold shadow-lg active:scale-95 transition-transform flex items-center gap-1.5">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.2} stroke="currentColor" className="w-3.5 h-3.5"><path strokeLinecap="round" strokeLinejoin="round" d="M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3" /></svg>
+                            回到当前聊天
+                        </button>
+                    </div>
+                )}
+                {collapsedCount > 0 && windowedFocusMsgId === null && (
                     <div className="flex justify-center mb-6">
                         <button onClick={async () => {
                             const nextVisibleCount = visibleCount + LOAD_BATCH_SIZE;
@@ -2118,8 +2180,12 @@ const Chat: React.FC = () => {
                         nextMessage.role !== m.role ||
                         Math.abs(nextMessage.timestamp - m.timestamp) > messageGroupGapMs;
                     return (
-                        <MessageItem
+                        <div
                             key={m.id || i}
+                            id={`chat-msg-${m.id}`}
+                            className={flashMsgId === m.id ? 'ring-2 ring-yellow-300 bg-yellow-50/40 rounded-2xl mx-2 transition-all duration-500' : ''}
+                        >
+                        <MessageItem
                             msg={m}
                             isFirstInGroup={breaksWithPrevious}
                             isLastInGroup={breaksWithNext}
@@ -2152,6 +2218,7 @@ const Chat: React.FC = () => {
                                 onOpenSettings: () => setShowThinkingChainModal(true),
                             }}
                         />
+                        </div>
                     );
                 })}
                 

--- a/components/chat/ChatModals.tsx
+++ b/components/chat/ChatModals.tsx
@@ -57,6 +57,7 @@ interface ChatModalsProps {
     onSavePrompt: () => void;
     onDeletePrompt: (id: string) => void;
     onSetHistoryStart: (id: number | undefined) => void;
+    onJumpToMessageInChat?: (id: number) => void;
     onEnterSelectionMode: () => void;
     onReplyMessage: () => void;
     onEditMessageStart: () => void;
@@ -129,7 +130,7 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     onTransfer, onImportEmoji, onSaveSettings,
     onBgUpload, onRemoveBg, onClearHistory,
     onArchive, onCreatePrompt, onEditPrompt, onSavePrompt, onDeletePrompt,
-    onSetHistoryStart, onEnterSelectionMode, onReplyMessage, onEditMessageStart, onConfirmEditMessage, onDeleteMessage, onCopyMessage, onDeleteEmoji, onDeleteCategory,
+    onSetHistoryStart, onJumpToMessageInChat, onEnterSelectionMode, onReplyMessage, onEditMessageStart, onConfirmEditMessage, onDeleteMessage, onCopyMessage, onDeleteEmoji, onDeleteCategory,
     allCharacters = [], onSaveCategoryVisibility,
     translationEnabled, onToggleTranslation, translateSourceLang, translateTargetLang, onSetTranslateSourceLang, onSetTranslateLang,
     xhsEnabled, onToggleXhs,
@@ -146,10 +147,40 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     const [visibilitySelection, setVisibilitySelection] = useState<Set<string>>(new Set());
     const [historyPage, setHistoryPage] = useState(0);
     const [historySearch, setHistorySearch] = useState('');
-    const [locatedMsgId, setLocatedMsgId] = useState<number | null>(null);
-    const locatedTimerRef = useRef<number | null>(null);
+    const [pendingHideMsgId, setPendingHideMsgId] = useState<number | null>(null);
+    const longPressTimerRef = useRef<number | null>(null);
+    const longPressTriggeredRef = useRef(false);
     const HISTORY_PAGE_SIZE = 50;
     const HISTORY_SEARCH_MAX = 200;
+    const LONG_PRESS_MS = 450;
+
+    const startHistoryLongPress = (msgId: number) => {
+        longPressTriggeredRef.current = false;
+        if (longPressTimerRef.current) window.clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = window.setTimeout(() => {
+            longPressTriggeredRef.current = true;
+            if (onJumpToMessageInChat) {
+                setModalType('none');
+                setHistoryPage(0);
+                setHistorySearch('');
+                setPendingHideMsgId(null);
+                onJumpToMessageInChat(msgId);
+            }
+        }, LONG_PRESS_MS);
+    };
+    const cancelHistoryLongPress = () => {
+        if (longPressTimerRef.current) {
+            window.clearTimeout(longPressTimerRef.current);
+            longPressTimerRef.current = null;
+        }
+    };
+    const handleHistoryItemClick = (msgId: number) => {
+        if (longPressTriggeredRef.current) {
+            longPressTriggeredRef.current = false;
+            return;
+        }
+        setPendingHideMsgId(msgId);
+    };
 
     // 模糊匹配：query 的所有字符按顺序在 content 里出现即算命中（大小写不敏感）。
     // 中文按字符级 subsequence 匹配，英文同理。
@@ -515,11 +546,11 @@ const ChatModals: React.FC<ChatModalsProps> = ({
 
             {/* History Manager Modal */}
             <Modal
-                isOpen={modalType === 'history-manager'} title="历史记录断点" onClose={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); }}
-                footer={<><button onClick={() => onSetHistoryStart(undefined)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">恢复全部</button><button onClick={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">完成</button></>}
+                isOpen={modalType === 'history-manager'} title="历史记录断点" onClose={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); setPendingHideMsgId(null); }}
+                footer={<><button onClick={() => onSetHistoryStart(undefined)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">恢复全部</button><button onClick={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); setPendingHideMsgId(null); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">完成</button></>}
             >
                 <div className="space-y-2 max-h-[50vh] overflow-y-auto no-scrollbar p-1">
-                    <p className="text-xs text-slate-400 text-center mb-2">点击某条消息，将其设为"新的起点"。此条之前的消息将被隐藏且不发送给 AI。</p>
+                    <p className="text-xs text-slate-400 text-center mb-2"><b>短按</b>消息 = 设为隐藏起点（会再次确认） · <b>长按</b>消息 = 跳转到聊天里查看原文</p>
                     {typeof activeCharacter.hideBeforeMessageId === 'number' && activeCharacter.hideBeforeMessageId > 0 && (
                         <div className="bg-violet-50 border border-violet-200 rounded-xl p-2.5 text-[11px] text-violet-800 leading-relaxed mb-2">
                             <b>💡 已经有隐藏起点了</b>：灰色消息是自动/手动归档时标记为"已总结"的，AI 现在看不到原文，但能看到它们的总结。<br/>
@@ -551,25 +582,10 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                         const totalPages = Math.max(1, Math.ceil(limited.length / HISTORY_PAGE_SIZE));
                         const pageMessages = limited.slice(historyPage * HISTORY_PAGE_SIZE, (historyPage + 1) * HISTORY_PAGE_SIZE);
                         const hideCut = activeCharacter.hideBeforeMessageId;
-                        // 搜索状态下点击 = 定位到原列表对应页（不设隐藏起点）
-                        const locateMessage = (msgId: number) => {
-                            const idx = reversed.findIndex(m => m.id === msgId);
-                            if (idx < 0) return;
-                            const targetPage = Math.floor(idx / HISTORY_PAGE_SIZE);
-                            setHistorySearch('');
-                            setHistoryPage(targetPage);
-                            setLocatedMsgId(msgId);
-                            if (locatedTimerRef.current) window.clearTimeout(locatedTimerRef.current);
-                            locatedTimerRef.current = window.setTimeout(() => {
-                                const el = document.getElementById(`history-msg-${msgId}`);
-                                el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                            }, 50);
-                            window.setTimeout(() => setLocatedMsgId(null), 2000);
-                        };
                         return (<>
                             {query && (
                                 <div className="text-xs text-slate-500 px-1 py-1">
-                                    找到 <b className="text-primary">{filtered.length}</b> 条匹配 <span className="text-slate-400">（点击跳转到该消息位置）</span>
+                                    找到 <b className="text-primary">{filtered.length}</b> 条匹配
                                     {filtered.length > HISTORY_SEARCH_MAX && <span className="text-slate-400">（仅显示前 {HISTORY_SEARCH_MAX} 条）</span>}
                                 </div>
                             )}
@@ -589,21 +605,23 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                             {pageMessages.map(m => {
                                 const isCurrentStart = hideCut === m.id;
                                 const isHidden = !!(hideCut && m.id < hideCut);
-                                const isLocated = locatedMsgId === m.id;
-                                const cls = isLocated
-                                    ? 'bg-yellow-50 border-yellow-300 ring-2 ring-yellow-300'
-                                    : isCurrentStart
-                                        ? 'bg-primary/10 border-primary ring-1 ring-primary'
-                                        : isHidden
-                                            ? 'bg-slate-50 border-slate-100 opacity-55'
-                                            : 'bg-white border-slate-100 hover:bg-slate-50';
+                                const cls = isCurrentStart
+                                    ? 'bg-primary/10 border-primary ring-1 ring-primary'
+                                    : isHidden
+                                        ? 'bg-slate-50 border-slate-100 opacity-55'
+                                        : 'bg-white border-slate-100 hover:bg-slate-50';
                                 const contentClass = isHidden ? 'text-slate-400 line-through decoration-slate-300/70' : 'text-slate-500';
                                 return (
                                     <div
                                         key={m.id}
                                         id={`history-msg-${m.id}`}
-                                        onClick={() => query ? locateMessage(m.id) : onSetHistoryStart(m.id)}
-                                        className={`p-3 rounded-xl border cursor-pointer text-xs flex gap-2 items-start transition-colors ${cls}`}
+                                        onClick={() => handleHistoryItemClick(m.id)}
+                                        onPointerDown={() => startHistoryLongPress(m.id)}
+                                        onPointerUp={cancelHistoryLongPress}
+                                        onPointerLeave={cancelHistoryLongPress}
+                                        onPointerCancel={cancelHistoryLongPress}
+                                        onContextMenu={(e) => e.preventDefault()}
+                                        className={`p-3 rounded-xl border cursor-pointer text-xs flex gap-2 items-start transition-colors select-none ${cls}`}
                                     >
                                         <span className="text-slate-400 font-mono whitespace-nowrap pt-0.5">[{new Date(m.timestamp).toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'})}]</span>
                                         <div className="flex-1 min-w-0">
@@ -624,7 +642,47 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                     })()}
                 </div>
             </Modal>
-            
+
+            {/* Confirm Set Hide Start Point */}
+            <Modal
+                isOpen={pendingHideMsgId !== null}
+                title="设为隐藏起点？"
+                onClose={() => setPendingHideMsgId(null)}
+                footer={<>
+                    <button onClick={() => setPendingHideMsgId(null)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">取消</button>
+                    <button onClick={() => { if (pendingHideMsgId !== null) onSetHistoryStart(pendingHideMsgId); setPendingHideMsgId(null); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">确认</button>
+                </>}
+            >
+                <div className="space-y-3 text-xs text-slate-600 leading-relaxed">
+                    {(() => {
+                        const m = allHistoryMessages.find(x => x.id === pendingHideMsgId);
+                        if (!m) return <p>消息不存在</p>;
+                        return (<>
+                            <p>该条之前的消息将被隐藏，不再发送给 AI（你仍能在聊天里翻看）。</p>
+                            <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
+                                <div className="font-bold text-slate-600 mb-1">{m.role === 'user' ? '我' : activeCharacter.name} <span className="text-slate-400 font-normal text-[10px] ml-1">{new Date(m.timestamp).toLocaleString()}</span></div>
+                                <div className="text-slate-500 line-clamp-3">{m.content}</div>
+                            </div>
+                            {onJumpToMessageInChat && (
+                                <button
+                                    onClick={() => {
+                                        const id = pendingHideMsgId;
+                                        setPendingHideMsgId(null);
+                                        setModalType('none');
+                                        setHistoryPage(0);
+                                        setHistorySearch('');
+                                        if (id !== null) onJumpToMessageInChat(id);
+                                    }}
+                                    className="w-full py-2 text-xs text-indigo-600 bg-indigo-50 hover:bg-indigo-100 rounded-xl transition-colors"
+                                >
+                                    或：跳转到聊天里查看原文
+                                </button>
+                            )}
+                        </>);
+                    })()}
+                </div>
+            </Modal>
+
             <Modal isOpen={modalType === 'message-options'} title="消息操作" onClose={() => setModalType('none')}>
                 <div className="space-y-3">
                     <button onClick={onEnterSelectionMode} className="w-full py-3 bg-slate-50 text-slate-700 font-medium rounded-2xl active:bg-slate-100 transition-colors flex items-center justify-center gap-2">


### PR DESCRIPTION
之前短按直接设隐藏起点太容易误触。改为：
- 短按消息 → 弹窗确认"是否设为隐藏起点"，可取消，也可改成跳转看原文
- 长按消息 → 关闭弹窗，跳转到聊天里那条消息所在位置（聊天里只渲染目标 周围 51 条避免 DOM 卡爆），顶部出现"回到当前聊天"按钮

Chat.tsx 加了 windowed 浏览模式：
- windowedFocusMsgId 非空时 displayMessages 切到 [target±25]
- 同时 visibleCount 拉到极大让 reloadMessages 加载全量
- 抑制 windowed 期间新消息的 auto-scroll，不打断翻旧记录
- 用户切角色 / 发消息 / 点"回到当前聊天" → 退出 windowed
- 跳转后目标消息黄色高亮 ~2s

https://claude.ai/code/session_01KxZ3PGrqT7EWspcnQfewMW