### PR TITLE
fix(启动): 单个 store 读取失败不再清空角色/世界书并崩溃

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -1928,6 +1928,22 @@ const Chat: React.FC = () => {
     // Memoize ChatInputArea callbacks
     const handleSendCallback = useCallback(() => handleSendText(), [char, input, replyTarget]);
     const handleCharSelectCallback = useCallback((id: string) => { setActiveCharacterId(id); setShowPanel('none'); }, []);
+
+    // 兜底：正常情况下 OSContext 启动时一定会保底一个角色，char 不该为空。
+    // 但若 init 期间某个 store 读取失败（数据其实还在 IndexedDB 里），characters 可能暂时为空，
+    // 此时下面 char.chatBackground 会直接抛 "undefined is not an object" 把整个 App 崩到错误页。
+    // 这里给个温和空态，避免硬崩，也好让用户能退回桌面/重启恢复。
+    if (!char) {
+        return (
+            <div className="flex flex-col items-center justify-center h-full bg-[#f1f5f9] text-center px-8 gap-3">
+                <div className="text-4xl">💤</div>
+                <div className="text-slate-600 text-sm font-medium">暂时没有可用的角色</div>
+                <div className="text-slate-400 text-xs leading-relaxed">数据可能未加载完成。请退回桌面后重新进入；若仍为空，重启应用即可恢复。</div>
+                <button onClick={closeApp} className="mt-2 px-4 py-2 rounded-full bg-slate-800 text-white text-xs">返回桌面</button>
+            </div>
+        );
+    }
+
     const chatChromeStyle = osTheme.chatChromeStyle || 'soft';
     const chatBackgroundStyle = osTheme.chatBackgroundStyle || 'plain';
     const chatRootClass =

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -969,14 +969,27 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
 
         await loadSettings();
 
+        // 用 allSettled 而非 all：早期 Promise.all 只要任意一个 store 读取 reject，
+        // 整批加载就全挂 → setCharacters / setWorldbooks 都不执行 → 角色和世界书"凭空消失"
+        // （数据其实还在 IndexedDB 里，只是没读进 state）→ Chat 渲染时 char 为 undefined 直接崩。
+        // 改成各 store 独立失败，一个坏掉不连累其余，最大限度保住用户数据。
+        const settle = async <T,>(p: Promise<T>, label: string, fallback: T): Promise<T> => {
+            try {
+                return await p;
+            } catch (e) {
+                console.error(`Data init: 读取 ${label} 失败，已降级`, e);
+                return fallback;
+            }
+        };
+
         const [dbChars, dbThemes, dbUser, dbGroups, dbWorldbooks, dbNovels, dbSongs] = await Promise.all([
-            DB.getAllCharacters(),
-            DB.getThemes(),
-            DB.getUserProfile(),
-            DB.getGroups(),
-            DB.getAllWorldbooks(),
-            DB.getAllNovels(),
-            DB.getAllSongs()
+            settle(DB.getAllCharacters(), 'characters', [] as CharacterProfile[]),
+            settle(DB.getThemes(), 'themes', [] as ChatTheme[]),
+            settle(DB.getUserProfile(), 'userProfile', null as UserProfile | null),
+            settle(DB.getGroups(), 'groups', [] as GroupProfile[]),
+            settle(DB.getAllWorldbooks(), 'worldbooks', [] as Worldbook[]),
+            settle(DB.getAllNovels(), 'novels', [] as NovelBook[]),
+            settle(DB.getAllSongs(), 'songs', [] as SongSheet[])
         ]);
 
         let finalChars = dbChars;


### PR DESCRIPTION
启动 init 用 Promise.all 同时读 7 个 store，任意一个 reject 就整批失败， setCharacters/setWorldbooks 全不执行 → 角色和世界书在 state 里同时变空 （数据其实还在 IndexedDB），随后 Chat 渲染 char.chatBackground 抛 'undefined is not an object' 把 App 崩到错误页。

- OSContext: Promise.all → 每个 store 独立 settle，失败降级为默认值并打日志， 一个 store 坏掉不再连累其余，最大限度保住已存在的数据。
- Chat: char 为空时给温和空态 + 返回桌面按钮，避免硬崩。