### PR TITLE
fix(instant-push): 情绪buff 全局同步 + 思维链(心象)竞态回填

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -649,32 +649,10 @@ const Chat: React.FC = () => {
 
     // （旧的"首次自动归档 banner"已移除，自动归档改为用户在神经链接里显式 opt-in）
 
-    // Reload char data when background emotion evaluation updates buffs
-    useEffect(() => {
-        const handler = (e: Event) => {
-            const detail = (e as CustomEvent).detail;
-            if (detail?.charId !== activeCharacterId) return;
-            // 优先用事件直接携带的 buffs/buffInjection 落 OSContext —— 不重读 DB, 避开
-            // saveCharacter 未等事务提交、以及 instant flush 下 DB 重读偶发拿旧值的竞态.
-            if (Array.isArray(detail.buffs)) {
-                updateCharacter(activeCharacterId, {
-                    activeBuffs: detail.buffs,
-                    buffInjection: typeof detail.buffInjection === 'string' ? detail.buffInjection : ''
-                });
-                return;
-            }
-            // 无 buffs 的纯 UI 刷新信号 (activeMsgRuntime line-300 等): 从 DB 兜底重读.
-            DB.getAllCharacters().then(all => {
-                const updated = all.find(c => c.id === activeCharacterId);
-                if (updated) updateCharacter(updated.id, {
-                    activeBuffs: updated.activeBuffs,
-                    buffInjection: updated.buffInjection
-                });
-            }).catch(() => {});
-        };
-        window.addEventListener('emotion-updated', handler);
-        return () => window.removeEventListener('emotion-updated', handler);
-    }, [activeCharacterId, updateCharacter]);
+    // buff 同步已上移到 OSContext 的 App 级 'emotion-updated' 监听 (无条件按事件 charId 更新内存,
+    // 不再受"当前是否开着该角色聊天页"限制). 之前这里有个 `charId === activeCharacterId` 守卫的
+    // handler, 导致 instant 模式下用户不在该角色页时 buff 回不到前端 (只落 DB), 故移除, 同时
+    // 避免和 OSContext 双写.
 
     // 🛟 人格抢救：进聊天后发现角色被卡在"情感型 0.3"显示（真实存储可能是 emotional/0.3，
     // 也可能是 undefined —— UI 的 `|| 'emotional'` 和 `?? 0.3` fallback 让两者看起来一样）。

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1191,14 +1191,45 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           setLastMsgTimestamp(Date.now());
       };
 
+      // 情绪 buff 落地后同步进内存 characters —— 必须是 App 级、不限当前打开的角色:
+      // instant 模式下 worker 推回 emotion_update 时用户常不在该角色聊天页 (在别的角色 /
+      // 列表 / 后台 / 还没点进去). 之前只有 Chat.tsx 里那个 `charId === activeCharacterId`
+      // 守卫的 handler 同步内存, 不匹配就直接 return —— buff 只落了 DB, 内存没更新; 而
+      // OSContext 只在启动时 getAllCharacters, 切回该角色也不重读 DB, 于是 buff "回不到前端".
+      // 更糟: 之后任一 updateCharacter 会拿旧内存合并写回 DB, 把后台刚生成的 buff 抹掉.
+      // 这里无条件按事件 charId 更新内存 (DB 已由 applyEmotionEvalRaw 写好), 顺带堵住反向覆盖.
+      const buffSyncHandler = (e: Event) => {
+          const detail = (e as CustomEvent).detail as { charId?: string; buffs?: unknown; buffInjection?: unknown };
+          const charId = detail?.charId;
+          if (!charId) return;
+          if (Array.isArray(detail.buffs)) {
+              const nextBuffs = detail.buffs as CharacterProfile['activeBuffs'];
+              const nextInjection = typeof detail.buffInjection === 'string' ? detail.buffInjection : '';
+              setCharacters(prev => prev.map(c => c.id === charId
+                  ? normalizeCharacterImpression({ ...c, activeBuffs: nextBuffs, buffInjection: nextInjection })
+                  : c));
+              return;
+          }
+          // 无 buffs 的纯刷新信号 (runPushTailPipeline 等): 从 DB 兜底重读该角色 buff.
+          DB.getAllCharacters().then(all => {
+              const updated = all.find(c => c.id === charId);
+              if (!updated) return;
+              setCharacters(prev => prev.map(c => c.id === charId
+                  ? normalizeCharacterImpression({ ...c, activeBuffs: updated.activeBuffs, buffInjection: updated.buffInjection })
+                  : c));
+          }).catch(() => {});
+      };
+
       window.addEventListener('active-msg-received', handler);
       window.addEventListener('active-msg-progress', progressHandler);
       window.addEventListener('active-msg-open', openHandler);
+      window.addEventListener('emotion-updated', buffSyncHandler);
       document.addEventListener('visibilitychange', onVisible);
       return () => {
           window.removeEventListener('active-msg-received', handler);
           window.removeEventListener('active-msg-progress', progressHandler);
           window.removeEventListener('active-msg-open', openHandler);
+          window.removeEventListener('emotion-updated', buffSyncHandler);
           document.removeEventListener('visibilitychange', onVisible);
       };
   }, [sendProactiveNativeNotification]);

--- a/public/sw-keep-alive.js
+++ b/public/sw-keep-alive.js
@@ -770,7 +770,7 @@ async function removeQueuedRequest(id) {
 }
 
 // worker/sw-keep-alive.ts
-var SW_VERSION = "1.9.0";
+var SW_VERSION = "1.10.0";
 var PING_INTERVAL = 15e3;
 var MAX_MANUAL_ALIVE_MS = 5 * 6e4;
 var ACTIVE_MSG_DB_NAME = "ActiveMsg";
@@ -963,6 +963,7 @@ async function saveReasoningToBuffer(payload) {
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error || new Error("reasoning buffer write aborted"));
   });
+  await notifyClients({ type: "active-msg-reasoning", sessionId, charId });
 }
 async function clearReasoningBuffer(sessionId) {
   if (!sessionId) return;

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -466,6 +466,41 @@ const runPendingToolCallsSafely = async () => {
   }
 };
 
+/**
+ * 思维链(心象)回填: SW 收到 reasoning push 写完 buffer 后会 fire 'active-msg-reasoning'.
+ *
+ * 正常情况 worker 先发 reasoning 再发 content, reasoning 先落 buffer, content flush 时
+ * claimReasoning 取到并挂上 thinkingChain. 但 reasoning / content 是两条独立 Web Push,
+ * 弱网/移动端到达或处理顺序可能反转: content 抢先 flush 时 claimReasoning 拿到 null, 首条
+ * 回复落库时没有 thinkingChain, 之后到的 reasoning 永远不再被 claim → 思维链丢失.
+ *
+ * 这里在 reasoning 到达后补一刀: 若该 session 的首条 assistant 回复已落库且还没挂 thinkingChain,
+ * 就 claim 出 reasoning 回填到那条消息的 metadata, 再 fire progress 让 Chat 重渲染.
+ * 若首条回复还没落库 (reasoning 先到的正常情形), 不 claim、留 buffer 给正常路径, 这里是 no-op.
+ */
+const backfillReasoningSafely = async (sessionId?: string, charId?: string): Promise<void> => {
+  if (!sessionId || !charId) return;
+  try {
+    const msgs = await DB.getRecentMessagesByCharId(charId, 200);
+    const sessionMsgs = msgs
+      .filter((m) => m.role === 'assistant' && (m.metadata as any)?.sessionId === sessionId)
+      .sort((a, b) => ((a as any).id ?? 0) - ((b as any).id ?? 0));
+    if (sessionMsgs.length === 0) return; // content 还没落库, 留给正常 claim 路径
+    const first = sessionMsgs[0] as any;
+    if (first.metadata?.thinkingChain) return; // 正常 claim 已挂上, 不重复
+    if (typeof first.id !== 'number') return;
+
+    const buffered = await ActiveMsgStore.claimReasoning(sessionId);
+    const reasoning = buffered?.reasoningContent;
+    if (!reasoning) return;
+
+    await DB.updateMessageMetadata(first.id, (prev: any) => ({ ...(prev || {}), thinkingChain: reasoning }));
+    window.dispatchEvent(new CustomEvent('active-msg-progress', { detail: { charId } }));
+  } catch (e) {
+    console.warn('[ActiveMsg] backfill reasoning failed', sessionId, e);
+  }
+};
+
 const handleDeepLink = () => {
   const currentUrl = new URL(window.location.href);
   const charId = currentUrl.searchParams.get('activeMsgCharId');
@@ -491,6 +526,14 @@ export const ActiveMsgRuntime = {
         const type = event.data?.type;
         if (type === 'active-msg-received') {
           void flushInboxToChat();
+          return;
+        }
+
+        if (type === 'active-msg-reasoning') {
+          // 先确保已到的 content 落库 (flush 链串行), 再尝试把思维链回填到首条回复上.
+          void flushInboxToChat().then(() =>
+            backfillReasoningSafely(event.data?.sessionId, event.data?.charId),
+          );
           return;
         }
 

--- a/worker/sw-keep-alive.ts
+++ b/worker/sw-keep-alive.ts
@@ -36,8 +36,11 @@ import { installReiSW } from '@rei-standard/amsg-sw';
  *           删除了应用层的 reasoning chunking 逻辑，现收到完整 reasoningContent。
  *           content 通知兜底也交给 amsg-sw，应用层只负责写 inbox / tool / emotion。
  *           修复了在应用关闭期间收到分片推送丢失的问题（通过 notificationclick 恢复及前台拦截 REI_AMSG_PUSH）。
+ *  - 1.10.0: saveReasoningToBuffer 写完后 notifyClients('active-msg-reasoning')，让主线程在
+ *           "content 抢先于 reasoning 落库" 的竞态下把思维链回填到已存的首条回复上，
+ *           修复 instant 模式弱网/移动端思维链(心象)间歇丢失。
  */
-const SW_VERSION = '1.9.0';
+const SW_VERSION = '1.10.0';
 
 const PING_INTERVAL = 15_000;
 const MAX_MANUAL_ALIVE_MS = 5 * 60_000;
@@ -298,6 +301,12 @@ async function saveReasoningToBuffer(payload: any) {
     tx.onerror = () => reject(tx.error);
     tx.onabort = () => reject(tx.error || new Error('reasoning buffer write aborted'));
   });
+
+  // reasoning push 与 content push 是两条独立 Web Push, 到达/处理顺序不保证. 主线程只在处理
+  // "首条 content" 时 claimReasoning, 若 content 抢先落库, reasoning 会变孤儿、思维链丢失.
+  // 这里写完 buffer 立刻通知主线程: 若该 session 首条回复已落库就把思维链回填上去 (见
+  // activeMsgRuntime 'active-msg-reasoning' 处理); 若 content 还没到则是 no-op, 等正常 claim.
+  await notifyClients({ type: 'active-msg-reasoning', sessionId, charId });
 }
 
 /**


### PR DESCRIPTION
问题1 情绪buff 回不到前端:
emotion_update 推回后 buff 只落了 DB, 同步进内存 characters 的唯一入口是 Chat.tsx 里一个 `charId === activeCharacterId` 守卫的 handler. instant 模式下 用户常不在该角色聊天页, 守卫直接 return → 内存不更新; OSContext 启动后不重读 DB, 切回该角色也看不到 buff; 更糟的是之后任一 updateCharacter 会用旧内存覆盖 DB 把 buff 抹掉. 改为在 OSContext 加 App 级 'emotion-updated' 监听, 无条件 按事件 charId 更新内存 (并堵住反向覆盖), 移除 Chat.tsx 里的守卫 handler.

问题2 思维链(心象)在 instant 弱网/移动端间歇丢失:
reasoning push 与 content push 是两条独立 Web Push, 主线程只在处理首条 content 时 claimReasoning. content 抢先落库时 claim 拿到 null, 之后到的 reasoning 永远 不再被 claim → 思维链丢. SW saveReasoningToBuffer 写完后新增 notifyClients ('active-msg-reasoning'); 主线程收到后先 flush 再回填: 若该 session 首条回复已 落库且未挂 thinkingChain, 就 claim 出 reasoning 回填到该消息 metadata. reasoning 先到的正常情形下为 no-op, 留给原 claim 路径. SW_VERSION 1.9.0 → 1.10.0.

https://claude.ai/code/session_016GMR8qJLmPrX4Utoo5L6Er