### PR TITLE
fix(instant-push): "对比已部署" 回到 ping worker, 但失败一律视为旧版

### DIFF
--- a/components/WorkerUpdateReminderEvent.tsx
+++ b/components/WorkerUpdateReminderEvent.tsx
@@ -33,18 +33,6 @@ export const markWorkerBuildSeen = (): void => {
 };
 
 /**
- * 读用户上次确认部署过的 worker 版本号 (`YYYY-MM-DD` 字符串)，没有记录则返回 null。
- * 设置面板用它判断「你部署的是不是最新版」, 不再去 ping worker。
- */
-export const getWorkerBuildSeen = (): string | null => {
-  try {
-    return localStorage.getItem(WORKER_UPDATE_SEEN_KEY);
-  } catch {
-    return null;
-  }
-};
-
-/**
  * 是否要弹「worker 有更新」提醒：
  *  - 只对启用了 Instant Push 的用户弹
  *  - 已确认版本与当前内置版本不一致才弹 (null 也算不一致 —— 老用户首次铺该功能时提醒一次)

--- a/components/settings/InstantPushSettingsModal.tsx
+++ b/components/settings/InstantPushSettingsModal.tsx
@@ -8,6 +8,7 @@ import {
   getOrCreateInstantSubscription,
   sendTestInstantPush,
   probeInstantWorkerCapabilities,
+  probeInstantWorkerVersion,
   copyInstantWorkerBundleToClipboard,
   buildCloudflareDashboardUrl,
   normalizeWorkerUrl,
@@ -15,7 +16,6 @@ import {
 import { isPushVapidReady } from '../../utils/pushVapid';
 import {
   markWorkerBuildSeen,
-  getWorkerBuildSeen,
 } from '../WorkerUpdateReminderEvent';
 import { INSTANT_WORKER_VERSION } from '../../utils/instantWorkerVersion';
 import { FAQ_TARGET_SECTION_KEY, CHANGELOG_2026_05_27 } from '../UpdateNotificationEvent';
@@ -52,9 +52,11 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
   const [capabilityStatusKind, setCapabilityStatusKind] = useState<'idle' | 'loading' | 'success' | 'warning' | 'error'>('idle');
   const [capabilityBusy, setCapabilityBusy] = useState(false);
   const [copyStatus, setCopyStatus] = useState('');
-  // 本地记录的「上次确认部署过的版本」, 跟随包的 INSTANT_WORKER_VERSION 一比就知道有没有过期。
-  // 不主动 ping worker —— 老 bundle 没有 /version 路由, 探测信号不可靠。
-  const [seenVersion, setSeenVersion] = useState<string | null>(() => getWorkerBuildSeen());
+  // 对比已部署的 worker 自报版本: 'idle' 初始, 'checking' 拉取中, 'latest' 完全匹配, 'stale' 任何
+  // 不匹配 (拉不到 / 旧 bundle 没 /version / 版本对不上). 故意不展开 stale 的子情况 —— 对用户而言
+  // 都是"该重新部署"。staleDetail 仅用于在 stale 时给出可读的原因 (HTTP xxx / 网络错误等)。
+  const [versionCheck, setVersionCheck] = useState<'idle' | 'checking' | 'latest' | 'stale'>('idle');
+  const [versionCheckDetail, setVersionCheckDetail] = useState('');
 
   // GitHub 上 worker.bundle.js 的地址 — 主路径是 app 内「复制 Worker 代码」直接拷贝
   // 本地随包的 bundle; 这个 URL 仅作复制失败时的兜底入口. vite.config.ts 注入的
@@ -82,7 +84,8 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
     setCapabilityStatus('');
     setCapabilityStatusKind('idle');
     setCopyStatus('');
-    setSeenVersion(getWorkerBuildSeen());
+    setVersionCheck('idle');
+    setVersionCheckDetail('');
   }, [open]);
 
   const normalizedWorkerUrl = normalizeWorkerUrl(workerUrl);
@@ -133,10 +136,24 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
     }
   };
 
-  const handleMarkDeployed = () => {
-    markWorkerBuildSeen();
-    setSeenVersion(INSTANT_WORKER_VERSION);
-    addToast('已记录为最新版部署完成', 'success');
+  const handleCheckDeployedVersion = async () => {
+    if (versionCheck === 'checking') return;
+    if (!normalizedWorkerUrl) {
+      setVersionCheck('stale');
+      setVersionCheckDetail('请先填 Worker URL');
+      return;
+    }
+    setVersionCheck('checking');
+    setVersionCheckDetail('');
+    const result = await probeInstantWorkerVersion(currentCfg());
+    if (result.ok) {
+      setVersionCheck('latest');
+      setVersionCheckDetail('');
+    } else {
+      // 任何拉取失败 / 版本不匹配 → 一律视为旧版, 不再细分 404/405/网络错误。
+      setVersionCheck('stale');
+      setVersionCheckDetail(result.error ?? '未知错误');
+    }
   };
 
   const handleOpenTutorial = () => {
@@ -434,31 +451,34 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
             VAPID 公钥/私钥到「推送凭据 (VAPID)」面板复制 env 清单，粘进 Worker 的 Variables。
           </p>
 
-          {/* Worker 代码版本: 本地已确认 vs 最新 (不 ping worker, 老 bundle 探不到) */}
+          {/* Worker 代码版本 + 对比已部署: 拉 worker /version 跟随包版本对, 拉不到 / 不一致都算旧 */}
           <div className="flex items-center justify-between gap-3 rounded-xl bg-white border border-slate-200 px-3 py-2">
             <div className="min-w-0">
               <p className="text-[11px] text-slate-500">最新 Worker 代码版本</p>
               <p className="text-[12px] font-bold text-slate-700 font-mono">{INSTANT_WORKER_VERSION}</p>
             </div>
-            {seenVersion === INSTANT_WORKER_VERSION ? (
-              <span className="shrink-0 px-3 py-2 text-[11px] rounded-xl font-bold bg-emerald-50 text-emerald-600 border border-emerald-100">
-                ✓ 已部署最新
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={handleMarkDeployed}
-                className="shrink-0 px-3 py-2 text-[11px] rounded-xl font-bold bg-white border border-slate-200 text-slate-600 hover:bg-slate-50"
-              >
-                我已部署
-              </button>
-            )}
+            <button
+              type="button"
+              onClick={() => void handleCheckDeployedVersion()}
+              disabled={versionCheck === 'checking' || !normalizedWorkerUrl}
+              className={`shrink-0 px-3 py-2 text-[11px] rounded-xl font-bold ${
+                versionCheck === 'checking' || !normalizedWorkerUrl
+                  ? 'bg-slate-100 text-slate-400'
+                  : 'bg-white border border-slate-200 text-slate-600 hover:bg-slate-50'
+              }`}
+            >
+              {versionCheck === 'checking' ? '查询中…' : '对比已部署'}
+            </button>
           </div>
-          {seenVersion !== INSTANT_WORKER_VERSION && (
+          {versionCheck === 'latest' && (
+            <p className="text-[11px] leading-relaxed text-emerald-600">
+              ✓ 你部署的 Worker 已是最新 ({INSTANT_WORKER_VERSION})
+            </p>
+          )}
+          {versionCheck === 'stale' && (
             <p className="text-[11px] leading-relaxed text-amber-600">
-              {seenVersion
-                ? `你上次确认的是 ${seenVersion},最新是 ${INSTANT_WORKER_VERSION} —— 按下面复制并 Deploy 后,点「我已部署」标记一下`
-                : `还没记录你部署过哪个版本 —— 按下面复制并 Deploy 后,点「我已部署」标记一下`}
+              你部署的 Worker 不是最新版 —— 按下面复制最新代码到 CF Worker 重新 Deploy 即可
+              {versionCheckDetail ? ` (${versionCheckDetail})` : ''}
             </p>
           )}
 

--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -9,6 +9,7 @@ import {
   subscribeWithRetry,
 } from './pushSubscribeShared';
 import { ReiClient } from '@rei-standard/amsg-client';
+import { INSTANT_WORKER_VERSION } from './instantWorkerVersion';
 
 export const INSTANT_PUSH_CONFIG_KEY = 'instant_push_config_v1';
 
@@ -322,6 +323,15 @@ export interface InstantWorkerCapabilityResult {
   raw?: unknown;
 }
 
+export interface InstantWorkerVersionResult {
+  /** 仅当 worker 自报版本 = 随包 INSTANT_WORKER_VERSION 时为 true。其它任何情况 (404 / 405 /
+   *  网络错误 / 版本对不上) 都算 false —— 老 bundle 根本没有 /version 路由, 拉不到就当不是最新。 */
+  ok: boolean;
+  /** worker 自报的版本号 (仅 ok=true 时有值); 调试用, 不影响 UI 判定。 */
+  version?: string;
+  error?: string;
+}
+
 // ── localStorage helpers ───────────────────────────────────────────────────
 
 const DEFAULT_CONFIG: InstantPushConfig = {
@@ -378,6 +388,40 @@ async function resolveSafeFetchText(res: Response): Promise<{ text: string; pars
   let parsed: any = null;
   try { parsed = text ? JSON.parse(text) : null; } catch { /* non-json */ }
   return { text, parsed };
+}
+
+/**
+ * GET {workerUrl}/version 拉用户部署的 worker 的自报版本, 跟随包的 INSTANT_WORKER_VERSION
+ * 比对。判定是二元的: 只有"拿到合法响应且版本字符串完全相等"才算 ok, 其它通通是"不是最新"
+ * (老 bundle 根本没这条路由, 拉不到 = 旧版)。
+ *
+ * 故意不区分 404 / 405 / 网络错误 / 版本不匹配 —— 用户视角下都是"该重新部署"。
+ */
+export async function probeInstantWorkerVersion(
+  cfg: InstantPushConfig = loadInstantConfig(),
+): Promise<InstantWorkerVersionResult> {
+  const workerUrl = normalizeWorkerUrl(cfg.workerUrl || '');
+  if (!workerUrl.startsWith('https://')) {
+    return { ok: false, error: 'Worker URL 未配置或不是 https' };
+  }
+  try {
+    const res = await fetch(`${workerUrl}/version`, { method: 'GET' });
+    const { parsed } = await resolveSafeFetchText(res);
+    if (!res.ok) {
+      return { ok: false, error: parsed?.error?.message ?? `HTTP ${res.status}` };
+    }
+    const version = parsed?.data?.version;
+    if (typeof version !== 'string' || !version) {
+      return { ok: false, error: 'Worker 未返回版本号' };
+    }
+    if (version !== INSTANT_WORKER_VERSION) {
+      return { ok: false, version, error: `Worker 自报 ${version}, 不是最新` };
+    }
+    return { ok: true, version };
+  } catch (e) {
+    const err = e as { message?: string } | null;
+    return { ok: false, error: err?.message ?? String(e) };
+  }
 }
 
 export async function probeInstantWorkerCapabilities(


### PR DESCRIPTION
上个 refactor 把判定改成本地 sullyos_worker_build_seen 标记, 但那个键的语义 是「popup 去重: 用户被通知过 / dismiss 过」, 不是「真实部署完成」:
  - handleSave 里 cfg.enabled 为 true 就 markWorkerBuildSeen
  - WorkerUpdateReminderPopup 的「稍后处理」也 markWorkerBuildSeen 两条路径都把 seen 推到 latest, 用户根本没去 CF Deploy 也会显示 ✓ 已部署最新, 谎报。

正确方向是 ping 用户部署的 worker /version 拿真实情况:
  - 老 bundle 没有 /version 路由 → 404 / 405 / METHOD_NOT_ALLOWED
  - 新 bundle 自报版本 → 跟随包 INSTANT_WORKER_VERSION 比对

UI 判定故意做成二元的, 不再细分错误类型 —— 用户视角下"拉不到 /version"和
"版本对不上"都是同一个动作: 重新部署。stale 文案里附原始错误供调试,
但不再让用户去理解 404 / 405 的区别。

- utils/instantPushClient.ts: 重写 probeInstantWorkerVersion, result 只有 { ok, version?, error }; ok 严格要求"拉到 + 版本完全相等"。
- components/settings/InstantPushSettingsModal.tsx: 恢复"对比已部署" 按钮, state 用单字段 versionCheck: 'idle' | 'checking' | 'latest' | 'stale'。
- components/WorkerUpdateReminderEvent.tsx: 删掉上次加的 getWorkerBuildSeen, 没人用。