### PR TITLE
聊天语音：假语音消息补上转文字按钮，未配置 MiniMax 只提醒一次

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -20,6 +20,7 @@ import ProactiveSettingsModal from '../components/chat/ProactiveSettingsModal';
 import ThinkingChainSettingsModal from '../components/chat/ThinkingChainSettingsModal';
 import { useChatAI } from '../hooks/useChatAI';
 import { synthesizeSpeechDetailed, cleanTextForTts } from '../utils/minimaxTts';
+import { resolveMiniMaxApiKey } from '../utils/minimaxApiKey';
 import { isInstantConfigReady, loadInstantConfig } from '../utils/instantPushClient';
 
 const VOICE_LANG_LABELS: Record<string, string> = { en: 'English', ja: '日本語', ko: '한국어', fr: 'Français', es: 'Español' };
@@ -196,6 +197,16 @@ const Chat: React.FC = () => {
     const prevIsTypingRef = useRef(false);
     // Track blob: URLs we created so we can revoke them on character switch / unmount.
     const voiceBlobUrlsRef = useRef<Set<string>>(new Set());
+    // We warn the user at most once (per character) that MiniMax voice isn't configured —
+    // a character can produce many <语音> messages and we don't want to spam toasts.
+    const minimaxWarnedRef = useRef(false);
+
+    /** Whether this character can synthesize real voice (MiniMax key + a voice profile). */
+    const isMinimaxReady = useCallback(() => {
+        const vp = char.voiceProfile;
+        const hasVoiceProfile = !!(vp?.voiceId || (vp?.timberWeights && vp.timberWeights.length > 0));
+        return hasVoiceProfile && !!resolveMiniMaxApiKey(apiConfig);
+    }, [char, apiConfig]);
 
     const persistVoice = async (msgId: number, url: string, blob: Blob | null, originalText: string, spokenText: string | undefined, lang: string | undefined) => {
         try {
@@ -268,6 +279,18 @@ const Chat: React.FC = () => {
 
         // Auto-TTS: only generate voice when AI explicitly used <语音> tag
         if (autoTriggered && !voiceTagContent) return;
+
+        // MiniMax not configured for this character: don't attempt synthesis (it would
+        // throw and surface an error toast on every message / every tap). Instead remind
+        // the user just once — the <语音> bubble still shows its 转文字 button so the
+        // text stays readable, matching real voice messages.
+        if (!isMinimaxReady()) {
+            if (!autoTriggered && !minimaxWarnedRef.current) {
+                minimaxWarnedRef.current = true;
+                addToast('该角色未配置 MiniMax 语音，无法播放真实语音，可点「转文字」查看内容', 'info');
+            }
+            return;
+        }
 
         setVoiceLoading(prev => new Set(prev).add(msg.id));
         try {
@@ -443,6 +466,8 @@ const Chat: React.FC = () => {
 
     // Revoke blob URLs when switching characters / unmounting to avoid leaks.
     useEffect(() => {
+        // Reset the "MiniMax not configured" warning so each character gets one reminder.
+        minimaxWarnedRef.current = false;
         const urls = voiceBlobUrlsRef.current;
         return () => {
             urls.forEach(u => { try { URL.revokeObjectURL(u); } catch { /* ignore */ } });

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -2049,6 +2049,10 @@ const MessageItem = React.memo(({
 
     // Check if raw content has a <语音> tag (voice-only message that hasn't been TTS'd yet)
     const hasVoiceTag = !isUser && /<[语語]音>[\s\S]*?<\/[语語]音>/.test(m.content);
+    // Spoken text inside the <语音> tag — lets the placeholder bar offer a 转文字 toggle
+    // even when no audio was synthesized (e.g. character has no MiniMax voice configured),
+    // so fake voice messages stay readable just like real ones.
+    const voiceTagText = hasVoiceTag ? (m.content.match(/<[语語]音>([\s\S]*?)<\/[语語]音>/)?.[1]?.trim() || '') : '';
     const hasVoiceContent = voiceData?.url || voiceLoading || hasVoiceTag;
     // Don't render empty bubbles (e.g. messages that were just "---"), unless voice data exists or pending
     if (!displayContent && !hasVoiceContent) return null;
@@ -2257,22 +2261,54 @@ const MessageItem = React.memo(({
                             <span className="text-[10px] shrink-0 animate-pulse" style={{ color: vbText || '#94a3b8' }}>合成中</span>
                         </div>
                     ) : hasVoiceTag ? (
-                        /* Voice tag exists in content but TTS hasn't been generated yet (e.g. app restart, or auto-TTS pending) */
-                        <button
-                            onClick={(e) => { e.stopPropagation(); e.preventDefault(); onPlayVoice?.(); }}
-                            className="flex items-center gap-2 px-3 py-2 max-w-[200px] rounded-2xl active:scale-[0.97] transition-transform"
-                            style={{ background: vbBg || 'linear-gradient(135deg, rgba(0,0,0,0.03) 0%, rgba(0,0,0,0.06) 100%)', border: '1px solid rgba(0,0,0,0.05)' }}
-                        >
-                            <div className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center" style={{ backgroundColor: vbBg ? 'rgba(255,255,255,0.25)' : 'rgba(148,163,184,0.2)' }}>
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill={vbBtn || '#64748b'} className="w-3 h-3 ml-0.5"><path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" /></svg>
+                        /* Voice tag exists in content but no audio yet — either TTS is still
+                           pending (app restart / auto-TTS) or the character has no MiniMax voice
+                           configured. Offer a 转文字 toggle here too so the text stays readable,
+                           aligning fake voice messages with real ones. */
+                        <div className="max-w-[260px]">
+                            <div
+                                className="flex items-center gap-2 px-3 py-2 rounded-2xl"
+                                style={{ background: vbBg || 'linear-gradient(135deg, rgba(0,0,0,0.03) 0%, rgba(0,0,0,0.06) 100%)', border: '1px solid rgba(0,0,0,0.05)' }}
+                            >
+                                <button
+                                    onClick={(e) => { e.stopPropagation(); e.preventDefault(); onPlayVoice?.(); }}
+                                    className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center active:scale-[0.92] transition-transform"
+                                    style={{ backgroundColor: vbBg ? 'rgba(255,255,255,0.25)' : 'rgba(148,163,184,0.2)' }}
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill={vbBtn || '#64748b'} className="w-3 h-3 ml-0.5"><path d="M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" /></svg>
+                                </button>
+                                <div className="flex-1 flex items-center gap-[3px] h-5 overflow-hidden">
+                                    {[4, 10, 6, 14, 8, 12, 5, 11, 7, 13, 4, 9, 6, 11, 5, 8, 10, 7, 12, 6].map((h, i) => (
+                                        <div key={i} className="w-[2.5px] rounded-full" style={{ height: `${Math.max(2, h * 0.4)}px`, backgroundColor: vbWave ? vbWave + '60' : `rgba(148, 163, 184, ${0.25 + (h / 14) * 0.35})` }} />
+                                    ))}
+                                </div>
+                                {(voiceTagText || displayContent) ? (
+                                    <div
+                                        className={`shrink-0 ml-0.5 px-1.5 py-0.5 rounded-lg text-[9px] font-medium transition-all ${showVoiceText ? 'ring-1 ring-current/20' : ''}`}
+                                        style={{
+                                            color: vbText || 'rgba(100,116,139,0.7)',
+                                            backgroundColor: showVoiceText ? 'rgba(0,0,0,0.08)' : 'rgba(0,0,0,0.04)',
+                                        }}
+                                        onClick={(e) => { e.stopPropagation(); e.preventDefault(); setShowVoiceText(v => !v); }}
+                                    >
+                                        {showVoiceText ? '收起' : '转文字'}
+                                    </div>
+                                ) : (
+                                    <span className="text-[9px] shrink-0" style={{ color: vbText || 'rgba(100,116,139,0.7)' }}>语音</span>
+                                )}
                             </div>
-                            <div className="flex-1 flex items-center gap-[3px] h-5 overflow-hidden">
-                                {[4, 10, 6, 14, 8, 12, 5, 11, 7, 13, 4, 9, 6, 11, 5, 8, 10, 7, 12, 6].map((h, i) => (
-                                    <div key={i} className="w-[2.5px] rounded-full" style={{ height: `${Math.max(2, h * 0.4)}px`, backgroundColor: vbWave ? vbWave + '60' : `rgba(148, 163, 184, ${0.25 + (h / 14) * 0.35})` }} />
-                                ))}
-                            </div>
-                            <span className="text-[9px] shrink-0" style={{ color: vbText || 'rgba(100,116,139,0.7)' }}>语音</span>
-                        </button>
+                            {showVoiceText && (voiceTagText || displayContent) && (
+                                <div className="mt-1.5 px-3 py-2 rounded-xl text-[11px] leading-relaxed whitespace-pre-wrap"
+                                    style={{
+                                        backgroundColor: vbBg || 'rgba(0,0,0,0.02)',
+                                        color: vbText || '#475569',
+                                        border: '1px solid rgba(0,0,0,0.04)',
+                                    }}
+                                >
+                                    {voiceTagText || displayContent}
+                                </div>
+                            )}
+                        </div>
                     ) : null}
                 </div>
                 );


### PR DESCRIPTION
- 角色未配置 MiniMax 语音（缺 voiceProfile/Key）时，<语音> 占位气泡 现在也提供「转文字」按钮，展开可读语音文本，与真实语音消息对齐
- 未配置时不再每条/每次点击都弹错误提示，改为每个角色只提醒一次 （点击播放按钮时），切换角色后重置提醒