### PR TITLE
fix(备份): 导出/导入对齐「彼方」房间 store —— 修复换设备后房间数据全空

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -2426,7 +2426,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               'handbook', 'trackers', 'tracker_entries', 'hotnews_snapshots',
               'memory_nodes', 'memory_vectors', 'memory_links', 'topic_boxes', 'anticipations', 'event_boxes',
               'daily_schedule', 'memory_batches',
-              'pixel_home_assets', 'pixel_home_layouts'
+              'pixel_home_assets', 'pixel_home_layouts',
+              // 「彼方」虚拟世界各房间 store —— 早期导出清单漏了，导致备份不含房间数据
+              'vr_novels', 'vr_annotations', 'cc_custom_parts', 'vr_music', 'vr_guestbook', 'vr_letters', 'vr_settings'
           ];
 
           if (mode === 'full') {
@@ -2781,6 +2783,15 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   case 'memory_batches': backupData.memoryBatches = processedData; break;
                   case 'pixel_home_assets': backupData.pixelHomeAssets = processedData; break;
                   case 'pixel_home_layouts': backupData.pixelHomeLayouts = processedData; break;
+                  // 「彼方」虚拟世界 —— 键名须与 importFullData 读取的字段对齐
+                  case 'vr_novels': backupData.vrNovels = processedData; break;
+                  case 'vr_annotations': backupData.vrAnnotations = processedData; break;
+                  case 'cc_custom_parts': backupData.customCreatorParts = processedData; break;
+                  case 'vr_letters': backupData.vrLetters = processedData; break;
+                  case 'vr_settings': backupData.vrSettings = processedData; break;
+                  // 单例 store：导入端期望单个对象（取首条），非数组
+                  case 'vr_music': backupData.vrMusicRoom = Array.isArray(processedData) ? (processedData[0] || undefined) : (processedData || undefined); break;
+                  case 'vr_guestbook': backupData.vrGuestbook = Array.isArray(processedData) ? (processedData[0] || undefined) : (processedData || undefined); break;
               }
 
               await new Promise(resolve => setTimeout(resolve, 10));

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -2011,7 +2011,7 @@ export const DB = {
           STORE_TRACKERS,
           STORE_TRACKER_ENTRIES,
           STORE_HOTNEWS,
-          STORE_VR_NOVELS, STORE_VR_ANNOTATIONS, STORE_CC_PARTS, STORE_VR_MUSIC, STORE_VR_GUESTBOOK, STORE_VR_LETTERS,
+          STORE_VR_NOVELS, STORE_VR_ANNOTATIONS, STORE_CC_PARTS, STORE_VR_MUSIC, STORE_VR_GUESTBOOK, STORE_VR_LETTERS, STORE_VR_SETTINGS,
           'memory_nodes', 'memory_vectors', 'memory_links', 'topic_boxes', 'anticipations', 'event_boxes',
           'memory_batches', 'pixel_home_assets', 'pixel_home_layouts'
       ].filter(name => db.objectStoreNames.contains(name));


### PR DESCRIPTION
导出备份走的 OSContext 路径是「彼方」功能上线前写的，allStores 清单与
分发 switch 都漏了全部 vr_* store（vr_novels/vr_annotations/cc_custom_parts/ vr_music/vr_guestbook/vr_letters/vr_settings），导致这些房间数据在导出时 被静默丢弃、从未写进备份文件。导入端因 data.vrXxx === undefined 把整块当
「没有」跳过，进度照常走完显示成功——于是换设备导入后，图书馆书籍、批注、
留言簿、听歌房、邮局信件全空，而动态（派生自一直在清单里的 messages）独活。

- OSContext.tsx：把 7 个 vr_* store 加进 allStores，并在分发 switch 补上 对应 case，键名与 importFullData 读取字段对齐；vr_music/vr_guestbook 是 单例 store，取首条而非数组。
- db.ts：importFullData 的 availableStores 漏了 STORE_VR_SETTINGS，补上， 否则彼方独立 API 配置即便导出也会因 hasStore=false 被跳过。

注：此前已导出的旧备份文件本就不含房间数据，无法找回；但导出源设备的
IndexedDB 原始数据仍在，修复后重新导出即可带上。