### PR TITLE
chore(xhs): start-xhs.bat 启动时自动跑 patch 脚本

### DIFF
--- a/scripts/start-xhs.bat
+++ b/scripts/start-xhs.bat
@@ -129,6 +129,19 @@ if not exist "%SKILLS_DIR%\.venv" (
     echo.
 )
 
+REM === Apply local patches to skills (idempotent, safe to re-run) ===
+REM Currently patches: publish.py tab-selector bug (off-screen carousel tabs).
+set "PATCH_SCRIPT=%TOOLKIT_DIR%\patch-xhs-publish.py"
+if not exist "%PATCH_SCRIPT%" (
+    if exist "%TOOLKIT_DIR%\scripts\patch-xhs-publish.py" set "PATCH_SCRIPT=%TOOLKIT_DIR%\scripts\patch-xhs-publish.py"
+)
+if exist "%PATCH_SCRIPT%" (
+    echo [PATCH] Checking xiaohongshu-skills patches...
+    pushd "%SKILLS_DIR%"
+    uv run python "%PATCH_SCRIPT%"
+    popd
+)
+
 REM === Open Chrome to xiaohongshu.com (uses your default profile + extension) ===
 REM New architecture no longer needs --remote-debugging-port.
 REM Chrome is controlled via the "XHS Bridge" extension installed in default profile.


### PR DESCRIPTION
之前要求用户每次升级 skill 后手动 uv run patch-xhs-publish.py，
不现实。改成 start-xhs.bat 在 deps 安装之后、Chrome/bridge 启动
之前自动检查并应用 patch。patch 脚本本身已 idempotent，每次启动
都跑也只是一次 grep 的成本。

发包给用户时只需把 patch-xhs-publish.py 跟 start-xhs.bat、
xhs-bridge.mjs 一起放在工具箱根目录即可，用户照常双击启动脚本，
patch 会自动生效。