### PR TITLE
fix(dev-debug): isCaptureEnabled 跟可用性绑定，堵 prod 刷新偷录漏洞

### DIFF
--- a/docs/dev-debug.md
+++ b/docs/dev-debug.md
@@ -33,7 +33,7 @@ isDevDebugAvailable()  // utils/devDebug.ts
 
 **怎么关掉**：
 - **刷新页面**：`manualUnlock` 清零 → prod 回到隐藏；非 prod 因 `__BUILD_BADGE_VISIBLE__` 默认可见，刷新后照常显示（即「非 prod 一直开」）。
-- **面板底部「关闭」按钮**：`closeDevDebug()` 置 `forceClosed`，**任意分支**强制关掉；会话级，**刷新后非 prod 自动恢复**。顺手把浮球位置收回默认、面板收起；**`isCaptureEnabled` 也会一并返 false**（避免面板看着关了但业务代码继续往 localStorage 写日志的隐私债），但**里面的捕获 / 行为开关存档不动**——刷新恢复后可见性回来，里面勾的还是原样。
+- **面板底部「关闭」按钮**：`closeDevDebug()` 置 `forceClosed`，**任意分支**强制关掉；会话级，**刷新后非 prod 自动恢复**。顺手把浮球位置收回默认、面板收起；**`isCaptureEnabled` 跟 `isDevDebugAvailable` 绑定**——只要面板看不见（关闭 / prod 未解锁 / prod 解锁后刷新 / 非 prod 强制关闭）都返 false，避免业务代码继续往 localStorage 写日志的隐私债。**里面的捕获 / 行为开关存档不动**——刷新恢复后可见性回来，里面勾的还是原样，但只有面板可见时才真正录。
 
 > 可用性 = `!forceClosed && (__BUILD_BADGE_VISIBLE__ || manualUnlock)`，三个量里只有 `__BUILD_BADGE_VISIBLE__` 是构建期常量，另两个是会话级内存标志（刷新归零）。
 

--- a/utils/devDebug.ts
+++ b/utils/devDebug.ts
@@ -248,9 +248,12 @@ export function isEmotionEvalSkipped(): boolean {
 }
 
 export function isCaptureEnabled(category: DevDebugCaptureCategory): boolean {
-    // 「关闭」按钮 = 强制下线整个调试系统（任意分支）。这里也必须挡住捕获，
-    // 否则面板已收起，业务代码却还往 localStorage 里写带 url/status 的日志条目（隐私债）。
-    if (devDebugForceClosed) return false;
+    // 跟可用性绑定：面板看不见就别录。覆盖三种「隐身但 flag 还在 localStorage 里」的场景：
+    //   1. 关闭按钮（devDebugForceClosed=true）
+    //   2. prod 刷新后（manualUnlock 重置为 false，但 captureEnabled 还在存档里）
+    //   3. master 构建（__BUILD_BADGE_VISIBLE__=false，未解锁）
+    // 不挡的话用户看不到面板还在偷偷写带 url/status 的日志条目——隐私债。
+    if (!isDevDebugAvailable()) return false;
     const flags = readDevDebugFlags();
     // 总开关关掉时一律不抓，哪怕该类别勾着。
     return flags.captureEnabled && flags.captureLogs.includes(category);


### PR DESCRIPTION
## Summary

补 PR #171 漏掉的一个等价 case。

之前 `isCaptureEnabled` 只挡 `devDebugForceClosed`（「关闭」按钮场景），但漏了：**prod 用户 5 连点解锁 → 开总开关 + 勾类型 → 刷新页面**。模块重载让 `manualUnlock` 回 `false` → `isDevDebugAvailable()` 返 false → 面板正确隐藏 ✓，但 `captureEnabled` / `captureLogs` 仍在 localStorage 里存着，`isCaptureEnabled` 只看 `forceClosed` 不看可用性，业务代码会继续往 localStorage 里偷偷写带 url / status 的日志条目——**用户看不到面板也不知道在录**，隐私债。

改成直接跟 `isDevDebugAvailable()` 绑：只要系统不可见就别录，覆盖四种隐身场景：
1. 关闭按钮（`forceClosed=true`）
2. **prod 解锁后刷新**（`manualUnlock` 模块重载归零，已存档 captureEnabled 还在）← 本 PR 修的
3. master 未解锁（`__BUILD_BADGE_VISIBLE__=false`）
4. 非 prod 强制关闭

## Test plan
- [ ] master 本地 prod 构建（`pnpm build && pnpm preview`）：设置页连点 5 下解锁 → 开总开关 + 勾 API → 刷新 → 面板隐藏 ✓ → 触发几次聊天 → 重新解锁面板看「复制」按钮 → 应该 `暂无日志`（没在刷新后偷录）
- [ ] 非 prod：点「关闭」后业务代码不录；刷新后面板自动恢复、勾选还在、再开总开关又能正常录

🤖 Generated with [Claude Code](https://claude.com/claude-code)