### PR TITLE
feat(trpg): 游戏内长按多选剧情→转发到聊天(trpg_card 卡片)

### DIFF
--- a/apps/GameApp.tsx
+++ b/apps/GameApp.tsx
@@ -211,6 +211,10 @@ const GameApp: React.FC = () => {
     const [isSummarizing, setIsSummarizing] = useState(false); // 自动总结全屏反馈
     const [showArchived, setShowArchived] = useState(false);    // 已归档剧情折叠展开
     const [expandedSummaries, setExpandedSummaries] = useState<Set<string>>(new Set()); // 每段总结对应原文的展开状态
+    // 长按多选 → 转发到聊天
+    const [selectMode, setSelectMode] = useState(false);
+    const [selectedLogIds, setSelectedLogIds] = useState<Set<string>>(new Set());
+    const [isForwarding, setIsForwarding] = useState(false);
     const [lastRoll, setLastRoll] = useState<number | null>(null); // 最近一次自动骰点结果（瞬时展示）
     const [lastTokenUsage, setLastTokenUsage] = useState<{prompt?: number, completion?: number, total: number} | null>(null);
     const [totalTokensUsed, setTotalTokensUsed] = useState(0);
@@ -221,6 +225,8 @@ const GameApp: React.FC = () => {
     // 长按删除存档卡片
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const longPressFired = useRef(false);
+    // 长按日志进入多选
+    const logPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // UI Toggles
     const [showSystemMenu, setShowSystemMenu] = useState(false);
@@ -1047,6 +1053,70 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
         }
     };
 
+    // --- 长按多选日志 → 转发到聊天 ---
+    const startLogPress = (logId: string) => {
+        if (selectMode) return;
+        cancelLogPress();
+        logPressTimer.current = setTimeout(() => {
+            if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(30);
+            setSelectMode(true);
+            setSelectedLogIds(new Set([logId]));
+        }, 500);
+    };
+    const cancelLogPress = () => {
+        if (logPressTimer.current) { clearTimeout(logPressTimer.current); logPressTimer.current = null; }
+    };
+    const toggleSelectLog = (logId: string) => {
+        setSelectedLogIds(prev => {
+            const n = new Set(prev);
+            n.has(logId) ? n.delete(logId) : n.add(logId);
+            return n;
+        });
+    };
+    const exitSelectMode = () => {
+        setSelectMode(false);
+        setSelectedLogIds(new Set());
+    };
+
+    // 把选中的剧情打包成 trpg_card，转发进每个参与角色的聊天上下文
+    const handleForwardToChat = async () => {
+        if (!activeGame || selectedLogIds.size === 0) return;
+        setIsForwarding(true);
+        try {
+            const players = characters.filter(c => activeGame.playerCharIds.includes(c.id));
+            // 按剧情原顺序取选中的日志（排除纯系统占位）
+            const selected = activeGame.logs.filter(l => selectedLogIds.has(l.id) && l.role !== 'system');
+            const excerpt = selected.map(l => ({
+                role: l.role,
+                speaker: l.role === 'gm' ? 'GM' : (l.speakerName || (l.role === 'player' ? userProfile.name : '')),
+                text: l.content,
+            }));
+            const trpg = {
+                gameTitle: activeGame.title,
+                theme: activeGame.theme,
+                userName: userProfile.name,
+                partyNames: players.map(p => p.name),
+                excerpt,
+                count: excerpt.length,
+            };
+            for (const p of players) {
+                await DB.saveMessage({
+                    charId: p.id,
+                    role: 'user',
+                    type: 'trpg_card',
+                    content: `[TRPG游戏片段]《${activeGame.title}》`,
+                    metadata: { trpg },
+                });
+            }
+            addToast(`已转发到 ${players.length} 位角色的聊天`, 'success');
+            exitSelectMode();
+        } catch (e: any) {
+            addToast(`转发失败: ${e.message}`, 'error');
+        } finally {
+            setIsForwarding(false);
+        }
+    };
+
     const handleDeleteGame = (e: React.MouseEvent, id: string) => {
         e.stopPropagation();
         setDeleteConfirmId(id);
@@ -1560,18 +1630,17 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
                     const isCharacter = log.role === 'character';
                     const charInfo = isCharacter ? activePlayers.find(p => p.name === log.speakerName) : null;
 
+                    let inner: React.ReactNode;
                     if (isSystem) {
-                        return (
-                            <div key={log.id || i} className="flex flex-col items-center my-4 animate-fade-in gap-1 group">
+                        inner = (
+                            <div className="flex flex-col items-center my-4 animate-fade-in gap-1 group">
                                 <span className="text-[10px] opacity-50 border-b border-dashed border-current pb-0.5 font-mono">{log.content}</span>
                                 <button onClick={() => handleRollbackLog(i)} className="text-[9px] text-red-400 opacity-0 group-hover:opacity-100 transition-opacity hover:underline">回退到此处</button>
                             </div>
                         );
-                    }
-
-                    if (isGM) {
-                        return (
-                            <div key={log.id || i} className="animate-fade-in my-4 group relative">
+                    } else if (isGM) {
+                        inner = (
+                            <div className="animate-fade-in my-4 group relative">
                                 <div className={`p-5 rounded-lg border-2 ${theme.border} ${theme.cardBg} shadow-sm relative mx-auto w-full text-sm`}>
                                     <div className="absolute -top-3 left-4 bg-inherit px-2 text-[10px] font-bold uppercase tracking-widest opacity-80 border border-inherit rounded">Game Master</div>
                                     <GameMarkdown content={log.content} theme={theme} customStyle={uiSettings} />
@@ -1579,12 +1648,9 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
                                 <button onClick={() => handleRollbackLog(i)} className="absolute top-2 right-2 text-[9px] bg-red-900/50 text-red-200 px-2 py-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-800">Rollback</button>
                             </div>
                         );
-                    }
-
-                    // Character Log
-                    if (isCharacter && charInfo) {
-                        return (
-                            <div key={log.id || i} className="flex gap-3 animate-slide-up group relative">
+                    } else if (isCharacter && charInfo) {
+                        inner = (
+                            <div className="flex gap-3 animate-slide-up group relative">
                                 <img src={charInfo.avatar} className={`w-10 h-10 rounded-full object-cover border ${theme.border} shrink-0 mt-1`} />
                                 <div className="flex flex-col max-w-[85%]">
                                     <span className="text-[10px] font-bold opacity-60 mb-1 ml-1">{charInfo.name}</span>
@@ -1595,23 +1661,46 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
                                 </div>
                             </div>
                         );
+                    } else {
+                        // Player (User) Log
+                        inner = (
+                            <div className="flex flex-col items-end animate-slide-up group relative">
+                                <div className="flex items-center gap-2 mb-1">
+                                    <span className={`text-[10px] font-bold opacity-60`}>{log.speakerName}</span>
+                                    {log.diceRoll && (
+                                        <span className="text-[10px] bg-white/20 px-1.5 rounded text-yellow-500 font-mono">
+                                            <DiceFive size={12} weight="fill" className="inline" /> {log.diceRoll.result}
+                                        </span>
+                                    )}
+                                </div>
+                                <div className={`px-4 py-2 rounded-2xl rounded-tr-none text-sm bg-orange-600 text-white shadow-md max-w-[85%]`}>
+                                    {log.content}
+                                </div>
+                                <button onClick={() => handleRollbackLog(i)} className="mt-1 text-[9px] text-red-400 opacity-0 group-hover:opacity-100 transition-opacity hover:underline">回退</button>
+                            </div>
+                        );
                     }
 
-                    // Player (User) Log
+                    const selected = selectedLogIds.has(log.id);
                     return (
-                        <div key={log.id || i} className="flex flex-col items-end animate-slide-up group relative">
-                            <div className="flex items-center gap-2 mb-1">
-                                <span className={`text-[10px] font-bold opacity-60`}>{log.speakerName}</span>
-                                {log.diceRoll && (
-                                    <span className="text-[10px] bg-white/20 px-1.5 rounded text-yellow-500 font-mono">
-                                        <DiceFive size={12} weight="fill" className="inline" /> {log.diceRoll.result}
-                                    </span>
-                                )}
+                        <div
+                            key={log.id || i}
+                            onPointerDown={() => startLogPress(log.id)}
+                            onPointerUp={cancelLogPress}
+                            onPointerLeave={cancelLogPress}
+                            onPointerCancel={cancelLogPress}
+                            onClick={() => { if (selectMode) toggleSelectLog(log.id); }}
+                            onContextMenu={(e) => { if (selectMode) e.preventDefault(); }}
+                            className={`relative ${selectMode ? `cursor-pointer rounded-xl px-1 transition-all ${selected ? 'ring-2 ring-purple-400 bg-purple-500/10' : 'hover:bg-white/[0.03]'}` : ''}`}
+                        >
+                            {selectMode && (
+                                <div className={`absolute left-0 top-1/2 -translate-y-1/2 z-30 w-5 h-5 rounded-full border-2 flex items-center justify-center ${selected ? 'bg-purple-500 border-purple-400' : 'border-white/40 bg-black/40'}`}>
+                                    {selected && <svg viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3 text-white"><path fillRule="evenodd" d="M16.7 5.3a1 1 0 0 1 0 1.4l-7.5 7.5a1 1 0 0 1-1.4 0l-3.5-3.5a1 1 0 1 1 1.4-1.4l2.8 2.79 6.8-6.79a1 1 0 0 1 1.4 0Z" clipRule="evenodd"/></svg>}
+                                </div>
+                            )}
+                            <div className={selectMode ? 'pointer-events-none select-none pl-5' : ''}>
+                                {inner}
                             </div>
-                            <div className={`px-4 py-2 rounded-2xl rounded-tr-none text-sm bg-orange-600 text-white shadow-md max-w-[85%]`}>
-                                {log.content}
-                            </div>
-                            <button onClick={() => handleRollbackLog(i)} className="mt-1 text-[9px] text-red-400 opacity-0 group-hover:opacity-100 transition-opacity hover:underline">回退</button>
                         </div>
                     );
                 })}
@@ -1620,9 +1709,24 @@ Output: A concise summary in Chinese (e.g. "探索了地牢并击败了史莱姆
                 {/* [FIX] Removed logsEndRef usage */}
             </div>
 
+            {/* 多选转发操作栏 */}
+            {selectMode && (
+                <div className={`p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] border-t ${theme.border} bg-black/50 backdrop-blur shrink-0 z-20 flex items-center gap-3 animate-slide-down`}>
+                    <button onClick={exitSelectMode} className="px-4 h-11 rounded-xl border border-white/15 text-sm font-bold text-white/70 active:scale-95 transition-transform">取消</button>
+                    <span className="text-xs text-white/50 flex-1 text-center">已选 {selectedLogIds.size} 条 · 长按可多选剧情</span>
+                    <button
+                        onClick={handleForwardToChat}
+                        disabled={selectedLogIds.size === 0 || isForwarding}
+                        className="px-5 h-11 rounded-xl bg-gradient-to-r from-purple-500 to-pink-500 text-white text-sm font-bold active:scale-95 transition-transform disabled:opacity-40 flex items-center gap-2 shadow-lg shadow-purple-500/20"
+                    >
+                        {isForwarding ? <><div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div> 转发中...</> : '转发到聊天'}
+                    </button>
+                </div>
+            )}
+
             {/* Controls */}
             {/* Added pb-[env(safe-area-inset-bottom)] to ensure content clears home bar on full screen devices */}
-            <div className={`p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] border-t ${theme.border} bg-opacity-90 backdrop-blur shrink-0 z-20 transition-colors duration-500`}>
+            <div className={`p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] border-t ${theme.border} bg-opacity-90 backdrop-blur shrink-0 z-20 transition-colors duration-500 ${selectMode ? 'hidden' : ''}`}>
                 
                 {/* AI Suggested Options Area */}
                 {activeGame.suggestedActions && activeGame.suggestedActions.length > 0 && !isTyping && (

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -1492,6 +1492,53 @@ const MessageItem = React.memo(({
         return commonLayout(card);
     }
 
+    if (m.type === 'trpg_card') {
+        const t: any = m.metadata?.trpg || {};
+        const gameTitle: string = t.gameTitle || 'TRPG 跑团';
+        const partyNames: string[] = Array.isArray(t.partyNames) ? t.partyNames.filter((n: string) => n && n !== charName) : [];
+        const excerpt: Array<{ speaker?: string; text?: string; role?: string }> = Array.isArray(t.excerpt) ? t.excerpt : [];
+        const card = (
+            <div className="w-72">
+                <div
+                    className="rounded-2xl overflow-hidden border border-purple-300/30 shadow-[0_6px_20px_rgba(70,40,110,0.28)]"
+                    style={{ background: 'linear-gradient(155deg,#2c1c44 0%,#1a1230 100%)' }}
+                >
+                    {/* 头部 */}
+                    <div className="px-3.5 pt-3 pb-2.5 flex items-center gap-2.5 border-b border-white/10">
+                        <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0" style={{ background: 'linear-gradient(135deg,#a855f7,#ec4899)' }}>
+                            <svg viewBox="0 0 24 24" fill="none" className="w-4 h-4 text-white"><path d="M12 2 4 6v6c0 5 3.4 8.5 8 10 4.6-1.5 8-5 8-10V6l-8-4Z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round"/></svg>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <div className="text-[9px] tracking-[0.25em] text-purple-300/80 font-bold uppercase">TRPG · 一起玩的游戏</div>
+                            <div className="text-[13px] text-purple-50 font-semibold truncate font-serif">{gameTitle}</div>
+                        </div>
+                    </div>
+                    {/* 剧情节选 */}
+                    <div className="px-3.5 py-3 space-y-2 max-h-60 overflow-hidden">
+                        {excerpt.length === 0 && <p className="text-[12px] text-purple-200/70 italic">一段冒险剧情</p>}
+                        {excerpt.slice(0, 6).map((e, i) => {
+                            const isGM = e.role === 'gm';
+                            const text = (e.text || '').replace(/^\*|\*$/g, '').trim();
+                            return (
+                                <div key={i} className={`text-[12px] leading-relaxed ${isGM ? 'text-purple-100/90 italic' : 'text-purple-50/95'}`}>
+                                    {!isGM && e.speaker && <span className="text-pink-300/90 font-semibold mr-1">{e.speaker}:</span>}
+                                    <span className={isGM ? 'border-l-2 border-purple-400/40 pl-2 block' : ''}>{text}</span>
+                                </div>
+                            );
+                        })}
+                        {excerpt.length > 6 && <div className="text-[10px] text-purple-300/60 text-center pt-0.5">…共 {excerpt.length} 条剧情</div>}
+                    </div>
+                    {/* 页脚 */}
+                    <div className="px-3.5 py-2 border-t border-white/10 flex items-center justify-between">
+                        <span className="text-[9px] text-purple-300/70 italic truncate">{partyNames.length ? `与 ${partyNames.join('、')} 同行` : '我们的冒险'}</span>
+                        <span className="text-[9px] text-pink-200/80 font-bold tracking-wide shrink-0 ml-2">＋共同回忆</span>
+                    </div>
+                </div>
+            </div>
+        );
+        return commonLayout(card);
+    }
+
     if (m.type === 'news_card') {
         const md: any = m.metadata || {};
         const title: string = md.title || '热点';

--- a/types.ts
+++ b/types.ts
@@ -1897,7 +1897,7 @@ export interface GameSession {
     lastPlayedAt: number;
 }
 
-export type MessageType = 'text' | 'image' | 'emoji' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'html_card' | 'news_card' | 'vr_card';
+export type MessageType = 'text' | 'image' | 'emoji' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'html_card' | 'news_card' | 'vr_card' | 'trpg_card';
 
 export interface Message {
     id: number;

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -3,6 +3,7 @@ import { CharacterProfile, UserProfile, Message, Emoji, EmojiCategory, GroupProf
 import { ContextBuilder } from './context';
 import { DB } from './db';
 import { formatLifeSimResetCardForContext } from './lifeSimChatCard';
+import { normalizeMessageContent } from './messageFormat';
 import { computeCurrentListening, getCurrentSlot } from './charMusicSchedule';
 import { getCharLyricSnippet } from './charLyricCache';
 import { MusicCfg, loadMusicCfgStandalone } from '../context/MusicContext';
@@ -33,6 +34,7 @@ function summarizeGroupMsgContent(m: Message): string {
         case 'mcd_card': return '[麦当劳点餐]';
         case 'html_card': return '[HTML卡片]';
         case 'news_card': return '[新闻卡片]';
+        case 'trpg_card': return `[TRPG游戏片段${meta.trpg?.gameTitle ? '：《' + meta.trpg.gameTitle + '》' : ''}]`;
         default: {
             const c = typeof m.content === 'string' ? m.content : '';
             // 兜底：任何 data:/http(s) 链接都不内联，防止异常/未来新增类型漏网
@@ -909,8 +911,13 @@ ${xhsEnabled ? `${[notionEnabled, feishuEnabled, notionNotesEnabled].filter(Bool
                         content = `${timeStr} [系统卡片]`;
                     }
                 }
+                else if ((m.type as string) === 'trpg_card') {
+                    // TRPG 跑团片段：从游戏多选转发进来的剧情。复用 normalizeMessageContent
+                    // 把完整节选翻成文本，让角色"记得"和用户一起玩游戏时发生了什么。
+                    content = `${timeStr} ${normalizeMessageContent(m, char?.name || '你', userProfile?.name || '用户')}`;
+                }
                 else content = `${timeStr} ${sourceTag} ${content}`;
-                
+
                 return { role: m.role, content };
             }),
             historySlice // Return original slice for Quote lookup

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -110,6 +110,27 @@ export function normalizeMessageContent(
         return '[音乐卡片]';
     }
 
+    // TRPG 跑团片段：从 TRPG 游戏里多选转发到聊天的剧情。必须翻成完整可读文本，
+    // 让上下文 / 归档 / palace 都能读到"和用户一起玩游戏时发生了什么"，并标明来自 TRPG。
+    if (type === 'trpg_card') {
+        const t = msg.metadata?.trpg as {
+            gameTitle?: string;
+            userName?: string;
+            partyNames?: string[];
+            excerpt?: Array<{ speaker?: string; text?: string }>;
+        } | undefined;
+        if (t) {
+            const others = (t.partyNames || []).filter(n => n && n !== charName);
+            const withPart = others.length ? `（和${others.join('、')}）` : '';
+            const lines = (t.excerpt || [])
+                .map(e => `${e.speaker || ''}: ${(e.text || '').replace(/\s*\n+\s*/g, ' ').trim()}`)
+                .filter(s => s.trim() !== ':')
+                .join('\n');
+            return `[TRPG游戏片段] 这是${charName}和${t.userName || userName}${withPart}一起玩《${t.gameTitle || 'TRPG'}》跑团时的一段剧情（从游戏里转发到聊天，相当于你们一起玩游戏的共同回忆）：\n${lines}`;
+        }
+        return '[TRPG游戏片段]';
+    }
+
     // 默认：text / 未知类型 → 用 content
     return msg.content || '';
 }
@@ -152,5 +173,5 @@ export function isMessageSemanticallyRelevant(msg: Message): boolean {
     const type = msg.type as string;
     if (type === 'image' || type === 'emoji' || type === 'voice') return false;
     // 有内容或有结构化 metadata 才算
-    return !!(msg.content?.trim() || msg.metadata?.scoreCard || msg.metadata?.amount || msg.metadata?.song);
+    return !!(msg.content?.trim() || msg.metadata?.scoreCard || msg.metadata?.amount || msg.metadata?.song || msg.metadata?.trpg);
 }


### PR DESCRIPTION
- GameApp 游戏界面：长按剧情进入多选模式，勾选多条后「转发到聊天」， 打包成 trpg_card 写入每个参与角色的私聊
- 新增 MessageType 'trpg_card'：
  - messageFormat.normalizeMessageContent 完整序列化为文本（标明来自 TRPG、 是和用户一起玩游戏的共同回忆），覆盖记忆宫殿/归档/月度总结
  - chatPrompts.buildMessageHistory 私聊上下文加 trpg_card 分支(复用 normalize)， 让完整节选真正进入角色上下文；群聊注入与语义过滤同步识别
  - MessageItem 新增紫色质感卡片渲染，标注剧本名/同行队友/剧情节选
- 卡片 content 留有占位兜底，metadata.trpg 携带结构化节选

https://claude.ai/code/session_01Rvv7Uij8qhyML9HHFovNjS