### PR TITLE
fix(api-log): 全量覆盖所有 LLM 调用（含 TRPG 等裸 fetch 的 App）

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -7,6 +7,8 @@ import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { runVRSession } from '../utils/vrWorld/runSession';
 import { ChatParser } from '../utils/chatParser';
 import { safeFetchJson } from '../utils/safeApi';
+import { recordApiCall, setApiCallAmbientContext } from '../utils/apiCallLog';
+import { INSTALLED_APPS } from '../constants';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
@@ -705,6 +707,14 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       }
   };
 
+  // --- API 调用记录的环境兜底：当前在哪个 App、当前角色是谁 ---
+  // 裸 fetch 调用点无法传 meta，全局拦截器记录时用这份兜底标出 App / 角色。
+  useEffect(() => {
+      const appName = INSTALLED_APPS.find(a => a.id === activeApp)?.name;
+      const char = characters.find(c => c.id === activeCharacterId);
+      setApiCallAmbientContext({ appId: activeApp, appName, charId: char?.id, charName: char?.name });
+  }, [activeApp, activeCharacterId, characters]);
+
   // --- Global Error Interception ---
   useEffect(() => {
       if (interceptorsInitialized.current) return;
@@ -719,7 +729,29 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           
           try {
               const response = await originalFetch(...args);
-              
+
+              // 「API 调用记录」统一记录入口：所有 /chat/completions（裸 fetch + safeFetchJson
+              // 内部 fetch 都会经过这里）都记一笔。meta 优先取调用方挂在 init 上的 __sullyMeta
+              // （safeFetchJson 传的精确信息），裸 fetch 没有就由 recordApiCall 用环境兜底。
+              if (urlStr.includes('/chat/completions')) {
+                  const meta = (config as any)?.__sullyMeta;
+                  const body = (config as any)?.body;
+                  const status = response.status;
+                  const ok = response.ok;
+                  // clone 出来异步读 usage，不阻塞调用方拿 response
+                  let usageClone: Response | null = null;
+                  try { usageClone = response.clone(); } catch { usageClone = null; }
+                  if (usageClone) {
+                      usageClone.text().then((t) => {
+                          let parsed: any = undefined;
+                          try { parsed = JSON.parse(t); } catch { /* 流式/非 JSON：无 usage，照样记 */ }
+                          recordApiCall({ url: urlStr, body, status, ok, response: parsed, meta });
+                      }).catch(() => recordApiCall({ url: urlStr, body, status, ok, meta }));
+                  } else {
+                      recordApiCall({ url: urlStr, body, status, ok, meta });
+                  }
+              }
+
               if (!response.ok) {
                   // Only log if it's likely an API call (contains chat/completions or models)
                   if (urlStr.includes('/chat/completions') || urlStr.includes('/models')) {
@@ -749,6 +781,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               return response;
           } catch (err: any) {
               // Network Failure
+              if (urlStr.includes('/chat/completions')) {
+                  recordApiCall({ url: urlStr, body: (config as any)?.body, ok: false, meta: (config as any)?.__sullyMeta });
+              }
               setSystemLogs(prev => [{
                   id: `log-${Date.now()}`,
                   timestamp: Date.now(),

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -1,12 +1,20 @@
 /**
  * 全局 API 调用记录（给 设置 → API 调用记录 页面用）。
  *
- * 设计：所有 OpenAI 兼容的 `/chat/completions` 调用都汇聚到 `utils/safeApi.ts`
- * 的 `safeFetchJson`，在那里统一调 `recordApiCall`。这样「时间 / 哪个 API / 哪个模型」
- * 对所有调用点零成本自动记录；而「哪个 App / 哪个角色 / 具体用途」由调用方通过
- * 可选的 `meta` 参数补充（见 ApiCallMeta）。只保留近 5 天，超期在 DB 层写入时丢弃。
+ * 设计：项目里 LLM 调用分两类——走 `utils/safeApi.ts` 的 `safeFetchJson` 的，和
+ * 各 App 自己写的裸 `fetch`（TRPG / 自习室 / 群聊 / 日记…）。为了一个都不漏，记录点
+ * 放在 `OSContext` 里那个全局 `fetch` monkey-patch 上：所有 `/chat/completions`
+ * （含 safeFetchJson 内部 fetch）都经过它，统一调 `recordApiCall`，不重复计。
  *
- * recordApiCall 是 best-effort：任何异常都吞掉，绝不影响主请求链路。
+ * 「时间 / 哪个 API / 哪个模型 / token」从请求体 + 响应里自动解析；「哪个 App / 哪个
+ * 角色 / 具体用途」靠两条来源：
+ *   1. 显式 meta —— safeFetchJson 调用点通过第 5 个参数传，挂到 RequestInit 的
+ *      `__sullyMeta` 上由拦截器读取（精确，含 purpose）。
+ *   2. 环境兜底 ambientMeta —— OSContext 在切 App / 角色时写入「当前在哪个 App、
+ *      当前角色」，裸 fetch 没有显式 meta 时用它兜底标 App / 角色。
+ *
+ * 只保留近 5 天，超期在 DB 层写入时丢弃。recordApiCall 是 best-effort：任何异常都
+ * 吞掉，绝不影响主请求链路。
  */
 
 /** 调用方可补充的语义信息（哪个 App / 角色 / 用途）。能填多少填多少。 */
@@ -45,6 +53,23 @@ export interface ApiCallLogEntry extends ApiCallMeta {
 }
 
 const PRESETS_STORAGE_KEY = 'os_api_presets';
+
+/**
+ * 环境上下文（兜底用）：很多 App 走的是裸 fetch，调用点无法/来不及传 meta。
+ * OSContext 会在切换 App / 角色时把「当前在哪个 App、当前角色是谁」写到这里，
+ * 全局 fetch 拦截器记录裸 fetch 调用时拿它当兜底标签。
+ * 注意：safeFetchJson 传了显式 meta 的调用以显式 meta 为准，不用兜底（避免后台
+ * 任务被误标成用户当前所在的 App）。
+ */
+let ambientMeta: ApiCallMeta = {};
+
+export function setApiCallAmbientContext(meta: ApiCallMeta): void {
+    ambientMeta = meta || {};
+}
+
+function hasMeta(meta?: ApiCallMeta): boolean {
+    return !!meta && Object.values(meta).some((v) => v != null && v !== '');
+}
 
 function stripTrailingSlash(s: string): string {
     return s.replace(/\/+$/, '');
@@ -127,7 +152,8 @@ export function recordApiCall(input: {
     try {
         const baseUrl = deriveBaseUrl(input.url);
         const model = extractModel(input.body);
-        const meta = input.meta || {};
+        // 显式 meta 优先（safeFetchJson 各调用点传的精确信息）；没有就用环境兜底（裸 fetch）。
+        const meta = hasMeta(input.meta) ? input.meta! : ambientMeta;
         const usage = extractUsage(input.response);
         const entry: ApiCallLogEntry = {
             id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,

--- a/utils/safeApi.ts
+++ b/utils/safeApi.ts
@@ -7,7 +7,7 @@
  */
 
 import { appendDevDebugLlmLog } from './devDebug';
-import { recordApiCall, type ApiCallMeta } from './apiCallLog';
+import { type ApiCallMeta } from './apiCallLog';
 
 function isChatCompletionUrl(url: string): boolean {
     return url.includes('/chat/completions');
@@ -139,10 +139,14 @@ export async function safeFetchJson(
     const urlStr = String(url);
     let lastStatus: number | undefined;
 
+    // 把 meta 挂到 RequestInit 上（浏览器忽略未知字段），交给全局 fetch 拦截器统一记录
+    // 到「API 调用记录」。这样裸 fetch 和 safeFetchJson 走同一个记录入口，不会重复计。
+    const metaOptions: RequestInit = meta ? { ...options, __sullyMeta: meta } as RequestInit : options;
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         // 每次 attempt 建一个独立的 AbortController（仅用于 timeout）
         // 调用方自己的 options.signal 仍然有效，两者任一触发就 abort
-        let attemptOptions = options;
+        let attemptOptions = metaOptions;
         let timeoutHandle: any = null;
         if (timeoutMs > 0) {
             const ac = new AbortController();
@@ -155,7 +159,7 @@ export async function safeFetchJson(
                 }
                 options.signal.addEventListener('abort', () => ac.abort(), { once: true });
             }
-            attemptOptions = { ...options, signal: ac.signal };
+            attemptOptions = { ...metaOptions, signal: ac.signal };
         }
         try {
             const response = await fetch(url, attemptOptions);
@@ -186,7 +190,6 @@ export async function safeFetchJson(
                     requestBody: options.body,
                     response: data,
                 });
-                recordApiCall({ url: urlStr, body: options.body, status: response.status, ok: true, response: data, meta });
             }
             return data;
         } catch (e: any) {
@@ -220,7 +223,6 @@ export async function safeFetchJson(
                     requestBody: options.body,
                     error: e,
                 });
-                recordApiCall({ url: urlStr, body: options.body, status: lastStatus, ok: false, meta });
             }
             throw e;
         }


### PR DESCRIPTION
此前只在 safeFetchJson 记录，导致大量用裸 fetch 直连的 App（TRPG/自习室/ 群聊/日记/约会/攻略本…约 40 处）完全没被记录。改为在 OSContext 既有的全局
fetch 拦截器上统一记录所有 /chat/completions（含 safeFetchJson 内部 fetch）， 一个不漏且不重复计。

- apiCallLog.ts：新增环境兜底 ambientMeta + setApiCallAmbientContext； recordApiCall 显式 meta 优先、否则用兜底。
- safeApi.ts：不再自记，改为把 meta 挂到 RequestInit.__sullyMeta 透传给拦截器。
- OSContext.tsx：patchedFetch 对 /chat/completions 成功/失败均记一笔（clone 异步 读 usage 不阻塞）；新增 effect 在切 App/角色时更新兜底标签（裸 fetch 也能标出 所在 App / 角色，如 TRPG）。

https://claude.ai/code/session_0184nQVzJ6wPQzxs3gxSsVCd