### PR TITLE
fix(push): 修重置订阅 race, 拿到 zombie 端点自动重试; 抽 pushSubscribeShared

### DIFF
--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -1,5 +1,11 @@
 import { InstantPushConfig, APIConfig } from '../types';
 import { loadPushVapid, isPushVapidReady } from './pushVapid';
+import {
+  SUBSCRIBE_SETTLE_MS,
+  bytesToB64u,
+  isDeadPushEndpoint,
+  subscribeWithRetry,
+} from './pushSubscribeShared';
 
 export const INSTANT_PUSH_CONFIG_KEY = 'instant_push_config_v1';
 
@@ -330,48 +336,9 @@ export function isInstantConfigReady(cfg?: InstantPushConfig): boolean {
 }
 
 // ── Web Push subscription helpers ─────────────────────────────────────────
-
-function b64uToBytes(b64u: string): Uint8Array<ArrayBuffer> {
-  const padded = b64u.replace(/-/g, '+').replace(/_/g, '/')
-    + '='.repeat((4 - (b64u.length % 4)) % 4);
-  const bin = atob(padded);
-  const buf = new ArrayBuffer(bin.length);
-  const out = new Uint8Array(buf);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-function bytesToB64u(buf: ArrayBuffer | null | undefined): string {
-  if (!buf) return '';
-  const bytes = new Uint8Array(buf);
-  let bin = '';
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function isDeadEndpoint(endpoint: string | null | undefined): boolean {
-  if (!endpoint) return false;
-  return endpoint.includes('permanently-removed.invalid');
-}
-
-function explainSubscribeError(e: unknown): string {
-  const err = e as { name?: string; message?: string } | null;
-  const name = err?.name || '';
-  const msg = err?.message || String(e || '未知错误');
-  if (name === 'NotAllowedError') {
-    return '浏览器拒绝创建订阅（NotAllowedError）——通常是站点权限被拦截或处于隐身模式';
-  }
-  if (name === 'NotSupportedError') {
-    return '当前浏览器不支持网页推送——国行安卓或自带浏览器常见，换 Chrome / Edge / Firefox 桌面版试试';
-  }
-  if (name === 'AbortError' || /push service|FCM|network/i.test(msg)) {
-    return '连不上推送服务器——常见于无谷歌服务的国行安卓，或网络挡住了推送服务器，建议换装了谷歌服务的设备或桌面 Chrome 试试';
-  }
-  if (name === 'InvalidStateError') {
-    return '订阅状态冲突（InvalidStateError）——可能旧订阅没清干净，刷新页面后重试';
-  }
-  return `订阅创建失败（${name || 'Error'}：${msg}）`;
-}
+//
+// 与 proactivePushConfig 共用一份 race 处理 / encoding helpers, 实现在
+// pushSubscribeShared.ts.
 
 export async function getOrCreateInstantSubscription(
   vapidPublicKey?: string,
@@ -388,8 +355,10 @@ export async function getOrCreateInstantSubscription(
   const reg = await navigator.serviceWorker.ready;
   let sub = await reg.pushManager.getSubscription();
 
-  if (sub && isDeadEndpoint(sub.endpoint)) {
+  if (sub && isDeadPushEndpoint(sub.endpoint)) {
     try { await sub.unsubscribe(); } catch { /* ignore */ }
+    // 等浏览器清内部 removed 标记, 否则下面 subscribe() 又拿到死哨兵
+    await new Promise(r => setTimeout(r, SUBSCRIBE_SETTLE_MS));
     sub = null;
   }
 
@@ -399,6 +368,7 @@ export async function getOrCreateInstantSubscription(
       const existingKey = bytesToB64u(sub.options.applicationServerKey);
       if (existingKey && existingKey !== pub) {
         await sub.unsubscribe();
+        await new Promise(r => setTimeout(r, SUBSCRIBE_SETTLE_MS));
         sub = null;
       }
     } catch { /* fall through */ }
@@ -411,20 +381,9 @@ export async function getOrCreateInstantSubscription(
     } else if (Notification.permission === 'denied') {
       return { sub: null, reason: '通知权限已被拒绝（请到浏览器站点设置里手动开启）' };
     }
-    try {
-      sub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: b64uToBytes(pub),
-      });
-    } catch (e) {
-      console.warn('[InstantPush] pushManager.subscribe failed', e);
-      return { sub: null, reason: explainSubscribeError(e) };
-    }
-  }
-
-  if (isDeadEndpoint(sub.endpoint)) {
-    try { await sub.unsubscribe(); } catch { /* ignore */ }
-    return { sub: null, reason: '浏览器返回了 zombie endpoint（permanently-removed.invalid），无法投递' };
+    const fresh = await subscribeWithRetry(reg, pub, '[InstantPush]');
+    if (!fresh.sub) return { sub: null, reason: fresh.reason };
+    sub = fresh.sub;
   }
 
   const p256dh = bytesToB64u(sub.getKey('p256dh'));

--- a/utils/proactivePushConfig.ts
+++ b/utils/proactivePushConfig.ts
@@ -26,6 +26,12 @@ const CLIENT_TOKEN = 'weqwqewqeqwdcsccagdgs32132';
 // ═══════════════════════════════════════════════════════════════════
 
 import { loadPushVapid, isPushVapidReady } from './pushVapid';
+import {
+  SUBSCRIBE_SETTLE_MS,
+  bytesToB64u,
+  isDeadPushEndpoint,
+  subscribeWithRetry,
+} from './pushSubscribeShared';
 
 const ENABLED_STORAGE_KEY = 'proactive_push_enabled_v1';
 const LAST_WAKE_AT_KEY = 'proactive_push_last_wake_at_v1';
@@ -71,24 +77,10 @@ export function isPushConfigAvailable(): boolean {
 }
 
 // ---------- Web Push subscription helpers ----------
-
-/** Convert base64url string to Uint8Array (for VAPID applicationServerKey). */
-function b64uToBytes(b64u: string): Uint8Array {
-  const padded = b64u.replace(/-/g, '+').replace(/_/g, '/')
-    + '='.repeat((4 - (b64u.length % 4)) % 4);
-  const bin = atob(padded);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-function bytesToB64u(buf: ArrayBuffer | null): string {
-  if (!buf) return '';
-  const bytes = new Uint8Array(buf);
-  let bin = '';
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
+//
+// b64uToBytes / bytesToB64u / isDeadPushEndpoint / explainSubscribeError /
+// subscribeWithRetry / SUBSCRIBE_SETTLE_MS 全部从 pushSubscribeShared.ts 取,
+// 与 instantPushClient.ts 共用同一份实现.
 
 interface SubscriptionInfo {
   endpoint: string;
@@ -97,46 +89,11 @@ interface SubscriptionInfo {
 }
 
 /**
- * True if a subscription's endpoint is a Chrome-internal "permanently
- * removed" sentinel.  Browsers occasionally revoke subscriptions due to
- * long inactivity, abuse signals, or the site being visited too rarely;
- * `getSubscription()` then returns an object whose endpoint URL is
- * `https://permanently-removed.invalid/...`.  `.invalid` is an RFC 2606
- * reserved TLD that never resolves, so any push send would fail with a
- * generic upstream error (which Cloudflare Workers wraps as HTTP 530).
- *
- * Detect this and treat the subscription as dead — unsubscribe + re-create.
+ * 旧 API 名 — 调用方 (apps/Settings.tsx 等) 还在引用, 保留为薄包装.
+ * 实现在 pushSubscribeShared.ts 的 isDeadPushEndpoint.
  */
 export function isDeadSubscriptionEndpoint(endpoint: string | null | undefined): boolean {
-  if (!endpoint) return false;
-  return endpoint.includes('permanently-removed.invalid');
-}
-
-/**
- * Translate the browser's raw subscribe() rejection into a Chinese,
- * end-user-actionable hint.  The common cases on Android phones without
- * Google Play Services (or in third-party Chromium-based browsers that
- * advertise `PushManager` but route through FCM internally) are
- * `AbortError` / generic network errors when the FCM endpoint cannot be
- * reached.  We surface those distinctly so the user knows it's not a
- * permission issue.
- */
-function explainSubscribeError(e: any): string {
-  const name = e?.name || '';
-  const msg = e?.message || String(e || '未知错误');
-  if (name === 'NotAllowedError') {
-    return '浏览器拒绝创建订阅（NotAllowedError）——通常是站点权限被拦截或处于隐身模式';
-  }
-  if (name === 'NotSupportedError') {
-    return '当前浏览器不支持网页推送——常见于没装谷歌服务的国行安卓手机（小米/华为/OPPO/vivo 大多默认就没有），或者手机自带的精简浏览器。换 Chrome / Edge / Firefox 桌面版试试';
-  }
-  if (name === 'AbortError' || /push service|FCM|network/i.test(msg)) {
-    return '连不上推送服务器——这台设备的网页推送链路走不通。最常见两种情况：1) 国行安卓手机没装谷歌服务（小米/华为/OPPO/vivo 默认就没有），系统层面就推不了；2) 当前网络挡住了谷歌的推送服务器。建议：换台装了谷歌服务的设备，或者用电脑上的 Chrome / Edge / Firefox 试试';
-  }
-  if (name === 'InvalidStateError') {
-    return '订阅状态冲突（InvalidStateError）——可能旧订阅没清干净，再点一次"重置订阅"';
-  }
-  return `订阅创建失败（${name || 'Error'}：${msg}）`;
+  return isDeadPushEndpoint(endpoint);
 }
 
 interface SubscribeAttempt {
@@ -155,8 +112,10 @@ export async function getOrCreateSubscription(vapidPublicKey: string): Promise<S
   if (sub) {
     // Drop the existing sub if it's been zombified by the browser
     // (`permanently-removed.invalid` endpoint) — those can never deliver.
-    if (isDeadSubscriptionEndpoint(sub.endpoint)) {
+    if (isDeadPushEndpoint(sub.endpoint)) {
       try { await sub.unsubscribe(); } catch { /* ignore */ }
+      // 等浏览器清内部 removed 标记, 否则后面 subscribe() 又拿到死哨兵
+      await new Promise(r => setTimeout(r, SUBSCRIBE_SETTLE_MS));
       sub = null;
     }
   }
@@ -168,6 +127,7 @@ export async function getOrCreateSubscription(vapidPublicKey: string): Promise<S
       const existingKey = bytesToB64u(sub.options.applicationServerKey);
       if (existingKey && existingKey !== vapidPublicKey) {
         await sub.unsubscribe();
+        await new Promise(r => setTimeout(r, SUBSCRIBE_SETTLE_MS));
         sub = null;
       }
     } catch {
@@ -182,23 +142,9 @@ export async function getOrCreateSubscription(vapidPublicKey: string): Promise<S
     } else if (Notification.permission === 'denied') {
       return { sub: null, reason: '通知权限已被拒绝（请到浏览器站点设置里手动开启）' };
     }
-    try {
-      sub = await reg.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: b64uToBytes(vapidPublicKey),
-      });
-    } catch (e) {
-      console.warn('[ProactivePush] pushManager.subscribe failed', e);
-      return { sub: null, reason: explainSubscribeError(e) };
-    }
-  }
-
-  // Final paranoia: subscribe() in some Chrome versions can also return a
-  // dead sentinel.  Fail loudly rather than ship a useless endpoint to D1.
-  if (isDeadSubscriptionEndpoint(sub.endpoint)) {
-    console.warn('[ProactivePush] subscribe() returned a dead sentinel endpoint; giving up');
-    try { await sub.unsubscribe(); } catch { /* ignore */ }
-    return { sub: null, reason: '浏览器返回的订阅地址是 permanently-removed.invalid（zombie endpoint），无法投递' };
+    const fresh = await subscribeWithRetry(reg, vapidPublicKey, '[ProactivePush]');
+    if (!fresh.sub) return { sub: null, reason: fresh.reason };
+    sub = fresh.sub;
   }
 
   const p256dh = bytesToB64u(sub.getKey('p256dh'));
@@ -466,6 +412,10 @@ export async function resetSubscription(): Promise<{ ok: boolean; reason?: strin
 
   if (oldSub) {
     try { await oldSub.unsubscribe(); } catch { /* ignore */ }
+    // 等浏览器清内部 PushMessagingAppIdentifier removed 标记; 不等的话紧接
+    // 着的 subscribe() 大概率又拿到 zombie sentinel, 进入 subscribeWithRetry
+    // 的重试链路也会多走一轮.
+    await new Promise(r => setTimeout(r, SUBSCRIBE_SETTLE_MS));
   }
 
   // ensureSubscribed will re-create from clean slate (permission, fresh

--- a/utils/pushSubscribeShared.ts
+++ b/utils/pushSubscribeShared.ts
@@ -113,6 +113,6 @@ export async function subscribeWithRetry(
   }
   return {
     sub: null,
-    reason: `浏览器持续返回 permanently-removed.invalid（已尝试 ${SUBSCRIBE_ATTEMPTS_MAX} 次）— site engagement 过低或站点数据残留导致, 试试清掉本站点数据后重试, 或换设备 / 浏览器`,
+    reason: `浏览器持续返回 permanently-removed.invalid（已尝试 ${SUBSCRIBE_ATTEMPTS_MAX} 次）— 可能是由于站点参与度 (Site Engagement) 过低或浏览器内部数据残留导致。请尝试清理站点数据后重试，或更换设备/浏览器`,
   };
 }

--- a/utils/pushSubscribeShared.ts
+++ b/utils/pushSubscribeShared.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared Web Push subscribe helpers used by both Instant Push and Proactive
+ * Push paths. Both flows hit the same browser race / encoding quirks; this
+ * file is the single source of truth so a future browser-quirk patch lands
+ * in one place instead of two.
+ */
+
+// unsubscribe() resolve 后 Chromium 内部 PushMessagingAppIdentifier 把当前
+// 订阅标成 removed-sentinel; 这段时间里紧接着的 subscribe() 会直接吐
+// `permanently-removed.invalid` 哨兵, 而不是去 FCM 拿新端点. 等一会再试就好.
+// 桌面 Chrome ~ 300ms 够, 移动端 / iOS PWA 给 800ms 起步, 失败再线性退避.
+export const SUBSCRIBE_SETTLE_MS = 800;
+/** 总尝试次数 (含首次), 不是"重试次数". 当前: 1 次首试 + 2 次重试 = 3 次. */
+export const SUBSCRIBE_ATTEMPTS_MAX = 3;
+
+/** Convert base64url string to Uint8Array<ArrayBuffer> (for VAPID applicationServerKey). */
+export function b64uToBytes(b64u: string): Uint8Array<ArrayBuffer> {
+  const padded = b64u.replace(/-/g, '+').replace(/_/g, '/')
+    + '='.repeat((4 - (b64u.length % 4)) % 4);
+  const bin = atob(padded);
+  // 显式拿 ArrayBuffer 而不是默认 ArrayBufferLike, 否则 PushManager.subscribe 在
+  // 严格 TS lib (ArrayBufferView<ArrayBuffer>) 下会判 SharedArrayBuffer 不兼容.
+  const buf = new ArrayBuffer(bin.length);
+  const out = new Uint8Array(buf);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export function bytesToB64u(buf: ArrayBuffer | null | undefined): string {
+  if (!buf) return '';
+  const bytes = new Uint8Array(buf);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * True if a subscription's endpoint is a Chrome-internal "permanently
+ * removed" sentinel.  Browsers occasionally revoke subscriptions due to
+ * long inactivity, abuse signals, or the site being visited too rarely;
+ * `getSubscription()` then returns an object whose endpoint URL is
+ * `https://permanently-removed.invalid/...`.  `.invalid` is an RFC 2606
+ * reserved TLD that never resolves, so any push send would fail with a
+ * generic upstream error (which Cloudflare Workers wraps as HTTP 530).
+ */
+export function isDeadPushEndpoint(endpoint: string | null | undefined): boolean {
+  if (!endpoint) return false;
+  return endpoint.includes('permanently-removed.invalid');
+}
+
+/**
+ * Translate the browser's raw subscribe() rejection into a Chinese,
+ * end-user-actionable hint.  The common cases on Android phones without
+ * Google Play Services (or in third-party Chromium-based browsers that
+ * advertise `PushManager` but route through FCM internally) are
+ * `AbortError` / generic network errors when the FCM endpoint cannot be
+ * reached.  We surface those distinctly so the user knows it's not a
+ * permission issue.
+ */
+export function explainSubscribeError(e: unknown): string {
+  const err = e as { name?: string; message?: string } | null;
+  const name = err?.name || '';
+  const msg = err?.message || String(e || '未知错误');
+  if (name === 'NotAllowedError') {
+    return '浏览器拒绝创建订阅（NotAllowedError）——通常是站点权限被拦截或处于隐身模式';
+  }
+  if (name === 'NotSupportedError') {
+    return '当前浏览器不支持网页推送——常见于没装谷歌服务的国行安卓手机（小米/华为/OPPO/vivo 大多默认就没有），或者手机自带的精简浏览器。换 Chrome / Edge / Firefox 桌面版试试';
+  }
+  if (name === 'AbortError' || /push service|FCM|network/i.test(msg)) {
+    return '连不上推送服务器——这台设备的网页推送链路走不通。最常见两种情况：1) 国行安卓手机没装谷歌服务（小米/华为/OPPO/vivo 默认就没有），系统层面就推不了；2) 当前网络挡住了谷歌的推送服务器。建议：换台装了谷歌服务的设备，或者用电脑上的 Chrome / Edge / Firefox 试试';
+  }
+  if (name === 'InvalidStateError') {
+    return '订阅状态冲突（InvalidStateError）——可能旧订阅没清干净，刷新页面或再点一次"重置订阅"';
+  }
+  return `订阅创建失败（${name || 'Error'}：${msg}）`;
+}
+
+/**
+ * Subscribe with retry on zombie sentinel.  Wait between attempts is linear:
+ * 800ms before attempt #2, 1600ms before attempt #3.  No wait before the
+ * first attempt — caller is responsible for any required settle delay after
+ * its own unsubscribe().
+ */
+export async function subscribeWithRetry(
+  reg: ServiceWorkerRegistration,
+  vapidPublicKey: string,
+  logPrefix: string,
+): Promise<{ sub: PushSubscription | null; reason?: string }> {
+  for (let attempt = 0; attempt < SUBSCRIBE_ATTEMPTS_MAX; attempt++) {
+    let sub: PushSubscription;
+    try {
+      sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: b64uToBytes(vapidPublicKey),
+      });
+    } catch (e) {
+      console.warn(`${logPrefix} pushManager.subscribe failed`, e);
+      return { sub: null, reason: explainSubscribeError(e) };
+    }
+    if (!isDeadPushEndpoint(sub.endpoint)) return { sub };
+    try { await sub.unsubscribe(); } catch (e) {
+      // 如果连 unsubscribe 都抛, 下一次 subscribe() 大概率还是同一个 zombie,
+      // 但仍然兜底重试 (重试上限挡着不会死循环).
+      console.warn(`${logPrefix} unsubscribe of zombie endpoint threw`, e);
+    }
+    const isLast = attempt === SUBSCRIBE_ATTEMPTS_MAX - 1;
+    if (!isLast) {
+      const wait = SUBSCRIBE_SETTLE_MS * (attempt + 1);
+      console.warn(`${logPrefix} subscribe() returned zombie endpoint; retry #${attempt + 1} after ${wait}ms`);
+      await new Promise(r => setTimeout(r, wait));
+    }
+  }
+  return {
+    sub: null,
+    reason: `浏览器持续返回 permanently-removed.invalid（已尝试 ${SUBSCRIBE_ATTEMPTS_MAX} 次）— site engagement 过低或站点数据残留导致, 试试清掉本站点数据后重试, 或换设备 / 浏览器`,
+  };
+}


### PR DESCRIPTION
## Summary

- **修订阅重置 race**: `unsubscribe()` resolve 后 Chromium 内部 `PushMessagingAppIdentifier` 仍把订阅标为 removed-sentinel 一会儿，紧接着的 `subscribe()` 会直接吐 `permanently-removed.invalid` 哨兵而不是去 FCM 拿新端点。`resetSubscription` 在 `oldSub.unsubscribe()` 后加 800ms settle 延迟，`getOrCreateSubscription` 在每处 unsubscribe 后也加同样延迟。
- **拿到死哨兵自动重试**: `subscribe()` 返回 zombie endpoint 不再立刻失败，现在会 unsubscribe + 线性退避（800ms → 1600ms）重试，总尝试 3 次。绝大多数 race 在第 2 次就拿到真端点。
- **真根因兜底文案**: 3 次都失败时 reason 改为指向 site engagement 过低 / 站点数据残留，明确告诉用户下一步是清站点数据或换设备，而不是反复点按钮。
- **抽 `utils/pushSubscribeShared.ts`**: 收 b64u 编解码 / dead-endpoint 检测 / 重试逻辑，instant 与 proactive 共用一份，删 91 行重复代码。`isDeadSubscriptionEndpoint` 保留为薄包装避免破坏 `apps/Settings.tsx` 调用方。
- **TS lib 严格化**: `b64uToBytes` 显式返回 `Uint8Array<ArrayBuffer>`，解开 `PushManager.subscribe` 重载在新 TS lib 下选不中的报错（`ArrayBufferLike` 含 `SharedArrayBuffer` 不兼容）。
- try to fix #73 

## Test plan

- [ ] Settings → 主动消息 Push 加速 → 诊断面板显示 zombie endpoint → 点"重置订阅" → 5s 内端点变成 `fcm.googleapis.com/...`
- [ ] 在聊天页触发 Instant Push 时，若旧 sub 是 zombie，自动清理 + 重订一次成功（不再立刻 `subscription-failed`）
- [ ] Mobile Chrome / Edge / iOS PWA 上点重置按钮，行为符合预期
- [ ] Engagement 过低或 permanently revoked 的设备（`edge://site-engagement` 分数为 0），3 次重试后 reason 显示 "site engagement 过低或站点数据残留..."，用户能据此清站点数据
- [ ] VAPID key 切换场景：旧 sub 也会被 unsubscribe + settle，重新拿正确 key 的新订阅
- [ ] \`npx tsc --noEmit\` 通过
- [ ] 通知权限 denied / Capacitor 原生 App / iOS 非 PWA 等既有早退路径不受影响