### PR TITLE
fix(xhs): start-xhs.bat 用 CRLF + REM 注释改英文

### DIFF
--- a/scripts/start-xhs.bat
+++ b/scripts/start-xhs.bat
@@ -130,8 +130,8 @@ if not exist "%SKILLS_DIR%\.venv" (
 )
 
 REM === Open Chrome to xiaohongshu.com (uses your default profile + extension) ===
-REM 新架构不再需要 --remote-debugging-port，改用 "XHS Bridge" 浏览器扩展控制。
-REM 必须用默认 profile（你安装扩展的那个），不要再用独立 profile。
+REM New architecture no longer needs --remote-debugging-port.
+REM Chrome is controlled via the "XHS Bridge" extension installed in default profile.
 
 REM Priority 1: CHROME_BIN environment variable (user can set this for portable Chrome)
 set "CHROME_EXE="


### PR DESCRIPTION
上一版改完 start-xhs.bat 行尾变成 LF，且我加了带中文逗号/全角括号
的 REM 注释。Windows cmd 在 chcp 65001 生效前按字节切行，遇到 LF
+ 多字节中文会把单行切成多个错误 token，导致 'ses' / 'LE' / 'd' 之类的报错。

修复：
- REM 注释改成纯 ASCII
- 整个 bat 强制 CRLF 行尾

echo 输出里的中文保留（在 chcp 65001 之后，纯输出不影响解析）。