### PR TITLE
fix(call): 通话记录被记忆宫殿高水位标记误隐藏导致"清空"

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -569,7 +569,10 @@ const CallApp: React.FC = () => {
   };
   const loadCallRecords = async (charId?: string) => {
     if (!charId) return setCallRecords([]);
-    const all = await DB.getMessagesByCharId(charId);
+    // includeProcessed=true：通话消息与聊天消息同存一个 store，记忆宫殿处理后会推进
+    // 高水位标记 mp_lastMsgId_<charId>，默认的 getMessagesByCharId 会过滤掉水位线之前的
+    // 消息——这会导致继续聊天后通话记录被"清空"。这里必须读取全部消息。
+    const all = await DB.getMessagesByCharId(charId, true);
     const callMsgs = all
       .filter(m => m.metadata?.source === 'call' && m.metadata?.callSessionId)
       .sort((a, b) => a.timestamp - b.timestamp);
@@ -920,7 +923,8 @@ const CallApp: React.FC = () => {
     const record = deleteConfirmRecord;
     if (!record) return;
     setDeleteConfirmRecord(null);
-    const all = await DB.getMessagesByCharId(record.characterId);
+    // includeProcessed=true：同 loadCallRecords，否则水位线之前的通话消息删不掉
+    const all = await DB.getMessagesByCharId(record.characterId, true);
     // 删除通话消息 + 聊天页的通话总结卡片
     const ids = all.filter(m => {
       if (m.metadata?.source === 'call' && m.metadata?.callSessionId === record.sessionId) return true;


### PR DESCRIPTION
通话消息与聊天消息同存于 messages store（type: 'text'）。记忆宫殿
pipeline 处理后会推进高水位标记 mp_lastMsgId_<charId>，而
loadCallRecords 经由默认的 getMessagesByCharId(charId) 读取消息， 该方法默认 includeProcessed=false，会过滤掉 id <= 高水位的全部消息。

结果：用户继续聊天后，记忆宫殿处理到通话消息的 id 区间，整段通话
记录就从列表中消失（数据仍在 IndexedDB，并未真正删除——故清空浏览器
数据无关）。

修复：loadCallRecords 与 confirmDeleteRecord 改为传 includeProcessed=true， 绕过高水位过滤，确保通话记录始终可见、可删除。