### PR TITLE
fix(彼方): 导入备份后角色不再按时自主登入

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -5,6 +5,7 @@ import { DB } from '../utils/db';
 import { ProactiveChat } from '../utils/proactiveChat';
 import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { runVRSession } from '../utils/vrWorld/runSession';
+import { VR_DEFAULT_INTERVAL_MIN } from '../utils/vrWorld/constants';
 import { ChatParser } from '../utils/chatParser';
 import { safeFetchJson } from '../utils/safeApi';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
@@ -1740,6 +1741,14 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           }
       };
       VRScheduler.onTrigger((charId: string, room?: string, letterId?: string) => { void runVR(charId, room, letterId); });
+
+      // 以角色 vrState 为准对账调度表：调度表存 localStorage、不随备份迁移，
+      // 导入备份后角色虽 enabled 但调度表为空，这里补建/清理使其按时触发。
+      VRScheduler.reconcile(
+          charactersRef.current
+              .filter(c => c.vrState?.enabled)
+              .map(c => ({ charId: c.id, intervalMinutes: c.vrState?.intervalMinutes || VR_DEFAULT_INTERVAL_MIN }))
+      );
 
       return () => {
           // Cleanup: detach proactive listeners when OSContext unmounts (unlikely but safe)

--- a/utils/vrWorld/scheduler.ts
+++ b/utils/vrWorld/scheduler.ts
@@ -180,6 +180,50 @@ export const VRScheduler = {
         handleVisibility();
     },
 
+    /**
+     * 以角色 vrState 为准重建调度。
+     *
+     * 调度表（vr_schedules / vr_last_fire）存 localStorage，**不随备份导出/导入迁移**，
+     * 而启用状态（vrState.enabled / intervalMinutes）存在角色对象里随 IndexedDB 备份走。
+     * 导入到新设备 / 新浏览器档案后，角色明明是 enabled 但调度表为空，resume() 直接
+     * 早退 → 角色永远不会自主登入。数据加载完成后调用本方法对账即可修复。
+     *
+     * - 启用但缺调度 → 补建（首火从现在起算，避免导入瞬间爆触发一堆 LLM 调用）
+     * - 间隔被改过 → 跟随最新设定
+     * - 已删除 / 已关闭的角色 → 清掉残留调度
+     */
+    reconcile(active: { charId: string; intervalMinutes: number }[]) {
+        const schedules = loadSchedules();
+        const activeIds = new Set(active.map(a => a.charId));
+        let changed = false;
+
+        for (const a of active) {
+            const clamped = Math.max(30, Math.round(a.intervalMinutes / 30) * 30);
+            const intervalMs = clamped * 60 * 1000;
+            const existing = schedules[a.charId];
+            if (!existing) {
+                schedules[a.charId] = { charId: a.charId, intervalMs };
+                if (getLastFire(a.charId) === 0) setLastFire(a.charId, Date.now());
+                changed = true;
+            } else if (existing.intervalMs !== intervalMs) {
+                existing.intervalMs = intervalMs;
+                changed = true;
+            }
+        }
+
+        for (const id of Object.keys(schedules)) {
+            if (!activeIds.has(id)) {
+                delete schedules[id];
+                removeLastFire(id);
+                changed = true;
+            }
+        }
+
+        if (changed) saveSchedules(schedules);
+        if (Object.keys(schedules).length > 0) attachListeners();
+        else detachListeners();
+    },
+
     isActiveFor(charId: string): boolean {
         return !!loadSchedules()[charId];
     },

--- a/utils/vrWorld/vrWorld.test.ts
+++ b/utils/vrWorld/vrWorld.test.ts
@@ -1,8 +1,48 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { chunkNovelText, chunkNovelTextAsync, getReadingWindow, buildNovel } from './novel';
 import { parseVROutput, parseMusicOutput, parseGuestbookOutput, parseGymOutput, parsePostOfficeOutput, parsePostOfficeReadOutput } from './prompts';
 import { maskPen } from './postOffice';
 import { decodeBytes } from './decodeText';
+import { VRScheduler } from './scheduler';
+
+// scheduler 的 attachListeners 会访问 document/window（node 环境下没有），补最简 stub。
+const g = globalThis as any;
+if (typeof g.document === 'undefined') g.document = { visibilityState: 'hidden', addEventListener() {}, removeEventListener() {} };
+if (typeof g.window === 'undefined') g.window = { addEventListener() {}, removeEventListener() {} };
+
+describe('VRScheduler.reconcile', () => {
+    beforeEach(() => {
+        localStorage.removeItem('vr_schedules');
+        localStorage.removeItem('vr_last_fire');
+    });
+
+    it('补建 enabled 但缺调度的角色（导入备份后的核心场景）', () => {
+        // 模拟导入后：角色在 IndexedDB 里 enabled，但 localStorage 调度表为空
+        VRScheduler.reconcile([{ charId: 'c1', intervalMinutes: 120 }]);
+        expect(VRScheduler.isActiveFor('c1')).toBe(true);
+        expect(VRScheduler.getIntervalMinutes('c1')).toBe(120);
+        // 首火时间从现在起算，不会立刻触发
+        const lastFire = JSON.parse(localStorage.getItem('vr_last_fire')!).c1;
+        expect(Date.now() - lastFire).toBeLessThan(2000);
+    });
+
+    it('清掉已删除/已关闭角色的残留调度', () => {
+        VRScheduler.start('c1', 120);
+        VRScheduler.start('c2', 60);
+        VRScheduler.reconcile([{ charId: 'c1', intervalMinutes: 120 }]); // c2 不再 enabled
+        expect(VRScheduler.isActiveFor('c1')).toBe(true);
+        expect(VRScheduler.isActiveFor('c2')).toBe(false);
+        expect(JSON.parse(localStorage.getItem('vr_last_fire')!).c2).toBeUndefined();
+    });
+
+    it('间隔被改过 → 跟随最新设定，且不重置已有首火时间', () => {
+        VRScheduler.start('c1', 120);
+        const fireBefore = JSON.parse(localStorage.getItem('vr_last_fire')!).c1;
+        VRScheduler.reconcile([{ charId: 'c1', intervalMinutes: 240 }]);
+        expect(VRScheduler.getIntervalMinutes('c1')).toBe(240);
+        expect(JSON.parse(localStorage.getItem('vr_last_fire')!).c1).toBe(fireBefore);
+    });
+});
 
 describe('parsePostOfficeReadOutput', () => {
     it('parses reaction + activity', () => {


### PR DESCRIPTION
调度表(vr_schedules/vr_last_fire)存 localStorage，不随备份导出/导入迁移， 而启用状态存在角色 vrState 里随 IndexedDB 备份走。导入到新设备/新档案后，
角色虽 enabled 但调度表为空，VRScheduler.resume() 直接早退 → 角色永远不会 自主登入。

新增 VRScheduler.reconcile(): 以角色 vrState 为准对账调度表(补建缺失的、 清理残留的、同步被改过的间隔)，在 OSContext 数据加载完成后调用。附回归测试。