### PR TITLE
fix(notion): 日记写入加长度保护, 避免 Claude 长输出被 Notion 拒

### DIFF
--- a/utils/realtimeContext.ts
+++ b/utils/realtimeContext.ts
@@ -1293,7 +1293,56 @@ function parseMarkdownToNotionBlocks(content: string, mood?: string, characterNa
         });
     }
 
-    return blocks;
+    return normalizeBlocksForNotion(blocks);
+}
+
+// Notion API 硬限制：单个 rich_text content ≤ 2000 字符；单次 POST children ≤ 100。
+// 留点 buffer 防 emoji / 双字节边界拼接。
+const NOTION_MAX_RICH_TEXT_LEN = 1900;
+const NOTION_MAX_CHILDREN = 100;
+
+function splitRichTextItem(item: any): any[] {
+    const content = item?.text?.content;
+    if (typeof content !== 'string' || content.length <= NOTION_MAX_RICH_TEXT_LEN) return [item];
+    const chunks: any[] = [];
+    for (let i = 0; i < content.length; i += NOTION_MAX_RICH_TEXT_LEN) {
+        chunks.push({
+            ...item,
+            text: { ...item.text, content: content.slice(i, i + NOTION_MAX_RICH_TEXT_LEN) }
+        });
+    }
+    return chunks;
+}
+
+function normalizeBlocksForNotion(blocks: any[]): any[] {
+    // 1. 每个 block 的 rich_text 切 2000 字符
+    const safe = blocks.map(block => {
+        const payload = block[block.type];
+        if (payload && Array.isArray(payload.rich_text)) {
+            const split: any[] = [];
+            for (const item of payload.rich_text) split.push(...splitRichTextItem(item));
+            return { ...block, [block.type]: { ...payload, rich_text: split } };
+        }
+        return block;
+    });
+
+    // 2. 总 block 数限制 100；超出截断并附提示
+    if (safe.length <= NOTION_MAX_CHILDREN) return safe;
+    const truncated = safe.slice(0, NOTION_MAX_CHILDREN - 1);
+    truncated.push({
+        object: 'block',
+        type: 'callout',
+        callout: {
+            rich_text: [{
+                type: 'text',
+                text: { content: `（日记内容过长，已截断 ${safe.length - (NOTION_MAX_CHILDREN - 1)} 个段落）` },
+                annotations: { italic: true, color: 'gray' }
+            }],
+            icon: { emoji: '✂️' },
+            color: 'gray_background'
+        }
+    });
+    return truncated;
 }
 
 // ============================================


### PR DESCRIPTION
Notion API 硬限制单个 rich_text content ≤ 2000 字符, 单次 POST children ≤ 100。 Claude 经常一写就是几千字的长段落, 直接被 Notion 400 validation_error 拒掉, 表现为"日记写入失败"; Gemini 输出短一些恰好绕过。

在 parseMarkdownToNotionBlocks 输出前统一过一遍 normalizeBlocksForNotion:
- 任何 rich_text item content > 1900 自动切分多个 item, 保留 annotations
- blocks 总数 > 100 时截断到 99 + 一个 "已截断" callout 提示