### PR TITLE
fix(instant-push): IndexedDB 连接韧性整治, 修确认超时

### DIFF
--- a/apps/pixelHome/pixelHomeDb.ts
+++ b/apps/pixelHome/pixelHomeDb.ts
@@ -10,22 +10,15 @@ import type { PixelAsset, PixelRoomLayout, PixelHomeState } from './types';
 import type { MemoryRoom } from '../../utils/memoryPalace/types';
 import { ROOM_SLOTS, DEFAULT_ROOM_COLORS, ALL_ROOMS } from './roomTemplates';
 import type { PlacedFurniture } from './types';
+import { openDB } from '../../utils/db';
 
 // ─── DB 常量 ─────────────────────────────────────────
+// pixel_home_* 两个 store 由 utils/db.ts 的 AetherOS_Data upgradeneeded 统一创建,
+// 这里直接复用 utils/db.ts 的单例 openDB —— 本地原来那个 openDB 每次操作都裸开一条
+// AetherOS_Data 连接 (连版本号都没传), 既漏连接又绕过单例, 会一起喂大连接风暴。
 
-const DB_NAME = 'AetherOS_Data';
 const STORE_ASSETS = 'pixel_home_assets';
 const STORE_LAYOUTS = 'pixel_home_layouts';
-
-// ─── 辅助：打开数据库 ───────────────────────────────
-
-async function openDB(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-}
 
 // ─── 资产 CRUD ──────────────────────────────────────
 

--- a/docs/amsg-sw-idb-resilience-spec.md
+++ b/docs/amsg-sw-idb-resilience-spec.md
@@ -1,0 +1,191 @@
+# Spec: `@rei-standard/amsg-sw` IndexedDB 连接韧性修复
+
+> ✅ **已实现并发版**：`@rei-standard/amsg-sw@2.3.0`（Gap 1 = onclose + 事务级 InvalidStateError 重开兜底，dedupe / queue / multipart 库全覆盖；Gap 2 = DELIVER ack 新增可选 `businessError` 字段，并把失败持久化到 dedupe 记录上，重复包也带 businessError）。SullyOS 侧已 bump 到 2.3.0、重打 bundle、`SW_VERSION` → 1.15.0，并在 `utils/instantPushClient.ts` 接入 `businessError` 让超时诊断更精确。下文保留为设计记录。
+
+> 交接给 amsg-sw 包维护方。本文描述两个**包内**的 IndexedDB 韧性缺口，给出修复方案与验收标准。
+> SullyOS 侧的根因（主库连接风暴）已在 SullyOS 仓库自行修复（见文末「分工」），这里只列需要包升级才能解决的部分。
+>
+> 当前 SullyOS 锁的版本：`@rei-standard/amsg-sw@2.2.0`、`amsg-shared@0.2.0`。
+> 下面引用的行号均指 `amsg-sw@2.2.0` 的 `dist/index.mjs`（发布产物），供你对照包源码定位。
+
+---
+
+## 背景：现象与触发链
+
+SullyOS 是 local-first 应用，整个 origin 跑着多个 IndexedDB 库（应用主库 `AetherOS_Data`、`ActiveMsg` inbox、以及本包的 `rei-sw` dedupe/queue 库）。在高并发下，Chromium 底层 backing store 一旦报错（`Internal error opening backing store for indexedDB.open`），**可能强制关闭**该 origin 已打开的连接（这是结合「多个库同时报错」的现场得出的推断，不是单条日志能坐实的铁证；也不排除磁盘/配额/profile 损坏等其它诱因）。被强关的连接通常不会触发 `versionchange` 事件，而是触发 `close` 事件，之后对它发起事务会抛：
+
+```
+InvalidStateError: Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing
+```
+
+本包当前对「连接被强关」这种失效**没有自愈**，于是出现两个问题。
+
+> 注意失败点的顺序：`handlePushPayload`（dist `:96`）**第一步**就是 `await maybeCleanupMultipart(...)`（dist `:97`，走 queue 库 `cachedDB`），multipart push 还会先过 `acceptMultipartChunk`（dist `:100`，同样 queue 库），**之后才轮到** `claimDedupe`（dist `:104`，dedupe 库）。所以一旦连接被强关，**queue/multipart 库往往比 dedupe 库更早把整条投递链路掐断**。下面 Gap 1 的修法对 dedupe 库和 queue 库要同等对待，不是「dedupe 为主、queue 同理」。
+
+---
+
+## Gap 1（必修）：dedupe / queue 连接被强关后，缓存里的死连接被无限复用
+
+### 现状
+
+- `openDedupeDatabase(dedupe)`（dist `dist/index.mjs:1010`）把连接缓存在 `dedupeDbCache`（Map，key=`${dbName}:${storeName}`），`openQueueDatabase()`（`:1035`）缓存在模块级 `cachedDB`。
+- 两者**只在 `onversionchange` 时**清缓存：
+
+  ```js
+  // openDedupeDatabase, :1026
+  db.onversionchange = () => { db.close(); dedupeDbCache.delete(cacheKey); };
+  // openQueueDatabase, :1055
+  cachedDB.onversionchange = () => { cachedDB.close(); cachedDB = null; };
+  ```
+
+- **没有挂 `db.onclose`**。当连接被浏览器强制关闭（backing store 出错 / 存储压力 / 用户清数据），`versionchange` 不会触发，缓存里这条**已死连接**一直留着。
+- `withDedupeStore`（`:984`）/ `withDatabaseStore`（`:975`）每次都复用缓存连接发事务：
+
+  ```js
+  async function withDedupeStore(dedupe, mode, handler) {
+    const db = await openDedupeDatabase(dedupe);          // 拿到死连接
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(dedupe.storeName, mode); // ← 抛 InvalidStateError
+      ...
+    });
+  }
+  ```
+
+  `db.transaction()` 在死连接上**同步抛** `InvalidStateError`，Promise executor 捕获后 reject。
+
+### 后果
+
+1. **去重彻底失灵 + push 落库被阻断**：`handlePushPayload`（`:104`）第一步就是 `await claimDedupe(...)`，它走 `withDedupeStore`。死连接让 `claimDedupe` 抛错 → `handlePushPayload` 在 `dispatchBusinessPayload` 之前就抛 → 业务回调（消费方写 inbox 等）**根本不执行** → `handleDeliverMessage`（`:120`）catch 后回 `ok:false` ack。**不重启 SW 永远好不了**，因为缓存里的死连接不会被任何路径清掉。
+2. **`dedupe cleanup failed` 刷屏**：`maybeCleanupDedupe`（`:450`）周期性跑 `cleanupDedupeStore`，同样复用死连接，每次都抛 `InvalidStateError`，被 `:459` 的 `console.error("dedupe cleanup failed:", error)` 打出来，刷屏几十上百条。
+3. 同理 `cachedDB`（queue / multipart 库）一旦被强关也是死的，multipart 重组、queue 操作全挂。
+
+### 修复方案
+
+**(a) 挂 `onclose` 清缓存**——和现有 `onversionchange` 对称：
+
+```js
+// openDedupeDatabase
+request.onsuccess = () => {
+  const db = request.result;
+  dedupeDbCache.set(cacheKey, db);
+  const drop = () => { dedupeDbCache.delete(cacheKey); };
+  db.onversionchange = () => { db.close(); drop(); };
+  db.onclose = () => { drop(); };   // ← 新增：被强关时清缓存
+  resolve(db);
+};
+```
+
+```js
+// openQueueDatabase
+request.onsuccess = () => {
+  cachedDB = request.result;
+  cachedDB.onversionchange = () => { cachedDB?.close(); cachedDB = null; };
+  cachedDB.onclose = () => { cachedDB = null; };   // ← 新增
+  resolve(cachedDB);
+};
+```
+
+**(b) 事务级一次重开兜底**——`onclose` 是异步事件，可能晚于下一次事务调用；而且 `db.transaction()` 是**同步抛**。所以 `withDedupeStore` / `withDatabaseStore` 要捕获「连接 closing/closed」错误，清缓存、重开一次、重试一次：
+
+```js
+function isConnectionClosingError(e) {
+  return e && (e.name === 'InvalidStateError' ||
+    /connection is closing|database connection is closing/i.test(String(e && e.message)));
+}
+
+async function withDedupeStore(dedupe, mode, handler) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let db;
+    try { db = await openDedupeDatabase(dedupe); }
+    catch (e) {
+      if (attempt === 0) { invalidateDedupeCache(dedupe); continue; }
+      throw e;
+    }
+    try {
+      return await new Promise((resolve, reject) => {
+        let transaction;
+        try { transaction = db.transaction(dedupe.storeName, mode); }  // 同步抛 InvalidStateError
+        catch (e) { reject(e); return; }
+        const store = transaction.objectStore(dedupe.storeName);
+        transaction.onerror = () => reject(transaction.error || new Error("Dedupe transaction failed"));
+        Promise.resolve(handler(store, resolve, reject)).catch(reject);
+      });
+    } catch (e) {
+      if (attempt === 0 && isConnectionClosingError(e)) { invalidateDedupeCache(dedupe); continue; }
+      throw e;
+    }
+  }
+}
+```
+
+`withDatabaseStore`（queue 库）同理，`invalidate` 改成 `cachedDB?.close(); cachedDB = null;`。重试上限 1 次，避免无限循环；第二次仍失败就如实抛出。
+
+---
+
+## Gap 2（建议修，SullyOS 不阻塞）：DELIVER ack 的 `ok:true` 不反映业务落库结果
+
+### 现状
+
+`dispatchBusinessPayload`（`:143`）把消费方 `onBusinessPayload` 的 rejection **吞掉**了：
+
+```js
+// :169
+if (typeof defaults.onBusinessPayload === "function") {
+  try {
+    const result = defaults.onBusinessPayload(payload);
+    if (result && typeof result.then === "function") {
+      businessWork = Promise.resolve(result).catch((error) => {     // ← rejection 被吞
+        console.error("[rei-standard-amsg-sw] onBusinessPayload promise rejected:", error);
+      });
+    }
+  } catch (error) { console.error(...); }
+}
+await Promise.all(notificationWork);
+...
+if (businessWork) await businessWork;   // :186 已经 catch 过, 永不 reject
+```
+
+于是 `handlePushPayload` 不会因为业务失败而抛，`handleDeliverMessage`（`:128`）照样回 `ok:true`。**即「业务落库失败，ack 仍报成功」。**
+
+### 影响评估
+
+- **对 SullyOS 不构成 bug**：SullyOS 客户端不信这个 ack——它把成功信号绑在业务侧自己 `postMessage` 的 `active-msg-received` 事件上（落库成功后才 fire），ack 的 `ok` 只用来区分超时文案。所以「ack 撒谎」在 SullyOS 这条链路上不会变成「假成功」。
+- **对「信 ack = 业务已处理」的其它消费方是真坑**：这类消费方会把没落库的消息当成功。
+
+### 建议（二选一，保持向后兼容）
+
+- **方案 A（推荐，非破坏）**：ack 增加一个可选字段透传业务错误，`ok` 维持现含义（= 已收下并分发）：
+
+  ```js
+  respondToSender(event, { ok: true, duplicate, key, requestId,
+    businessError: result.businessError /* 业务回调 reject 时填 message, 否则 undefined */ });
+  ```
+
+  需要 `dispatchBusinessPayload` 把 `onBusinessPayload` 的 rejection 捕获后**回传**（而不是只 console.error），并 `await` 它再 ack。
+
+- **方案 B（opt-in 改语义）**：`installReiSW` 增加 `ackReflectsBusiness?: boolean`，开启后业务失败让 `handleDeliverMessage` 回 `ok:false`。默认 false 保持现状。
+
+无论哪种，文档里要写清 DELIVER ack 的 `ok` 到底代表「收下」还是「已落库」。
+
+---
+
+## 验收标准
+
+1. **dedupe 自愈**：下一次 `claimDedupe` 能透明重开并成功，**不再持续抛 `InvalidStateError`**，无需重启 SW。注意两条失效路径要分开测，别混为一谈：
+   - **事务级重开兜底（(b)）**：让缓存里的连接处于 closing/closed 态后再发事务——可 mock `db.transaction` 抛 `InvalidStateError`，或对拿到的连接调 `db.close()` 后复用它（`close()` 是正常关闭、**不会**触发 `close` 事件，所以这条测的是「死连接 → 事务抛错 → 清缓存重开」，不是在验证 `onclose`）。
+   - **`onclose` 清缓存（(a)）**：要单独验证「连接被强关 → `close` 事件 → 缓存被清」，得 mock/手动派发那条失效路径（如直接调用挂在连接上的 `onclose` 回调），不能用 `db.close()` 代替。
+2. **业务不被阻断**：上述场景下，dedupe 短暂失败并恢复后，`onBusinessPayload` 仍被调用、push 仍能落库。
+3. **cleanup 不刷屏**：连接被强关后，`maybeCleanupDedupe` 重开成功，不再每轮 `dedupe cleanup failed`。
+4. queue / multipart 库（`cachedDB`）同样适用 1–3。
+5.（若采纳 Gap 2）DELIVER ack 能区分「业务落库失败」与「传输成功」。
+
+---
+
+## 分工与发版
+
+| 侧 | 改什么 | 状态 |
+|----|--------|------|
+| **amsg-sw 包** | 本 spec 的 Gap 1（必修）、Gap 2（建议） | 待这边 agent 实现 + 发版 |
+| **SullyOS** | 主库 `utils/db.ts`、`utils/activeMsgStore.ts`、SW `worker/sw-keep-alive.ts` 的 IDB 连接全部改单例复用 + `onversionchange`/`onclose` 失效自愈 + `onblocked` 统一清缓存重试；另把 `apps/pixelHome/pixelHomeDb.ts`（之前自带一个裸开同一个 `AetherOS_Data` 的 `openDB`）并到共享单例。这是连接风暴的**根因**，消除后 backing store 不再被撑爆，Gap 1 的强关诱因基本消失，Gap 1 退化为「极少数其它原因强关」的兜底 | ✅ 已修 |
+
+**发版后 SullyOS 侧动作**：bump `package.json` 里 `@rei-standard/amsg-sw` 版本 → `pnpm install` → `pnpm run build:workers`（bundle 自动带上修好的包）→ bump `worker/sw-keep-alive.ts` 的 `SW_VERSION`（触发字节比较让浏览器重装 SW）。

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@rei-standard/amsg-instant": "0.9.0",
     "@rei-standard/amsg-server": "2.5.0",
     "@rei-standard/amsg-shared": "0.2.0",
-    "@rei-standard/amsg-sw": "2.2.0",
+    "@rei-standard/amsg-sw": "2.3.0",
     "jszip": "^3.10.1",
     "pg": "^8.20.0",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       '@rei-standard/amsg-sw':
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 2.3.0
+        version: 2.3.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -877,6 +877,10 @@ packages:
 
   '@rei-standard/amsg-sw@2.2.0':
     resolution: {integrity: sha512-GHVlrWXmIlPAnA3+VRpRS7kHiJO/b7CTP62uvYnyGZB4uR/Axt02Bcr7Std91+t0YLcPNLMlgU9CmaHFUldLaQ==}
+    engines: {node: '>=20'}
+
+  '@rei-standard/amsg-sw@2.3.0':
+    resolution: {integrity: sha512-2L7peDYidVBY/daQ+Nxtel+Nns8ILkkp9oh9Sfrd/DRbRFVXWNdFOd2NL9n/+X9NJ1gvMkxCG0eFullfiMFOKQ==}
     engines: {node: '>=20'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
@@ -2754,6 +2758,10 @@ snapshots:
   '@rei-standard/amsg-shared@0.2.0': {}
 
   '@rei-standard/amsg-sw@2.2.0':
+    dependencies:
+      '@rei-standard/amsg-shared': 0.2.0
+
+  '@rei-standard/amsg-sw@2.3.0':
     dependencies:
       '@rei-standard/amsg-shared': 0.2.0
 

--- a/public/sw-keep-alive.js
+++ b/public/sw-keep-alive.js
@@ -40,7 +40,7 @@ function concatBytes(...chunks) {
   return out;
 }
 
-// node_modules/.pnpm/@rei-standard+amsg-sw@2.2.0/node_modules/@rei-standard/amsg-sw/dist/index.mjs
+// node_modules/.pnpm/@rei-standard+amsg-sw@2.3.0/node_modules/@rei-standard/amsg-sw/dist/index.mjs
 var REI_SW_DB_NAME = "rei-sw";
 var REI_SW_DB_STORE = "request-outbox";
 var REI_SW_MULTIPART_STORE = "multipart-pending";
@@ -147,15 +147,25 @@ async function handlePushPayload(sw2, payload, ctx) {
     const duplicateNotification = await maybeShowDuplicateNotification(sw2, payload, claim, ctx);
     claim.duplicateNotification = duplicateNotification;
     await notifyDuplicate(payload, claim, ctx);
-    return { ...claim, duplicateNotification };
+    const result = { ...claim, duplicateNotification };
+    const businessError2 = await readDuplicateBusinessError(claim, ctx);
+    if (businessError2 !== void 0) {
+      result.businessError = businessError2;
+    }
+    return result;
   }
-  await dispatchBusinessPayload(sw2, payload, {
+  const dispatchResult = await dispatchBusinessPayload(sw2, payload, {
     defaultIcon: ctx.defaultIcon,
     defaultBadge: ctx.defaultBadge,
     onBusinessPayload: ctx.onBusinessPayload
   }, async (intermediateResult) => {
     await updateDedupeNotificationState(claim, ctx, intermediateResult);
   });
+  const businessError = dispatchResult ? dispatchResult.businessError : void 0;
+  if (businessError !== void 0) {
+    claim.businessError = businessError;
+    await updateDedupeBusinessState(claim, ctx, businessError);
+  }
   return claim;
 }
 async function handleDeliverMessage(sw2, event, message, ctx) {
@@ -166,12 +176,16 @@ async function handleDeliverMessage(sw2, event, message, ctx) {
     }
     const source = typeof message.source === "string" && message.source ? message.source : "message";
     result = await handlePushPayload(sw2, message.payload, { ...ctx, source }) || {};
-    respondToSender(event, {
+    const ack = {
       ok: true,
       duplicate: Boolean(result.duplicate),
       key: result.key,
       requestId: message.requestId
-    });
+    };
+    if (result.businessError !== void 0) {
+      ack.businessError = result.businessError;
+    }
+    respondToSender(event, ack);
   } catch (error) {
     respondToSender(event, {
       ok: false,
@@ -207,15 +221,22 @@ async function dispatchBusinessPayload(sw2, payload, defaults, onNotificationSet
     }
   }
   let businessWork = null;
+  let businessError;
   if (typeof defaults.onBusinessPayload === "function") {
     try {
       const result = defaults.onBusinessPayload(payload);
       if (result && typeof result.then === "function") {
-        businessWork = Promise.resolve(result).catch((error) => {
-          console.error("[rei-standard-amsg-sw] onBusinessPayload promise rejected:", error);
-        });
+        businessWork = Promise.resolve(result).then(
+          () => {
+          },
+          (error) => {
+            businessError = errorToMessage(error);
+            console.error("[rei-standard-amsg-sw] onBusinessPayload promise rejected:", error);
+          }
+        );
       }
     } catch (error) {
+      businessError = errorToMessage(error);
       console.error("[rei-standard-amsg-sw] onBusinessPayload error:", error);
     }
   }
@@ -225,6 +246,7 @@ async function dispatchBusinessPayload(sw2, payload, defaults, onNotificationSet
     await onNotificationSettled(settledResult);
   }
   if (businessWork) await businessWork;
+  settledResult.businessError = businessError;
   return settledResult;
 }
 function resolveEventName(payload) {
@@ -414,6 +436,33 @@ async function updateDedupeNotificationState(claim, ctx, dispatchResult) {
     console.error("[rei-standard-amsg-sw] dedupe notification state update failed:", error);
   }
 }
+async function updateDedupeBusinessState(claim, ctx, businessError) {
+  if (businessError === void 0) return;
+  if (!claim || claim.duplicate || !claim.key || !ctx.dedupe || ctx.dedupe.enabled === false) return;
+  try {
+    const latest = await readDedupeRecord(ctx.dedupe, claim.key);
+    if (!latest || !claim.record || latest.firstSeenAt !== claim.record.firstSeenAt) return;
+    const next = { ...latest, key: claim.key, businessError };
+    await putDedupeRecord(ctx.dedupe, next);
+    claim.record = next;
+  } catch (error) {
+    console.error("[rei-standard-amsg-sw] dedupe business state update failed:", error);
+  }
+}
+async function readDuplicateBusinessError(claim, ctx) {
+  const snapshot = claim && claim.existing ? claim.existing.businessError : void 0;
+  if (!ctx.dedupe || ctx.dedupe.enabled === false || !claim || !claim.key || !claim.existing) {
+    return snapshot;
+  }
+  try {
+    const latest = await readDedupeRecord(ctx.dedupe, claim.key);
+    if (latest && latest.firstSeenAt === claim.existing.firstSeenAt && latest.businessError !== void 0) {
+      return latest.businessError;
+    }
+  } catch (_readError) {
+  }
+  return snapshot;
+}
 async function maybeShowDuplicateNotification(sw2, payload, claim, ctx) {
   const existing = claim && claim.existing ? claim.existing : null;
   if (!existing || existing.notificationShown === true) {
@@ -441,8 +490,10 @@ async function maybeShowDuplicateNotification(sw2, payload, claim, ctx) {
     return { shown: false, reason: "no-notification" };
   }
   await sw2.registration.showNotification(notification.title, notification.options);
+  const latest = await readDedupeRecord(ctx.dedupe, claim.key);
+  const base = latest || existing;
   const next = {
-    ...existing,
+    ...base,
     notificationShown: true,
     notificationStatePending: false
   };
@@ -840,6 +891,9 @@ async function registerFlushSync(sw2) {
     console.error("RESTORE ERROR", _error);
   }
 }
+function errorToMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
 function respondToSender(event, message) {
   const messagePort = event.ports && event.ports[0];
   if (messagePort && typeof messagePort.postMessage === "function") {
@@ -1013,23 +1067,87 @@ async function deleteStoreRecord(storeName, id) {
     request.onerror = () => reject(request.error || new Error(`Failed to delete ${storeName}`));
   });
 }
-async function withDatabaseStore(storeName, mode, handler) {
-  const db = await openQueueDatabase();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(storeName, mode);
+function isConnectionClosingError(error) {
+  if (!error) return false;
+  if (error.name === "InvalidStateError") return true;
+  const message = String(error.message || error);
+  return /connection is closing|database connection is closing/i.test(message);
+}
+function invalidateDedupeCache(dedupe, db) {
+  const cacheKey = `${dedupe.dbName}:${dedupe.storeName}`;
+  const cached = dedupeDbCache.get(cacheKey);
+  if (cached && cached === db) {
+    try {
+      cached.close();
+    } catch (_closeError) {
+    }
+    dedupeDbCache.delete(cacheKey);
+  }
+}
+function invalidateQueueCache(db) {
+  if (cachedDB && cachedDB === db) {
+    try {
+      cachedDB.close();
+    } catch (_closeError) {
+    }
+    cachedDB = null;
+  }
+}
+async function withConnectionRetry(open, invalidate, run) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let db;
+    try {
+      db = await open();
+    } catch (error) {
+      if (attempt === 0) {
+        invalidate(void 0);
+        continue;
+      }
+      throw error;
+    }
+    try {
+      return await run(db);
+    } catch (error) {
+      if (attempt === 0 && isConnectionClosingError(error)) {
+        invalidate(db);
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error("[rei-standard-amsg-sw] store connection retry exhausted");
+}
+function withDatabaseStore(storeName, mode, handler) {
+  return withConnectionRetry(openQueueDatabase, invalidateQueueCache, (db) => new Promise((resolve, reject) => {
+    let transaction;
+    try {
+      transaction = db.transaction(storeName, mode);
+    } catch (error) {
+      reject(error);
+      return;
+    }
     const store = transaction.objectStore(storeName);
     transaction.onerror = () => reject(transaction.error || new Error("Database transaction failed"));
     Promise.resolve(handler(store, resolve, reject)).catch(reject);
-  });
+  }));
 }
-async function withDedupeStore(dedupe, mode, handler) {
-  const db = await openDedupeDatabase(dedupe);
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(dedupe.storeName, mode);
-    const store = transaction.objectStore(dedupe.storeName);
-    transaction.onerror = () => reject(transaction.error || new Error("Dedupe transaction failed"));
-    Promise.resolve(handler(store, resolve, reject)).catch(reject);
-  });
+function withDedupeStore(dedupe, mode, handler) {
+  return withConnectionRetry(
+    () => openDedupeDatabase(dedupe),
+    (db) => invalidateDedupeCache(dedupe, db),
+    (db) => new Promise((resolve, reject) => {
+      let transaction;
+      try {
+        transaction = db.transaction(dedupe.storeName, mode);
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      const store = transaction.objectStore(dedupe.storeName);
+      transaction.onerror = () => reject(transaction.error || new Error("Dedupe transaction failed"));
+      Promise.resolve(handler(store, resolve, reject)).catch(reject);
+    })
+  );
 }
 function hasIndexedDB() {
   return typeof indexedDB !== "undefined" && indexedDB && typeof indexedDB.open === "function";
@@ -1064,9 +1182,15 @@ function openDedupeDatabase(dedupe) {
     request.onsuccess = () => {
       const db = request.result;
       dedupeDbCache.set(cacheKey, db);
+      const drop = () => {
+        if (dedupeDbCache.get(cacheKey) === db) dedupeDbCache.delete(cacheKey);
+      };
       db.onversionchange = () => {
         db.close();
-        dedupeDbCache.delete(cacheKey);
+        drop();
+      };
+      db.onclose = () => {
+        drop();
       };
       resolve(db);
     };
@@ -1092,12 +1216,16 @@ function openQueueDatabase() {
       }
     };
     request.onsuccess = () => {
-      cachedDB = request.result;
-      cachedDB.onversionchange = () => {
-        cachedDB.close();
-        cachedDB = null;
+      const db = request.result;
+      cachedDB = db;
+      db.onversionchange = () => {
+        db.close();
+        if (cachedDB === db) cachedDB = null;
       };
-      resolve(cachedDB);
+      db.onclose = () => {
+        if (cachedDB === db) cachedDB = null;
+      };
+      resolve(db);
     };
     request.onerror = () => reject(request.error || new Error("Failed to open queue database"));
   });
@@ -1106,15 +1234,20 @@ function createObjectStoreIfMissing(db, tx, name, options) {
   if (db.objectStoreNames.contains(name)) return tx.objectStore(name);
   return db.createObjectStore(name, options);
 }
-async function withQueueStore(mode, handler) {
-  const db = await openQueueDatabase();
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(REI_SW_DB_STORE, mode);
+function withQueueStore(mode, handler) {
+  return withConnectionRetry(openQueueDatabase, invalidateQueueCache, (db) => new Promise((resolve, reject) => {
+    let transaction;
+    try {
+      transaction = db.transaction(REI_SW_DB_STORE, mode);
+    } catch (error) {
+      reject(error);
+      return;
+    }
     const store = transaction.objectStore(REI_SW_DB_STORE);
     transaction.oncomplete = () => resolve(void 0);
     transaction.onerror = () => reject(transaction.error || new Error("Queue transaction failed"));
     Promise.resolve(handler(store, resolve, reject)).catch(reject);
-  });
+  }));
 }
 async function addQueuedRequest(request) {
   return withQueueStore("readwrite", (store, resolve, reject) => {
@@ -1143,7 +1276,7 @@ async function removeQueuedRequest(id) {
 }
 
 // worker/sw-keep-alive.ts
-var SW_VERSION = "1.14.0";
+var SW_VERSION = "1.15.0";
 var PING_INTERVAL = 15e3;
 var MAX_MANUAL_ALIVE_MS = 5 * 6e4;
 var ACTIVE_MSG_DB_NAME = "ActiveMsg";
@@ -1244,14 +1377,40 @@ function syncProactive(configs) {
   }
   refreshKeepAlive();
 }
+var inboxDbPromise = null;
 function openInboxDb() {
-  return new Promise((resolve, reject) => {
+  if (inboxDbPromise) return inboxDbPromise;
+  inboxDbPromise = new Promise((resolve, reject) => {
     const request = indexedDB.open(ACTIVE_MSG_DB_NAME, ACTIVE_MSG_DB_VERSION);
-    request.onerror = () => reject(request.error);
+    let settled = false;
+    request.onerror = () => {
+      inboxDbPromise = null;
+      settled = true;
+      reject(request.error);
+    };
     request.onblocked = () => {
+      inboxDbPromise = null;
+      settled = true;
       reject(new Error("IndexedDB open blocked (older version still open elsewhere)"));
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      const db = request.result;
+      if (settled) {
+        try {
+          db.close();
+        } catch {
+        }
+        return;
+      }
+      db.onversionchange = () => {
+        db.close();
+        inboxDbPromise = null;
+      };
+      db.onclose = () => {
+        inboxDbPromise = null;
+      };
+      resolve(db);
+    };
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains(ACTIVE_MSG_INBOX_STORE)) {
@@ -1268,6 +1427,38 @@ function openInboxDb() {
       }
     };
   });
+  return inboxDbPromise;
+}
+function isInboxConnectionClosingError(error) {
+  if (!error || typeof error !== "object") return false;
+  const e = error;
+  return e.name === "InvalidStateError" || /connection is closing/i.test(String(e.message || ""));
+}
+async function withInboxTx(storeName, mode, run) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const db = await openInboxDb();
+    try {
+      return await new Promise((resolve, reject) => {
+        let tx;
+        try {
+          tx = db.transaction(storeName, mode);
+        } catch (e) {
+          reject(e);
+          return;
+        }
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error || new Error(`inbox tx error (${storeName})`));
+        tx.onabort = () => reject(tx.error || new Error(`inbox tx aborted (${storeName})`));
+        run(tx.objectStore(storeName));
+      });
+    } catch (e) {
+      if (attempt === 0 && isInboxConnectionClosingError(e)) {
+        inboxDbPromise = null;
+        continue;
+      }
+      throw e;
+    }
+  }
 }
 async function saveContentToInbox(payload) {
   const charId = payload?.metadata?.charId;
@@ -1280,10 +1471,8 @@ async function saveContentToInbox(payload) {
   const parsedSentAt = payloadTimestamp ? new Date(payloadTimestamp).getTime() : NaN;
   const sentAt = Number.isFinite(parsedSentAt) ? parsedSentAt : Date.now();
   if (!charId) return;
-  const db = await openInboxDb();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_INBOX_STORE, "readwrite");
-    tx.objectStore(ACTIVE_MSG_INBOX_STORE).put({
+  await withInboxTx(ACTIVE_MSG_INBOX_STORE, "readwrite", (store) => {
+    store.put({
       messageId,
       charId,
       charName,
@@ -1305,8 +1494,6 @@ async function saveContentToInbox(payload) {
       sentAt,
       receivedAt: Date.now()
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
   await notifyClients({
     type: "active-msg-received",
@@ -1322,31 +1509,20 @@ async function saveReasoningToBuffer(payload) {
   const charId = payload?.metadata?.charId;
   const reasoningContent = String(payload?.reasoningContent ?? "");
   if (!sessionId || !charId || !reasoningContent) return;
-  const db = await openInboxDb();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_REASONING_BUFFER_STORE, "readwrite");
-    const store = tx.objectStore(ACTIVE_MSG_REASONING_BUFFER_STORE);
+  await withInboxTx(ACTIVE_MSG_REASONING_BUFFER_STORE, "readwrite", (store) => {
     store.put({
       sessionId,
       charId,
       reasoningContent,
       receivedAt: Date.now()
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-    tx.onabort = () => reject(tx.error || new Error("reasoning buffer write aborted"));
   });
   await notifyClients({ type: "active-msg-reasoning", sessionId, charId });
 }
 async function clearReasoningBuffer(sessionId) {
   if (!sessionId) return;
-  const db = await openInboxDb();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_REASONING_BUFFER_STORE, "readwrite");
-    tx.objectStore(ACTIVE_MSG_REASONING_BUFFER_STORE).delete(sessionId);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-    tx.onabort = () => reject(tx.error || new Error("reasoning buffer clear aborted"));
+  await withInboxTx(ACTIVE_MSG_REASONING_BUFFER_STORE, "readwrite", (store) => {
+    store.delete(sessionId);
   });
 }
 async function savePendingToolCall(payload) {
@@ -1358,10 +1534,8 @@ async function savePendingToolCall(payload) {
     console.warn("[amsg] clearReasoningBuffer before tool_request failed", e);
   });
   const iteration = Number.isFinite(payload?.metadata?.iteration) ? Number(payload.metadata.iteration) : 0;
-  const db = await openInboxDb();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE, "readwrite");
-    tx.objectStore(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE).put({
+  await withInboxTx(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE, "readwrite", (store) => {
+    store.put({
       sessionId,
       charId,
       toolCalls,
@@ -1369,8 +1543,6 @@ async function savePendingToolCall(payload) {
       iteration,
       createdAt: Date.now()
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
 }
 async function notifyVisibleClientForToolRequest(payload) {
@@ -1403,10 +1575,8 @@ async function saveEmotionUpdateToInbox(payload) {
   const emotionRaw = payload?.metadata?.emotionRaw || "";
   if (!charId) return;
   const messageId = String(payload?.messageId || `${charId}-emotion-${Date.now()}`);
-  const db = await openInboxDb();
-  await new Promise((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_INBOX_STORE, "readwrite");
-    tx.objectStore(ACTIVE_MSG_INBOX_STORE).put({
+  await withInboxTx(ACTIVE_MSG_INBOX_STORE, "readwrite", (store) => {
+    store.put({
       messageId,
       charId,
       charName: payload?.contactName || "",
@@ -1416,8 +1586,6 @@ async function saveEmotionUpdateToInbox(payload) {
       sentAt: Date.now(),
       receivedAt: Date.now()
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
   await notifyClients({ type: "active-msg-received", charId, charName: payload?.contactName || "", body: "", emotionUpdate: true });
 }

--- a/public/sw-keep-alive.js
+++ b/public/sw-keep-alive.js
@@ -1380,16 +1380,16 @@ function syncProactive(configs) {
 var inboxDbPromise = null;
 function openInboxDb() {
   if (inboxDbPromise) return inboxDbPromise;
-  inboxDbPromise = new Promise((resolve, reject) => {
+  const promise = new Promise((resolve, reject) => {
     const request = indexedDB.open(ACTIVE_MSG_DB_NAME, ACTIVE_MSG_DB_VERSION);
     let settled = false;
     request.onerror = () => {
-      inboxDbPromise = null;
+      if (inboxDbPromise === promise) inboxDbPromise = null;
       settled = true;
       reject(request.error);
     };
     request.onblocked = () => {
-      inboxDbPromise = null;
+      if (inboxDbPromise === promise) inboxDbPromise = null;
       settled = true;
       reject(new Error("IndexedDB open blocked (older version still open elsewhere)"));
     };
@@ -1404,10 +1404,10 @@ function openInboxDb() {
       }
       db.onversionchange = () => {
         db.close();
-        inboxDbPromise = null;
+        if (inboxDbPromise === promise) inboxDbPromise = null;
       };
       db.onclose = () => {
-        inboxDbPromise = null;
+        if (inboxDbPromise === promise) inboxDbPromise = null;
       };
       resolve(db);
     };
@@ -1427,7 +1427,8 @@ function openInboxDb() {
       }
     };
   });
-  return inboxDbPromise;
+  inboxDbPromise = promise;
+  return promise;
 }
 function isInboxConnectionClosingError(error) {
   if (!error || typeof error !== "object") return false;

--- a/utils/activeMsgStore.test.ts
+++ b/utils/activeMsgStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ActiveMsgStore } from './activeMsgStore';
 import type { InstantPushReasoningBufferEntry } from '../types';
 
@@ -111,6 +111,21 @@ describe('ActiveMsgStore reasoning chunking', () => {
 
   it('clearReasoning 空 sessionId 静默 no-op', async () => {
     await expect(ActiveMsgStore.clearReasoning('')).resolves.toBeUndefined();
+  });
+
+  it('连接复用: 单例建立后后续操作不再新开 indexedDB 连接', async () => {
+    // 先跑一次确保单例已建立 (前面的用例多半已经建立, 这里幂等)。
+    await ActiveMsgStore.getGlobalConfig();
+    const openSpy = vi.spyOn(indexedDB, 'open');
+    try {
+      await ActiveMsgStore.getGlobalConfig();
+      await ActiveMsgStore.listInboxMessages();
+      await ActiveMsgStore.consumeInboxMessages();
+      // 修复前: 3 个操作 = 3 次 open。修复后: 复用单例, 0 次。
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it('多 sessionId 互相隔离', async () => {

--- a/utils/activeMsgStore.ts
+++ b/utils/activeMsgStore.ts
@@ -29,40 +29,78 @@ const defaultGlobalConfig: ActiveMsg2GlobalConfig = {
   databaseUrl: '',
 };
 
-const openDB = (): Promise<IDBDatabase> => new Promise((resolve, reject) => {
-  const request = indexedDB.open(DB_NAME, DB_VERSION);
+// 单例连接缓存。同 utils/db.ts 的根因: 原本每个 op 都新开一条 ActiveMsg 连接且从不
+// close, 跟主库一起在并发下撑爆 Chromium backing store, 连带 SW 写 inbox 也失败。
+// 复用同一条连接, 并在连接被外部失效 (版本升级 / 浏览器强制关闭) 时清缓存自愈。
+let dbPromise: Promise<IDBDatabase> | null = null;
 
-  request.onerror = () => reject(request.error);
-  request.onblocked = () => {
-    // SW or another tab holds an older version; can't upgrade. Reject so callers don't hang.
-    reject(new Error('IndexedDB open blocked — close other tabs / unregister SW and retry'));
-  };
-  request.onsuccess = () => resolve(request.result);
-  request.onupgradeneeded = () => {
-    const db = request.result;
+const openDB = (): Promise<IDBDatabase> => {
+  if (dbPromise) return dbPromise;
 
-    if (!db.objectStoreNames.contains(STORE_KV)) {
-      db.createObjectStore(STORE_KV, { keyPath: 'id' });
-    }
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    // onblocked 不是终态: 先 reject, 但底层 open request 还活着, 占用方关闭后仍会触发
+    // onsuccess。用 settled 标记 promise 已 settle, 让迟到的连接被 close 而非泄漏成
+    // 一条没人持有、却能 block 后续升级 / 删库的孤儿连接。
+    let settled = false;
 
-    if (!db.objectStoreNames.contains(STORE_INBOX)) {
-      db.createObjectStore(STORE_INBOX, { keyPath: 'messageId' });
-    }
+    request.onerror = () => {
+      dbPromise = null; // 打开失败别缓存 rejected promise
+      settled = true;
+      reject(request.error);
+    };
+    request.onblocked = () => {
+      // SW or another tab holds an older version; can't upgrade. Reject so callers don't hang.
+      dbPromise = null;
+      settled = true;
+      reject(new Error('IndexedDB open blocked — close other tabs / unregister SW and retry'));
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      // 已经 reject 过 (onblocked / onerror): 迟到的连接没人接收, 直接 close, 否则它开着
+      // 会 block 后续升级 / deleteDatabase。
+      if (settled) {
+        try { db.close(); } catch { /* ignore */ }
+        return;
+      }
+      // 另一个 tab / SW 升级版本时主动 close 让位 + 清缓存; 强制关闭时也清缓存自愈。
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null;
+      };
+      db.onclose = () => {
+        dbPromise = null;
+      };
+      resolve(db);
+    };
+    request.onupgradeneeded = () => {
+      const db = request.result;
 
-    // Phase 2 Round 1 stores (v1 → v2 migration is additive — no data touch on existing stores)
-    if (!db.objectStoreNames.contains(STORE_OUTBOUND_SESSIONS)) {
-      db.createObjectStore(STORE_OUTBOUND_SESSIONS, { keyPath: 'sessionId' });
-    }
+      if (!db.objectStoreNames.contains(STORE_KV)) {
+        db.createObjectStore(STORE_KV, { keyPath: 'id' });
+      }
 
-    if (!db.objectStoreNames.contains(STORE_PENDING_TOOL_CALLS)) {
-      db.createObjectStore(STORE_PENDING_TOOL_CALLS, { keyPath: 'sessionId' });
-    }
+      if (!db.objectStoreNames.contains(STORE_INBOX)) {
+        db.createObjectStore(STORE_INBOX, { keyPath: 'messageId' });
+      }
 
-    if (!db.objectStoreNames.contains(STORE_REASONING_BUFFER)) {
-      db.createObjectStore(STORE_REASONING_BUFFER, { keyPath: 'sessionId' });
-    }
-  };
-});
+      // Phase 2 Round 1 stores (v1 → v2 migration is additive — no data touch on existing stores)
+      if (!db.objectStoreNames.contains(STORE_OUTBOUND_SESSIONS)) {
+        db.createObjectStore(STORE_OUTBOUND_SESSIONS, { keyPath: 'sessionId' });
+      }
+
+      if (!db.objectStoreNames.contains(STORE_PENDING_TOOL_CALLS)) {
+        db.createObjectStore(STORE_PENDING_TOOL_CALLS, { keyPath: 'sessionId' });
+      }
+
+      if (!db.objectStoreNames.contains(STORE_REASONING_BUFFER)) {
+        db.createObjectStore(STORE_REASONING_BUFFER, { keyPath: 'sessionId' });
+      }
+    };
+  });
+
+  return dbPromise;
+};
 
 const getKv = async <T>(id: string): Promise<T | null> => {
   const db = await openDB();

--- a/utils/activeMsgStore.ts
+++ b/utils/activeMsgStore.ts
@@ -37,21 +37,24 @@ let dbPromise: Promise<IDBDatabase> | null = null;
 const openDB = (): Promise<IDBDatabase> => {
   if (dbPromise) return dbPromise;
 
-  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+  const promise = new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     // onblocked 不是终态: 先 reject, 但底层 open request 还活着, 占用方关闭后仍会触发
     // onsuccess。用 settled 标记 promise 已 settle, 让迟到的连接被 close 而非泄漏成
     // 一条没人持有、却能 block 后续升级 / 删库的孤儿连接。
+    // 清缓存一律先比对 dbPromise === promise: onclose/onerror 等都是异步回调, 若期间已
+    // 重开并缓存了新 promise (如 SW withInboxTx 强关后重试), 陈旧连接的回调不能把新单例
+    // 误清, 否则又凭空多开一条连接 (见 amsg-sw 2.3.0 同款守卫)。
     let settled = false;
 
     request.onerror = () => {
-      dbPromise = null; // 打开失败别缓存 rejected promise
+      if (dbPromise === promise) dbPromise = null; // 打开失败别缓存 rejected promise
       settled = true;
       reject(request.error);
     };
     request.onblocked = () => {
       // SW or another tab holds an older version; can't upgrade. Reject so callers don't hang.
-      dbPromise = null;
+      if (dbPromise === promise) dbPromise = null;
       settled = true;
       reject(new Error('IndexedDB open blocked — close other tabs / unregister SW and retry'));
     };
@@ -66,10 +69,10 @@ const openDB = (): Promise<IDBDatabase> => {
       // 另一个 tab / SW 升级版本时主动 close 让位 + 清缓存; 强制关闭时也清缓存自愈。
       db.onversionchange = () => {
         db.close();
-        dbPromise = null;
+        if (dbPromise === promise) dbPromise = null;
       };
       db.onclose = () => {
-        dbPromise = null;
+        if (dbPromise === promise) dbPromise = null;
       };
       resolve(db);
     };
@@ -99,7 +102,8 @@ const openDB = (): Promise<IDBDatabase> => {
     };
   });
 
-  return dbPromise;
+  dbPromise = promise;
+  return promise;
 };
 
 const getKv = async <T>(id: string): Promise<T | null> => {

--- a/utils/db.test.ts
+++ b/utils/db.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DB, openDB } from './db';
+
+// fake-indexeddb 已通过 test-setup.ts 注入。这组用例锁住「单例连接复用」这条修复:
+// 修复前 openDB 每次调用都 indexedDB.open() 新开一条连接 (a !== b, 且每个 DB 操作
+// 都触发一次 open) —— 在记忆管线并发下堆出几十条连接撑爆 backing store。修复后复用
+// 同一条连接。
+
+describe('openDB 单例连接复用', () => {
+  it('多次 openDB 返回同一条连接 (不再每次新开)', async () => {
+    const a = await openDB();
+    const b = await openDB();
+    expect(a).toBe(b);
+  });
+
+  it('连续 DB 操作复用已缓存连接, 不再触发新的 indexedDB.open', async () => {
+    await openDB(); // 确保单例已建立 (幂等)
+    const openSpy = vi.spyOn(indexedDB, 'open');
+    try {
+      await DB.getAllCharacters();
+      await DB.getAllCharacters();
+      await DB.getAllCharacters();
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});
+
+// 单例只解决「复用」, 还得保证连接被外部失效后能自愈, 否则下次拿到的还是死连接。
+// 这里直接触发挂在连接上的 onversionchange / onclose 回调, 验证缓存被清、下次 openDB 重开。
+describe('openDB 失效自愈', () => {
+  it('onversionchange 触发后 close 让位并清缓存, 下次 openDB 重开新连接', async () => {
+    const a = await openDB();
+    // 模拟另一个 tab 升级版本时浏览器派发的 versionchange
+    (a as unknown as { onversionchange?: (e: Event) => void }).onversionchange?.(new Event('versionchange'));
+    const b = await openDB();
+    expect(b).not.toBe(a);
+  });
+
+  it('onclose 触发后清缓存, 下次 openDB 重开新连接', async () => {
+    const a = await openDB();
+    // 真实场景: 浏览器是先强制关闭连接、再 fire close 事件。先 close(a) 让 fake-indexeddb
+    // 进入"连接已关"的真实状态 (否则 a 会作为一条开着的孤儿连接残留, 拖累后面的删库),
+    // 再手动触发我们挂的 onclose 处理器 (它只负责清缓存, 不负责关连接)。
+    a.close();
+    (a as unknown as { onclose?: (e: Event) => void }).onclose?.(new Event('close'));
+    const b = await openDB();
+    expect(b).not.toBe(a);
+  });
+});
+
+describe('DB.deleteDB', () => {
+  it('删库前先关掉单例连接, 不被本页自己的连接 block', async () => {
+    await openDB(); // 建立单例连接
+    // 修复前: 单例连接一直开着 → deleteDatabase 被 onblocked 卡住, 这里会 hang/超时。
+    // 修复后: deleteDB 先 close 单例再删, 正常 resolve。
+    await expect(DB.deleteDB()).resolves.toBeUndefined();
+  });
+});
+
+// blocked-then-unblocked 连接泄漏: onblocked 先 reject, 但底层 open request 还活着 ——
+// 占用方关闭后 onsuccess 仍会触发。修复前那条迟到的连接没人持有也没缓存, 开着会 block
+// 后续升级/删库; 修复后 settled 守卫让它被 close。这里复现整条链路, 用「事后 deleteDatabase
+// 不被 block」来证明孤儿连接确实被关掉了。
+describe('openDB blocked-then-unblocked 不泄漏连接', () => {
+  it('占用方关闭后迟到的 onsuccess 关掉孤儿连接, 不 block 后续删库', async () => {
+    await DB.deleteDB(); // 复位到 version 0, 让下面能从低版本起步
+
+    // 一条 raw 连接占住 v50 且不挂 onversionchange (模拟不肯让位的旧 tab)
+    const blocker = await new Promise<IDBDatabase>((resolve, reject) => {
+      const r = indexedDB.open('AetherOS_Data', 50);
+      r.onsuccess = () => resolve(r.result);
+      r.onerror = () => reject(r.error);
+    });
+
+    // openDB 要升到 DB_VERSION(51) → 被 blocker 挡住 → reject
+    await expect(openDB()).rejects.toBeTruthy();
+
+    // 放行: 关掉 blocker, 那条挂起的 51-open 会走完 onsuccess (此时 settled=true → 应 close)
+    blocker.close();
+    await new Promise((r) => setTimeout(r, 50)); // 等事件队列把 onsuccess 跑掉
+
+    // 若孤儿连接没被关, 这里 deleteDatabase 会触发 onblocked → reject; 关掉了则正常 resolve
+    await expect(new Promise<void>((resolve, reject) => {
+      const del = indexedDB.deleteDatabase('AetherOS_Data');
+      del.onsuccess = () => resolve();
+      del.onerror = () => reject(del.error);
+      del.onblocked = () => reject(new Error('deleteDatabase 被 block —— 有孤儿连接没关闭'));
+    })).resolves.toBeUndefined();
+  });
+});

--- a/utils/db.test.ts
+++ b/utils/db.test.ts
@@ -48,6 +48,19 @@ describe('openDB 失效自愈', () => {
     const b = await openDB();
     expect(b).not.toBe(a);
   });
+
+  it('陈旧连接迟到的 onclose 不误清已重开的新单例 (=== promise 守卫)', async () => {
+    const a = await openDB();
+    // 重开: 触发 a 的 onversionchange (会 close a + 清缓存), 再 openDB 拿到新单例 b
+    (a as unknown as { onversionchange?: (e: Event) => void }).onversionchange?.(new Event('versionchange'));
+    const b = await openDB();
+    expect(b).not.toBe(a);
+    // 此刻才迟到触发 a (陈旧连接) 的 onclose —— 不带守卫会把 b 误清成 null，
+    // 下次 openDB 凭空多开一条连接 (正是本次要消灭的 churn)。带守卫则 b 保留。
+    (a as unknown as { onclose?: (e: Event) => void }).onclose?.(new Event('close'));
+    const c = await openDB();
+    expect(c).toBe(b);
+  });
 });
 
 describe('DB.deleteDB', () => {

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -68,17 +68,70 @@ const SULLY_PRESET_EMOJIS = [
     { name: 'Sully等你消息', url: 'https://sharkpan.xyz/f/5nrJsj/wait.png', categoryId: SULLY_CATEGORY_ID },
 ];
 
+// 单例连接缓存。openDB 原本每次调用都新开一条 IDB 连接, 既不复用也不 close ——
+// 在记忆管线 (hybridSearch / touchAccess 等) 并发读写下会瞬间堆出几十条 AetherOS_Data
+// 连接, 撑爆 Chromium 底层 backing store; 一旦底层报错, 整个 origin 的 IndexedDB
+// (含 Service Worker 的 dedupe / inbox 库) 可能跟着开不了或被强关, Instant Push 因此确认超时。
+// 改成复用同一条连接, 并在连接被外部失效 (另一 tab 升级版本 / 浏览器强制关闭) 时
+// 清掉缓存, 下次 openDB 自动重开 —— 一处改, 全部 ~165 个调用点受益。
+let dbPromise: Promise<IDBDatabase> | null = null;
+
 export const openDB = (): Promise<IDBDatabase> => {
-  return new Promise((resolve, reject) => {
+  if (dbPromise) return dbPromise;
+
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
-    
+    // onblocked 不是终态: 它先 reject, 但底层 open request 还活着, 等占用方关闭后仍会
+    // 触发 onsuccess。用 settled 标记 promise 已 settle, 让那条迟到的连接被 close 掉而
+    // 不是泄漏成一条没人持有、却能 block 后续升级/删库的孤儿连接。
+    let settled = false;
+
     request.onerror = () => {
         console.error("DB Open Error:", request.error);
+        dbPromise = null; // 打开失败别把 rejected promise 缓存住, 否则之后每次 openDB 都拿到同一个失败
+        settled = true;
         reject(request.error);
     };
-    
-    request.onsuccess = () => resolve(request.result);
-    
+
+    request.onsuccess = () => {
+        const db = request.result;
+        // 已经 reject 过 (onblocked / onerror): 这条迟到的连接没人接收, 直接 close,
+        // 否则它开着会 block 后续的版本升级 / deleteDatabase。
+        if (settled) {
+            try { db.close(); } catch { /* ignore */ }
+            return;
+        }
+        // 另一个 tab 触发版本升级时必须主动 close 让位, 否则对方 open 会被 block;
+        // 顺手清缓存, 下次 openDB 重开到新版本。
+        db.onversionchange = () => {
+            db.close();
+            dbPromise = null;
+        };
+        // Chromium 因 backing store 出错等原因强制关闭连接时触发 —— 清缓存自愈,
+        // 避免后续操作一直复用一条已死的连接。
+        //
+        // 已知残余 (有意不修): onclose 是异步派发的, 强关到回调跑之间, 命中这条 fast-path
+        // 的调用方会拿到将死连接, 其 db.transaction() 同步抛 InvalidStateError —— 当次操作
+        // 失败, 但下一次调用就自愈。主库这 ~165 个调用点全是记忆管线 / UI 读写, 失败是
+        // 瞬时且会自然重试的 (不丢数据), 不值得为它给每个调用点铺事务级重试 (要全覆盖得上
+        // 共享 runTx 层并迁移所有 DB.* 方法, 是独立大重构)。SW inbox 那条路径不一样: 同样
+        // 的竞态会让 push 静默丢失 → 主线程超时, 所以那边 (worker/sw-keep-alive.ts 的
+        // withInboxTx) 单独补了「InvalidStateError 清缓存重开一次」的事务级兜底。
+        db.onclose = () => {
+            dbPromise = null;
+        };
+        resolve(db);
+    };
+
+    request.onblocked = () => {
+        // 另一个 tab 仍持有旧版本连接, 升级被挡。清缓存 + reject, 别让调用方无限挂着;
+        // 与 activeMsgStore / sw-keep-alive 的 openDB 一致, 对方 tab 关闭后下次调用可重试。
+        console.warn('[DB] open blocked —— 另一个 tab 仍持有旧版本连接未关闭');
+        dbPromise = null;
+        settled = true;
+        reject(new Error('IndexedDB open blocked —— 关闭其它标签页后重试'));
+    };
+
     request.onupgradeneeded = (event) => {
       const db = (event.target as IDBOpenDBRequest).result;
 
@@ -273,10 +326,17 @@ export const openDB = (): Promise<IDBDatabase> => {
       }
     };
   });
+
+  return dbPromise;
 };
 
 export const DB = {
   deleteDB: async (): Promise<void> => {
+      // 删库前先关掉单例连接, 否则这条还开着的连接会 block 掉 deleteDatabase。
+      if (dbPromise) {
+          try { (await dbPromise).close(); } catch { /* ignore */ }
+          dbPromise = null;
+      }
       return new Promise((resolve, reject) => {
           const req = indexedDB.deleteDatabase(DB_NAME);
           req.onsuccess = () => resolve();

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -79,16 +79,18 @@ let dbPromise: Promise<IDBDatabase> | null = null;
 export const openDB = (): Promise<IDBDatabase> => {
   if (dbPromise) return dbPromise;
 
-  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+  const promise = new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     // onblocked 不是终态: 它先 reject, 但底层 open request 还活着, 等占用方关闭后仍会
     // 触发 onsuccess。用 settled 标记 promise 已 settle, 让那条迟到的连接被 close 掉而
     // 不是泄漏成一条没人持有、却能 block 后续升级/删库的孤儿连接。
+    // 清缓存一律先比对 dbPromise === promise: onclose/onerror 等都是异步回调, 期间若已
+    // 重开并缓存了新 promise, 陈旧连接的回调不能误清新单例 (否则又凭空多开一条连接)。
     let settled = false;
 
     request.onerror = () => {
         console.error("DB Open Error:", request.error);
-        dbPromise = null; // 打开失败别把 rejected promise 缓存住, 否则之后每次 openDB 都拿到同一个失败
+        if (dbPromise === promise) dbPromise = null; // 打开失败别把 rejected promise 缓存住
         settled = true;
         reject(request.error);
     };
@@ -105,7 +107,7 @@ export const openDB = (): Promise<IDBDatabase> => {
         // 顺手清缓存, 下次 openDB 重开到新版本。
         db.onversionchange = () => {
             db.close();
-            dbPromise = null;
+            if (dbPromise === promise) dbPromise = null;
         };
         // Chromium 因 backing store 出错等原因强制关闭连接时触发 —— 清缓存自愈,
         // 避免后续操作一直复用一条已死的连接。
@@ -118,7 +120,7 @@ export const openDB = (): Promise<IDBDatabase> => {
         // 的竞态会让 push 静默丢失 → 主线程超时, 所以那边 (worker/sw-keep-alive.ts 的
         // withInboxTx) 单独补了「InvalidStateError 清缓存重开一次」的事务级兜底。
         db.onclose = () => {
-            dbPromise = null;
+            if (dbPromise === promise) dbPromise = null;
         };
         resolve(db);
     };
@@ -127,7 +129,7 @@ export const openDB = (): Promise<IDBDatabase> => {
         // 另一个 tab 仍持有旧版本连接, 升级被挡。清缓存 + reject, 别让调用方无限挂着;
         // 与 activeMsgStore / sw-keep-alive 的 openDB 一致, 对方 tab 关闭后下次调用可重试。
         console.warn('[DB] open blocked —— 另一个 tab 仍持有旧版本连接未关闭');
-        dbPromise = null;
+        if (dbPromise === promise) dbPromise = null;
         settled = true;
         reject(new Error('IndexedDB open blocked —— 关闭其它标签页后重试'));
     };
@@ -327,7 +329,8 @@ export const openDB = (): Promise<IDBDatabase> => {
     };
   });
 
-  return dbPromise;
+  dbPromise = promise;
+  return promise;
 };
 
 export const DB = {

--- a/utils/instantPushClient.test.ts
+++ b/utils/instantPushClient.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   sendInstantPush,
   saveInstantConfig,
   INSTANT_PUSH_CONFIG_KEY,
   probeInstantWorkerCapabilities,
+  postSsePayloadToServiceWorker,
 } from './instantPushClient';
 import type { InstantPushPayload } from './instantPushClient';
 import { savePushVapid } from './pushVapid';
@@ -127,5 +128,75 @@ describe('probeInstantWorkerCapabilities', () => {
       'https://worker.example.com/capabilities',
       expect.objectContaining({ method: 'POST' }),
     );
+  });
+});
+
+// postSsePayloadToServiceWorker: amsg-sw 2.3.0+ 的 ack 在落库失败时回 { ok:true, businessError }。
+// 这里用最小 stub 模拟 SW 回 ack, 锁住 businessError 被正确透传 (而不是被吞回一个干净的 true)。
+describe('postSsePayloadToServiceWorker ack 解析', () => {
+  // node 环境没有这些浏览器全局 (且 navigator 是只读 getter), 用 vi.stubGlobal 注入,
+  // afterEach 一并 unstub 还原, 避免污染其它用例。
+  let ackToReturn: any;
+
+  class FakePort {
+    onmessage: ((e: any) => void) | null = null;
+    peer: FakePort | null = null;
+    postMessage(data: any) {
+      const peer = this.peer;
+      if (peer) Promise.resolve().then(() => peer.onmessage?.({ data }));
+    }
+    close() {}
+  }
+  class FakeMessageChannel {
+    port1 = new FakePort();
+    port2 = new FakePort();
+    constructor() {
+      this.port1.peer = this.port2;
+      this.port2.peer = this.port1;
+    }
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('MessageChannel', FakeMessageChannel);
+    vi.stubGlobal('window', {
+      setTimeout: setTimeout.bind(globalThis),
+      clearTimeout: clearTimeout.bind(globalThis),
+    });
+    // controller 收到投递后, 在被转移的 port (port2) 上回 ack —— 路由到 client 的 port1.onmessage。
+    vi.stubGlobal('navigator', {
+      serviceWorker: {
+        controller: {
+          postMessage: (_msg: any, transfer: any[]) => {
+            const port2 = transfer?.[0] as FakePort;
+            port2?.postMessage(ackToReturn);
+          },
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('落库失败: ack ok:true + businessError 被透传, 不被吞成干净的 true', async () => {
+    ackToReturn = { ok: true, businessError: 'inbox write failed: QuotaExceededError' };
+    const res = await postSsePayloadToServiceWorker({ messageId: 'm1' });
+    expect(res.ok).toBe(true);
+    expect(res.businessError).toBe('inbox write failed: QuotaExceededError');
+  });
+
+  it('正常落库: ack ok:true 无 businessError', async () => {
+    ackToReturn = { ok: true };
+    const res = await postSsePayloadToServiceWorker({ messageId: 'm2' });
+    expect(res.ok).toBe(true);
+    expect(res.businessError).toBeUndefined();
+  });
+
+  it('无 controller 时返回 { ok:false }', async () => {
+    vi.stubGlobal('navigator', { serviceWorker: { controller: null } });
+    const res = await postSsePayloadToServiceWorker({ messageId: 'm3' });
+    expect(res.ok).toBe(false);
+    expect(res.businessError).toBeUndefined();
   });
 });

--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -736,39 +736,55 @@ function resolveInstantTraceId(payload: any, fallback?: string): string {
   return String(candidate);
 }
 
+export interface SsePostResult {
+  /** SW 收下并分发了 payload (含去重命中); 超时 / 无 controller / 通道异常时为 false。 */
+  ok: boolean;
+  /**
+   * amsg-sw 2.3.0+: SW 收下并分发了, 但业务回调 (写 inbox) 抛错时带上错误信息;
+   * 此时 ok 仍为 true (ack 语义 = 已收下并分发, 非已落库)。上层据此把超时文案
+   * 从笼统的「未确认写入」升级成精确的「SW 写库失败: <原因>」。
+   */
+  businessError?: string;
+}
+
 export async function postSsePayloadToServiceWorker(
   payload: any,
   traceId?: string,
   timeoutMs = 5_000,
-): Promise<boolean> {
+): Promise<SsePostResult> {
   const resolvedTraceId = resolveInstantTraceId(payload, traceId);
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
-    return false;
+    return { ok: false };
   }
 
   const controller = navigator.serviceWorker.controller;
   if (!controller) {
-    return false;
+    return { ok: false };
   }
 
   // 把 SSE 直达 payload 交给 SW 走通用 REI_AMSG_DELIVER 路由 (inbox/tool/emotion + dedupe)。
   // 用 MessageChannel 等 SW 回 ack: ok=true 表示 SW 收下 (可能是去重命中), 超时/异常按未达处理。
-  return await new Promise<boolean>((resolve) => {
+  // amsg-sw 2.3.0+ 的 ack 在落库失败时仍 ok:true 但带 businessError, 一并透传给上层。
+  return await new Promise<SsePostResult>((resolve) => {
     const channel = new MessageChannel();
     let settled = false;
 
-    const finish = (ok: boolean) => {
+    const finish = (result: SsePostResult) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       try { channel.port1.close(); } catch { /* ignore */ }
-      resolve(ok);
+      resolve(result);
     };
 
-    const timer = window.setTimeout(() => finish(false), timeoutMs);
+    const timer = window.setTimeout(() => finish({ ok: false }), timeoutMs);
 
     channel.port1.onmessage = (event) => {
-      finish(!!(event.data || {}).ok);
+      const data = (event.data || {}) as { ok?: unknown; businessError?: unknown };
+      finish({
+        ok: !!data.ok,
+        businessError: typeof data.businessError === 'string' ? data.businessError : undefined,
+      });
     };
 
     try {
@@ -779,7 +795,7 @@ export async function postSsePayloadToServiceWorker(
         requestId: resolvedTraceId,
       }, [channel.port2]);
     } catch {
-      finish(false);
+      finish({ ok: false });
     }
   });
 }
@@ -908,16 +924,20 @@ export async function sendInstantPushAndAwaitReply(
       instantClientToken: cfg.clientToken || '',
     });
 
-    // postSsePayloadToServiceWorker 投递失败时 resolve(false) 而非 throw, 单看 stream
+    // postSsePayloadToServiceWorker 投递失败时返回 { ok:false } 而非 throw, 单看 stream
     // 是否跑完识别不出失败。这里记下投递结果, 供下面 stream_done 分支判定 / 诊断用。
+    // amsg-sw 2.3.0+: ack 落库失败时 ok:true 但带 businessError —— 记下来好把超时文案
+    // 从笼统的「未确认写入」升级成精确的「SW 写库失败: <原因>」。
     let sseDeliveredOk = false;
     let sseDeliveryFailed = false;
+    let sseBusinessError: string | undefined;
     const streamPromise = reiClient.consumeInstantStream(wirePayload, '/instant', {
       signal: abortController.signal,
       onPayload: async (p: any) => {
-        const delivered = await postSsePayloadToServiceWorker(p);
-        if (delivered) sseDeliveredOk = true;
+        const ack = await postSsePayloadToServiceWorker(p);
+        if (ack.ok) sseDeliveredOk = true;
         else sseDeliveryFailed = true;
+        if (ack.businessError) sseBusinessError = ack.businessError;
       },
     });
     // `consumeInstantStream()` calls fetch() synchronously before its first await,
@@ -986,17 +1006,22 @@ export async function sendInstantPushAndAwaitReply(
           },
           response: {
             outcome: 'timeout',
-            reason: sseDeliveryFailed ? 'sse-delivery-failed' : 'flush-not-confirmed',
+            reason: sseBusinessError
+              ? 'business-error'
+              : (sseDeliveryFailed ? 'sse-delivery-failed' : 'flush-not-confirmed'),
             sseDeliveredOk,
+            sseBusinessError,
             waitedMs,
           },
         });
         return {
           ok: false,
           outcome: 'timeout',
-          error: sseDeliveryFailed
-            ? 'AI 回复已生成，但本机 Service Worker 未确认收下（无 controller / 通道异常），消息可能未落库 —— 刷新页面后重试'
-            : `AI 回复已生成，但 ${Math.round(SSE_FLUSH_GRACE_MS / 1000)}s 内未确认写入本地 —— 刷新页面后重试`,
+          error: sseBusinessError
+            ? `AI 回复已生成，但本机 Service Worker 写入本地库失败（${sseBusinessError}），消息未落库 —— 刷新页面后重试`
+            : sseDeliveryFailed
+              ? 'AI 回复已生成，但本机 Service Worker 未确认收下（无 controller / 通道异常），消息可能未落库 —— 刷新页面后重试'
+              : `AI 回复已生成，但 ${Math.round(SSE_FLUSH_GRACE_MS / 1000)}s 内未确认写入本地 —— 刷新页面后重试`,
           diagnostics: {
             env, context,
             timeout: {

--- a/worker/sw-keep-alive.ts
+++ b/worker/sw-keep-alive.ts
@@ -49,8 +49,21 @@ import { installReiSW } from '@rei-standard/amsg-sw';
  *           和 WebPush backup 统一在包层 showNotification 前去重。
  *  - 1.14.0: 升级 amsg-sw dedupe 语义：去重记录区分业务处理与通知展示，
  *           SSE-first 且前台未展示通知时，WebPush backup 可在隐藏态只补通知。
+ *  - 1.15.0: IndexedDB 连接韧性整治（修 Instant Push 确认超时）。
+ *           1) openInboxDb 改单例复用 + onversionchange/onclose 失效自愈 —— 之前每条 push
+ *              都新开一条 ActiveMsg 连接且从不 close，与主库 (utils/db.ts) 的连接风暴一起
+ *              撑爆 Chromium backing store，导致写 inbox 失败、永不 active-msg-received、超时。
+ *           2) openInboxDb 的所有事务过 withInboxTx：onclose 清缓存是异步的，强关到回调之间
+ *              命中 fast-path 会拿到将死连接、db.transaction() 同步抛 InvalidStateError，事务层
+ *              兜一次「清缓存重开重试」(同 amsg-sw 2.3.0 的 withDedupeStore)。
+ *           3) openInboxDb 修 blocked-then-unblocked 连接泄漏：onblocked 先 reject 但底层 open
+ *              还活着，占用方关闭后 onsuccess 仍触发、留下能 block 升级/删库的孤儿连接；加
+ *              settled 标记让迟到的 onsuccess 直接 close。
+ *           4) 升级 amsg-sw 2.2.0 → 2.3.0：包侧 dedupe/queue/multipart 连接补 onclose + 事务级
+ *              InvalidStateError 重开兜底；DELIVER ack 新增 businessError，落库失败 ok:true 仍带
+ *              错误，前台据此把超时文案精确化。
  */
-const SW_VERSION = '1.14.0';
+const SW_VERSION = '1.15.0';
 
 const PING_INTERVAL = 15_000;
 const MAX_MANUAL_ALIVE_MS = 5 * 60_000;
@@ -195,17 +208,53 @@ function readPushPayload(event: PushEvent): any | null {
   }
 }
 
-function openInboxDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(ACTIVE_MSG_DB_NAME, ACTIVE_MSG_DB_VERSION);
+// 单例连接缓存。SW 原本每条 push 都新开一条 ActiveMsg 连接且从不 close —— 在主库
+// (utils/db.ts) 连接风暴撑爆 Chromium backing store 后, 这里 open 同样失败 →
+// saveContentToInbox 抛错 → 永不 notifyClients('active-msg-received') → 主线程 Instant
+// Push 等不到落库确认而超时。复用同一条连接, 失效 (版本升级 / 浏览器强制关闭) 时清
+// 缓存自愈, 下条 push 自动重开。
+let inboxDbPromise: Promise<IDBDatabase> | null = null;
 
-    request.onerror = () => reject(request.error);
+function openInboxDb(): Promise<IDBDatabase> {
+  if (inboxDbPromise) return inboxDbPromise;
+
+  inboxDbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(ACTIVE_MSG_DB_NAME, ACTIVE_MSG_DB_VERSION);
+    // onblocked 不是终态: 先 reject, 但底层 open request 还活着, 占用方关闭后仍会触发
+    // onsuccess。用 settled 标记 promise 已 settle, 让迟到的连接被 close 而非泄漏成
+    // 一条没人持有、却能 block 后续升级 / 删库的孤儿连接。
+    let settled = false;
+
+    request.onerror = () => {
+      inboxDbPromise = null; // 打开失败别缓存 rejected promise
+      settled = true;
+      reject(request.error);
+    };
     request.onblocked = () => {
       // Main thread or another SW connection holds the DB at a lower version and isn't closing.
       // Push will fail to persist; reject rather than hang forever so event.waitUntil unblocks.
+      inboxDbPromise = null;
+      settled = true;
       reject(new Error('IndexedDB open blocked (older version still open elsewhere)'));
     };
-    request.onsuccess = () => resolve(request.result);
+    request.onsuccess = () => {
+      const db = request.result;
+      // 已经 reject 过 (onblocked / onerror): 迟到的连接没人接收, 直接 close, 否则它开着
+      // 会 block 后续升级 / deleteDatabase。
+      if (settled) {
+        try { db.close(); } catch { /* ignore */ }
+        return;
+      }
+      // 主线程升级版本时 close 让位 + 清缓存; 浏览器强制关闭连接时也清缓存自愈。
+      db.onversionchange = () => {
+        db.close();
+        inboxDbPromise = null;
+      };
+      db.onclose = () => {
+        inboxDbPromise = null;
+      };
+      resolve(db);
+    };
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains(ACTIVE_MSG_INBOX_STORE)) {
@@ -225,6 +274,51 @@ function openInboxDb(): Promise<IDBDatabase> {
       }
     };
   });
+
+  return inboxDbPromise;
+}
+
+function isInboxConnectionClosingError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as { name?: string; message?: string };
+  return e.name === 'InvalidStateError' || /connection is closing/i.test(String(e.message || ''));
+}
+
+// 事务级一次重开兜底。单例的 onclose 清缓存是异步的: 连接被浏览器强关到 onclose 回调
+// 跑之间, 命中 fast-path 的调用方会拿到一条将死的连接, db.transaction() 同步抛
+// InvalidStateError —— 此时 saveContentToInbox 会在写 inbox / fire active-msg-received 前
+// 就挂掉, push 静默丢、主线程超时。这里捕获该错误后清缓存、重开一次、重试一次
+// (镜像 amsg-sw 2.3.0 的 withDedupeStore), 守住这条关键路径。重试上限 1 次; 失败的
+// 事务不会 commit, 故 run() 重跑是幂等的 (含 read-modify-write)。
+async function withInboxTx(
+  storeName: string,
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore) => void,
+): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const db = await openInboxDb();
+    try {
+      return await new Promise<void>((resolve, reject) => {
+        let tx: IDBTransaction;
+        try {
+          tx = db.transaction(storeName, mode);
+        } catch (e) {
+          reject(e); // 连接 closing 时 db.transaction() 同步抛, 交给下面的重试判定
+          return;
+        }
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error || new Error(`inbox tx error (${storeName})`));
+        tx.onabort = () => reject(tx.error || new Error(`inbox tx aborted (${storeName})`));
+        run(tx.objectStore(storeName));
+      });
+    } catch (e) {
+      if (attempt === 0 && isInboxConnectionClosingError(e)) {
+        inboxDbPromise = null; // 丢掉将死的缓存连接, 下一轮 openInboxDb 重开
+        continue;
+      }
+      throw e;
+    }
+  }
 }
 
 // ─── content / inbox (kind=content 老路径, tool_request 的 prefix 也走这里) ───
@@ -250,10 +344,8 @@ async function saveContentToInbox(payload: any) {
   //     最多让 OSContext 弹一句默认 toast. 这种 case 应该在 worker 端修, SW 不二次验证契约.
   if (!charId) return;
 
-  const db = await openInboxDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_INBOX_STORE, 'readwrite');
-    tx.objectStore(ACTIVE_MSG_INBOX_STORE).put({
+  await withInboxTx(ACTIVE_MSG_INBOX_STORE, 'readwrite', (store) => {
+    store.put({
       messageId,
       charId,
       charName,
@@ -275,8 +367,6 @@ async function saveContentToInbox(payload: any) {
       sentAt,
       receivedAt: Date.now(),
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
 
   await notifyClients({
@@ -297,19 +387,13 @@ async function saveReasoningToBuffer(payload: any) {
   const reasoningContent: string = String(payload?.reasoningContent ?? '');
   if (!sessionId || !charId || !reasoningContent) return;
 
-  const db = await openInboxDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_REASONING_BUFFER_STORE, 'readwrite');
-    const store = tx.objectStore(ACTIVE_MSG_REASONING_BUFFER_STORE);
+  await withInboxTx(ACTIVE_MSG_REASONING_BUFFER_STORE, 'readwrite', (store) => {
     store.put({
       sessionId,
       charId,
       reasoningContent,
       receivedAt: Date.now(),
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-    tx.onabort = () => reject(tx.error || new Error('reasoning buffer write aborted'));
   });
 
   // reasoning push 与 content push 是两条独立 Web Push, 到达/处理顺序不保证. 主线程只在处理
@@ -326,13 +410,8 @@ async function saveReasoningToBuffer(payload: any) {
  */
 async function clearReasoningBuffer(sessionId: string) {
   if (!sessionId) return;
-  const db = await openInboxDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_REASONING_BUFFER_STORE, 'readwrite');
-    tx.objectStore(ACTIVE_MSG_REASONING_BUFFER_STORE).delete(sessionId);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-    tx.onabort = () => reject(tx.error || new Error('reasoning buffer clear aborted'));
+  await withInboxTx(ACTIVE_MSG_REASONING_BUFFER_STORE, 'readwrite', (store) => {
+    store.delete(sessionId);
   });
 }
 
@@ -354,10 +433,8 @@ async function savePendingToolCall(payload: any) {
   // 客户端 /continue 时取它 + 1; 多轮 tool 链路里 iteration 单调递增, worker 也按它做 fail-fast 400.
   const iteration = Number.isFinite(payload?.metadata?.iteration) ? Number(payload.metadata.iteration) : 0;
 
-  const db = await openInboxDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE, 'readwrite');
-    tx.objectStore(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE).put({
+  await withInboxTx(ACTIVE_MSG_PENDING_TOOL_CALLS_STORE, 'readwrite', (store) => {
+    store.put({
       sessionId,
       charId,
       toolCalls,
@@ -365,8 +442,6 @@ async function savePendingToolCall(payload: any) {
       iteration,
       createdAt: Date.now(),
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
 }
 
@@ -412,10 +487,8 @@ async function saveEmotionUpdateToInbox(payload: any) {
   if (!charId) return;
   const messageId = String(payload?.messageId || `${charId}-emotion-${Date.now()}`);
 
-  const db = await openInboxDb();
-  await new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(ACTIVE_MSG_INBOX_STORE, 'readwrite');
-    tx.objectStore(ACTIVE_MSG_INBOX_STORE).put({
+  await withInboxTx(ACTIVE_MSG_INBOX_STORE, 'readwrite', (store) => {
+    store.put({
       messageId,
       charId,
       charName: payload?.contactName || '',
@@ -425,8 +498,6 @@ async function saveEmotionUpdateToInbox(payload: any) {
       sentAt: Date.now(),
       receivedAt: Date.now(),
     });
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
   });
 
   // 触发客户端 flush (不带真实内容, 客户端 flush 时按 messageType 静默处理). 不 showNotification.

--- a/worker/sw-keep-alive.ts
+++ b/worker/sw-keep-alive.ts
@@ -218,22 +218,25 @@ let inboxDbPromise: Promise<IDBDatabase> | null = null;
 function openInboxDb(): Promise<IDBDatabase> {
   if (inboxDbPromise) return inboxDbPromise;
 
-  inboxDbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+  const promise = new Promise<IDBDatabase>((resolve, reject) => {
     const request = indexedDB.open(ACTIVE_MSG_DB_NAME, ACTIVE_MSG_DB_VERSION);
     // onblocked 不是终态: 先 reject, 但底层 open request 还活着, 占用方关闭后仍会触发
     // onsuccess。用 settled 标记 promise 已 settle, 让迟到的连接被 close 而非泄漏成
     // 一条没人持有、却能 block 后续升级 / 删库的孤儿连接。
+    // 清缓存一律先比对 inboxDbPromise === promise: onclose/onerror 都是异步回调 —— 尤其
+    // withInboxTx 强关后会清缓存并重开新 promise, 此时陈旧连接的迟到 onclose 不能把新单例
+    // 误清 (否则又凭空多开一条连接, 正是本次要消灭的 churn; 见 amsg-sw 2.3.0 同款守卫)。
     let settled = false;
 
     request.onerror = () => {
-      inboxDbPromise = null; // 打开失败别缓存 rejected promise
+      if (inboxDbPromise === promise) inboxDbPromise = null; // 打开失败别缓存 rejected promise
       settled = true;
       reject(request.error);
     };
     request.onblocked = () => {
       // Main thread or another SW connection holds the DB at a lower version and isn't closing.
       // Push will fail to persist; reject rather than hang forever so event.waitUntil unblocks.
-      inboxDbPromise = null;
+      if (inboxDbPromise === promise) inboxDbPromise = null;
       settled = true;
       reject(new Error('IndexedDB open blocked (older version still open elsewhere)'));
     };
@@ -248,10 +251,10 @@ function openInboxDb(): Promise<IDBDatabase> {
       // 主线程升级版本时 close 让位 + 清缓存; 浏览器强制关闭连接时也清缓存自愈。
       db.onversionchange = () => {
         db.close();
-        inboxDbPromise = null;
+        if (inboxDbPromise === promise) inboxDbPromise = null;
       };
       db.onclose = () => {
-        inboxDbPromise = null;
+        if (inboxDbPromise === promise) inboxDbPromise = null;
       };
       resolve(db);
     };
@@ -275,7 +278,8 @@ function openInboxDb(): Promise<IDBDatabase> {
     };
   });
 
-  return inboxDbPromise;
+  inboxDbPromise = promise;
+  return promise;
 }
 
 function isInboxConnectionClosingError(error: unknown): boolean {


### PR DESCRIPTION
fix #146

## 问题
Instant Push 偶发「AI 回复已生成，但本机 Service Worker 未确认收下」超时，并连带记忆管线报错。根因不在 instant push 本身：各处 IndexedDB 每次操作都新开连接、不复用也不 close，在记忆管线并发下瞬间堆出几十条 `AetherOS_Data` 连接撑爆 Chromium backing store，连带 SW 写 inbox 失败、永不 `active-msg-received`，主线程因此确认超时。

## 改后
| 方面 | 改动 |
|------|------|
| 连接复用 | `utils/db.ts` / `utils/activeMsgStore.ts` / `worker/sw-keep-alive.ts` / `apps/pixelHome/pixelHomeDb.ts` 的 IDB 连接全部改单例复用 + `onversionchange`/`onclose` 失效自愈；pixelHome 不再自带裸 `openDB`，并入主库单例 |
| blocked 不泄漏 | 三处 open 加 `settled` 标记：blocked 先 reject 后，占用方关闭触发的迟到 `onsuccess` 直接 `close` 掉孤儿连接，不再泄漏成阻塞后续升级/删库的开连接 |
| SW 落库兜底 | SW inbox 所有事务过 `withInboxTx`：强关竞态下命中将死连接时清缓存重开重试一次，守住「写失败 = push 静默丢」的关键路径 |
| 上游升级 | `@rei-standard/amsg-sw` 2.2.0 → 2.3.0：包内 dedupe/queue/multipart 连接同样补 `onclose` + 事务级重试；DELIVER ack 新增 `businessError`，客户端据此把超时文案从笼统的「未确认写入」精确成「SW 写库失败: <原因>」 |
| 其它 | 重打 `public/sw-keep-alive.js`（`SW_VERSION` → 1.15.0）；补回归测试（连接复用 / 失效自愈 / blocked 不泄漏 / businessError 解析）；`docs/amsg-sw-idb-resilience-spec.md` 留存上游修复的设计记录 |

## 验证
- vitest 216 全绿（新增 IDB 韧性相关用例）
- 改动文件 tsc 零新增错误，pnpm-lock 无 link 污染
- Codex review 多轮收敛到零意见
- 与 `master` 实测 `git merge-tree` 零冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)