### PR TITLE
feat(trpg): 世界观生成鲁棒化 + 独立灵感输入 + 创建界面美化

### DIFF
--- a/apps/GameApp.tsx
+++ b/apps/GameApp.tsx
@@ -68,6 +68,45 @@ const KEEP_RECENT_AFTER_SUMMARY = 4;
 // AI 世界观生成的可选风格
 const WORLD_STYLES = ['高奇幻', '赛博朋克', '克苏鲁恐怖', '武侠江湖', '末世废土', '校园日常', '悬疑推理', '蒸汽朋克', '西部拓荒', '宫廷权谋'];
 
+// 鲁棒解析 AI 世界观生成结果。
+// 兼容三种情况：① 期望的「标题：xxx === 正文」分隔格式；② 模型不听话仍吐 JSON
+// （含被截断的残缺 JSON）；③ 完全无结构的纯文本。任何情况都不把脏标记露给用户。
+const parseWorldGen = (raw: string): { title: string; worldSetting: string } => {
+    let text = raw.trim();
+    // 去掉可能的代码块围栏
+    text = text.replace(/^```[a-zA-Z]*\s*/, '').replace(/```\s*$/, '').trim();
+
+    let title = '';
+    let worldSetting = '';
+
+    // 情况②：看起来像 JSON（即使被截断）—— 用正则抠字段，不依赖 JSON.parse
+    if (/"?worldSetting"?\s*:/.test(text) || /^\s*\{/.test(text)) {
+        const tMatch = text.match(/"?title"?\s*:\s*"((?:[^"\\]|\\.)*)"/);
+        // worldSetting 可能未闭合（被截断），所以允许匹配到结尾
+        const wMatch = text.match(/"?worldSetting"?\s*:\s*"((?:[^"\\]|\\.)*?)(?:"\s*[},]|"\s*$|$)/);
+        if (tMatch) title = tMatch[1];
+        if (wMatch) worldSetting = wMatch[1];
+        // 还原被转义的字符
+        const unescape = (s: string) => s.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+        title = unescape(title);
+        worldSetting = unescape(worldSetting);
+        if (worldSetting || title) return { title: title.trim(), worldSetting: worldSetting.trim() };
+    }
+
+    // 情况①：分隔符格式
+    const titleMatch = text.match(/^\s*(?:标题|title)\s*[:：]\s*(.+)$/im);
+    if (titleMatch) {
+        title = titleMatch[1].trim().replace(/^[《"']|[》"']$/g, '');
+        text = text.replace(titleMatch[0], '').trim();
+    }
+    // 去掉分隔线与可能的「世界观/正文」标签
+    text = text.replace(/^\s*[=\-—]{2,}\s*$/m, '').trim();
+    text = text.replace(/^\s*(?:世界观设定|世界观|正文|lore)\s*[:：]?\s*/i, '').trim();
+
+    worldSetting = text;
+    return { title: title.trim(), worldSetting: worldSetting.trim() };
+};
+
 // 投掷一颗 D20
 const rollD20 = () => Math.floor(Math.random() * 20) + 1;
 // 把骰点结果翻译成成功度描述，供 GM 判定
@@ -158,6 +197,7 @@ const GameApp: React.FC = () => {
     const [isCreating, setIsCreating] = useState(false);
     // 世界观 AI 辅助生成
     const [worldStyle, setWorldStyle] = useState<string>('高奇幻');
+    const [worldIdea, setWorldIdea] = useState('');        // 用户额外给的灵感/想法（可选）
     const [isGeneratingWorld, setIsGeneratingWorld] = useState(false);
 
     // Play State
@@ -353,28 +393,25 @@ ${recentLog}
         }
         setIsGeneratingWorld(true);
         try {
+            // [鲁棒性] 改用带分隔符的纯文本格式而非 JSON——即使被截断也能干净解析；
+            // 不再限制字数，给足 token 防止半路砍断。
             const prompt = `你是一位资深的 TRPG（桌面跑团）剧本设计师。请按照指定风格，原创一个适合开团的世界观设定。
 **风格基调**: ${worldStyle}
-${newWorld.trim() ? `**用户的灵感关键词（请围绕它发挥）**: ${newWorld.trim()}` : ''}
+${worldIdea.trim() ? `**玩家的灵感/想法（请务必围绕它发挥）**: ${worldIdea.trim()}` : ''}
 
-要求：
-1. **title**: 一个有吸引力的剧本标题（不超过 15 字）。
-2. **worldSetting**: 200~400 字的世界观设定，需包含：① 时代/地点背景与基调氛围；② 当前世界的核心矛盾或危机；③ 玩家小队的处境/初始目标钩子；④ 一两个可探索的悬念或势力。语言生动，留足玩家发挥空间，不要写死结局。
+请严格按下面的纯文本格式输出，**不要用 JSON，不要代码块，不要额外说明**：
 
-仅输出 JSON，不要任何额外说明或代码块：
-{ "title": "剧本标题", "worldSetting": "世界观设定正文..." }`;
+标题：<一个有吸引力的剧本标题>
+===
+<世界观正文。请写充分、生动，篇幅自由不设上限，包含：时代/地点背景与基调氛围、当前世界的核心矛盾或危机、玩家小队的处境与初始目标钩子、一两个可探索的悬念或势力。留足玩家发挥空间，不要写死结局。>`;
 
-            const data = await fetchGameAPI(prompt, 2000);
-            const raw = extractContent(data);
+            const data = await fetchGameAPI(prompt, 6000);
+            const raw = (extractContent(data) || '').trim();
             if (!raw) throw new Error('AI 返回了空响应');
-            const res = extractJson(raw);
-            if (res && (res.worldSetting || res.title)) {
-                if (res.worldSetting) setNewWorld(res.worldSetting);
-                if (res.title && !newTitle.trim()) setNewTitle(res.title);
-            } else {
-                // JSON 失败，退化为把全文塞进世界观
-                setNewWorld(raw);
-            }
+
+            const parsed = parseWorldGen(raw);
+            if (parsed.worldSetting) setNewWorld(parsed.worldSetting);
+            if (parsed.title && !newTitle.trim()) setNewTitle(parsed.title);
             addToast('世界观已生成，可继续编辑', 'success');
         } catch (e: any) {
             addToast(`生成失败: ${e.message}`, 'error');
@@ -507,6 +544,7 @@ ${playerContext}
             // Reset form
             setNewTitle('');
             setNewWorld('');
+            setWorldIdea('');
             setSelectedPlayers(new Set());
 
         } catch (e: any) {
@@ -1060,69 +1098,124 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
 
     // 2. Create View
     if (view === 'create') {
+        const THEME_META: Record<GameTheme, { label: string; emoji: string; gradient: string }> = {
+            fantasy: { label: '奇幻', emoji: '🗡️', gradient: 'from-amber-700 to-orange-900' },
+            cyber: { label: '赛博', emoji: '🤖', gradient: 'from-cyan-600 to-indigo-900' },
+            horror: { label: '恐怖', emoji: '💀', gradient: 'from-red-800 to-black' },
+            modern: { label: '现代', emoji: '🏙️', gradient: 'from-sky-500 to-slate-700' },
+        };
+        const canStart = newTitle.trim() && newWorld.trim() && selectedPlayers.size > 0;
         return (
-            <div className="h-full w-full bg-slate-50 flex flex-col font-sans">
-                <div className="h-20 flex items-end px-4 pb-3 border-b border-slate-200 bg-white shrink-0 sticky top-0 z-10">
-                    <button onClick={() => setView('lobby')} className="p-2 -ml-2 text-slate-500"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg></button>
-                    <span className="font-bold text-slate-700 ml-2 mb-1.5">创建世界</span>
+            <div className="h-full w-full bg-[#0a0a0a] text-white flex flex-col font-sans relative overflow-hidden">
+                {/* Ambient Background */}
+                <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-indigo-900/30 via-slate-900/40 to-black z-0"></div>
+                <div className="absolute inset-0 z-0 opacity-20" style={{ backgroundImage: 'url("https://www.transparenttextures.com/patterns/stardust.png")' }}></div>
+
+                {/* Header */}
+                <div className="h-20 flex items-end px-5 pb-4 shrink-0 z-10">
+                    <button onClick={() => setView('lobby')} className="p-2 -ml-2 rounded-full text-white/70 hover:bg-white/10 transition-colors"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg></button>
+                    <span className="font-black tracking-[0.15em] text-base ml-1 mb-1 text-transparent bg-clip-text bg-gradient-to-r from-purple-300 to-pink-500">创建新世界</span>
                 </div>
-                <div className="flex-1 overflow-y-auto p-6 space-y-6">
+
+                <div className="flex-1 overflow-y-auto px-5 pb-6 space-y-5 z-10 no-scrollbar">
+                    {/* 剧本标题 */}
                     <div>
-                        <label className="text-xs font-bold text-slate-400 uppercase block mb-2">剧本标题</label>
-                        <input value={newTitle} onChange={e => setNewTitle(e.target.value)} className="w-full bg-white border border-slate-200 rounded-xl px-4 py-3 text-sm focus:border-orange-500 outline-none transition-colors" placeholder="例如：勇者斗恶龙" />
+                        <label className="text-[11px] font-bold text-white/40 uppercase tracking-wider block mb-2 flex items-center gap-1.5">📖 剧本标题</label>
+                        <input value={newTitle} onChange={e => setNewTitle(e.target.value)} className="w-full bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-sm text-white placeholder-white/25 focus:border-purple-400/60 focus:bg-white/10 outline-none transition-all" placeholder="例如：勇者斗恶龙" />
                     </div>
+
+                    {/* 世界观设定 */}
                     <div>
-                        <label className="text-xs font-bold text-slate-400 uppercase block mb-2">世界观设定 (Lore)</label>
-                        <textarea value={newWorld} onChange={e => setNewWorld(e.target.value)} className="w-full h-32 bg-white border border-slate-200 rounded-xl px-4 py-3 text-sm focus:border-orange-500 outline-none resize-none transition-colors" placeholder="这是一个魔法与科技共存的世界... (没思路？选个风格让 AI 帮你写)" />
-                        {/* AI 世界观生成 (帮想不出剧本的用户) */}
-                        <div className="mt-3 bg-slate-100 rounded-xl p-3 border border-slate-200">
-                            <div className="flex items-center justify-between mb-2">
-                                <span className="text-[11px] font-bold text-slate-500">✨ 没思路？让 AI 帮你写</span>
-                                <button
-                                    onClick={handleGenerateWorld}
-                                    disabled={isGeneratingWorld}
-                                    className="text-[11px] font-bold px-3 py-1.5 rounded-lg bg-slate-800 text-white active:scale-95 transition-transform flex items-center gap-1.5 disabled:opacity-60"
-                                >
-                                    {isGeneratingWorld ? <><div className="w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin"></div> 生成中...</> : <>生成世界观</>}
-                                </button>
+                        <label className="text-[11px] font-bold text-white/40 uppercase tracking-wider block mb-2 flex items-center gap-1.5">🌍 世界观设定 (Lore)</label>
+                        <textarea value={newWorld} onChange={e => setNewWorld(e.target.value)} className="w-full h-36 bg-white/5 border border-white/10 rounded-2xl px-4 py-3.5 text-sm leading-relaxed text-white placeholder-white/25 focus:border-purple-400/60 focus:bg-white/10 outline-none resize-none transition-all" placeholder="描述你的世界... 没思路的话，用下方 AI 帮你生成 ✨" />
+
+                        {/* AI 世界观生成面板 */}
+                        <div className="mt-3 rounded-2xl p-4 bg-gradient-to-br from-purple-500/10 to-pink-500/5 border border-purple-400/20 backdrop-blur-sm">
+                            <div className="flex items-center gap-2 mb-3">
+                                <span className="text-sm">✨</span>
+                                <span className="text-xs font-bold text-purple-200">没思路？让 AI 帮你写</span>
                             </div>
-                            <div className="flex gap-1.5 flex-wrap">
+
+                            {/* 风格选择 */}
+                            <div className="grid grid-cols-5 gap-1.5 mb-3">
                                 {WORLD_STYLES.map(s => (
                                     <button
                                         key={s}
                                         onClick={() => setWorldStyle(s)}
-                                        className={`px-2.5 py-1 rounded-lg text-[10px] font-medium border transition-all active:scale-95 ${worldStyle === s ? 'bg-orange-500 text-white border-orange-500' : 'bg-white text-slate-500 border-slate-200'}`}
+                                        className={`px-1 py-1.5 rounded-lg text-[10px] font-medium border transition-all active:scale-95 ${worldStyle === s ? 'bg-purple-500 text-white border-purple-400 shadow-lg shadow-purple-500/30' : 'bg-white/5 text-white/50 border-white/10 hover:bg-white/10'}`}
                                     >{s}</button>
                                 ))}
                             </div>
-                            <p className="text-[9px] text-slate-400 mt-2">提示：上方输入框留空会纯靠风格生成；写了关键词则 AI 会围绕它发挥。</p>
+
+                            {/* 额外灵感输入 (可选) */}
+                            <input
+                                value={worldIdea}
+                                onChange={e => setWorldIdea(e.target.value)}
+                                className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2.5 text-xs text-white placeholder-white/25 focus:border-purple-400/60 outline-none transition-all mb-3"
+                                placeholder="再补充点想法？(可选，如：主角是失忆的赏金猎人)"
+                            />
+
+                            <button
+                                onClick={handleGenerateWorld}
+                                disabled={isGeneratingWorld}
+                                className="w-full text-xs font-bold py-2.5 rounded-xl bg-gradient-to-r from-purple-500 to-pink-500 text-white active:scale-95 transition-transform flex items-center justify-center gap-2 disabled:opacity-60 shadow-lg shadow-purple-500/20"
+                            >
+                                {isGeneratingWorld ? <><div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div> 正在生成「{worldStyle}」世界...</> : <>✨ 生成世界观</>}
+                            </button>
                         </div>
                     </div>
+
+                    {/* 画风主题 */}
                     <div>
-                        <label className="text-xs font-bold text-slate-400 uppercase block mb-2">画风主题</label>
-                        <div className="flex gap-2 flex-wrap">
-                            {(['fantasy', 'cyber', 'horror', 'modern'] as GameTheme[]).map(t => (
-                                <button key={t} onClick={() => setNewTheme(t)} className={`px-4 py-2 rounded-xl text-xs font-bold capitalize border transition-all active:scale-95 ${newTheme === t ? 'bg-orange-500 text-white border-orange-500 shadow-md' : 'bg-white text-slate-500 border-slate-200'}`}>{t}</button>
-                            ))}
+                        <label className="text-[11px] font-bold text-white/40 uppercase tracking-wider block mb-2 flex items-center gap-1.5">🎨 画风主题</label>
+                        <div className="grid grid-cols-4 gap-2">
+                            {(['fantasy', 'cyber', 'horror', 'modern'] as GameTheme[]).map(t => {
+                                const meta = THEME_META[t];
+                                const active = newTheme === t;
+                                return (
+                                    <button key={t} onClick={() => setNewTheme(t)} className={`relative overflow-hidden rounded-xl py-3 flex flex-col items-center gap-1 border transition-all active:scale-95 ${active ? 'border-white/60 ring-1 ring-white/40' : 'border-white/10'}`}>
+                                        <div className={`absolute inset-0 bg-gradient-to-br ${meta.gradient} ${active ? 'opacity-90' : 'opacity-40'} transition-opacity`}></div>
+                                        <span className="relative text-lg">{meta.emoji}</span>
+                                        <span className="relative text-[11px] font-bold">{meta.label}</span>
+                                    </button>
+                                );
+                            })}
                         </div>
                     </div>
+
+                    {/* 邀请玩家 */}
                     <div>
-                        <label className="text-xs font-bold text-slate-400 uppercase block mb-2">邀请玩家</label>
-                        <div className="grid grid-cols-4 gap-3">
-                            {characters.map(c => (
-                                <div key={c.id} onClick={() => { const s = new Set(selectedPlayers); if(s.has(c.id)) s.delete(c.id); else s.add(c.id); setSelectedPlayers(s); }} className={`flex flex-col items-center p-2 rounded-xl border cursor-pointer transition-all active:scale-95 ${selectedPlayers.has(c.id) ? 'border-orange-500 bg-orange-50 ring-1 ring-orange-500' : 'border-transparent hover:bg-slate-100'}`}>
-                                    <img src={c.avatar} className="w-12 h-12 rounded-full object-cover shadow-sm" />
-                                    <span className={`text-[9px] mt-2 truncate w-full text-center font-medium ${selectedPlayers.has(c.id) ? 'text-orange-600' : 'text-slate-600'}`}>{c.name}</span>
-                                </div>
-                            ))}
-                        </div>
+                        <label className="text-[11px] font-bold text-white/40 uppercase tracking-wider block mb-2 flex items-center justify-between">
+                            <span className="flex items-center gap-1.5">👥 邀请队友</span>
+                            {selectedPlayers.size > 0 && <span className="text-purple-300 normal-case font-mono">已选 {selectedPlayers.size} 人</span>}
+                        </label>
+                        {characters.length === 0 ? (
+                            <p className="text-xs text-white/30 py-4 text-center bg-white/5 rounded-xl border border-white/10">还没有角色，先去创建角色吧</p>
+                        ) : (
+                            <div className="grid grid-cols-4 gap-3">
+                                {characters.map(c => {
+                                    const sel = selectedPlayers.has(c.id);
+                                    return (
+                                        <div key={c.id} onClick={() => { const s = new Set(selectedPlayers); if(s.has(c.id)) s.delete(c.id); else s.add(c.id); setSelectedPlayers(s); }} className={`flex flex-col items-center p-2 rounded-2xl border cursor-pointer transition-all active:scale-95 ${sel ? 'border-purple-400 bg-purple-500/15' : 'border-white/5 hover:bg-white/5'}`}>
+                                            <div className="relative">
+                                                <img src={c.avatar} className={`w-12 h-12 rounded-full object-cover transition-all ${sel ? 'ring-2 ring-purple-400 ring-offset-2 ring-offset-[#0a0a0a]' : 'opacity-80'}`} />
+                                                {sel && <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-purple-500 rounded-full flex items-center justify-center border-2 border-[#0a0a0a]"><svg viewBox="0 0 20 20" fill="currentColor" className="w-2.5 h-2.5 text-white"><path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" /></svg></div>}
+                                            </div>
+                                            <span className={`text-[9px] mt-2 truncate w-full text-center font-medium ${sel ? 'text-purple-200' : 'text-white/50'}`}>{c.name}</span>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
                     </div>
                 </div>
-                <div className="p-4 border-t border-slate-200 bg-white">
-                    <button 
-                        onClick={handleCreateGame} 
-                        disabled={isCreating}
-                        className="w-full py-3 bg-slate-800 text-white font-bold rounded-2xl shadow-lg active:scale-95 transition-transform flex items-center justify-center gap-2"
+
+                {/* 底部开始按钮 */}
+                <div className="p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] border-t border-white/5 bg-black/40 backdrop-blur-md z-10">
+                    <button
+                        onClick={handleCreateGame}
+                        disabled={isCreating || !canStart}
+                        className={`w-full py-3.5 font-bold rounded-2xl shadow-lg active:scale-95 transition-all flex items-center justify-center gap-2 ${canStart ? 'bg-gradient-to-r from-purple-500 to-pink-500 text-white shadow-purple-500/30' : 'bg-white/10 text-white/30'}`}
                     >
                         {isCreating ? <><div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div> 生成序章...</> : <><RocketLaunch size={18} /> 开始冒险</>}
                     </button>


### PR DESCRIPTION
- 解析鲁棒性：改用「标题：xxx === 正文」分隔格式而非 JSON，新增 parseWorldGen 容错解析，兼容残缺/截断 JSON、代码块、中英文冒号、纯文本，绝不把脏标记露给用户
- 去字数限制：移除 200~400 字硬约束，token 上限提到 6000 防半路截断
- 交互：新增独立「灵感」输入框（选风格→补想法→生成），不再与世界观文本框混用
- UI：创建页重做为暗色宇宙风，与大厅统一；风格 5 列网格、主题色卡、队友选择高亮 与计数、底部渐变 CTA（信息不全时禁用）

https://claude.ai/code/session_01Rvv7Uij8qhyML9HHFovNjS