### PR TITLE
fix(group-chat): 修复群聊输入框右侧表情/发送键被挤出屏幕

### DIFF
--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -1312,13 +1312,13 @@ ${attachedImagesNote}
                         </button>
 
                         {/* Input Field Container */}
-                        <div className="flex-1 bg-white rounded-xl flex items-end px-3 py-2 border border-slate-200 focus-within:border-violet-400 focus-within:ring-2 focus-within:ring-violet-100 transition-all">
+                        <div className="flex-1 min-w-0 overflow-hidden bg-white rounded-xl flex items-end px-3 py-2 border border-slate-200 focus-within:border-violet-400 focus-within:ring-2 focus-within:ring-violet-100 transition-all">
                             <textarea 
                                 rows={1} 
                                 value={input} 
                                 onChange={e => setInput(e.target.value)} 
                                 onKeyDown={e => { if(e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSendMessage(input); }}} 
-                                className="flex-1 bg-transparent text-[16px] outline-none resize-none max-h-28 text-slate-800 placeholder:text-slate-400 py-1" 
+                                className="flex-1 min-w-0 bg-transparent text-[16px] outline-none resize-none max-h-28 text-slate-800 placeholder:text-slate-400 py-1"
                                 placeholder="Message..." 
                                 style={{ height: 'auto', minHeight: '24px' }} 
                             />
@@ -1335,7 +1335,7 @@ ${attachedImagesNote}
                         {input.trim() ? (
                             <button 
                                 onClick={() => handleSendMessage(input)} 
-                                className="h-9 px-4 bg-violet-500 text-white rounded-xl font-bold text-sm shadow-md active:scale-95 transition-all"
+                                className="h-9 px-4 shrink-0 bg-violet-500 text-white rounded-xl font-bold text-sm shadow-md active:scale-95 transition-all"
                             >
                                 发送
                             </button>


### PR DESCRIPTION
群聊输入框的 flex 子元素缺少 min-w-0，flex 项默认 min-width:auto
等于内容固有宽度（textarea 默认 cols 宽度），在字号偏大的浏览器上
不肯收缩，把右侧表情按钮和发送键挤出屏幕外。

对齐单聊 ChatInputArea 的写法：输入容器与 textarea 加 min-w-0，
发送键加 shrink-0。