### PR TITLE
彼方：修复日文小说乱码 + 支持手动选编码

### DIFF
--- a/apps/VRWorldApp.tsx
+++ b/apps/VRWorldApp.tsx
@@ -11,7 +11,7 @@ import { DB } from '../utils/db';
 import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { VR_ROOMS, getRoom, VR_DEFAULT_INTERVAL_MIN } from '../utils/vrWorld/constants';
 import { buildNovelAsync, groupAnnotationsBySeg, getBookmark } from '../utils/vrWorld/novel';
-import { decodeTextFile } from '../utils/vrWorld/decodeText';
+import { decodeBytes } from '../utils/vrWorld/decodeText';
 import { PostOffice, MAX_LETTER_CHARS, exportIdentity, importIdentity, getAdminToken, setAdminToken, type RemoteReply, type RemoteLetterStat, type RemoteAdminLetter } from '../utils/vrWorld/postOffice';
 import { getVRApi, setVRApi, getVRApiLog, clearVRApiLog, type VRApiCall } from '../utils/vrWorld/vrApi';
 import { safeResponseJson } from '../utils/safeApi';
@@ -1995,23 +1995,34 @@ const UploadModal: React.FC<{
     const [pasteText, setPasteText] = useState('');
     const [fileInfo, setFileInfo] = useState<{ name: string; chars: number; preview: string; encoding: string } | null>(null);
     const fileContentRef = useRef<string>('');
+    // 留着原始字节，手动换编码时无需重新读盘即可重解码
+    const fileBufRef = useRef<ArrayBuffer | null>(null);
+    const [chosenEncoding, setChosenEncoding] = useState<string>('auto');
     const fileRef = useRef<HTMLInputElement>(null);
     const [reading, setReading] = useState(false);
     const [busy, setBusy] = useState(false);
     const [progress, setProgress] = useState(0);
 
+    // 用某个编码（auto = 自动识别）解码当前缓存的字节并刷新预览
+    const applyDecode = (name: string, buf: ArrayBuffer, enc: string) => {
+        const { text: content, encoding } = decodeBytes(buf, enc === 'auto' ? undefined : enc);
+        fileContentRef.current = content;
+        setFileInfo({
+            name,
+            chars: content.length,
+            preview: content.slice(0, 300).replace(/\s+/g, ' ').trim(),
+            encoding,
+        });
+    };
+
     const onFile = async (f: File | undefined) => {
         if (!f) return;
         setReading(true);
         try {
-            const { text: content, encoding } = await decodeTextFile(f);
-            fileContentRef.current = content;
-            setFileInfo({
-                name: f.name,
-                chars: content.length,
-                preview: content.slice(0, 300).replace(/\s+/g, ' ').trim(),
-                encoding,
-            });
+            const buf = await f.arrayBuffer();
+            fileBufRef.current = buf;
+            setChosenEncoding('auto');
+            applyDecode(f.name, buf, 'auto');
             setPasteText(''); // 文件优先，清掉粘贴框
             if (!title.trim()) setTitle(f.name.replace(/\.(txt|text)$/i, ''));
         } catch (e) {
@@ -2022,8 +2033,18 @@ const UploadModal: React.FC<{
         }
     };
 
+    // 手动换编码（乱码时用）：拿缓存字节重新解码，不必再选一遍文件
+    const redecode = (enc: string) => {
+        const buf = fileBufRef.current;
+        if (!buf || !fileInfo) return;
+        setChosenEncoding(enc);
+        applyDecode(fileInfo.name, buf, enc);
+    };
+
     const clearFile = () => {
         fileContentRef.current = '';
+        fileBufRef.current = null;
+        setChosenEncoding('auto');
         setFileInfo(null);
         if (fileRef.current) fileRef.current.value = '';
     };
@@ -2075,6 +2096,20 @@ const UploadModal: React.FC<{
                         </div>
                         <div className="text-[10px] text-indigo-300/60 mt-1">{fileInfo.chars.toLocaleString()} 字 · 预计 ~{Math.ceil(fileInfo.chars / 400).toLocaleString()} 段</div>
                         <p className="text-[10.5px] text-indigo-200/50 mt-1.5 leading-snug line-clamp-2">{fileInfo.preview}…</p>
+                        {!busy && (
+                            <div className="flex items-center gap-1.5 mt-2">
+                                <span className="text-[9.5px] text-indigo-300/55 shrink-0">乱码？换编码</span>
+                                <select value={chosenEncoding} onChange={e => redecode(e.target.value)}
+                                    className="flex-1 text-[10px] bg-[#1b2236] text-indigo-100 border border-indigo-300/25 rounded px-1.5 py-1 outline-none">
+                                    <option value="auto">自动识别</option>
+                                    <option value="utf-8">UTF-8</option>
+                                    <option value="gb18030">简体中文 · GB18030 / GBK</option>
+                                    <option value="big5">繁体中文 · Big5</option>
+                                    <option value="shift_jis">日文 · Shift_JIS</option>
+                                    <option value="euc-jp">日文 · EUC-JP</option>
+                                </select>
+                            </div>
+                        )}
                     </div>
                 ) : (
                     <button onClick={() => fileRef.current?.click()}

--- a/utils/vrWorld/decodeText.ts
+++ b/utils/vrWorld/decodeText.ts
@@ -1,11 +1,14 @@
 /**
- * 小说 txt 解码 —— 中文小说常见 GB18030/GBK 编码，不能写死 UTF-8。
+ * 小说 txt 解码 —— 不能写死 UTF-8，也不能 UTF-8 失败就一律当中文 GB18030。
+ * 日文小说常见 Shift_JIS / EUC-JP，被 GB18030 解码器"将就"解出来就是一堆乱码。
  *
  * 策略：
- *   1. 先看 BOM（UTF-8 / UTF-16 LE / UTF-16 BE）
+ *   1. 先看 BOM（UTF-8 / UTF-16 LE / UTF-16 BE）—— 无歧义，直接定
  *   2. 用 fatal 模式试 UTF-8；能过就是 UTF-8
- *   3. 过不了 → 按 GB18030 解码（覆盖 GBK / GB2312）
+ *   3. 否则在候选编码（GB18030 / Shift_JIS / EUC-JP / Big5）里按"文本质量"打分挑最优
  *   4. 兜底 UTF-8 宽松模式
+ *
+ * 也支持手动指定编码（forced）：自动识别判错时，UI 可以让用户强制换一个。
  */
 
 export interface DecodeResult {
@@ -13,10 +16,78 @@ export interface DecodeResult {
     encoding: string;
 }
 
-export function decodeBytes(buf: ArrayBuffer): DecodeResult {
+/** 自动识别时参与评分的候选编码。GB18030 放最前 —— 同分时优先（中文是主场景）。 */
+const CANDIDATES = ['gb18030', 'shift_jis', 'euc-jp', 'big5'] as const;
+
+/** 识别只取前若干字节做样本，避免大文件（数 MB）反复全量解码拖慢上传。 */
+const SAMPLE_BYTES = 256 * 1024;
+
+function tryDecode(buf: ArrayBuffer, enc: string): string | null {
+    try {
+        return new TextDecoder(enc).decode(buf);
+    } catch {
+        // 引擎不认识这个编码 label
+        return null;
+    }
+}
+
+/**
+ * 给一段解码结果打分：越像"正常人类文本"分越高。
+ * 核心：用错编码会大量产生替换符 U+FFFD、私用区字符、半角片假名乱码；
+ * 用对编码则是连片的汉字 / 假名 / ASCII。
+ */
+function scoreText(s: string): number {
+    let score = 0;
+    for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i);
+        if (c === 0xFFFD) { score -= 100; continue; }              // 解码失败的替换符：强惩罚
+        if (c >= 0x3040 && c <= 0x30FF) { score += 4; continue; }  // 平/片假名：强日文信号
+        if (c >= 0x4E00 && c <= 0x9FFF) { score += 1; continue; }  // CJK 汉字
+        if (c >= 0x3000 && c <= 0x303F) { score += 1; continue; }  // CJK 标点（含全角空格）
+        if (c >= 0xFF01 && c <= 0xFF5E) { score += 1; continue; }  // 全角 ASCII
+        if (c >= 0xFF61 && c <= 0xFF9F) { score -= 1; continue; }  // 半角片假名：乱码高发区，压一压
+        if (c === 0x09 || c === 0x0A || c === 0x0D) { score += 1; continue; } // 制表/换行
+        if (c >= 0x20 && c <= 0x7E) { score += 1; continue; }      // ASCII 可见字符
+        if (c >= 0xE000 && c <= 0xF8FF) { score -= 20; continue; } // 私用区：几乎一定是乱码
+        if (c < 0x20) { score -= 5; continue; }                    // 其它控制符
+        score -= 0.3;                                               // 其余生僻符号：轻微减分
+    }
+    return score;
+}
+
+/** 在候选编码里按文本质量挑一个。GB18030 同分优先（数组顺序 + 严格大于）。 */
+function detectEncoding(buf: ArrayBuffer): string {
+    const sample = buf.byteLength > SAMPLE_BYTES ? buf.slice(0, SAMPLE_BYTES) : buf;
+    let best = 'gb18030';
+    let bestScore = -Infinity;
+    for (const enc of CANDIDATES) {
+        const t = tryDecode(sample, enc);
+        if (t == null) continue;
+        const sc = scoreText(t);
+        if (sc > bestScore) {
+            bestScore = sc;
+            best = enc;
+        }
+    }
+    return best;
+}
+
+/**
+ * 解码字节流为文本。
+ * @param buf    原始字节
+ * @param forced 手动指定编码（如 'utf-8' / 'shift_jis'）。传了就直接用，识别失败再回退自动。
+ */
+export function decodeBytes(buf: ArrayBuffer, forced?: string): DecodeResult {
     const bytes = new Uint8Array(buf);
 
-    // BOM
+    // 手动指定：优先按用户选的来
+    if (forced) {
+        const t = tryDecode(buf, forced);
+        if (t != null) return { text: t, encoding: forced };
+        // 本引擎不认识这个 label → 落到下面的自动识别
+    }
+
+    // BOM（无歧义）
     if (bytes.length >= 3 && bytes[0] === 0xEF && bytes[1] === 0xBB && bytes[2] === 0xBF) {
         return { text: new TextDecoder('utf-8').decode(buf), encoding: 'utf-8' };
     }
@@ -35,19 +106,17 @@ export function decodeBytes(buf: ArrayBuffer): DecodeResult {
         /* not utf-8 */
     }
 
-    // 中文小说最常见：GB18030（含 GBK/GB2312）
-    try {
-        const t = new TextDecoder('gb18030').decode(buf);
-        return { text: t, encoding: 'gb18030' };
-    } catch {
-        /* gb18030 不被支持时兜底 */
-    }
+    // 非 UTF-8：在候选编码里挑文本质量最高的（区分中文 GB18030 / 日文 Shift_JIS·EUC-JP / 繁体 Big5）
+    const enc = detectEncoding(buf);
+    const t = tryDecode(buf, enc);
+    if (t != null) return { text: t, encoding: enc };
 
+    // 兜底：宽松 UTF-8
     return { text: new TextDecoder('utf-8').decode(buf), encoding: 'utf-8?' };
 }
 
 /** 直接解码一个 File（读 ArrayBuffer + 识别编码）。 */
-export async function decodeTextFile(file: File): Promise<DecodeResult> {
+export async function decodeTextFile(file: File, forced?: string): Promise<DecodeResult> {
     const buf = await file.arrayBuffer();
-    return decodeBytes(buf);
+    return decodeBytes(buf, forced);
 }

--- a/utils/vrWorld/vrWorld.test.ts
+++ b/utils/vrWorld/vrWorld.test.ts
@@ -152,6 +152,28 @@ describe('decodeBytes', () => {
         expect(r.encoding === 'gb18030' || r.encoding === 'utf-8?').toBe(true);
         if (r.encoding === 'gb18030') expect(r.text).toBe('你好');
     });
+
+    it('picks shift_jis for Japanese kana (not gb18030 mojibake)', () => {
+        // こんにちは in Shift_JIS
+        const bytes = new Uint8Array([0x82, 0xB1, 0x82, 0xF1, 0x82, 0xC9, 0x82, 0xBF, 0x82, 0xCD]);
+        const r = decodeBytes(bytes.buffer);
+        expect(r.encoding).not.toBe('gb18030'); // 关键：别再当成中文乱码
+        if (r.encoding === 'shift_jis') expect(r.text).toBe('こんにちは');
+    });
+
+    it('decodes EUC-JP Japanese kana correctly (no mojibake)', () => {
+        // こんにちは in EUC-JP（这串假名字节在 gb18030 里恰好同样映射，关键是结果别是乱码）
+        const bytes = new Uint8Array([0xA4, 0xB3, 0xA4, 0xF3, 0xA4, 0xCB, 0xA4, 0xC1, 0xA4, 0xCF]);
+        const r = decodeBytes(bytes.buffer);
+        expect(r.text).toBe('こんにちは');
+    });
+
+    it('honors a forced encoding override', () => {
+        const bytes = new Uint8Array([0x82, 0xB1, 0x82, 0xF1]); // こん in Shift_JIS
+        const r = decodeBytes(bytes.buffer, 'shift_jis');
+        expect(r.encoding).toBe('shift_jis');
+        expect(r.text).toBe('こん');
+    });
 });
 
 describe('chunkNovelText', () => {


### PR DESCRIPTION
UTF-8 解不出来时不再一律回退 GB18030（会把 Shift_JIS 日文小说解成乱码）。
改为在 GB18030 / Shift_JIS / EUC-JP / Big5 候选里按文本质量打分自动识别， 并在上传弹窗加了手动换编码下拉，自动判错时可一键重解码。