### PR TITLE
彼方：清除批注/留言正文里泄漏的 回应="#xxxx" 标签残渣

### DIFF
--- a/apps/VRWorldApp.tsx
+++ b/apps/VRWorldApp.tsx
@@ -12,6 +12,7 @@ import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { VR_ROOMS, getRoom, VR_DEFAULT_INTERVAL_MIN } from '../utils/vrWorld/constants';
 import { buildNovelAsync, groupAnnotationsBySeg, getBookmark } from '../utils/vrWorld/novel';
 import { decodeBytes } from '../utils/vrWorld/decodeText';
+import { stripLeakedAttrs } from '../utils/vrWorld/prompts';
 import { PostOffice, MAX_LETTER_CHARS, exportIdentity, importIdentity, getAdminToken, setAdminToken, type RemoteReply, type RemoteLetterStat, type RemoteAdminLetter } from '../utils/vrWorld/postOffice';
 import { getVRApi, setVRApi, getVRApiLog, clearVRApiLog, type VRApiCall } from '../utils/vrWorld/vrApi';
 import { safeResponseJson } from '../utils/safeApi';
@@ -993,14 +994,14 @@ const FeedCard: React.FC<{ item: FeedItem; onJump: (novelId: string | undefined,
                         {item.meta.annotationRefs.slice(0, 3).map((ref, i) => (
                             <button key={i} onClick={() => onJump(item.meta.novelId, ref.segIdx)}
                                 className="block w-full text-left text-[10.5px] text-indigo-200/80 pl-2 border-l-2 border-amber-300/50 leading-snug active:opacity-60 hover:text-amber-100">
-                                {ref.text} <span className="text-amber-300/60">↗原文</span>
+                                {stripLeakedAttrs(ref.text)} <span className="text-amber-300/60">↗原文</span>
                             </button>
                         ))}
                     </div>
                 ) : item.meta.annotationExcerpts && item.meta.annotationExcerpts.length > 0 ? (
                     <div className="mt-1 space-y-0.5">
                         {item.meta.annotationExcerpts.slice(0, 2).map((ex, i) => (
-                            <div key={i} className="text-[10.5px] text-indigo-200/70 pl-2 border-l-2 border-amber-300/40 leading-snug">{ex}</div>
+                            <div key={i} className="text-[10.5px] text-indigo-200/70 pl-2 border-l-2 border-amber-300/40 leading-snug">{stripLeakedAttrs(ex)}</div>
                         ))}
                     </div>
                 ) : null}
@@ -1694,11 +1695,11 @@ const RoomScene: React.FC<{
                                         ? m.annotationRefs.map((ref, i) => (
                                             <button key={i} onClick={() => { onJump(m.novelId, ref.segIdx); setDetail(null); }}
                                                 className="block w-full text-left mt-1.5 text-[11.5px] text-indigo-200/85 pl-2 border-l-2 border-amber-300/50 leading-snug active:opacity-60">
-                                                {ref.text} <span className="text-amber-300/70">↗原文</span>
+                                                {stripLeakedAttrs(ref.text)} <span className="text-amber-300/70">↗原文</span>
                                             </button>
                                         ))
                                         : m.annotationExcerpts?.map((ex, i) => (
-                                            <div key={i} className="mt-1.5 text-[11.5px] text-indigo-200/80 pl-2 border-l-2 border-amber-300/50 leading-snug">{ex}</div>
+                                            <div key={i} className="mt-1.5 text-[11.5px] text-indigo-200/80 pl-2 border-l-2 border-amber-300/50 leading-snug">{stripLeakedAttrs(ex)}</div>
                                         ))}
                                     <p className="text-[9px] text-indigo-300/50 mt-2">{new Date(latestByChar[detail.id].timestamp).toLocaleString('zh-CN')}</p>
                                 </>
@@ -1788,7 +1789,7 @@ const SegBlock: React.FC<{
             <div key={a.id} className="mt-2 ml-2 rounded-lg px-3 py-2" style={{ background: theme.annBg, borderLeft: `3px solid ${theme.accent}` }}>
                 <span className="font-bold" style={{ color: theme.accent, fontSize: fontSize - 3 }}>{nameOf(a.authorId) || a.authorName}</span>
                 {a.targetAnnotationId && <span style={{ color: theme.sub, fontSize: fontSize - 3 }}> 回应</span>}
-                <span style={{ color: theme.text, fontSize: fontSize - 3 }}>：{a.content}</span>
+                <span style={{ color: theme.text, fontSize: fontSize - 3 }}>：{stripLeakedAttrs(a.content)}</span>
             </div>
         ))}
     </div>

--- a/utils/vrWorld/prompts.ts
+++ b/utils/vrWorld/prompts.ts
@@ -267,6 +267,29 @@ export interface ParsedVROutput {
     activity: string;
 }
 
+/**
+ * 模型偶尔会把 回应="#xxxx" / 段落="N" 这类标签属性又复读进正文开头，
+ * 导致 #cgis、回应="#cgis" 之类残渣泄漏到批注/留言正文里显示出来。
+ * 这里只剥正文「开头」、且只认「属性形态」（回应/回复/段落=… 或裸的 #xxxx），
+ * 避免误删正文里合法的引号、井号等内容。
+ */
+const LEAKED_ATTR_HEAD = new RegExp(
+    '^\\s*(?:' +
+        '(?:回应|回复|段落|段)\\s*[=:：]\\s*["\'“”‘’「『]?\\s*#?[0-9A-Za-z]{1,8}\\s*["\'“”‘’」』]?' + // 回应="#xxxx"
+        '|#[0-9A-Za-z]{2,8}' + // 裸的 #xxxx 引用标签
+    ')[\\s,，、:：]*'
+);
+
+export function stripLeakedAttrs(content: string): string {
+    let s = content.trim();
+    let prev: string;
+    do {
+        prev = s;
+        s = s.replace(LEAKED_ATTR_HEAD, '').trim();
+    } while (s !== prev && s.length > 0);
+    return s;
+}
+
 /** 解析角色输出的 <彼方>...</彼方> 块。 */
 export function parseVROutput(raw: string): ParsedVROutput {
     const annotations: ParsedVRAnnotation[] = [];
@@ -277,7 +300,7 @@ export function parseVROutput(raw: string): ParsedVROutput {
     let m: RegExpExecArray | null;
     while ((m = annPat.exec(raw)) !== null) {
         const attrs = m[1];
-        const content = m[2].trim();
+        const content = stripLeakedAttrs(m[2]);
         if (!content) continue;
         const segMatch = attrs.match(/段落?\s*[^\d]{0,4}(\d+)/);
         if (!segMatch) continue;
@@ -356,7 +379,7 @@ export function parseGuestbookOutput(raw: string): ParsedGuestbookOutput {
     const pat = /<留言([^>]*)>([\s\S]*?)<\/留言>/g;
     let m: RegExpExecArray | null;
     while ((m = pat.exec(raw)) !== null) {
-        const content = m[2].trim();
+        const content = stripLeakedAttrs(m[2]);
         if (!content) continue;
         const refMatch = m[1].match(/回复\s*[^0-9A-Za-z]{0,4}([0-9A-Za-z]{2,8})/);
         posts.push({ content, replyLabel: refMatch ? refMatch[1] : undefined });

--- a/utils/vrWorld/vrWorld.test.ts
+++ b/utils/vrWorld/vrWorld.test.ts
@@ -276,4 +276,25 @@ describe('parseVROutput', () => {
         const out = parseVROutput(raw);
         expect(out.annotations).toHaveLength(5);
     });
+
+    it('strips leaked 回应/段落 attribute residue from content', () => {
+        // 模型把 #cgis 回应="#cgis" 复读进了正文开头（用户实测里的真实泄漏）
+        const raw = '<批注 段落="5" 回应="#cgis">#cgis 回应="#cgis" 莲干并蒂？这姿势虽缠人</批注><动态>读完</动态>';
+        const out = parseVROutput(raw);
+        expect(out.annotations).toHaveLength(1);
+        expect(out.annotations[0].refLabel).toBe('cgis');
+        expect(out.annotations[0].content).toBe('莲干并蒂？这姿势虽缠人');
+        expect(out.annotations[0].content).not.toContain('回应');
+        expect(out.annotations[0].content).not.toContain('#cgis');
+    });
+
+    it('strips a bare leaked #label prefix', () => {
+        const out = parseVROutput('<批注 段落="2">#vo2m 这一处写得真好</批注><动态>x</动态>');
+        expect(out.annotations[0].content).toBe('这一处写得真好');
+    });
+
+    it('does NOT strip legitimate content starting with a quote', () => {
+        const out = parseVROutput('<批注 段落="1">「凤骑龙」这名字太刻意了</批注><动态>x</动态>');
+        expect(out.annotations[0].content).toBe('「凤骑龙」这名字太刻意了');
+    });
 });


### PR DESCRIPTION
模型偶尔把引用属性（回应="#xxxx"、段落="N"、裸的 #xxxx）复读进正文开头，
解析时只从属性区取引用、正文区的重复残渣没清掉，于是显示成乱码（用户实测截图）。
- parseVROutput / parseGuestbookOutput 解析时剥掉正文开头的属性残渣（只动开头、只认属性形态，不误删合法引号开头）
- 阅读器与活动卡片渲染处也套一层 stripLeakedAttrs，让存量已落库的脏批注同样正常显示
- 加 3 个测试：泄漏剥除、裸 #label 剥除、合法引号开头不被误删