### PR TITLE
fix(xhs): start-xhs.bat 避免 echo 里的 ) 误闭合 else 块

### DIFF
--- a/scripts/start-xhs.bat
+++ b/scripts/start-xhs.bat
@@ -158,8 +158,8 @@ if not defined CHROME_EXE (
     echo        Example: set CHROME_BIN=D:\Tools\Chrome\chrome.exe
     echo        cli.py will try to start Chrome automatically on first request.
 ) else (
-    echo [1] Opening Chrome to xiaohongshu.com (default profile)...
-    echo     Path: %CHROME_EXE%
+    echo [1] Opening Chrome to xiaohongshu.com [default profile]...
+    echo     Path: "%CHROME_EXE%"
     start "" "%CHROME_EXE%" --start-maximized https://www.xiaohongshu.com
     timeout /t 2 /nobreak >nul
 )


### PR DESCRIPTION
if/else 块里 echo 文本带未转义的 ) 会让 cmd 把它当成块的闭合
括号，提前结束 else 分支。chrome 路径 Program Files (x86) 也是
同样问题。改用方括号文案 + 给 %CHROME_EXE% 加引号保护。