### PR TITLE
修复彼方用户捏人崩溃：VR_OVERLAY_TOP 漏改 → VR_TOP

### DIFF
--- a/apps/VRWorldApp.tsx
+++ b/apps/VRWorldApp.tsx
@@ -2219,7 +2219,7 @@ const UserChibiEditor: React.FC<{
 
     if (creating) {
         return (
-            <div className="fixed inset-0 z-[60] flex flex-col bg-black" style={{ paddingTop: VR_OVERLAY_TOP }}>
+            <div className="fixed inset-0 z-[60] flex flex-col bg-black" style={{ paddingTop: VR_TOP }}>
                 <CreatorIframe mode="user" charName={userName} presets={presets}
                     draftKey="vr_user" title={`捏一个你自己 · ${userName}`} subtitle="彼方 · 你的 CHIBI"
                     onConfirm={onConfirm} />


### PR DESCRIPTION
安全区单一来源重构时把全文件 paddingTop 统一成了 VR_TOP，
但 UserChibiEditor(用户本人捏 chibi 的全屏层)漏改，仍引用已不存在的
VR_OVERLAY_TOP，生产环境一进用户捏人即 ReferenceError: VR_OVERLAY_TOP is not defined。角色捏人用的是 VR_TOP 故不受影响——正是'只有 user 报错'。 对齐到同文件其余 5 处 VR_TOP。