### PR TITLE
fix(mcd): 适配 MCP v1.0.4 外送链路 — 地址不再带 storeCode/beCode

### DIFF
--- a/components/mcd/McdMiniApp.tsx
+++ b/components/mcd/McdMiniApp.tsx
@@ -45,6 +45,8 @@ interface CartLine {
 
 interface OrderContext {
     orderType: 1 | 2;
+    /** 业务类型: 1 到店自取 / 2 麦乐送。query-meals / calculate-price / create-order 现在都必填 (MCP v1.0.4) */
+    beType?: 1 | 2;
     storeCode: string;
     storeName?: string;
     beCode?: string;
@@ -126,7 +128,7 @@ const ModeStep: React.FC<{ onPick: (t: 1 | 2) => void }> = ({ onPick }) => (
 
 // ========== Step 2: 选地址 / 门店 ==========
 
-interface AddressItem { addressId: string; storeCode: string; beCode: string; fullAddress?: string; storeName?: string; phone?: string; contactName?: string; }
+interface AddressItem { addressId: string; storeCode?: string; beCode?: string; fullAddress?: string; storeName?: string; phone?: string; contactName?: string; }
 interface StoreItem { storeCode: string; beCode?: string; storeName: string; address?: string; distance?: any; }
 
 const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => void; onBack: () => void }> = ({ orderType, onPick, onBack }) => {
@@ -134,6 +136,12 @@ const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => v
     const [err, setErr] = useState<string | null>(null);
     const [addresses, setAddresses] = useState<AddressItem[]>([]);
     const [stores, setStores] = useState<StoreItem[]>([]);
+    // 外送二级页: MCP v1.0.4 起 delivery-query-addresses 不再返回 storeCode/beCode,
+    // 选完地址后必须再调 delivery-query-stores 拿可配送门店的 storeCode + beCode。
+    const [pickedAddr, setPickedAddr] = useState<AddressItem | null>(null);
+    const [deliveryStores, setDeliveryStores] = useState<StoreItem[]>([]);
+    const [dsLoading, setDsLoading] = useState(false);
+    const [dsErr, setDsErr] = useState<string | null>(null);
 
     const reload = async () => {
         setLoading(true); setErr(null);
@@ -158,10 +166,76 @@ const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => v
         }
     };
 
+    const finishDelivery = (addr: AddressItem, s: StoreItem) => {
+        onPick({
+            orderType: 2,
+            beType: 2,
+            storeCode: s.storeCode,
+            beCode: s.beCode,
+            addressId: addr.addressId,
+            addressLabel: addr.fullAddress,
+            storeName: s.storeName,
+        });
+    };
+
+    // 外送: 选了一个地址 → 用 delivery-query-stores 拉这个地址可配送的门店
+    const loadDeliveryStores = async (addr: AddressItem) => {
+        setPickedAddr(addr);
+        setDsLoading(true); setDsErr(null); setDeliveryStores([]);
+        try {
+            const r = await callMcdTool('delivery-query-stores', { addressId: addr.addressId, beType: 2 });
+            if (!r.success) throw new Error(r.error || '拉取可配送门店失败');
+            const list = (Array.isArray(r.data) ? r.data : (r.data?.stores || r.data?.list || [])) as StoreItem[];
+            const arr = (list || []).filter((s: StoreItem) => s?.storeCode);
+            setDeliveryStores(arr);
+            // 只有一家可配送门店时直接进菜单, 省一次点击
+            if (arr.length === 1) finishDelivery(addr, arr[0]);
+        } catch (e: any) {
+            setDsErr(e?.message || String(e));
+        } finally {
+            setDsLoading(false);
+        }
+    };
+
     useEffect(() => { reload(); /* eslint-disable-next-line */ }, [orderType]);
 
     if (loading) return <Spinner label={orderType === 2 ? '正在拉取你的收货地址...' : '正在拉取收藏门店...'} />;
     if (err) return <ErrorBox msg={err} onRetry={reload} />;
+
+    // 外送二级页: 已选地址 → 展示该地址可配送门店列表
+    if (orderType === 2 && pickedAddr) {
+        return (
+            <div className="px-3 py-3 space-y-2">
+                <div className="flex items-center justify-between mb-1">
+                    <button onClick={() => { setPickedAddr(null); setDeliveryStores([]); setDsErr(null); }} className="text-[12px] text-yellow-700 active:scale-95">‹ 换地址</button>
+                    <div className="text-[13px] font-bold text-yellow-900">选配送门店</div>
+                    <div className="w-12" />
+                </div>
+                <div className="text-[11px] text-slate-500 px-1 line-clamp-2">📍 {pickedAddr.fullAddress}</div>
+                {dsLoading ? <Spinner label="正在查可配送门店..." />
+                : dsErr ? <ErrorBox msg={dsErr} onRetry={() => loadDeliveryStores(pickedAddr)} />
+                : deliveryStores.length === 0 ? (
+                    <div className="text-center py-8 text-[12px] text-slate-500 leading-relaxed">
+                        这个地址附近暂时没有可配送的门店。<br />换个地址试试。
+                    </div>
+                ) : deliveryStores.map((s: StoreItem) => (
+                    <button
+                        key={s.storeCode}
+                        onClick={() => finishDelivery(pickedAddr, s)}
+                        className="w-full p-3 rounded-xl bg-white border border-yellow-200 active:scale-[0.99] active:bg-yellow-50 transition text-left"
+                    >
+                        <div className="flex items-start gap-2">
+                            <span className="text-xl shrink-0 mt-0.5">🏪</span>
+                            <div className="flex-1 min-w-0">
+                                <div className="font-bold text-[13px] text-slate-800 truncate">{s.storeName}</div>
+                                {s.address && <div className="text-[11px] text-slate-600 line-clamp-2 leading-snug mt-0.5">{s.address}</div>}
+                            </div>
+                        </div>
+                    </button>
+                ))}
+            </div>
+        );
+    }
 
     return (
         <div className="px-3 py-3 space-y-2">
@@ -178,14 +252,7 @@ const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => v
                 ) : addresses.map((a: AddressItem) => (
                     <button
                         key={a.addressId}
-                        onClick={() => onPick({
-                            orderType: 2,
-                            storeCode: a.storeCode,
-                            beCode: a.beCode,
-                            addressId: a.addressId,
-                            addressLabel: a.fullAddress,
-                            storeName: a.storeName,
-                        })}
+                        onClick={() => loadDeliveryStores(a)}
                         className="w-full p-3 rounded-xl bg-white border border-yellow-200 active:scale-[0.99] active:bg-yellow-50 transition text-left"
                     >
                         <div className="flex items-start gap-2">
@@ -196,8 +263,8 @@ const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => v
                                     {a.phone && <span className="text-[10px] text-slate-500 font-normal ml-1.5">{a.phone}</span>}
                                 </div>
                                 <div className="text-[11px] text-slate-600 line-clamp-2 leading-snug mt-0.5">{a.fullAddress}</div>
-                                {a.storeName && <div className="text-[10px] text-yellow-700 mt-0.5">配送门店: {a.storeName}</div>}
                             </div>
+                            <span className="text-yellow-700 text-sm shrink-0 mt-1">›</span>
                         </div>
                     </button>
                 ))
@@ -211,6 +278,7 @@ const AddressStep: React.FC<{ orderType: 1 | 2; onPick: (ctx: OrderContext) => v
                         key={s.storeCode}
                         onClick={() => onPick({
                             orderType: 1,
+                            beType: 1,
                             storeCode: s.storeCode,
                             storeName: s.storeName,
                         })}
@@ -263,6 +331,7 @@ const MenuStep: React.FC<{
         setLoading(true); setErr(null);
         try {
             const args: any = { storeCode: ctx.storeCode, orderType: ctx.orderType };
+            if (ctx.beType) args.beType = ctx.beType;
             if (ctx.orderType === 2 && ctx.beCode) args.beCode = ctx.beCode;
             const r = await callMcdTool('query-meals', args);
             if (!r.success) throw new Error(r.error || '拉取菜单失败');
@@ -276,7 +345,7 @@ const MenuStep: React.FC<{
         }
     };
 
-    useEffect(() => { reload(); /* eslint-disable-next-line */ }, [ctx.storeCode, ctx.orderType, ctx.beCode]);
+    useEffect(() => { reload(); /* eslint-disable-next-line */ }, [ctx.storeCode, ctx.orderType, ctx.beCode, ctx.beType]);
 
     const cats = data?.categories || [];
     const mealMap = data?.meals || {};
@@ -399,10 +468,11 @@ const CouponPicker: React.FC<{
     storeCode: string;
     beCode?: string;
     orderType: 1 | 2;
+    beType?: 1 | 2;
     selected: Set<string>;
     onToggle: (c: CouponEntry) => void;
     onClose: () => void;
-}> = ({ storeCode, beCode, orderType, selected, onToggle, onClose }) => {
+}> = ({ storeCode, beCode, orderType, beType, selected, onToggle, onClose }) => {
     const [loading, setLoading] = useState(true);
     const [err, setErr] = useState<string | null>(null);
     const [coupons, setCoupons] = useState<CouponEntry[]>([]);
@@ -413,6 +483,7 @@ const CouponPicker: React.FC<{
         setLoading(true); setErr(null);
         try {
             const args: any = { storeCode, orderType };
+            if (beType) args.beType = beType;
             if (orderType === 2 && beCode) args.beCode = beCode;
             const r = await callMcdTool('query-store-coupons', args);
             if (!r.success) throw new Error(r.error || '拉取优惠券失败');
@@ -449,7 +520,7 @@ const CouponPicker: React.FC<{
         }
     };
 
-    useEffect(() => { reload(); /* eslint-disable-next-line */ }, [storeCode, beCode, orderType]);
+    useEffect(() => { reload(); /* eslint-disable-next-line */ }, [storeCode, beCode, orderType, beType]);
 
     return (
         <div className="fixed inset-0 z-[60] bg-black/40 flex items-end justify-center" onClick={onClose}>
@@ -572,6 +643,7 @@ const ReviewStep: React.FC<{
             orderType: ctx.orderType,
             items: buildItemsForCalc(),
         };
+        if (ctx.beType) args.beType = ctx.beType;
         if (ctx.orderType === 2 && ctx.beCode) args.beCode = ctx.beCode;
         callMcdTool('calculate-price', args).then((r: any) => {
             if (cancelled) return;
@@ -585,7 +657,7 @@ const ReviewStep: React.FC<{
         });
         return () => { cancelled = true; };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [cartHash, couponsHash, ctx.storeCode, ctx.orderType, ctx.beCode]);
+    }, [cartHash, couponsHash, ctx.storeCode, ctx.orderType, ctx.beCode, ctx.beType]);
 
     const handleOrder = async () => {
         if (!lines.length) return;
@@ -595,6 +667,7 @@ const ReviewStep: React.FC<{
             orderType: ctx.orderType,
             items: buildItemsForCalc(),
         };
+        if (ctx.beType) args.beType = ctx.beType;
         if (ctx.orderType === 2) {
             if (ctx.beCode) args.beCode = ctx.beCode;
             if (ctx.addressId) args.addressId = ctx.addressId;
@@ -727,6 +800,7 @@ const ReviewStep: React.FC<{
                     storeCode={ctx.storeCode}
                     beCode={ctx.beCode}
                     orderType={ctx.orderType}
+                    beType={ctx.beType}
                     selected={new Set(selectedCoupons.keys())}
                     onToggle={(c: CouponEntry) => {
                         setSelectedCoupons((prev: Map<string, CouponEntry>) => {


### PR DESCRIPTION
麦当劳 MCP 5.21 更新后, delivery-query-addresses 不再返回 storeCode/beCode, 需新增 delivery-query-stores (addressId + beType) 步骤拿可配送门店, 否则 query-meals 只带 {orderType:2} 调用, 上游返回空菜单。同时按新文档给
query-meals / query-store-coupons / calculate-price / create-order 补传必填 beType。

https://claude.ai/code/session_01SRoXi8nx9jjexgfLNRcTcK