### PR TITLE
fix(memoryPalace): 未同步条数按真实缓冲区算，不含热区

### DIFF
--- a/apps/MemoryPalaceApp.tsx
+++ b/apps/MemoryPalaceApp.tsx
@@ -949,13 +949,10 @@ export default function MemoryPalaceApp() {
         updateCharacter(charId, { autoArchiveEnabled: true } as any);
 
         // 统计未同步消息数并决定是否立即追平历史
-        const { DB } = await import('../utils/db');
-        const { getMemoryPalaceHighWaterMark, processNewMessages, mergePalaceFragmentsIntoMemories } = await import('../utils/memoryPalace/pipeline');
-        const { isMessageSemanticallyRelevant } = await import('../utils/messageFormat');
-
-        const allMsgs = await DB.getMessagesByCharId(charId, true);
-        const hwm0 = getMemoryPalaceHighWaterMark(charId);
-        const unprocessedCount = allMsgs.filter(m => isMessageSemanticallyRelevant(m) && m.id > hwm0).length;
+        // 口径必须和 pipeline 的缓冲区定义一致：排除热区（最后 200 条），
+        // 否则会把"永远不会被处理"的热区也算成未同步，欺骗用户去点立即追平。
+        const { getMemoryPalaceUnprocessedBufferCount } = await import('../utils/memoryPalace/pipeline');
+        const unprocessedCount = await getMemoryPalaceUnprocessedBufferCount(charId);
 
         if (unprocessedCount < 10) {
             addToast('全自动记忆已开启（历史消息都已同步）', 'success');
@@ -986,28 +983,32 @@ export default function MemoryPalaceApp() {
         const target = characters.find(c => c.id === charId);
         if (!target) return;
 
-        const { DB } = await import('../utils/db');
-        const { getMemoryPalaceHighWaterMark, processNewMessages, mergePalaceFragmentsIntoMemories } = await import('../utils/memoryPalace/pipeline');
-        const { isMessageSemanticallyRelevant } = await import('../utils/messageFormat');
+        const {
+            getMemoryPalaceHighWaterMark,
+            getMemoryPalaceUnprocessedBufferCount,
+            processNewMessages,
+            mergePalaceFragmentsIntoMemories,
+        } = await import('../utils/memoryPalace/pipeline');
 
         setAutoArchiveSyncingId(charId);
         setAutoArchiveSyncProgress(`准备中... (${unprocessedCount} 条)`);
         try {
-            const BATCH_SIZE = 170;
             const MAX_ROUNDS = 50;
             let accumulatedMemories = (target as any).memories ? [...(target as any).memories] : [];
             let latestHideBefore = (target as any).hideBeforeMessageId;
             let totalProcessed = 0;
 
             for (let round = 1; round <= MAX_ROUNDS; round++) {
-                const curMsgs = await DB.getMessagesByCharId(charId, true);
                 const curHwm = getMemoryPalaceHighWaterMark(charId);
-                const unprocessed = curMsgs.filter(m => isMessageSemanticallyRelevant(m) && m.id > curHwm).sort((a, b) => a.id - b.id);
-                if (unprocessed.length < 10) break;
-                const batch = unprocessed.slice(0, BATCH_SIZE);
-                setAutoArchiveSyncProgress(`第 ${round} 轮：${batch.length} 条 / 剩余 ${unprocessed.length}`);
+                // 用 pipeline 的真实缓冲区口径（排除热区），避免把热区的 200 条
+                // 当未同步反复重试——下面的 force=true 调用其实也只会处理缓冲区，
+                // 用同一口径循环才能正确收敛。
+                const remaining = await getMemoryPalaceUnprocessedBufferCount(charId);
+                if (remaining < 10) break;
+                setAutoArchiveSyncProgress(`第 ${round} 轮：剩余 ${remaining} 条`);
 
-                const result = await processNewMessages(batch, charId, charName, mpEmb, mpLLM, userProfile.name, true);
+                // processNewMessages 忽略首个参数（内部直接从 DB 加载），传 [] 即可
+                const result = await processNewMessages([], charId, charName, mpEmb, mpLLM, userProfile.name, true);
 
                 // 软跳过：缓冲区没到阈值 / 热区还没被挤出 / 已有任务在跑 —— 不是 palace 失败
                 if (result?.skipReason) {
@@ -1016,8 +1017,6 @@ export default function MemoryPalaceApp() {
                     }
                     break;
                 }
-
-                totalProcessed += batch.length;
 
                 if (result?.autoArchive) {
                     accumulatedMemories = mergePalaceFragmentsIntoMemories(accumulatedMemories, result.autoArchive.fragments);
@@ -1029,6 +1028,7 @@ export default function MemoryPalaceApp() {
                     addToast('追平中断：palace 处理失败，请检查副 API 配置', 'error');
                     break;
                 }
+                totalProcessed += result?.processedMessages || 0;
             }
 
             updateCharacter(charId, { memories: accumulatedMemories, hideBeforeMessageId: latestHideBefore } as any);

--- a/utils/memoryPalace/pipeline.ts
+++ b/utils/memoryPalace/pipeline.ts
@@ -987,6 +987,33 @@ const BUFFER_THRESHOLD = 100;
 /** 处理比例：取缓冲区前 85%，保留尾部 15% 作为下次总结的上下文 */
 const PROCESS_RATIO = 0.85;
 
+/**
+ * 计算当前"真正可被 pipeline 处理"的缓冲区消息数。
+ *
+ * 与 processNewMessages 的口径完全一致：
+ *   - 只数语义相关消息（排除纯图片/语音/表情）
+ *   - 排除最后 HOT_ZONE_SIZE 条（热区永远不会被处理）
+ *   - 只数 id > 高水位标记的部分
+ *
+ * 切勿用"id > hwm"裸过滤——那会把热区的 200 条也算进未同步，
+ * 导致 UI 显示的"未同步条数"远大于 pipeline 实际能处理的量
+ * （表现：弹窗说有几百条未同步，点立即追平却跑不出新 hwm）。
+ */
+export async function getMemoryPalaceUnprocessedBufferCount(charId: string): Promise<number> {
+    const allMessages = await DB.getMessagesByCharId(charId, true);
+    const semantic = allMessages
+        .filter(m => isMessageSemanticallyRelevant(m))
+        .sort((a, b) => a.id - b.id);
+    if (semantic.length <= HOT_ZONE_SIZE) return 0;
+    const hotZoneStartId = semantic[semantic.length - HOT_ZONE_SIZE].id;
+    const hwm = getLastProcessedId(charId);
+    let count = 0;
+    for (const m of semantic) {
+        if (m.id > hwm && m.id < hotZoneStartId) count++;
+    }
+    return count;
+}
+
 /** 并发锁：防止多次 AI 回复同时触发 processNewMessages 产生竞态 */
 const processingLocks = new Set<string>();
 
@@ -1005,6 +1032,8 @@ const processingLocks = new Set<string>();
 export interface PipelineResult {
     stored: number;
     skipped: number;
+    /** 本轮 pipeline 从缓冲区取出处理的消息条数（caller 用于进度展示） */
+    processedMessages?: number;
     memories: { content: string; room: string; importance: number; mood: string; tags: string[] }[];
     batches: { index: number; total: number; extracted: number; ok: boolean; error?: string }[];
     /**
@@ -1280,6 +1309,7 @@ export async function processNewMessages(
         const pipelineResult: PipelineResult = {
             stored: vectorResult.stored,
             skipped: vectorResult.skipped,
+            processedMessages: toProcess.length,
             memories: memories.map(m => ({ content: m.content, room: m.room, importance: m.importance, mood: m.mood, tags: m.tags })),
             batches: batchResults,
             autoArchive,


### PR DESCRIPTION
用户报告：打开全自动记忆开关时弹窗显示「302 条未同步」/「750 条未同步」，
但 pipeline 的水位线规则是「最后 200 条热区不处理 + 缓冲区累积 ≥ 100 才触发」， 点立即追平后副 API 处理失败/反复跑空，体感「全自动记忆没按水位线运作」。

根因：MemoryPalaceApp 的 unprocessedCount = msgs.filter(m.id > hwm)， 裸过滤会把永远不会被处理的热区 200 条也算成「未同步」，
导致弹窗数字比 pipeline 真正能跑的缓冲区大得多，
立即追平循环也以同样错误口径判断剩余，会在缓冲区已空时仍不停尝试。

修复：
- pipeline.ts 新增 getMemoryPalaceUnprocessedBufferCount，复用与 processNewMessages 完全一致的「排热区 + > hwm」口径
- MemoryPalaceApp 的开关弹窗触发与「立即追平」循环都改用这个口径
- PipelineResult 增加 processedMessages，让 caller 拿到真实进度， 不再依赖被忽略的外层 BATCH_SIZE