### PR TITLE
fix(memoryPalace): honor disable during in-flight AI reply

### DIFF
--- a/apps/DateApp.tsx
+++ b/apps/DateApp.tsx
@@ -23,6 +23,11 @@ const DateApp: React.FC = () => {
     const [memoryPalaceResult, setMemoryPalaceResult] = useState<PipelineResult | null>(null);
     const memoryPalaceStatusRef = useRef(memoryPalaceStatus);
     memoryPalaceStatusRef.current = memoryPalaceStatus;
+
+    // characters ref：见面 hook 跑完后用户可能已经在 MemoryPalaceApp 里关掉了宫殿，
+    // 直接闭包里的 charForHook 是回复开始时捕获的，会读到 stale memoryPalaceEnabled=true。
+    const charactersRef = useRef(characters);
+    charactersRef.current = characters;
     
     // Modes: 'select' -> 'peek' -> 'session' | 'settings' | 'history'
     const [mode, setMode] = useState<'select' | 'peek' | 'session' | 'settings' | 'history'>('select');
@@ -236,7 +241,10 @@ const DateApp: React.FC = () => {
     // 与聊天侧 useChatAI 完全一致的 Memory Palace 后台流程：
     // 触发缓冲区处理 + 自动归档（如开启） + 50 轮认知消化。
     const runMemoryPalacePostHook = useCallback(async (charForHook: CharacterProfile) => {
-        if (!charForHook.memoryPalaceEnabled) return;
+        // 用 charactersRef 读最新状态，避免见面流程中用户去 MemoryPalaceApp 关掉宫殿后
+        // 这里仍然按 charForHook 闭包里的旧 enabled 触发一次 LLM 总结
+        const liveBefore = charactersRef.current.find(c => c.id === charForHook.id) || null;
+        if (!liveBefore?.memoryPalaceEnabled) return;
         const mpEmb = memoryPalaceConfig?.embedding;
         const mpLLMConfigured = memoryPalaceConfig?.lightLLM;
         const mpLLM = (mpLLMConfigured?.baseUrl)
@@ -257,14 +265,18 @@ const DateApp: React.FC = () => {
                 (stage) => setMemoryPalaceStatus(stage),
             );
 
+            // pipeline 跑的过程中用户可能又关了宫殿，再 check 一次
+            const liveAfter = charactersRef.current.find(c => c.id === charForHook.id) || null;
+            if (!liveAfter?.memoryPalaceEnabled) return;
+
             if (pipelineResult && pipelineResult.stored > 0) {
                 setMemoryPalaceResult(pipelineResult);
             }
 
-            if (pipelineResult?.autoArchive && (charForHook as any).autoArchiveEnabled) {
+            if (pipelineResult?.autoArchive && (liveAfter as any).autoArchiveEnabled) {
                 try {
                     const mergedMemories = mergePalaceFragmentsIntoMemories(
-                        charForHook.memories || [],
+                        liveAfter.memories || [],
                         pipelineResult.autoArchive.fragments,
                     );
                     updateCharacter(charForHook.id, {
@@ -280,7 +292,7 @@ const DateApp: React.FC = () => {
             const shouldAutoDigest = incrementDigestRound(charForHook.id);
             if (shouldAutoDigest) {
                 setMemoryPalaceStatus(`${charForHook.name}闭上眼睛，开始整理内心…`);
-                const persona = [charForHook.systemPrompt || '', charForHook.worldview || ''].filter(Boolean).join('\n');
+                const persona = [liveAfter.systemPrompt || '', liveAfter.worldview || ''].filter(Boolean).join('\n');
                 await runCognitiveDigestion(charForHook.id, charForHook.name, persona, mpLLM, false, userProfile?.name, mpEmb);
             }
         } catch (e: any) {

--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -187,6 +187,11 @@ const GroupChat: React.FC = () => {
     /** 群记忆宫殿"提取中"状态文本——非空时显示顶部胶囊状态条 */
     const [groupPalaceStatus, setGroupPalaceStatus] = useState<string>('');
 
+    // ref 出最新 characters，让 finally 里跑的群记忆宫殿能读到"用户刚关掉某个成员宫殿"
+    // 的最新状态——闭包里的 characters 还是发消息那一刻捕获的旧值，会让关闭后还触发一次
+    const charactersRef = useRef(characters);
+    charactersRef.current = characters;
+
     // Token 统计 — 对齐私聊 ChatHeader 的 token badge
     const [lastTokenUsage, setLastTokenUsage] = useState<number | null>(null);
     const [tokenBreakdown, setTokenBreakdown] = useState<{ prompt: number; completion: number; total: number; msgCount: number; pass: string } | null>(null);
@@ -991,7 +996,10 @@ ${recentGroupMsgs}
             // groupMembers 在 try 块内声明，这里在 finally 重新解析
             if (activeGroup) {
                 const groupForPalace = activeGroup;
-                const membersForPalace = characters.filter(c => groupForPalace.members.includes(c.id));
+                // 读 ref 拿最新 characters，否则群里有成员在回复中途被用户关掉 palace
+                // 时，下面这一次还是会按"那时还有人启用"的旧状态去触发 LLM 提取
+                const liveCharacters = charactersRef.current;
+                const membersForPalace = liveCharacters.filter(c => groupForPalace.members.includes(c.id));
                 const hasAnyEnabled = membersForPalace.some(m => m.memoryPalaceEnabled);
                 if (hasAnyEnabled) {
                     processGroupNewMessages(

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -533,6 +533,13 @@ export const useChatAI = ({
     const memoryPalaceStatusRef = useRef(memoryPalaceStatus);
     memoryPalaceStatusRef.current = memoryPalaceStatus;
 
+    // triggerAI 的 finally 在 AI 流式回复完后才跑记忆宫殿后台任务。
+    // 闭包里捕获的 char 是 hook 调用时那一份，如果用户在流式中途把宫殿关了，
+    // 这里读 char.memoryPalaceEnabled 仍然是 true，导致关掉后还会再触发一次
+    // LLM 提取（+ 50 轮认知消化）。用 ref 在 finally 里读最新状态。
+    const charRef = useRef(char);
+    charRef.current = char;
+
     // beforeunload 保护：记忆宫殿后台处理中时，阻止用户意外关闭页面
     useEffect(() => {
         const handler = (e: BeforeUnloadEvent) => {
@@ -2599,7 +2606,9 @@ export const useChatAI = ({
             const mpLLM = (mpLLMConfigured?.baseUrl)
                 ? mpLLMConfigured
                 : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model };
-            if (char.memoryPalaceEnabled && mpEmb?.baseUrl && mpEmb?.apiKey && mpLLM.baseUrl) {
+            // 读 ref 拿到最新的 char 状态；同 id 才信任，否则保守跳过（用户已经切角色了）
+            const liveChar = charRef.current?.id === char.id ? charRef.current : null;
+            if (liveChar?.memoryPalaceEnabled && mpEmb?.baseUrl && mpEmb?.apiKey && mpLLM.baseUrl) {
                 const charName = char.name;
                 // 不再预置"正在回味"状态：pipeline 会在水位线未到时立刻 skip，
                 // 预置状态会让"沉思"指示器一闪让用户误以为在干活。
@@ -2612,6 +2621,11 @@ export const useChatAI = ({
                         setMemoryPalaceStatus(stage);
                     })
                     .then(async (pipelineResult) => {
+                        // pipeline 跑的过程中用户可能又关掉了宫殿，跑完后所有"额外动作"
+                        // （autoArchive 写 char.memories / 50 轮认知消化的 LLM 调用）都要再 check 一次。
+                        const liveAfter = charRef.current?.id === char.id ? charRef.current : null;
+                        if (!liveAfter?.memoryPalaceEnabled) return;
+
                         // 显示结果让用户看到
                         if (pipelineResult && pipelineResult.stored > 0) {
                             setMemoryPalaceResult(pipelineResult);
@@ -2620,7 +2634,7 @@ export const useChatAI = ({
                         // 自动归档：把 palace 提取出的记忆按日期合成 YAML bullets 追加到
                         // char.memories，同时推 hideBeforeMessageId 自动隐藏已总结的聊天
                         // 仅在 char.autoArchiveEnabled 显式开启时执行（默认 off，opt-in）
-                        if (pipelineResult?.autoArchive && updateCharacter && (char as any).autoArchiveEnabled) {
+                        if (pipelineResult?.autoArchive && updateCharacter && (liveAfter as any).autoArchiveEnabled) {
                             try {
                                 const mergedMemories = mergePalaceFragmentsIntoMemories(
                                     char.memories || [],


### PR DESCRIPTION
triggerAI 的 finally 在 AI 流式回复完才 fire 记忆宫殿后台任务，
读的是闭包里捕获的 char。如果用户因为 embedding API 抽风/不想烧 token
在流式中途关掉宫殿，闭包里 memoryPalaceEnabled 仍然是 true，
关掉后还是会再触发一次 LLM 提取（命中 50 轮的话再叠一次认知消化）。

加 charRef/charactersRef，在触发点和 .then 里读最新状态，
出现"关闭→pipeline 已经在跑"的 race 时静默跳过 autoArchive 写入
和后续的认知消化 LLM 调用。同一 race 在 DateApp 见面流和
GroupChat 群聊后台路径也存在，一起补上。