### PR TITLE
feat(error-dialog): 全局长报错弹窗, Instant Push 失败接入

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -25,7 +25,7 @@ import { isInstantConfigReady } from '../utils/instantPushClient';
 const VOICE_LANG_LABELS: Record<string, string> = { en: 'English', ja: '日本語', ko: '한국어', fr: 'Français', es: 'Español' };
 
 const Chat: React.FC = () => {
-    const { characters, activeCharacterId, setActiveCharacterId, updateCharacter, apiConfig, apiPresets, addApiPreset, closeApp, customThemes, removeCustomTheme, addToast, userProfile, lastMsgTimestamp, groups, clearUnread, realtimeConfig, memoryPalaceConfig, syncEmotionApiToAllCharacters, theme: osTheme, proactiveComposingChars } = useOS();
+    const { characters, activeCharacterId, setActiveCharacterId, updateCharacter, apiConfig, apiPresets, addApiPreset, closeApp, customThemes, removeCustomTheme, addToast, showError, userProfile, lastMsgTimestamp, groups, clearUnread, realtimeConfig, memoryPalaceConfig, syncEmotionApiToAllCharacters, theme: osTheme, proactiveComposingChars } = useOS();
     const isProactiveComposing = !!(activeCharacterId && proactiveComposingChars[activeCharacterId]);
 
     // 记忆宫殿高水位（用于清空聊天时的安全检查）
@@ -164,6 +164,7 @@ const Chat: React.FC = () => {
         emojis: aiVisibleEmojis,
         categories: visibleCategories,
         addToast,
+        showError,
         setMessages,
         realtimeConfig,
         translationConfig: translationEnabled

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -47,6 +47,7 @@ import { Capacitor } from '@capacitor/core';
 import { isIOSStandaloneWebApp } from '../utils/iosStandalone';
 import AppErrorBoundary from './os/AppErrorBoundary';
 import GlobalMiniPlayer from './os/GlobalMiniPlayer';
+import ErrorDialog from './os/ErrorDialog';
 
 /*
 // Internal Error Boundary Component
@@ -204,7 +205,7 @@ const DisclaimerPopup: React.FC<{ onAccept: () => void }> = ({ onAccept }) => (
 );
 
 const PhoneShell: React.FC = () => {
-  const { theme, isLocked, unlock, activeApp, closeApp, virtualTime, isDataLoaded, toasts, unreadMessages, characters, handleBack, suspendedCall, resumeCall, activeCharacterId } = useOS();
+  const { theme, isLocked, unlock, activeApp, closeApp, virtualTime, isDataLoaded, toasts, unreadMessages, characters, handleBack, suspendedCall, resumeCall, activeCharacterId, errorDialog, dismissError } = useOS();
   const useIOSStandaloneLayout = isIOSStandaloneWebApp();
 
   // Disclaimer popup for first-time users
@@ -478,6 +479,14 @@ const PhoneShell: React.FC = () => {
               ))}
            </div>
        </div>
+
+       {/* Global error dialog (长报错走它, 替代单行 toast) */}
+       <ErrorDialog
+         isOpen={!!errorDialog}
+         title={errorDialog?.title ?? ''}
+         details={errorDialog?.details ?? ''}
+         onClose={dismissError}
+       />
 
        {/* First-time disclaimer popup */}
        {showDisclaimer && <DisclaimerPopup onAccept={handleAcceptDisclaimer} />}

--- a/components/os/ErrorDialog.tsx
+++ b/components/os/ErrorDialog.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+
+interface ErrorDialogProps {
+    isOpen: boolean;
+    title: string;
+    details: string;
+    onClose: () => void;
+}
+
+// 全局错误弹窗：toast 一行装不下的长报错走这里 —— 多行 monospace 预览框 + 复制按钮,
+// 手机上没法开 console 时, 用户能直接看清、长按复制原文反馈过来。
+const ErrorDialog: React.FC<ErrorDialogProps> = ({ isOpen, title, details, onClose }) => {
+    const [copied, setCopied] = useState(false);
+
+    if (!isOpen) return null;
+
+    const handleCopy = async () => {
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(details);
+            } else {
+                // iOS 旧版 PWA / 非 HTTPS 场景 clipboard API 可能缺失, fallback 到 execCommand
+                const ta = document.createElement('textarea');
+                ta.value = details;
+                ta.style.position = 'fixed';
+                ta.style.opacity = '0';
+                document.body.appendChild(ta);
+                ta.select();
+                document.execCommand('copy');
+                document.body.removeChild(ta);
+            }
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch {
+            setCopied(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-[110] flex items-center justify-center p-4 animate-fade-in" style={{ zIndex: 10000 }}>
+            <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+            <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden animate-pop-in">
+                <div className="p-5 pb-3">
+                    <div className="flex gap-3 items-start">
+                        <div className="w-10 h-10 rounded-full bg-red-50 text-red-500 flex items-center justify-center shrink-0">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6">
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+                            </svg>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <h3 className="text-base font-bold text-slate-800 leading-6 break-words">{title}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div className="px-5 pb-3">
+                    <pre className="bg-slate-50 border border-slate-200 rounded-xl px-3 py-2.5 text-[11px] leading-relaxed text-slate-700 whitespace-pre-wrap break-words max-h-[40vh] overflow-y-auto font-mono select-text">
+{details}
+                    </pre>
+                </div>
+                <div className="bg-slate-50 px-5 py-3 flex gap-2 justify-end border-t border-slate-100">
+                    <button
+                        onClick={handleCopy}
+                        className="px-4 py-2 bg-white border border-slate-200 rounded-xl text-sm font-bold text-slate-600 active:scale-95 transition-transform"
+                    >
+                        {copied ? '已复制' : '复制'}
+                    </button>
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 bg-red-500 rounded-xl text-sm font-bold text-white shadow-lg shadow-red-200 active:scale-95 transition-transform"
+                    >
+                        关闭
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ErrorDialog;

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -212,6 +212,12 @@ interface OSContextType {
   toasts: Toast[];
   addToast: (message: string, type?: Toast['type']) => void;
 
+  // 长报错弹窗：toast 一行装不下 / 手机没法开 console 时, 用 showError 弹一个
+  // 多行预览框 + 复制按钮, 方便用户把原文反馈过来。
+  errorDialog: { title: string; details: string } | null;
+  showError: (title: string, details: string) => void;
+  dismissError: () => void;
+
   // Icons
   customIcons: Record<string, string>;
   setCustomIcon: (appId: string, iconUrl: string | undefined) => void;
@@ -553,6 +559,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   const [customIcons, setCustomIcons] = useState<Record<string, string>>({});
   const [appearancePresets, setAppearancePresets] = useState<AppearancePreset[]>([]);
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [errorDialog, setErrorDialog] = useState<{ title: string; details: string } | null>(null);
   
   const [lastMsgTimestamp, setLastMsgTimestamp] = useState<number>(0);
   const [unreadMessages, setUnreadMessages] = useState<Record<string, number>>({});
@@ -1988,6 +1995,8 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   const removeCustomTheme = async (id: string) => { setCustomThemes(prev => prev.filter(t => t.id !== id)); await DB.deleteTheme(id); };
   const setCustomIcon = async (appId: string, iconUrl: string | undefined) => { setCustomIcons(prev => { const next = { ...prev }; if (iconUrl) next[appId] = iconUrl; else delete next[appId]; return next; }); if (iconUrl) { await DB.saveAsset(`icon_${appId}`, iconUrl); } else { await DB.deleteAsset(`icon_${appId}`); } };
   const addToast = (message: string, type: Toast['type'] = 'info') => { const id = Date.now().toString(); setToasts(prev => [...prev, { id, message, type }]); setTimeout(() => { setToasts(prev => prev.filter(t => t.id !== id)); }, 3000); };
+  const showError = (title: string, details: string) => { setErrorDialog({ title, details }); };
+  const dismissError = () => { setErrorDialog(null); };
 
   // --- APPEARANCE PRESETS ---
   const saveAppearancePreset = async (name: string) => {
@@ -3044,6 +3053,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     importAppearancePreset,
     toasts,
     addToast,
+    errorDialog,
+    showError,
+    dismissError,
     customIcons,
     setCustomIcon,
     resetAppearance,

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -498,6 +498,8 @@ interface UseChatAIProps {
     emojis: Emoji[];
     categories: EmojiCategory[];
     addToast: (msg: string, type: 'info'|'success'|'error') => void;
+    /** 长报错走弹窗 (toast 一行装不下), 手机用户能看清并复制反馈 */
+    showError?: (title: string, details: string) => void;
     setMessages: (msgs: Message[]) => void; // Callback to update UI messages
     realtimeConfig?: RealtimeConfig; // 新增：实时配置
     translationConfig?: { enabled: boolean; sourceLang: string; targetLang: string };
@@ -516,6 +518,7 @@ export const useChatAI = ({
     emojis,
     categories,
     addToast,
+    showError,
     setMessages,
     realtimeConfig,  // 新增
     translationConfig,
@@ -806,7 +809,25 @@ export const useChatAI = ({
                     metadata: { source: 'sullyos-chat', charId: char.id },
                 }, char.id, undefined, onInstantPosted);
                 if (!instantResult.ok) {
-                    addToast(`Instant Push: ${instantResult.error}`, 'error');
+                    // 长报错 (worker 400 校验信息可能很长) 走弹窗, 手机用户能看清并复制反馈;
+                    // 没注入 showError 时降级到 toast, 保证调用方不强依赖。
+                    const errMsg = instantResult.error || '未知错误';
+                    const detailsLines = [
+                        `outcome: ${instantResult.outcome}`,
+                        '',
+                        errMsg,
+                        '',
+                        '— context —',
+                        `char: ${char.name}`,
+                        `model: ${effectiveApi.model}`,
+                        `apiUrl: ${effectiveApi.baseUrl}`,
+                        `msgs: ${fullMessages.length}`,
+                    ];
+                    if (showError) {
+                        showError('Instant Push 发送失败', detailsLines.join('\n'));
+                    } else {
+                        addToast(`Instant Push: ${errMsg}`, 'error');
+                    }
                 }
                 return;
             }


### PR DESCRIPTION
## Summary
- 新增 `components/os/ErrorDialog.tsx`：全局长报错弹窗，多行 monospace 预览框 + 复制（clipboard API + execCommand fallback）
- `OSContext` 暴露 `showError(title, details)` / `dismissError`，`PhoneShell` 全局挂载
- `useChatAI` 里 Instant Push 失败时改走弹窗：显示 outcome / worker 原文 / char + model + apiUrl + msgs 上下文 —— toast 一行装不下，手机也没法开 console，用户能直接看清并复制反馈

## Test plan
- [ ] 触发 Instant Push 400（例如让 `avatarUrl` 是 emoji），确认弹窗显示完整错误 + 上下文
- [ ] 复制按钮在 HTTPS / iOS PWA 下都能正确复制
- [ ] 关闭按钮 / 点蒙层 dismiss 正常
- [ ] 普通短 toast 流（success / info / 一行 error）不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)