### PR TITLE
二轮重生: 一轮正文 A 在执行功能前先展示, 二轮结果 B 回来后再展示

### DIFF
--- a/utils/applyAssistantPostProcessing.ts
+++ b/utils/applyAssistantPostProcessing.ts
@@ -409,21 +409,242 @@ export async function applyAssistantPostProcessing(
     let aiContent = replayedTagPrefix ? `${replayedTagPrefix}${rawAiContent}` : rawAiContent;
     aiContent = normalizeAiContent(aiContent);
 
-    // 模型常在"执行功能"那条回复里先写一段正文 A (例: "来了来了！让我搜个应景的好东西…"), 再跟一个
-    // [[RECALL/SEARCH/XHS_...]] 指令。下面的二轮重生会把 aiContent 整段换成基于结果的 B, A 就丢了
-    // (用户只看到 B)。这里把 A 的原文留底, 末尾在确实跑过二轮时 (data !== initialData) 拼回 B 前面,
-    // 做到 A + B 一起展示。
-    const firstPassForLeadIn = aiContent;
+    // ── 渲染基础设施 (提前声明, 供"执行功能前先展示本轮正文 A" + 末尾展示二轮结果 B 复用) ──
+    // 引用/回复标签的匹配 + 清理正则 (提前声明避免 lead-in 渲染时落入 TDZ)。
+    const QUOTE_RE_DOUBLE = /\[\[(?:QU[OA]TE|引用)[：:]\s*([\s\S]*?)\]\]/;
+    const QUOTE_RE_SINGLE = /\[(?:QU[OA]TE|引用)[：:]\s*([^\]]*)\]/;
+    const REPLY_RE_CN = /\[回复\s*[""“]([^""”]*?)[""”](?:\.{0,3})\]\s*[：:]?\s*/;
+    const QUOTE_CLEAN_DOUBLE = /\[\[(?:QU[OA]TE|引用)[：:][\s\S]*?\]\]/g;
+    const QUOTE_CLEAN_SINGLE = /\[(?:QU[OA]TE|引用)[：:][^\]]*\]/g;
+    const REPLY_CLEAN_CN = /\[回复\s*[""“][^""”]*?[""”](?:\.{0,3})\]\s*[：:]?\s*/g;
+
+    // 抽取思考链 (showThinkingChain 开启时): reasoning_content + 内联 <think> 块。
+    const extractThinkingChain = (dataObj: any, reasoningOverride?: string): string | null => {
+        if (!(char as any).showThinkingChain) return null;
+        const lastRaw = dataObj?.choices?.[0]?.message?.content || '';
+        const lastReasoning = (
+            (reasoningOverride && reasoningOverride.trim())
+            || dataObj?.choices?.[0]?.message?.reasoning_content
+            || ''
+        ).trim();
+        const thinkBlocks: string[] = [];
+        const thinkPat = /<(think|thinking|thought)>([\s\S]*?)<\/\1>/gi;
+        let tm: RegExpExecArray | null;
+        while ((tm = thinkPat.exec(lastRaw)) !== null) {
+            const t = tm[2].trim();
+            if (t) thinkBlocks.push(t);
+        }
+        if (!/<\/(?:think|thinking|thought)>/i.test(lastRaw)) {
+            const openOnly = lastRaw.match(/<(?:think|thinking|thought)>([\s\S]*$)/i);
+            if (openOnly && openOnly[1].trim()) thinkBlocks.push(openOnly[1].trim());
+        }
+        const chain = [lastReasoning, ...thinkBlocks].filter(s => !!s).join('\n\n').trim();
+        return chain || null;
+    };
+
+    // 把一段文本 (parseAndExecuteActions / HTML 之外的部分) 渲染成气泡并落库 —— 双语 / 表情 / 引用 / 分段
+    // 与原 inline 末尾逻辑一致。抽出来是为了让"执行功能前的本轮正文 A"能在二轮前先展示, 二轮结果 B 复用同一套。
+    const renderAndPersist = async (rawContent: string, firstThinkingChain: string | null): Promise<void> => {
+        let firstMeta: any = firstThinkingChain ? { thinkingChain: firstThinkingChain } : null;
+        const takeMeta = (base: any): any => {
+            const merged = firstMeta ? { ...(base || {}), ...firstMeta } : base;
+            firstMeta = null;
+            return merged;
+        };
+
+        // Quote/Reply 目标 (双语路径用)
+        let aiReplyTarget: { id: number, content: string, name: string } | undefined;
+        const firstQuoteMatch = rawContent.match(QUOTE_RE_DOUBLE) || rawContent.match(QUOTE_RE_SINGLE) || rawContent.match(REPLY_RE_CN);
+        if (firstQuoteMatch) {
+            const quotedText = firstQuoteMatch[1].trim();
+            if (quotedText) {
+                const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
+                    || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
+                if (targetMsg) {
+                    const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
+                    aiReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
+                }
+            }
+        }
+
+        let content = ChatParser.sanitize(rawContent, { keepCitations: true });
+        content = content.replace(/\[\[INNER_STATE:\s*[\s\S]*?\]\]/g, '').trim();
+        if (!content) return;
+
+        const hasTranslationTags = /<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/.test(content);
+        let globalMsgIndex = 0;
+
+        if (hasTranslationTags) {
+            // ─── 双语 ───
+            const bilingualEmojis: string[] = [];
+            let bEm;
+            const bEmojiPat = /\[\[SEND_EMOJI:\s*(.*?)\]\]/g;
+            while ((bEm = bEmojiPat.exec(content)) !== null) {
+                const name = bEm[1].trim();
+                if (!bilingualEmojis.includes(name)) bilingualEmojis.push(name);
+            }
+            content = content.replace(/\[\[SEND_EMOJI:\s*.*?\]\]/g, '').trim();
+            const tagPattern = /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*<\/翻译>/g;
+            let lastIndex = 0;
+            let tagMatch;
+
+            while ((tagMatch = tagPattern.exec(content)) !== null) {
+                const textBefore = content.slice(lastIndex, tagMatch.index).trim();
+                if (textBefore) {
+                    const cleaned = ChatParser.sanitize(textBefore);
+                    if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
+                        const chunks = ChatParser.chunkText(cleaned);
+                        for (const chunk of chunks) {
+                            if (!chunk) continue;
+                            const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
+                            await new Promise(r => setTimeout(r, Math.min(Math.max(chunk.length * 50, 500), 2000)));
+                            await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: chunk, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
+                            setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                            globalMsgIndex++;
+                        }
+                    }
+                }
+
+                const originalText = ChatParser.sanitize(tagMatch[1].trim());
+                const translatedText = ChatParser.sanitize(tagMatch[2].trim());
+                if (originalText || translatedText) {
+                    const biContent = originalText && translatedText
+                        ? `${originalText}\n%%BILINGUAL%%\n${translatedText}`
+                        : (originalText || translatedText);
+                    const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
+                    await new Promise(r => setTimeout(r, Math.min(Math.max(biContent.length * 30, 400), 2000)));
+                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: biContent, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
+                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                    globalMsgIndex++;
+                }
+
+                lastIndex = tagMatch.index + tagMatch[0].length;
+            }
+
+            const textAfter = content.slice(lastIndex).trim();
+            if (textAfter) {
+                const cleaned = ChatParser.sanitize(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
+                if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
+                    const chunks = ChatParser.chunkText(cleaned);
+                    for (const chunk of chunks) {
+                        if (!chunk) continue;
+                        const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
+                        await new Promise(r => setTimeout(r, Math.min(Math.max(chunk.length * 50, 500), 2000)));
+                        await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: chunk, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
+                        setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                        globalMsgIndex++;
+                    }
+                }
+            }
+
+            for (const emojiName of bilingualEmojis) {
+                const foundEmoji = emojis.find(e => e.name === emojiName);
+                if (foundEmoji) {
+                    await new Promise(r => setTimeout(r, Math.random() * 500 + 300));
+                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: takeMeta(mcdInheritMeta) } as any);
+                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                }
+            }
+        } else {
+            // ─── normal path (splitResponse → chunkText → per-chunk save) ───
+            const parts = ChatParser.splitResponse(content);
+            for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+                const part = parts[partIndex];
+
+                if (part.type === 'emoji') {
+                    const foundEmoji = emojis.find(e => e.name === part.content);
+                    if (foundEmoji) {
+                        await new Promise(r => setTimeout(r, Math.random() * 500 + 300));
+                        await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: takeMeta(mcdInheritMeta) } as any);
+                        setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                    }
+                } else {
+                    const rawBlocks = part.content.split(/^\s*---\s*$/m).filter(b => b.trim());
+                    const allChunks: string[] = [];
+                    for (const block of rawBlocks) {
+                        allChunks.push(...ChatParser.chunkText(block.trim()));
+                    }
+                    if (allChunks.length === 0 && part.content.trim()) allChunks.push(part.content.trim());
+
+                    for (let i = 0; i < allChunks.length; i++) {
+                        let chunk = allChunks[i];
+                        const delay = Math.min(Math.max(chunk.length * 50, 500), 2000);
+                        await new Promise(r => setTimeout(r, delay));
+
+                        let chunkReplyTarget: { id: number, content: string, name: string } | undefined;
+                        const chunkQuoteMatch = chunk.match(QUOTE_RE_DOUBLE) || chunk.match(QUOTE_RE_SINGLE) || chunk.match(REPLY_RE_CN);
+                        if (chunkQuoteMatch) {
+                            const quotedText = chunkQuoteMatch[1].trim();
+                            if (quotedText) {
+                                const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
+                                    || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
+                                if (targetMsg) {
+                                    const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
+                                    chunkReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
+                                }
+                            }
+                            chunk = chunk.replace(QUOTE_CLEAN_DOUBLE, '').replace(QUOTE_CLEAN_SINGLE, '').replace(REPLY_CLEAN_CN, '').trim();
+                        }
+
+                        const replyData = chunkReplyTarget;
+
+                        if (ChatParser.hasDisplayContent(chunk)) {
+                            const cleanChunk = ChatParser.sanitize(chunk);
+                            if (cleanChunk) {
+                                await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: cleanChunk, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
+                                setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                                globalMsgIndex++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    // 「执行功能前的本轮正文 A」: 在二轮重生开始前先把 A 渲染成气泡, 这样用户看到的顺序是
+    // A 气泡 → "正在搜索/调阅…" 状态 → 二轮结果 B 气泡 (而不是等 B 回来才一起冒出来)。
+    // XHS_*/READ_NOTE 标签 sanitize 不剥, 这里先剥掉; 其余 RECALL/SEARCH/DIARY... 由 renderAndPersist
+    // 内 sanitize 统一清。A 的思考链取一轮 reasoning。
+    const round1ThinkingChain = extractThinkingChain(initialData, pushReasoningContent);
+    let leadInRendered = false;
+    const renderLeadIn = async (raw: string): Promise<void> => {
+        if (leadInRendered) return;
+        leadInRendered = true;
+        await renderAndPersist(
+            raw.replace(/\[\[READ_NOTE:[\s\S]*?\]\]/g, '').replace(/\[\[XHS_[A-Z_]+(?::[\s\S]*?)?\]\]/g, ''),
+            round1ThinkingChain,
+        );
+    };
 
     // ─── Step 2: 二轮 LLM 钩子 ───
+
+    // 本轮回复里只要含"会触发二轮重生"的指令 (RECALL / SEARCH / READ_DIARY / FS_READ_DIARY /
+    // READ_NOTE / XHS_SEARCH|BROWSE|MY_PROFILE|DETAIL), 就先把指令之外的本轮正文 A 落库展示。
+    // 纯副作用 (XHS_SHARE/COMMENT/LIKE/FAV/POST、写日记) 不重生、不需要先展示, 故不在此列。
+    // 之后各分支正常跑功能 + 二轮; 末尾再展示 B。若分支因未配置等原因没真正发起二轮 (data 不变),
+    // 末尾会跳过重复渲染 (见下方收尾)。
+    if (!skipSecondPassLLM) {
+        const willRegenerate =
+            /\[\[RECALL:\s*\d{4}[-/年]\d{1,2}\]\]/.test(aiContent)
+            || /\[\[SEARCH:\s*.+?\]\]/.test(aiContent)
+            || /\[\[READ_DIARY:\s*.+?\]\]/.test(aiContent)
+            || /\[\[FS_READ_DIARY:\s*.+?\]\]/.test(aiContent)
+            || /\[\[READ_NOTE:\s*.+?\]\]/.test(aiContent)
+            || /\[\[XHS_SEARCH:\s*.+?\]\]/.test(aiContent)
+            || /\[\[XHS_BROWSE(?::\s*.+?)?\]\]/.test(aiContent)
+            || /\[\[XHS_MY_PROFILE\]\]/.test(aiContent)
+            || /\[\[XHS_DETAIL:\s*.+?\]\]/.test(aiContent);
+        if (willRegenerate) await renderLeadIn(aiContent);
+    }
 
     // 5. Handle Recall (Loop if needed)
     const recallMatch = aiContent.match(/\[\[RECALL:\s*(\d{4})[-/年](\d{1,2})\]\]/);
     if (!skipSecondPassLLM && recallMatch) {
         const year = recallMatch[1];
         const month = recallMatch[2];
-        // 模型常把 [[RECALL]] 指令和本轮正文 A 写在同一条回复里。把 A 作为 assistant 上文喂给二轮,
-        // 让二轮结果 B 接着 A 往下说 (A 会在末尾被统一拼回 B 前面一起展示)。
+        // 模型常把 [[RECALL]] 指令和本轮正文 A 写在同一条回复里 (A 已在 Step 2 开头先行展示)。把 A
+        // 作为 assistant 上文喂给二轮, 让二轮结果 B 接着 A 往下说, 更连贯。
         const recallLeadIn = aiContent.replace(/\[\[RECALL:\s*\d{4}[-/年]\d{1,2}\]\]/g, '').trim();
         const rr = await runRecall({ year, month }, agenticCtx);
 
@@ -1479,47 +1700,13 @@ export async function applyAssistantPostProcessing(
     }
     aiContent = aiContent.replace(/\[\[XHS_POST:.*?\]\]/gs, '').trim();
 
-    // ─── Step 2.9: 把"执行功能前的本轮正文 A"拼回二轮结果 B 前面, 让一轮+二轮都展示 ───
-    // 只在确实跑过二轮 (data !== initialData; 只有重生分支会重新赋值 data) 时拼; 没跑二轮时 aiContent
-    // 本来就是 A, 再拼会重复。XHS_* / READ_NOTE 标签 ChatParser.sanitize 不剥, 这里先在 A 上剥掉
-    // (其余 RECALL/SEARCH/DIARY/... 由后面的 sanitize 统一清), SEND_EMOJI 等留着走正常渲染。
-    // 下游 chunkText 按换行/句子切, A、B 自然落成相邻的不同气泡。
-    if (data !== initialData) {
-        const leadIn = firstPassForLeadIn
-            .replace(/\[\[READ_NOTE:[\s\S]*?\]\]/g, '')
-            .replace(/\[\[XHS_[A-Z_]+(?::[\s\S]*?)?\]\]/g, '')
-            .trim();
-        if (leadIn) aiContent = aiContent.trim() ? `${leadIn}\n\n${aiContent}` : leadIn;
-    }
-
     // ─── Step 3: ChatParser.parseAndExecuteActions ───
     aiContent = await ChatParser.parseAndExecuteActions(aiContent, char.id, char.name, addToast, musicHooks);
 
-    // ─── Step 4: thinking chain 抽取 ───
-    // push 路径 (ctx.reasoningContent 非空) 优先用 worker 写到 reasoning_buffer 的内容;
-    // 本地 fetch 路径走 data.choices[0].message.reasoning_content (initialData 或 2nd-pass result).
-    let pendingThinkingChain: string | null = null;
-    if ((char as any).showThinkingChain) {
-        const lastRaw = data?.choices?.[0]?.message?.content || '';
-        const lastReasoning = (
-            (pushReasoningContent && pushReasoningContent.trim())
-            || data?.choices?.[0]?.message?.reasoning_content
-            || ''
-        ).trim();
-        const thinkBlocks: string[] = [];
-        const thinkPat = /<(think|thinking|thought)>([\s\S]*?)<\/\1>/gi;
-        let tm: RegExpExecArray | null;
-        while ((tm = thinkPat.exec(lastRaw)) !== null) {
-            const t = tm[2].trim();
-            if (t) thinkBlocks.push(t);
-        }
-        if (!/<\/(?:think|thinking|thought)>/i.test(lastRaw)) {
-            const openOnly = lastRaw.match(/<(?:think|thinking|thought)>([\s\S]*$)/i);
-            if (openOnly && openOnly[1].trim()) thinkBlocks.push(openOnly[1].trim());
-        }
-        const chain = [lastReasoning, ...thinkBlocks].filter(s => !!s).join('\n\n').trim();
-        if (chain) pendingThinkingChain = chain;
-    }
+    // ─── Step 4: thinking chain 抽取 (本轮末尾展示用) ───
+    // 跑过二轮 (data !== initialData) → 取二轮 data 的 reasoning; 没跑二轮 → 取一轮 (round1ThinkingChain,
+    // 已含 push 路径 reasoning)。一轮正文 A 的思考链在 Step 2 开头展示时已单独带上。
+    let pendingThinkingChain: string | null = data !== initialData ? extractThinkingChain(data) : round1ThinkingChain;
     const mergeAssistantMeta = (base: any): any => {
         if (!pendingThinkingChain) return base;
         const merged = { ...(base || {}), thinkingChain: pendingThinkingChain };
@@ -1552,171 +1739,23 @@ export async function applyAssistantPostProcessing(
         aiContent = cleanedContent;
     }
 
-    // ─── Step 7 (前置 Quote): Handle Quote/Reply Logic ───
-    const QUOTE_RE_DOUBLE = /\[\[(?:QU[OA]TE|引用)[：:]\s*([\s\S]*?)\]\]/;
-    const QUOTE_RE_SINGLE = /\[(?:QU[OA]TE|引用)[：:]\s*([^\]]*)\]/;
-    const REPLY_RE_CN = /\[回复\s*[""“]([^""”]*?)[""”](?:\.{0,3})\]\s*[：:]?\s*/;
-    const QUOTE_CLEAN_DOUBLE = /\[\[(?:QU[OA]TE|引用)[：:][\s\S]*?\]\]/g;
-    const QUOTE_CLEAN_SINGLE = /\[(?:QU[OA]TE|引用)[：:][^\]]*\]/g;
-    const REPLY_CLEAN_CN = /\[回复\s*[""“][^""”]*?[""”](?:\.{0,3})\]\s*[：:]?\s*/g;
-    let aiReplyTarget: { id: number, content: string, name: string } | undefined;
-    const firstQuoteMatch = aiContent.match(QUOTE_RE_DOUBLE) || aiContent.match(QUOTE_RE_SINGLE) || aiContent.match(REPLY_RE_CN);
-    if (firstQuoteMatch) {
-        const quotedText = firstQuoteMatch[1].trim();
-        if (quotedText) {
-            const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
-                || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
-            if (targetMsg) {
-                const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
-                aiReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
-            }
-        }
-    }
-
-    // ─── Step 6: sanitize + Step 7: INNER_STATE 兜底 ───
-    aiContent = ChatParser.sanitize(aiContent, { keepCitations: true });
-    aiContent = aiContent.replace(/\[\[INNER_STATE:\s*[\s\S]*?\]\]/g, '').trim();
-
-    // 空内容兜底 — 任何二轮重生 (recall / search / read-diary / read-note / 各 XHS...) 一旦吐空 / 只剩标签,
-    // 都会让本轮回复整段消失 (前端只闪一下状态)。data !== initialData 精确表示"本轮真的跑过二轮重生"
-    // (只有重生分支会重新赋值 data, 纯副作用的 SHARE/COMMENT/LIKE/POST/写日记 不动它); 再并上原有的
-    // recall/search/readDiary/fsReadDiary tag 判断, 兼容"有标签但因未配置等原因没真正发起二轮"的旧路径。
-    if (!aiContent.trim() && (data !== initialData || recallMatch || searchMatch || readDiaryMatch || fsReadDiaryMatch)) {
-        aiContent = '嗯...';
-    }
-
-    if (aiContent) {
-        const hasTranslationTags = /<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/.test(aiContent);
-
-        let globalMsgIndex = 0;
-
-        if (hasTranslationTags) {
-            // ─── Step 8: 双语 ───
-            const bilingualEmojis: string[] = [];
-            let bEm;
-            const bEmojiPat = /\[\[SEND_EMOJI:\s*(.*?)\]\]/g;
-            while ((bEm = bEmojiPat.exec(aiContent)) !== null) {
-                const name = bEm[1].trim();
-                if (!bilingualEmojis.includes(name)) bilingualEmojis.push(name);
-            }
-            aiContent = aiContent.replace(/\[\[SEND_EMOJI:\s*.*?\]\]/g, '').trim();
-            const tagPattern = /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*<\/翻译>/g;
-            let lastIndex = 0;
-            let tagMatch;
-
-            while ((tagMatch = tagPattern.exec(aiContent)) !== null) {
-                const textBefore = aiContent.slice(lastIndex, tagMatch.index).trim();
-                if (textBefore) {
-                    const cleaned = ChatParser.sanitize(textBefore);
-                    if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
-                        const chunks = ChatParser.chunkText(cleaned);
-                        for (const chunk of chunks) {
-                            if (!chunk) continue;
-                            const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
-                            await new Promise(r => setTimeout(r, Math.min(Math.max(chunk.length * 50, 500), 2000)));
-                            await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: chunk, replyTo: replyData, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                            setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                            globalMsgIndex++;
-                        }
-                    }
-                }
-
-                const originalText = ChatParser.sanitize(tagMatch[1].trim());
-                const translatedText = ChatParser.sanitize(tagMatch[2].trim());
-                if (originalText || translatedText) {
-                    const biContent = originalText && translatedText
-                        ? `${originalText}\n%%BILINGUAL%%\n${translatedText}`
-                        : (originalText || translatedText);
-                    const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
-                    await new Promise(r => setTimeout(r, Math.min(Math.max(biContent.length * 30, 400), 2000)));
-                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: biContent, replyTo: replyData, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                    globalMsgIndex++;
-                }
-
-                lastIndex = tagMatch.index + tagMatch[0].length;
-            }
-
-            const textAfter = aiContent.slice(lastIndex).trim();
-            if (textAfter) {
-                const cleaned = ChatParser.sanitize(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
-                if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
-                    const chunks = ChatParser.chunkText(cleaned);
-                    for (const chunk of chunks) {
-                        if (!chunk) continue;
-                        const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
-                        await new Promise(r => setTimeout(r, Math.min(Math.max(chunk.length * 50, 500), 2000)));
-                        await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: chunk, replyTo: replyData, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                        setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                        globalMsgIndex++;
-                    }
-                }
-            }
-
-            for (const emojiName of bilingualEmojis) {
-                const foundEmoji = emojis.find(e => e.name === emojiName);
-                if (foundEmoji) {
-                    await new Promise(r => setTimeout(r, Math.random() * 500 + 300));
-                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                }
-            }
-        } else {
-            // ─── Step 9-13: normal path (splitResponse → chunkText → per-chunk save) ───
-            const parts = ChatParser.splitResponse(aiContent);
-            for (let partIndex = 0; partIndex < parts.length; partIndex++) {
-                const part = parts[partIndex];
-
-                if (part.type === 'emoji') {
-                    const foundEmoji = emojis.find(e => e.name === part.content);
-                    if (foundEmoji) {
-                        await new Promise(r => setTimeout(r, Math.random() * 500 + 300));
-                        await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                        setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                    }
-                } else {
-                    const rawBlocks = part.content.split(/^\s*---\s*$/m).filter(b => b.trim());
-                    const allChunks: string[] = [];
-                    for (const block of rawBlocks) {
-                        allChunks.push(...ChatParser.chunkText(block.trim()));
-                    }
-                    if (allChunks.length === 0 && part.content.trim()) allChunks.push(part.content.trim());
-
-                    for (let i = 0; i < allChunks.length; i++) {
-                        let chunk = allChunks[i];
-                        const delay = Math.min(Math.max(chunk.length * 50, 500), 2000);
-                        await new Promise(r => setTimeout(r, delay));
-
-                        let chunkReplyTarget: { id: number, content: string, name: string } | undefined;
-                        const chunkQuoteMatch = chunk.match(QUOTE_RE_DOUBLE) || chunk.match(QUOTE_RE_SINGLE) || chunk.match(REPLY_RE_CN);
-                        if (chunkQuoteMatch) {
-                            const quotedText = chunkQuoteMatch[1].trim();
-                            if (quotedText) {
-                                const targetMsg = contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText))
-                                    || (quotedText.length > 10 ? contextMsgs.slice().reverse().find((m: Message) => m.role === 'user' && m.content.includes(quotedText.slice(0, 10))) : undefined);
-                                if (targetMsg) {
-                                    const truncated = targetMsg.content.length > 10 ? targetMsg.content.slice(0, 10) + '...' : targetMsg.content;
-                                    chunkReplyTarget = { id: targetMsg.id, content: truncated, name: userProfile.name };
-                                }
-                            }
-                            chunk = chunk.replace(QUOTE_CLEAN_DOUBLE, '').replace(QUOTE_CLEAN_SINGLE, '').replace(REPLY_CLEAN_CN, '').trim();
-                        }
-
-                        const replyData = chunkReplyTarget;
-
-                        if (ChatParser.hasDisplayContent(chunk)) {
-                            const cleanChunk = ChatParser.sanitize(chunk);
-                            if (cleanChunk) {
-                                await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: cleanChunk, replyTo: replyData, metadata: mergeAssistantMeta(mcdInheritMeta) } as any);
-                                setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                                globalMsgIndex++;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    } else {
+    // ─── Step 6: 展示本轮回复 (二轮结果 B / 无二轮时的单轮回复) ───
+    // - 跑过二轮 (data !== initialData): aiContent 现在是 B; 一轮正文 A 已在 Step 2 开头先行展示, 这里只展示 B。
+    // - 有重生指令但没真正发起二轮 (data 不变: 未配置/无结果/无日志/已激活/二轮异常 等): A 已展示, 跳过避免重复。
+    // - 没有重生 (普通回复 / instant push): leadInRendered 必为 false, 正常展示本轮唯一回复。
+    if (leadInRendered && data === initialData) {
         setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+    } else {
+        const sanitizedBody = ChatParser.sanitize(aiContent, { keepCitations: true })
+            .replace(/\[\[INNER_STATE:\s*[\s\S]*?\]\]/g, '')
+            .trim();
+        if (sanitizedBody) {
+            await renderAndPersist(aiContent, pendingThinkingChain);
+        } else if (!leadInRendered && (data !== initialData || recallMatch || searchMatch || readDiaryMatch || fsReadDiaryMatch)) {
+            // 跑过二轮却吐空, 且本轮还没展示过任何内容 → 至少补一句, 避免整轮静默。
+            await renderAndPersist('嗯...', pendingThinkingChain);
+        } else {
+            setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+        }
     }
 }


### PR DESCRIPTION
之前 A 只喂给二轮当上下文、从不渲染, 用户只看到 B; 上一版把 A+B 拼一起也要等
B 回来才一起冒出来。现在改成:

1. 抽出 renderAndPersist(rawContent, thinkingChain) —— 把原末尾的渲染逻辑 (双语/表情/引用/分段落库) 提成可复用函数, 一轮 A 和二轮 B 共用同一套。
2. Step 2 开头检测到会触发二轮重生的指令 (RECALL/SEARCH/READ_DIARY/ FS_READ_DIARY/READ_NOTE/XHS_SEARCH|BROWSE|MY_PROFILE|DETAIL) 时, 先把指令 之外的本轮正文 A 落库展示 —— 于是顺序变成 A 气泡 → '正在搜索/调阅…'状态 → B 气泡。XHS_*/READ_NOTE 先剥, 其余标签由 renderAndPersist 内 sanitize 清。
3. 末尾收尾: 真跑过二轮 (data 变) 展示 B; 有重生指令但没真跑二轮 (未配置/无 结果/无日志/已激活/异常 → data 不变) 则跳过, 避免和开头已展示的 A 重复; 普通回复 / instant push 走原单轮渲染。
4. 思考链拆分: A 取一轮 reasoning, B 取二轮 reasoning。