### PR TITLE
feat(chat): 新增「时间感知强化」per-角色开关

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -2124,6 +2124,8 @@ const Chat: React.FC = () => {
                 onSetTranslateLang={(lang: string) => { setTranslateTargetLang(lang); localStorage.setItem(`chat_translate_lang_${activeCharacterId}`, lang); setShowingTargetIds(new Set()); }}
                 xhsEnabled={!!char.xhsEnabled}
                 onToggleXhs={() => updateCharacter(char.id, { xhsEnabled: !char.xhsEnabled })}
+                timeAwarenessEnabled={char.timeAwarenessEnabled !== false}
+                onToggleTimeAwareness={() => updateCharacter(char.id, { timeAwarenessEnabled: char.timeAwarenessEnabled === false })}
                 htmlModeEnabled={!!(char as any).htmlModeEnabled}
                 onToggleHtmlMode={() => updateCharacter(char.id, { htmlModeEnabled: !((char as any).htmlModeEnabled) } as any)}
                 htmlModeCustomPrompt={settingsHtmlModeCustomPrompt}

--- a/components/chat/ChatModals.tsx
+++ b/components/chat/ChatModals.tsx
@@ -84,6 +84,9 @@ interface ChatModalsProps {
     onToggleHtmlMode?: () => void;
     htmlModeCustomPrompt?: string;
     setHtmlModeCustomPrompt?: (v: string) => void;
+    // 时间感知强化
+    timeAwarenessEnabled?: boolean;
+    onToggleTimeAwareness?: () => void;
     // Voice TTS
     chatVoiceEnabled?: boolean;
     onToggleChatVoice?: () => void;
@@ -135,6 +138,7 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     translationEnabled, onToggleTranslation, translateSourceLang, translateTargetLang, onSetTranslateSourceLang, onSetTranslateLang,
     xhsEnabled, onToggleXhs,
     htmlModeEnabled, onToggleHtmlMode, htmlModeCustomPrompt, setHtmlModeCustomPrompt,
+    timeAwarenessEnabled, onToggleTimeAwareness,
     chatVoiceEnabled, onToggleChatVoice, chatVoiceLang, onSetChatVoiceLang,
     onGenerateVoice, voiceAvailable,
     scheduleData, isScheduleGenerating, onScheduleEdit, onScheduleDelete, onScheduleReroll, onScheduleCoverChange,
@@ -416,6 +420,26 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                                  {chatVoiceLang && <p className="text-[10px] text-emerald-600/70 mt-1.5">选择非默认语种时，AI 台词会先翻译再生成语音。</p>}
                              </div>
                          )}
+                     </div>
+
+                     {/* 时间感知强化 */}
+                     <div className="pt-2 border-t border-slate-100">
+                         <div className="flex justify-between items-center cursor-pointer" onClick={onToggleTimeAwareness}>
+                             <div className="flex items-center gap-1.5 pointer-events-none">
+                                 <label className="text-xs font-bold text-slate-400 uppercase">时间感知强化</label>
+                                 <span
+                                     className="w-4 h-4 rounded-full bg-slate-200 text-slate-500 text-[10px] font-bold flex items-center justify-center pointer-events-auto cursor-help"
+                                     title="时间感知强化是「时间感知」的重要功能。开启时会向上下文注入「距离上次聊天已过去多久」的提示，强化角色的时间观念、让 ta 主动匹配现实世界时间。关掉后不再注入这组提示词，角色不会被强制强化时间观念、也不会被强制匹配现实世界——但具体会弱化多少，取决于 API（模型）自己的理解。"
+                                 >?</span>
+                             </div>
+                             <div className={`w-10 h-6 rounded-full p-1 transition-colors flex items-center ${timeAwarenessEnabled ? 'bg-primary' : 'bg-slate-200'}`}>
+                                 <div className={`w-4 h-4 bg-white rounded-full shadow-sm transition-transform ${timeAwarenessEnabled ? 'translate-x-4' : ''}`}></div>
+                             </div>
+                         </div>
+                         <p className="text-[10px] text-slate-400 mt-2 leading-relaxed">
+                             默认开启。开启时角色会强化时间观念、主动匹配现实世界时间。关掉后不再强化时间观念，也不会强制匹配现实世界；
+                             但具体弱化多少取决于 API 自己的理解。
+                         </p>
                      </div>
 
                      <div className="pt-2 border-t border-slate-100">

--- a/types.ts
+++ b/types.ts
@@ -1037,6 +1037,11 @@ export interface CharacterProfile {
       pitch?: number;
   };
 
+  // 时间感知强化：开启（默认）时会向上下文注入「距离上次聊天已过去多久」的强化提示，
+  // 让角色强化时间观念、主动匹配现实世界时间。关掉后不再注入这组提示词
+  // （注意：历史消息本身仍带时间戳，关掉后弱化程度取决于模型自身理解）。
+  timeAwarenessEnabled?: boolean;
+
   // Chat & Date voice TTS settings
   chatVoiceEnabled?: boolean;
   chatVoiceLang?: string;

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -719,7 +719,8 @@ ${xhsEnabled ? `${[notionEnabled, feishuEnabled, notionNotesEnabled].filter(Bool
                     break;
                 }
             }
-            if (lastRealMsg && currentMsg) timeGapHint = ChatPrompts.getTimeGapHint(lastRealMsg, currentMsg.timestamp);
+            // 时间感知强化开关：默认开启（undefined 视为 true），显式关掉后不再注入「距离上次聊天多久」提示
+            if (lastRealMsg && currentMsg && char.timeAwarenessEnabled !== false) timeGapHint = ChatPrompts.getTimeGapHint(lastRealMsg, currentMsg.timestamp);
         }
 
         return {


### PR DESCRIPTION
在聊天设置中新增「时间感知强化」开关，默认开启，带问号悬浮说明。
关掉后 buildMessageHistory 不再向上下文注入「距离上次聊天已过去多久」
的强化提示，角色不再被强制强化时间观念 / 匹配现实世界时间；具体弱化
程度取决于模型自身理解。开关随 CharacterProfile 持久化，向后兼容
（undefined 视为开启）。