### PR TITLE
fix(instant-push): 修工具调用后气泡乱序 + 小红书分享卡片丢失

### DIFF
--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -141,6 +141,23 @@ const processInboxMessageWithPostProcessing = async (message: ActiveMsg2InboxMes
     }
   }
 
+  // 恢复本 session round 1 工具抓到的 XHS 笔记: instantToolRunner 落了库, 这里读回内存单例.
+  // 跨 SW 唤醒 / 页面回收后内存 ref 被清空, 不恢复的话 round 2 的 [[XHS_SHARE]] / 评论 / 点赞
+  // 会因 lastXhsNotesRef 为空而静默掉卡片. 持久化优先于内存 (同 session 时两者等价, 重载后只剩持久化).
+  if (sessionId) {
+    try {
+      const persisted = await ActiveMsgStore.getXhsSessionNotes(sessionId);
+      if (persisted?.notes?.length) {
+        pushLastXhsNotesRef.current = persisted.notes as XhsNote[];
+        for (const [noteId, token] of (persisted.xsecTokens || [])) {
+          pushXhsCaches.xsecTokenCache.set(noteId, token);
+        }
+      }
+    } catch (e) {
+      console.warn('[ActiveMsg] restore xhs session notes failed', sessionId, e);
+    }
+  }
+
   await applyAssistantPostProcessing(message.body || '', {
     char,
     userProfile,
@@ -301,7 +318,7 @@ async function runPushTailPipeline(
   } catch { /* SSR-safe / not browser, ignore */ }
 }
 
-const flushInboxToChat = async () => {
+const flushInboxToChatImpl = async () => {
   const pendingMessages = await ActiveMsgStore.consumeInboxMessages();
   // consumeInboxMessages 是 "先 ack 后处理" 语义 —— inbox 已经原子地清空。
   // 这里 per-message try/catch: 单条处理抛错 (quota / DB 故障 / postprocess 异常) 不连累
@@ -420,6 +437,26 @@ const flushInboxToChat = async () => {
   }
 };
 
+// 串行化所有 flush. 两个原因:
+//   1. 防并发 flush 交错 saveMessage —— 显示顺序 = IndexedDB 自增 id = saveMessage 调用先后
+//      (见 db.ts getRecentMessagesByCharId 按 charId 索引游标取, 即 id 顺序), 并发就会乱序.
+//   2. 返回的 promise 在"本次及之前排队的 flush"全部完成后才 resolve, 这样调用方能
+//      await flushInboxToChat() 保证 round-1 旁白已落库, 再去跑 tool runner (它会触发 round-2),
+//      从根上消除跨轮 B 抢在 A 前面入库 (用户看到的 "B+A").
+// 每段都吞掉自身异常, 保证链不被一个失败的 flush 卡死.
+let flushChain: Promise<void> = Promise.resolve();
+const flushInboxToChat = (): Promise<void> => {
+  const next = flushChain.then(async () => {
+    try {
+      await flushInboxToChatImpl();
+    } catch (e) {
+      console.warn('[ActiveMsg] flushInboxToChat failed', e);
+    }
+  });
+  flushChain = next;
+  return next;
+};
+
 // Phase 2 Round 2: 真实 tool runner. 启动时排空 + SW postMessage 触发. 失败诊断在 instantToolRunner 内.
 const runPendingToolCallsSafely = async () => {
   try {
@@ -470,23 +507,26 @@ export const ActiveMsgRuntime = {
           return;
         }
 
-        // Phase 2 Round 2: SW 收到 tool_request push 且当前 window visible → 立即跑 runner.
+        // Phase 2 Round 2: SW 收到 tool_request push 且当前 window visible → 跑 runner.
         // 不 visible 时 SW 发的是 showNotification, 用户点击后落到 active-msg-open 分支,
         // ActiveMsgRuntime.init 时这里的启动消费会兜底 (runPendingToolCallsSafely).
+        // 先 flush 再跑 runner: 同一轮的旁白 (round-1 prefix) 是单独的 content push, 必须保证
+        // 它先入库, 再让 runner 触发 round-2, 否则 round-2 回复可能抢在旁白前面 ("B+A").
         if (type === 'instant-tool-request') {
-          void runPendingToolCallsSafely();
+          void flushInboxToChat().then(() => runPendingToolCallsSafely());
           return;
         }
 
         if (type === 'active-msg-open') {
-          void flushInboxToChat().then(() => {
+          // 严格串行: 先把 inbox 里的 round-1 旁白落库, 再跑 tool runner (它会触发 round-2),
+          // 保证用户回到界面时先看到旁白, 且 round-2 回复排在旁白之后.
+          void (async () => {
+            await flushInboxToChat();
             window.dispatchEvent(new CustomEvent('active-msg-open', {
               detail: { charId: event.data?.charId },
             }));
-          });
-          // notification → open 路径里大概率刚好有一条 pending_tool_call 等着 (visibility=false
-          // 时 SW 走的通知支线), 顺手消费一次.
-          void runPendingToolCallsSafely();
+            await runPendingToolCallsSafely();
+          })();
         }
       });
     }
@@ -499,16 +539,21 @@ export const ActiveMsgRuntime = {
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', () => {
         if (document.visibilityState !== 'visible') return;
-        void flushInboxToChat();
-        void drainPendingDiaries(loadRealtimeConfigFromLocalStorage(), (charId) => {
-          window.dispatchEvent(new CustomEvent('active-msg-progress', { detail: { charId } }));
-        });
-        void runPendingToolCallsSafely();
+        // 先 await flush 落库 round-1 旁白, 再跑 runner 触发 round-2, 避免 "B+A".
+        void (async () => {
+          await flushInboxToChat();
+          void drainPendingDiaries(loadRealtimeConfigFromLocalStorage(), (charId) => {
+            window.dispatchEvent(new CustomEvent('active-msg-progress', { detail: { charId } }));
+          });
+          void runPendingToolCallsSafely();
+        })();
       });
     }
 
-    await runPendingToolCallsSafely();
+    // 启动兜底: 先 flush 落库 (含上次被杀进程时卡在 inbox 的 round-1 旁白), 再跑 runner
+    // 触发 round-2, 保证冷启动恢复时旁白也排在 round-2 回复之前.
     await flushInboxToChat();
+    await runPendingToolCallsSafely();
     void drainPendingDiaries(loadRealtimeConfigFromLocalStorage(), (charId) => {
       window.dispatchEvent(new CustomEvent('active-msg-progress', { detail: { charId } }));
     });

--- a/utils/activeMsgStore.ts
+++ b/utils/activeMsgStore.ts
@@ -84,6 +84,44 @@ const setKv = async <T>(id: string, value: T): Promise<void> => {
   });
 };
 
+// XHS 跨轮笔记缓冲: round 1 工具跑完写, round 2 [[XHS_SHARE]]/评论/点赞 重放时读.
+// 存在 KV 是因为内存单例 (pushLastXhsNotesRef) 跨 SW 唤醒 / 页面回收会清空 —— 移动端
+// instant 流程的 round 1 与 round 2 之间常隔一次后台重载, 笔记一丢 XHS_SHARE 就静默掉卡片.
+const XHS_SESSION_NOTES_PREFIX = 'xhs_session_notes:';
+const XHS_SESSION_NOTES_TTL_MS = 3 * 60 * 60 * 1000;
+
+export type XhsSessionNotes = {
+  notes: unknown[];
+  xsecTokens: Array<[string, string]>;
+  savedAt: number;
+};
+
+// 写入时顺手清理过期条目, 防 KV 无界增长 (outbound_sessions 本身也没清理, 这里不重蹈覆辙).
+const pruneStaleXhsSessionNotes = async (): Promise<void> => {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve) => {
+      const tx = db.transaction(STORE_KV, 'readwrite');
+      const store = tx.objectStore(STORE_KV);
+      const cutoff = Date.now() - XHS_SESSION_NOTES_TTL_MS;
+      const req = store.openCursor();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (!cursor) return;
+        const rec = cursor.value as KvRecord<{ savedAt?: number }> | undefined;
+        if (rec && typeof rec.id === 'string' && rec.id.startsWith(XHS_SESSION_NOTES_PREFIX)) {
+          const savedAt = Number(rec.value?.savedAt ?? 0);
+          if (savedAt < cutoff) cursor.delete();
+        }
+        cursor.continue();
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+      tx.onabort = () => resolve();
+    });
+  } catch { /* prune 尽力而为, 失败不影响主流程 */ }
+};
+
 const generateUuidV4 = () => {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -221,6 +259,25 @@ export const ActiveMsgStore = {
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
+  },
+
+  // ─── XHS 跨轮笔记缓冲 (持久化) ─────────────────────────────────────────────
+  async saveXhsSessionNotes(
+    sessionId: string,
+    payload: { notes: unknown[]; xsecTokens: Array<[string, string]> },
+  ): Promise<void> {
+    if (!sessionId) return;
+    await setKv<XhsSessionNotes>(`${XHS_SESSION_NOTES_PREFIX}${sessionId}`, {
+      notes: payload.notes,
+      xsecTokens: payload.xsecTokens,
+      savedAt: Date.now(),
+    });
+    await pruneStaleXhsSessionNotes();
+  },
+
+  async getXhsSessionNotes(sessionId: string): Promise<XhsSessionNotes | null> {
+    if (!sessionId) return null;
+    return getKv<XhsSessionNotes>(`${XHS_SESSION_NOTES_PREFIX}${sessionId}`);
   },
 
   // ─── Phase 2 Round 2 wire: pending_tool_calls ─────────────────────────────

--- a/utils/applyAssistantPostProcessing.ts
+++ b/utils/applyAssistantPostProcessing.ts
@@ -1019,6 +1019,10 @@ export async function applyAssistantPostProcessing(
                 metadata: { xhsNote: note }
             });
             setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+        } else {
+            // 笔记缓冲为空 / 越界 → 卡片发不出来. instant 路径靠 saveXhsSessionNotes 持久化恢复,
+            // 走到这里说明恢复也没命中 (TTL 过期 / 跨 session), 留日志便于排查, 不再静默吞掉.
+            console.warn('📕 [XHS] XHS_SHARE 序号越界, 跳过卡片', { idx: idx + 1, available: lastXhsNotesRef.current.length });
         }
     }
     aiContent = aiContent.replace(/\[\[XHS_SHARE:\s*\d+\]\]/g, '').trim();

--- a/utils/instantToolRunner.ts
+++ b/utils/instantToolRunner.ts
@@ -125,6 +125,20 @@ async function runOnePendingToolCall(item: InstantPushPendingToolCall): Promise<
     });
   }
 
+  // 把这一轮 XHS 工具抓到的笔记 + xsecToken 落库 (按 sessionId). round 2 worker 发回
+  // [[XHS_SHARE: 序号]] / 评论 / 点赞 时, applyAssistantPostProcessing 要靠这份笔记取卡片;
+  // 内存单例 pushLastXhsNotesRef 跨 SW 唤醒 / 页面回收会清空, 不持久化就会静默掉卡片.
+  if (pushLastXhsNotesRef.current.length > 0) {
+    try {
+      await ActiveMsgStore.saveXhsSessionNotes(item.sessionId, {
+        notes: pushLastXhsNotesRef.current,
+        xsecTokens: Array.from(pushXhsCaches.xsecTokenCache.entries()),
+      });
+    } catch (e) {
+      console.warn('[instant-tool-runner] persist xhs notes failed', item.sessionId, e);
+    }
+  }
+
   // 2. 拼下一轮 LLM 看到的 messages: outbound history + assistant tool_call message + tool results.
   //    这是 OpenAI tool-call 协议的标准形状; worker 拿到后会直接转发给 LLM.
   const assistantMsg = {


### PR DESCRIPTION
两个 instant 模式下的 bug:

1. 消息错位 (B+A): 聊天显示按 IndexedDB 自增 id (插入顺序), 而 push 消息没有持久化的全局序号, consumeInboxMessages 的 messageIndex 排序 又只在单次 drain 内、且每轮重新从 1 编号。跨轮 (round-1 旁白 vs round-2 回复) 的入库顺序由并发 flush + FCM 不保序决定, 导致 round-2 抢在旁白前面。改法: 串行化所有 flushInboxToChat, 并在 active-msg-open / visibilitychange / instant-tool-request / 启动兜底 四条路径上, 先 await flush 落库旁白, 再跑 tool runner (它才触发 round-2)。

2. 小红书分享卡片消失: [[XHS_SHARE]] / 评论 / 点赞 依赖内存单例 pushLastXhsNotesRef 里 round-1 抓到的笔记, 但它跨 SW 唤醒 / 页面回收会 清空, 越界时还静默丢卡片。改法: round-1 工具跑完把笔记 + xsecToken 按 sessionId 持久化到 IndexedDB KV (带 3h TTL 清理), round-2 处理前恢复回 内存单例; 越界时改为打 warn 不再静默。

https://claude.ai/code/session_01GGorpBhRdFUQx1dL6Zk8Xy