### PR TITLE
feat(settings): 设置底部常驻显示构建 / SW 版本

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -15,6 +15,7 @@ import { ProactiveChat } from '../utils/proactiveChat';
 import { InstantPushSettingsModal } from '../components/settings/InstantPushSettingsModal';
 import { PushVapidSettingsModal } from '../components/settings/PushVapidSettingsModal';
 import { isPushVapidReady } from '../utils/pushVapid';
+import VersionInfo from '../components/settings/VersionInfo';
 
 // hot_news（orz.ai）可选热榜平台。key 必须与 API 的 ?platform= 完全一致。
 const HOTNEWS_PLATFORM_OPTIONS: { key: string; label: string }[] = [
@@ -1546,9 +1547,7 @@ const Settings: React.FC = () => {
             </p>
         </section>
 
-        <div className="text-center text-[10px] text-slate-300 pb-8 font-mono tracking-widest uppercase">
-            v2.2 (Realtime Awareness)
-        </div>
+        <VersionInfo />
       </div>
 
       {/* 主动消息 Push 加速 · 启用前确认 */}

--- a/components/BuildBadge.tsx
+++ b/components/BuildBadge.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { querySwVersion } from '../utils/swVersion';
 
 /**
  * 构建版本指示器：右下角阶梯式堆三行
@@ -10,31 +11,15 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
  *   分支名长度可变，所以行宽顺序不固定，需要 useLayoutEffect 在 paint 前测量。
  * - 仅当 vite.config 注入的 __BUILD_BADGE_VISIBLE__ 为 true 时挂载
  *   （VITE_HIDE_BUILD_BADGE=1 时构建会把它编译成 false → 树摇掉）
- * - SW 版本通过 MessageChannel postMessage GET_SW_VERSION 查询；SW 未注册 /
+ * - SW 版本通过 utils/swVersion 的 GET_SW_VERSION 协议查询；SW 未注册 /
  *   不响应时显示 sw@?
  * - pointer-events-none + select-none：不可点、不可选、不影响下层交互
  * - z-[2147483647]：保证盖在所有 modal / 动画 / 全屏覆盖层之上
  * - safe-area-inset：iOS PWA 底部 home indicator 区域避让
+ *
+ * 注：这是 dev / fork 专用的醒目角标。正式版（main/master）会被树摇掉，
+ * 但构建 / SW 版本仍通过 Settings 底部的 VersionInfo 低调展示，方便用户报障。
  */
-async function querySwVersion(): Promise<string> {
-    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return '?';
-    try {
-        const reg = await navigator.serviceWorker.ready;
-        const target = reg.active || reg.waiting || reg.installing;
-        if (!target) return '?';
-        return await new Promise<string>((resolve) => {
-            const channel = new MessageChannel();
-            const timer = setTimeout(() => resolve('?'), 1500);
-            channel.port1.onmessage = (e) => {
-                clearTimeout(timer);
-                resolve(e.data?.version ?? '?');
-            };
-            target.postMessage({ type: 'GET_SW_VERSION' }, [channel.port2]);
-        });
-    } catch {
-        return '?';
-    }
-}
 
 const BuildBadge: React.FC = () => {
     if (!__BUILD_BADGE_VISIBLE__) return null;

--- a/components/settings/VersionInfo.tsx
+++ b/components/settings/VersionInfo.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { querySwVersion } from '../../utils/swVersion';
+
+/**
+ * Settings 底部的版本信息脚注。
+ *
+ * 与右下角的 BuildBadge 不同：BuildBadge 只在 dev / fork 构建可见（正式版树摇掉），
+ * 这里在**所有**构建（含正式版）里都低调显示，方便用户截图报障时附带版本上下文：
+ *   - APP_VERSION：手工维护的产品版本名（之前硬编码的 v2.2）
+ *   - build：vite.config 注入的 __BUILD_BRANCH__@__BUILD_COMMIT__
+ *   - sw：运行时向 Service Worker 查询的 SW_VERSION
+ *
+ * 构建全局（__BUILD_BRANCH__ 等）由 vite define 始终注入，prod 也有值，
+ * 所以无需任何 dev 条件判断。SW 未注册 / 未响应时 sw 显示 '?'。
+ */
+
+const APP_VERSION = 'v2.2 (Realtime Awareness)';
+
+const VersionInfo: React.FC = () => {
+    const [swVersion, setSwVersion] = useState<string>('…');
+
+    useEffect(() => {
+        let cancelled = false;
+        querySwVersion().then((v) => { if (!cancelled) setSwVersion(v); });
+        return () => { cancelled = true; };
+    }, []);
+
+    const buildLabel = `${__BUILD_BRANCH__}@${__BUILD_COMMIT__}`;
+
+    return (
+        <div className="flex flex-col items-center gap-1.5 pt-2 pb-8 select-none">
+            <div className="text-[10px] text-slate-300 font-mono tracking-widest uppercase">
+                {APP_VERSION}
+            </div>
+            <div className="flex items-center gap-1.5 text-[9px] font-mono text-slate-400/80">
+                <span className="px-1.5 py-0.5 rounded-md bg-slate-100 tracking-wide">
+                    build&nbsp;<span className="text-slate-500">{buildLabel}</span>
+                </span>
+                <span className="px-1.5 py-0.5 rounded-md bg-slate-100 tracking-wide">
+                    sw&nbsp;<span className="text-slate-500">{swVersion}</span>
+                </span>
+            </div>
+        </div>
+    );
+};
+
+export default VersionInfo;

--- a/utils/swVersion.ts
+++ b/utils/swVersion.ts
@@ -3,25 +3,34 @@
  *
  * 通过 MessageChannel + postMessage 的 GET_SW_VERSION 协议向 SW 询问，
  * SW 在 worker/sw-keep-alive.ts 里用 event.ports[0].postMessage({ version }) 回包。
- * SW 未注册 / 不响应（1.5s 超时）时返回 '?'。
+ *
+ * 超时返回 '?'：用一个 1.5s 的总超时 race 整个流程，而不仅是回包那一步。
+ * 关键点——navigator.serviceWorker.ready 在没有 SW 接管页面时（隐私模式、
+ * 浏览器禁用 SW、首次注册完成前）会永远 pending，单独 await 它会无限挂起，
+ * 让调用方（如 Settings 底部版本信息）一直卡在加载态。所以连 .ready 一起 race。
  *
  * BuildBadge（右下角开发指示器）与 Settings 底部的版本信息都复用这个函数。
  */
+const SW_QUERY_TIMEOUT_MS = 1500;
+
 export async function querySwVersion(): Promise<string> {
     if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return '?';
-    try {
+
+    const query = (async (): Promise<string> => {
         const reg = await navigator.serviceWorker.ready;
         const target = reg.active || reg.waiting || reg.installing;
         if (!target) return '?';
         return await new Promise<string>((resolve) => {
             const channel = new MessageChannel();
-            const timer = setTimeout(() => resolve('?'), 1500);
-            channel.port1.onmessage = (e) => {
-                clearTimeout(timer);
-                resolve(e.data?.version ?? '?');
-            };
+            channel.port1.onmessage = (e) => resolve(e.data?.version ?? '?');
             target.postMessage({ type: 'GET_SW_VERSION' }, [channel.port2]);
         });
+    })();
+
+    const timeout = new Promise<string>((resolve) => setTimeout(() => resolve('?'), SW_QUERY_TIMEOUT_MS));
+
+    try {
+        return await Promise.race([query, timeout]);
     } catch {
         return '?';
     }

--- a/utils/swVersion.ts
+++ b/utils/swVersion.ts
@@ -1,0 +1,28 @@
+/**
+ * 查询当前激活 Service Worker 的版本号。
+ *
+ * 通过 MessageChannel + postMessage 的 GET_SW_VERSION 协议向 SW 询问，
+ * SW 在 worker/sw-keep-alive.ts 里用 event.ports[0].postMessage({ version }) 回包。
+ * SW 未注册 / 不响应（1.5s 超时）时返回 '?'。
+ *
+ * BuildBadge（右下角开发指示器）与 Settings 底部的版本信息都复用这个函数。
+ */
+export async function querySwVersion(): Promise<string> {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return '?';
+    try {
+        const reg = await navigator.serviceWorker.ready;
+        const target = reg.active || reg.waiting || reg.installing;
+        if (!target) return '?';
+        return await new Promise<string>((resolve) => {
+            const channel = new MessageChannel();
+            const timer = setTimeout(() => resolve('?'), 1500);
+            channel.port1.onmessage = (e) => {
+                clearTimeout(timer);
+                resolve(e.data?.version ?? '?');
+            };
+            target.postMessage({ type: 'GET_SW_VERSION' }, [channel.port2]);
+        });
+    } catch {
+        return '?';
+    }
+}


### PR DESCRIPTION
## 背景

构建版本采集（`vite.config.ts` 注入 `__BUILD_BRANCH__` / `__BUILD_COMMIT__`，SW 端 `GET_SW_VERSION` 协议）此前只喂给右下角的 `BuildBadge`。而 `BuildBadge` 在正式版（main/master）会被树摇掉，导致**线上完全看不到版本信息**，用户报障时缺少版本上下文。

本 PR 在设置页最底部加一处常驻、低调的版本脚注，**所有构建（含 prod）都显示**。

## 改动

- **`utils/swVersion.ts`（新）** — 抽出 `querySwVersion()`（原在 BuildBadge 内联），供 BuildBadge 与新组件共用，避免重复。
- **`components/settings/VersionInfo.tsx`（新）** — 设置页底部脚注：APP 版本名 + `build branch@commit` + `sw <version>`，两枚灰底 chip，样式克制不抢戏。构建全局由 vite `define` 始终注入，prod 也有值，无需任何 dev 条件判断。
- **`apps/Settings.tsx`** — 底部原硬编码 `v2.2 (Realtime Awareness)` 替换为 `<VersionInfo />`。

右下角的 dev 角标 `BuildBadge` 行为完全不变，依旧只在 dev/fork 构建显示。

## 展示

```
        V2.2 (REALTIME AWARENESS)
  [ build  branch@69a1b44 ]  [ sw  1.15.0 ]
```

SW 未注册 / 未响应时 `sw` 显示 `?`，查询中显示 `…`。

## 验证

- `tsc --noEmit`：改动文件无报错
- `vite build`：通过，确认 prod 包内已注入 `…@69a1b44` 与版本文案

## 备注

`APP_VERSION` 仍是手工维护的产品版本名（原本就硬编码），保留为 `VersionInfo.tsx` 顶部常量，后续改版本号改这一处即可。

https://claude.ai/code/session_01RbdtE3QRuUsdSFHx6XknDf

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbdtE3QRuUsdSFHx6XknDf)_