### PR TITLE
perf(embedding): 多批并行发送(并发上限5), 消除拆批后的串行延迟

### DIFF
--- a/utils/memoryPalace/embedding.test.ts
+++ b/utils/memoryPalace/embedding.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getEmbeddings } from './embedding';
+import type { EmbeddingConfig } from './types';
+
+// 这组测试守护「分批 / 并行不破坏结果」这条契约：
+//   1. 无论多少条文本，返回的向量条数 = 输入条数，且顺序严格对应下标
+//   2. 任何单次请求塞的条数都 ≤ 10（DashScope/Qwen 的硬上限）
+//   3. 多批走并行 + 并发上限，不改变上面两条
+//
+// 调用方（pipeline 的 queryVectors[i]、vectorStore 的 vectors[i]）全靠
+// 「第 i 个向量对应第 i 条输入」这个保序契约，所以这是召回正确性的地基。
+
+const config: EmbeddingConfig = {
+    baseUrl: 'https://api.test/v1',
+    apiKey: 'test-key',
+    model: 'BAAI/bge-m3',
+    dimensions: 1024,
+};
+
+// 记录每次 fetch 实际塞了几条 input，用于断言 batch 上限
+let batchSizes: number[] = [];
+
+beforeEach(() => {
+    batchSizes = [];
+    // mock fetch：把每条输入文本「原样编码」进它的向量第一位。
+    // 文本约定是 String(i)，所以正确情况下 results[i][0] === i。
+    // 用文本身份编码（而非请求内的局部下标）→ 一旦顺序错乱，断言立刻失败。
+    global.fetch = vi.fn(async (_url: any, init: any) => {
+        const body = JSON.parse(init.body as string);
+        const input: string[] = body.input;
+        batchSizes.push(input.length);
+        return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+                data: input.map((text, localIdx) => ({
+                    index: localIdx,
+                    embedding: [Number(text)],
+                })),
+            }),
+        } as any;
+    }) as any;
+});
+
+describe('getEmbeddings 分批 / 并行保序', () => {
+    it('空输入返回空数组，不发请求', async () => {
+        const out = await getEmbeddings([], config);
+        expect(out).toEqual([]);
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('单条输入返回单条向量', async () => {
+        const out = await getEmbeddings(['0'], config);
+        expect(out).toHaveLength(1);
+        expect(out[0][0]).toBe(0);
+        expect(batchSizes).toEqual([1]);
+    });
+
+    it('恰好 10 条 → 一次请求，顺序正确', async () => {
+        const texts = Array.from({ length: 10 }, (_, i) => String(i));
+        const out = await getEmbeddings(texts, config);
+        expect(out).toHaveLength(10);
+        out.forEach((v, i) => expect(v[0]).toBe(i));
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(Math.max(...batchSizes)).toBeLessThanOrEqual(10);
+    });
+
+    it('12 条（检索典型场景）→ 拆成 ≤10 的多批，顺序仍严格对应', async () => {
+        const texts = Array.from({ length: 12 }, (_, i) => String(i));
+        const out = await getEmbeddings(texts, config);
+        expect(out).toHaveLength(12);
+        // 关键：第 i 个向量必须仍是第 i 条输入算出来的
+        out.forEach((v, i) => expect(v[0]).toBe(i));
+        expect(fetch).toHaveBeenCalledTimes(2);
+        // 没有任何一批超过 10（否则 Qwen 会 400）
+        batchSizes.forEach(n => expect(n).toBeLessThanOrEqual(10));
+    });
+
+    it('100 条（重建场景）→ 全部保序，且每批都 ≤10', async () => {
+        const texts = Array.from({ length: 100 }, (_, i) => String(i));
+        const out = await getEmbeddings(texts, config);
+        expect(out).toHaveLength(100);
+        out.forEach((v, i) => expect(v[0]).toBe(i));
+        expect(batchSizes.reduce((a, b) => a + b, 0)).toBe(100); // 不多不少
+        batchSizes.forEach(n => expect(n).toBeLessThanOrEqual(10));
+    });
+});

--- a/utils/memoryPalace/embedding.ts
+++ b/utils/memoryPalace/embedding.ts
@@ -28,13 +28,28 @@ export async function getEmbeddings(texts: string[], config: EmbeddingConfig): P
     // 硬上限是 10 条，超过直接 400 InvalidParameter。取 10 作为通用安全值：
     // 硅基流动等 bge 系列用 10 也照常工作，纯按 token 计费不受影响。
     const BATCH_SIZE = 10;
-    const results: Float32Array[] = [];
+    // 多批并行发送，避免拆批后变成串行多往返拖慢检索（尤其硅基用户本来一次
+    // 就发完）。但限制并发数，防止「重建全部记忆」(上百批) 一次性轰出去触发
+    // 服务商限流 / 429。检索通常就 1~2 批 → 全并行 ≈ 1 个往返。
+    const MAX_CONCURRENCY = 5;
 
+    // 先按顺序切成 ≤BATCH_SIZE 的块（顺序很重要：调用方按下标取向量）
+    const chunks: string[][] = [];
     for (let i = 0; i < texts.length; i += BATCH_SIZE) {
-        const batch = texts.slice(i, i + BATCH_SIZE);
-        const batchResults = await callEmbeddingAPI(batch, config);
-        // 转为 Float32Array
-        results.push(...batchResults.map(v => new Float32Array(v)));
+        chunks.push(texts.slice(i, i + BATCH_SIZE));
+    }
+
+    const results: Float32Array[] = [];
+    // 每次并行跑 MAX_CONCURRENCY 个块；块间顺序、块内顺序都严格保持
+    for (let i = 0; i < chunks.length; i += MAX_CONCURRENCY) {
+        const window = chunks.slice(i, i + MAX_CONCURRENCY);
+        const windowResults = await Promise.all(
+            window.map(chunk => callEmbeddingAPI(chunk, config)),
+        );
+        // Promise.all 保序：windowResults[j] 对应 window[j]，按序展开
+        for (const batchResult of windowResults) {
+            results.push(...batchResult.map(v => new Float32Array(v)));
+        }
     }
 
     return results;


### PR DESCRIPTION
batch 降到 10 后, 检索时 >10 条 query 会拆成多批。原串行循环导致每多一批
就多一个网络往返, 对本来一次发完的硅基(bge)用户是无谓的延迟回归。改为并行
发送多批, 检索(1~2批)≈1个往返; 加并发上限 5, 避免重建(上百批)打爆限流/429。

保序契约不变: 块按顺序切、Promise.all 保序展开, 第 i 个向量仍对应第 i 条输入。 新增 embedding.test.ts 守护此契约(空/单条/10/12/100 条的条数、顺序、batch≤10)。