### PR TITLE
fix(embedding): bge 等固定维度模型不再发送 dimensions 参数

### DIFF
--- a/utils/memoryPalace/embedding.ts
+++ b/utils/memoryPalace/embedding.ts
@@ -38,6 +38,17 @@ export async function getEmbeddings(texts: string[], config: EmbeddingConfig): P
 }
 
 /**
+ * 该模型是否支持自定义 `dimensions` 参数。
+ *
+ * 硅基流动文档明确：`dimensions` 仅 Qwen/Qwen3-Embedding 系列支持。
+ * bge 系列（bge-m3、bge-large 等）输出维度固定，传入 `dimensions` 会被
+ * 服务端拒绝（2026-06 起返回 500）。这里只给支持的模型带上该参数。
+ */
+function modelSupportsDimensions(model: string): boolean {
+    return /qwen3?-?embedding/i.test(model);
+}
+
+/**
  * 实际调用 Embedding API
  */
 async function callEmbeddingAPI(
@@ -48,12 +59,15 @@ async function callEmbeddingAPI(
     baseUrl = baseUrl.replace('ai.siliconflow.cn', 'api.siliconflow.cn');
     const url = `${baseUrl}/embeddings`;
 
-    const body = {
+    const body: Record<string, unknown> = {
         model: config.model,
         input,
-        dimensions: config.dimensions,
         encoding_format: 'float',
     };
+    // 仅在模型支持时才发送 dimensions，否则 bge 等固定维度模型会报 500
+    if (modelSupportsDimensions(config.model) && config.dimensions) {
+        body.dimensions = config.dimensions;
+    }
 
     try {
         const response = await fetch(url, {


### PR DESCRIPTION
硅基流动 2026-06 起收紧校验, 给 bge 系列(输出维度固定)传入 dimensions
会直接返回 500。dimensions 实际仅 Qwen3-Embedding 系列支持, 故改为按模型 条件发送。bge-m3 原生即 1024 维, 去掉该参数后输出维度不变, 存量向量与检索
不受影响。