### PR TITLE
feat(instant-push): version compare + redesigned worker update popup

### DIFF
--- a/components/WorkerUpdateReminderEvent.tsx
+++ b/components/WorkerUpdateReminderEvent.tsx
@@ -4,20 +4,23 @@
  *
  * 背景：用户的 worker 跑在自己的 Cloudflare 账户里，目前没法保证自动跟上游同步
  * (见 worker/instant-push/README.md 阶段 2 第 5 条存疑说明)。所以每次我们更新
- * worker 代码就 bump 下面的 WORKER_BUILD_VERSION，启用了 Instant Push 的用户会被
- * 提醒一次：去重新部署 / 同步一下 worker，确认后记下版本，不再反复弹。
+ * worker 代码就 bump utils/instantWorkerVersion.ts 里的 INSTANT_WORKER_VERSION,
+ * 启用了 Instant Push 的用户会被提醒一次：去重新部署 / 同步一下 worker。
  *
  * 只提醒启用了 Instant Push 的用户；没开的人完全不受打扰。
+ * 同一个版本号只弹一次 (sullyos_worker_build_seen 记 dismiss 过的版本)。
  */
 
-import React from 'react';
-import { useOS } from '../context/OSContext';
-import { AppID } from '../types';
-import { loadInstantConfig } from '../utils/instantPushClient';
-import { FAQ_TARGET_SECTION_KEY, CHANGELOG_2026_05_27 } from './UpdateNotificationEvent';
+import React, { useState } from 'react';
+import {
+  loadInstantConfig,
+  copyInstantWorkerBundleToClipboard,
+  buildCloudflareDashboardUrl,
+} from '../utils/instantPushClient';
+import { INSTANT_WORKER_VERSION } from '../utils/instantWorkerVersion';
 
-// 每次更新 worker 代码就 bump 这个值 (用日期最直观)。
-export const WORKER_BUILD_VERSION = '2026-05-26';
+// 兼容旧调用方: 仍然导出 WORKER_BUILD_VERSION, 内部指向单一来源常量。
+export const WORKER_BUILD_VERSION = INSTANT_WORKER_VERSION;
 
 // 记录用户「已确认过的 worker 版本号」。
 const WORKER_UPDATE_SEEN_KEY = 'sullyos_worker_build_seen';
@@ -28,7 +31,7 @@ const WORKER_UPDATE_SEEN_KEY = 'sullyos_worker_build_seen';
  */
 export const markWorkerBuildSeen = (): void => {
   try {
-    localStorage.setItem(WORKER_UPDATE_SEEN_KEY, WORKER_BUILD_VERSION);
+    localStorage.setItem(WORKER_UPDATE_SEEN_KEY, INSTANT_WORKER_VERSION);
   } catch { /* ignore */ }
 };
 
@@ -42,7 +45,7 @@ export const shouldShowWorkerUpdateReminder = (): boolean => {
     const cfg = loadInstantConfig();
     if (!cfg.enabled) return false;
     const seen = localStorage.getItem(WORKER_UPDATE_SEEN_KEY);
-    return seen !== WORKER_BUILD_VERSION;
+    return seen !== INSTANT_WORKER_VERSION;
   } catch {
     return false;
   }
@@ -53,21 +56,47 @@ interface WorkerUpdateReminderPopupProps {
 }
 
 export const WorkerUpdateReminderPopup: React.FC<WorkerUpdateReminderPopupProps> = ({ onClose }) => {
-  const { openApp } = useOS();
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [copyError, setCopyError] = useState('');
 
-  const handleViewHelp = () => {
-    markWorkerBuildSeen();
+  const cfg = loadInstantConfig();
+  const dashboardUrl = buildCloudflareDashboardUrl(cfg.workerUrl);
+  // workers.dev 子域才能推出确切的 worker name; 自定义域 / 反代退化成 workers 列表页。
+  const dashboardLabel = dashboardUrl.includes('/services/view/')
+    ? '打开我的 Worker'
+    : '打开 Worker 列表';
+
+  const handleCopy = async () => {
+    setCopyStatus('loading');
     try {
-      sessionStorage.setItem(FAQ_TARGET_SECTION_KEY, CHANGELOG_2026_05_27);
-    } catch { /* ignore */ }
-    openApp(AppID.FAQ);
-    onClose();
+      await copyInstantWorkerBundleToClipboard();
+      setCopyStatus('done');
+      setTimeout(() => setCopyStatus((s) => (s === 'done' ? 'idle' : s)), 2500);
+    } catch (e) {
+      const err = e as { message?: string } | null;
+      setCopyError(err?.message ?? '未知错误');
+      setCopyStatus('error');
+    }
   };
 
-  const handleDismiss = () => {
+  const handleOpenWorker = () => {
+    // 不在这里 markWorkerBuildSeen —— 用户可能只是先打开 dashboard, 还没真粘贴部署。
+    // 等他再次回来发"对比已部署"时若一致, 那个流程会顺其自然不再触发提醒。
+    window.open(dashboardUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleLater = () => {
     markWorkerBuildSeen();
     onClose();
   };
+
+  const copyButtonLabel = copyStatus === 'loading'
+    ? '复制中…'
+    : copyStatus === 'done'
+      ? '✓ 已复制'
+      : copyStatus === 'error'
+        ? '重试复制'
+        : '复制最新代码';
 
   return (
     <div className="fixed inset-0 z-[9998] flex items-center justify-center p-5 animate-fade-in">
@@ -79,38 +108,53 @@ export const WorkerUpdateReminderPopup: React.FC<WorkerUpdateReminderPopupProps>
             alt="worker update"
             className="w-10 h-10 mx-auto mb-2"
           />
-          <h2 className="text-lg font-extrabold text-slate-800">Worker 有更新</h2>
-          <p className="text-[11px] text-slate-400 mt-1">Instant Push · 建议同步一下你的 Worker</p>
+          <h2 className="text-lg font-extrabold text-slate-800">Worker 后端有更新</h2>
+          <p className="text-[11px] text-slate-400 mt-1">最新版本 {INSTANT_WORKER_VERSION} · Instant Push</p>
         </div>
 
         <div className="px-6 pb-4 space-y-3">
-          <div className="bg-gradient-to-br from-indigo-50 to-sky-50 border border-indigo-100 rounded-2xl p-4">
+          <div className="bg-gradient-to-br from-indigo-50 to-sky-50 border border-indigo-100 rounded-2xl p-4 space-y-2">
             <p className="text-[13px] text-slate-700 leading-relaxed">
-              我们更新了 <strong className="text-indigo-600">Instant Push 的后端 Worker 代码</strong>。
-              由于 Worker 跑在<strong>你自己的 Cloudflare 账户</strong>里，
-              <strong className="text-rose-600">不会自动跟着我们更新</strong>，
-              需要你手动同步一次才能用上最新版本。
+              推送 worker 有新版本，需要你手动同步一下：
             </p>
-            <p className="text-[12px] text-slate-500 leading-relaxed mt-2">
-              不更新通常也能继续用，只是可能缺少新功能或修复。更新方式：到
-              <strong> worker 目录的 README</strong> 按「备用方案」重新粘贴一次
-              <strong> worker.bundle.js</strong>，或重新克隆部署。
+            <ol className="text-[12px] text-slate-600 leading-relaxed list-decimal pl-5 space-y-0.5">
+              <li>点下面「复制最新代码」</li>
+              <li>打开你的 Cloudflare worker 编辑界面</li>
+              <li>全选粘贴覆盖，点 Deploy</li>
+            </ol>
+            <p className="text-[11px] text-slate-500 leading-relaxed pt-1">
+              如果不方便现在处理，新代码也已经同步到「设置 → Instant 消息设置」里，
+              随时按提示操作即可。
             </p>
+            {copyStatus === 'error' && (
+              <p className="text-[11px] text-rose-500 leading-relaxed">复制失败：{copyError}</p>
+            )}
           </div>
         </div>
 
         <div className="px-6 pb-7 pt-2 space-y-2">
           <button
-            onClick={handleViewHelp}
-            className="w-full py-3.5 bg-gradient-to-r from-indigo-500 to-sky-500 text-white font-bold rounded-2xl shadow-lg shadow-indigo-200 active:scale-95 transition-transform text-sm"
+            onClick={() => void handleCopy()}
+            disabled={copyStatus === 'loading'}
+            className={`w-full py-3.5 font-bold rounded-2xl text-sm transition-transform active:scale-95 ${
+              copyStatus === 'done'
+                ? 'bg-emerald-500 text-white'
+                : 'bg-gradient-to-r from-indigo-500 to-sky-500 text-white shadow-lg shadow-indigo-200'
+            }`}
           >
-            去看怎么更新
+            {copyButtonLabel}
           </button>
           <button
-            onClick={handleDismiss}
+            onClick={handleOpenWorker}
+            className="w-full py-3 bg-white border border-slate-200 text-slate-700 font-bold rounded-2xl text-sm active:scale-95 transition-transform"
+          >
+            ↗ {dashboardLabel}
+          </button>
+          <button
+            onClick={handleLater}
             className="w-full py-2.5 text-slate-400 font-medium text-[12px]"
           >
-            知道了，先不更新
+            稍后处理
           </button>
         </div>
       </div>

--- a/components/settings/InstantPushSettingsModal.tsx
+++ b/components/settings/InstantPushSettingsModal.tsx
@@ -8,12 +8,16 @@ import {
   getOrCreateInstantSubscription,
   sendTestInstantPush,
   probeInstantWorkerCapabilities,
+  probeInstantWorkerVersion,
+  copyInstantWorkerBundleToClipboard,
+  buildCloudflareDashboardUrl,
   normalizeWorkerUrl,
 } from '../../utils/instantPushClient';
 import { isPushVapidReady } from '../../utils/pushVapid';
 import {
   markWorkerBuildSeen,
 } from '../WorkerUpdateReminderEvent';
+import { INSTANT_WORKER_VERSION } from '../../utils/instantWorkerVersion';
 import { FAQ_TARGET_SECTION_KEY, CHANGELOG_2026_05_27 } from '../UpdateNotificationEvent';
 import { InstantPushConfig, AppID } from '../../types';
 
@@ -48,6 +52,9 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
   const [capabilityStatusKind, setCapabilityStatusKind] = useState<'idle' | 'loading' | 'success' | 'warning' | 'error'>('idle');
   const [capabilityBusy, setCapabilityBusy] = useState(false);
   const [copyStatus, setCopyStatus] = useState('');
+  const [versionStatus, setVersionStatus] = useState('');
+  const [versionStatusKind, setVersionStatusKind] = useState<'idle' | 'loading' | 'success' | 'warning' | 'error'>('idle');
+  const [versionBusy, setVersionBusy] = useState(false);
 
   // GitHub 上 worker.bundle.js 的地址 — 主路径是 app 内「复制 Worker 代码」直接拷贝
   // 本地随包的 bundle; 这个 URL 仅作复制失败时的兜底入口. vite.config.ts 注入的
@@ -75,6 +82,8 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
     setCapabilityStatus('');
     setCapabilityStatusKind('idle');
     setCopyStatus('');
+    setVersionStatus('');
+    setVersionStatusKind('idle');
   }, [open]);
 
   const normalizedWorkerUrl = normalizeWorkerUrl(workerUrl);
@@ -115,17 +124,54 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
   const handleCopyWorkerCode = async () => {
     setCopyStatus('加载中…');
     try {
-      const base = import.meta.env.BASE_URL || '/';
-      const res = await fetch(`${base}instant-worker.bundle.js`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const text = await res.text();
-      await navigator.clipboard.writeText(text);
+      await copyInstantWorkerBundleToClipboard();
       setCopyStatus('已复制');
       setTimeout(() => setCopyStatus(''), 2000);
     } catch (e) {
       const err = e as { message?: string } | null;
       setCopyStatus('');
       addToast(`复制失败：${err?.message ?? '未知错误'}`, 'error');
+    }
+  };
+
+  const handleCheckDeployedVersion = async () => {
+    if (versionBusy) return;
+    if (!normalizedWorkerUrl) {
+      setVersionStatus('请先填 Worker URL');
+      setVersionStatusKind('warning');
+      return;
+    }
+    setVersionBusy(true);
+    setVersionStatus('正在查询已部署版本…');
+    setVersionStatusKind('loading');
+    try {
+      const result = await probeInstantWorkerVersion(currentCfg());
+      if (!result.ok) {
+        const errText = result.error || '未知错误';
+        // /version 是新增路由,老 bundle 没有,Cloudflare 通常返 404。提示用户这就是要重新部署的信号。
+        const looksLikeOldBundle = /404|not found/i.test(errText);
+        setVersionStatus(
+          looksLikeOldBundle
+            ? `你部署的 Worker 没有 /version 路由,通常意味着是旧版 bundle —— 重新部署即可解决`
+            : `查询失败：${errText}`
+        );
+        setVersionStatusKind(looksLikeOldBundle ? 'warning' : 'error');
+        return;
+      }
+      const deployed = result.version!;
+      if (deployed === INSTANT_WORKER_VERSION) {
+        setVersionStatus(`✓ 你部署的版本 (${deployed}) 已是最新`);
+        setVersionStatusKind('success');
+      } else {
+        setVersionStatus(`你部署的是 ${deployed},最新是 ${INSTANT_WORKER_VERSION} —— 建议重新部署`);
+        setVersionStatusKind('warning');
+      }
+    } catch (e) {
+      const err = e as { message?: string } | null;
+      setVersionStatus(`查询失败：${err?.message ?? String(e)}`);
+      setVersionStatusKind('error');
+    } finally {
+      setVersionBusy(false);
     }
   };
 
@@ -423,6 +469,27 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
             <code className="font-mono"> worker.bundle.js </code>全部内容粘贴覆盖，再 Deploy；
             VAPID 公钥/私钥到「推送凭据 (VAPID)」面板复制 env 清单，粘进 Worker 的 Variables。
           </p>
+
+          {/* Worker 代码版本 + 对比已部署 */}
+          <div className="flex items-center justify-between gap-3 rounded-xl bg-white border border-slate-200 px-3 py-2">
+            <div className="min-w-0">
+              <p className="text-[11px] text-slate-500">当前 Worker 代码版本</p>
+              <p className="text-[12px] font-bold text-slate-700 font-mono">{INSTANT_WORKER_VERSION}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleCheckDeployedVersion()}
+              disabled={versionBusy || !normalizedWorkerUrl}
+              className={`shrink-0 px-3 py-2 text-[11px] rounded-xl font-bold ${versionBusy || !normalizedWorkerUrl ? 'bg-slate-100 text-slate-400' : 'bg-white border border-slate-200 text-slate-600 hover:bg-slate-50'}`}
+            >
+              {versionBusy ? '查询中…' : '对比已部署'}
+            </button>
+          </div>
+          {versionStatus && (
+            <p className={`text-[11px] leading-relaxed ${versionStatusKind === 'success' ? 'text-emerald-600' : versionStatusKind === 'warning' ? 'text-amber-600' : versionStatusKind === 'error' ? 'text-rose-500' : 'text-slate-500'}`}>
+              {versionStatus}
+            </p>
+          )}
 
           <div className="grid grid-cols-2 gap-2">
             <button

--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -320,6 +320,13 @@ export interface InstantWorkerCapabilityResult {
   raw?: unknown;
 }
 
+export interface InstantWorkerVersionResult {
+  ok: boolean;
+  error?: string;
+  /** Worker self-reported INSTANT_WORKER_VERSION (YYYY-MM-DD). */
+  version?: string;
+}
+
 // ── localStorage helpers ───────────────────────────────────────────────────
 
 const DEFAULT_CONFIG: InstantPushConfig = {
@@ -425,6 +432,71 @@ export async function probeInstantWorkerCapabilities(
     const err = e as { message?: string } | null;
     return { ok: false, error: err?.message ?? String(e) };
   }
+}
+
+export async function probeInstantWorkerVersion(
+  cfg: InstantPushConfig = loadInstantConfig(),
+): Promise<InstantWorkerVersionResult> {
+  const workerUrl = normalizeWorkerUrl(cfg.workerUrl || '');
+  if (!workerUrl.startsWith('https://')) {
+    return { ok: false, error: 'Worker URL 未配置或不是 https' };
+  }
+  try {
+    const res = await fetch(`${workerUrl}/version`, { method: 'GET' });
+    const { text, parsed } = await resolveSafeFetchText(res);
+    if (!res.ok) {
+      return { ok: false, error: parsed?.error?.message ?? `HTTP ${res.status}` };
+    }
+    const version = parsed?.data?.version;
+    if (typeof version !== 'string' || !version) {
+      // 旧版 worker 没有 /version 路由,Cloudflare 通常返 404 然后被前面 !res.ok 捕获;
+      // 这里兜底处理 200 但格式不对的情况 (理论上不会发生)。
+      return { ok: false, error: 'Worker 未返回版本号 (可能是旧版部署)', raw: text } as any;
+    }
+    return { ok: true, version };
+  } catch (e) {
+    const err = e as { message?: string } | null;
+    return { ok: false, error: err?.message ?? String(e) };
+  }
+}
+
+/**
+ * 复制最新版 worker bundle 到剪贴板。Settings 部署区和「Worker 有更新」弹窗
+ * 共用同一份逻辑, 避免两边 fetch 路径漂移。
+ *
+ * 抛出原始错误让调用方决定怎么显示 (toast / inline status / 不显示)。
+ */
+export async function copyInstantWorkerBundleToClipboard(): Promise<void> {
+  const base = import.meta.env.BASE_URL || '/';
+  const res = await fetch(`${base}instant-worker.bundle.js`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const text = await res.text();
+  await navigator.clipboard.writeText(text);
+}
+
+/**
+ * 根据用户填的 workerUrl 推算 Cloudflare dashboard 编辑界面的 deep link。
+ *
+ * Cloudflare 接受 `?to=/:account/...` 模式, 登录后会自动用当前账号 ID 替换 :account
+ * (多账号会出选择器)。这样我们不需要知道用户的 account ID, 只要从 workers.dev
+ * 子域名里抠出 worker name 就能直达 /production 编辑界面。
+ *
+ * 非 workers.dev 域名 (自定义域 / 反代) 没法可靠反推 worker name, 退回 worker 列表页,
+ * 用户自己点项目名进去 —— 这类用户清楚自己的部署结构, 不会被卡住。
+ */
+export function buildCloudflareDashboardUrl(workerUrl: string | undefined): string {
+  const FALLBACK = 'https://dash.cloudflare.com/?to=/:account/workers/overview';
+  if (!workerUrl) return FALLBACK;
+  try {
+    const u = new URL(workerUrl);
+    if (u.hostname.endsWith('.workers.dev')) {
+      const workerName = u.hostname.split('.')[0];
+      if (workerName) {
+        return `https://dash.cloudflare.com/?to=/:account/workers/services/view/${encodeURIComponent(workerName)}/production`;
+      }
+    }
+  } catch { /* invalid url → fallback */ }
+  return FALLBACK;
 }
 
 // ── Web Push subscription helpers ─────────────────────────────────────────

--- a/utils/instantWorkerVersion.ts
+++ b/utils/instantWorkerVersion.ts
@@ -1,0 +1,12 @@
+// Single source of truth for Instant Push worker code version.
+//
+// Both the worker bundle (worker/instant-push/src/index.ts → /version route)
+// and the SullyOS frontend (Settings 显示 + 部署对比 + 更新弹窗触发) import
+// from here, so the date returned by the user's deployed worker and the date
+// shown in the app cannot drift apart unless the bundle was rebuilt against
+// an older source tree.
+//
+// Bump this whenever worker/instant-push/src/* gets a behavior change that
+// requires users to redeploy their worker. Use YYYY-MM-DD; the frontend
+// compares strings directly.
+export const INSTANT_WORKER_VERSION = '2026-05-28';

--- a/worker/instant-push/src/index.ts
+++ b/worker/instant-push/src/index.ts
@@ -23,6 +23,7 @@ import {
 
 import { classifyLLMOutput } from './classifier';
 import { sanitizeIntoSegments, type Segment } from '../../../utils/sanitize';
+import { INSTANT_WORKER_VERSION } from '../../../utils/instantWorkerVersion';
 
 export interface Env {
   VAPID_PUBLIC_KEY: string;
@@ -266,6 +267,25 @@ function verifyUtilityClientToken(request: Request, env: Env): Response | null {
   return null;
 }
 
+// /version: 用户部署的 worker 自报版本日期。前端拿这个跟内置 INSTANT_WORKER_VERSION
+// 比对, 不一致就提示重新部署。不要求 client token (这只是个静态查询, 不暴露任何
+// secret), 也不接受 POST — 没有副作用就用 GET。
+function handleVersionRequest(request: Request): Response {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: UTILITY_CORS_HEADERS });
+  }
+  if (request.method !== 'GET') {
+    return utilityJson(405, {
+      success: false,
+      error: { code: 'METHOD_NOT_ALLOWED', message: 'Use GET' },
+    });
+  }
+  return utilityJson(200, {
+    success: true,
+    data: { version: INSTANT_WORKER_VERSION },
+  });
+}
+
 async function handleCapabilitiesRequest(request: Request, env: Env): Promise<Response> {
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: UTILITY_CORS_HEADERS });
@@ -429,6 +449,9 @@ async function runEmotionEval(body: any, env: Env, requestUrl?: string): Promise
 export default {
   fetch: async (request: Request, env: Env, ctx: { waitUntil(p: Promise<unknown>): void }) => {
     const url = new URL(request.url);
+    if (url.pathname === '/version') {
+      return handleVersionRequest(request);
+    }
     if (url.pathname === '/capabilities' || url.pathname === '/health') {
       return handleCapabilitiesRequest(request, env);
     }

--- a/worker/instant-push/worker.bundle.js
+++ b/worker/instant-push/worker.bundle.js
@@ -2935,6 +2935,9 @@ function classifyLLMOutput(text) {
   return { kind: "finish", cleanedText, sanitizedBody, directives };
 }
 
+// utils/instantWorkerVersion.ts
+var INSTANT_WORKER_VERSION = "2026-05-28";
+
 // worker/instant-push/src/index.ts
 var MULTIPART_TRANSPORT = { enabled: true };
 var UTILITY_CORS_HEADERS = {
@@ -3112,6 +3115,21 @@ function verifyUtilityClientToken(request, env) {
   }
   return null;
 }
+function handleVersionRequest(request) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: UTILITY_CORS_HEADERS });
+  }
+  if (request.method !== "GET") {
+    return utilityJson(405, {
+      success: false,
+      error: { code: "METHOD_NOT_ALLOWED", message: "Use GET" }
+    });
+  }
+  return utilityJson(200, {
+    success: true,
+    data: { version: INSTANT_WORKER_VERSION }
+  });
+}
 async function handleCapabilitiesRequest(request, env) {
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: UTILITY_CORS_HEADERS });
@@ -3233,6 +3251,9 @@ async function runEmotionEval(body, env, requestUrl) {
 var src_default = {
   fetch: async (request, env, ctx) => {
     const url = new URL(request.url);
+    if (url.pathname === "/version") {
+      return handleVersionRequest(request);
+    }
     if (url.pathname === "/capabilities" || url.pathname === "/health") {
       return handleCapabilitiesRequest(request, env);
     }


### PR DESCRIPTION
Worker self-reports its bundled INSTANT_WORKER_VERSION via a new GET /version route. Settings → Instant 显示当前内置版本号并提供"对比已部署"按钮,前端 fetch worker 的 /version 与本地常量对比,直接告诉用户是否已是最新。

更新提醒弹窗重写,提供三个明确动作:复制最新代码 / 打开我的 Worker(根据用户
填的 workers.dev URL 推算 dashboard /production deep link)/ 稍后处理。同一版本 号只弹一次。