### PR TITLE
主动消息 Push 加速：加全局 kill switch 强制下线

### DIFF
--- a/utils/proactivePushConfig.ts
+++ b/utils/proactivePushConfig.ts
@@ -25,6 +25,16 @@ const WORKER_URL = 'https://noir2.cc.cd';
 const CLIENT_TOKEN = 'weqwqewqeqwdcsccagdgs32132';
 // ═══════════════════════════════════════════════════════════════════
 
+// ── 全局停用开关（KILL SWITCH）─────────────────────────────────────
+// 主动消息 Push 加速这层已经全局下线（设置面板也藏了）。已经开过的用户
+// localStorage 里 proactive_push_enabled_v1 还是 'true'，光藏 UI 改不了，
+// 他们的客户端会照常心跳、Worker 照常发 wake push。把这里设成 true 后，
+// loadPushConfig() 一律返回 enabled=false：心跳不再启动、不再向 Worker
+// 注册，Worker 在心跳窗口（默认 5 分钟）内自动对这些设备停发。
+// 注意：只关掉 Worker 加速层，proactiveChat.ts 的本地定时主动消息不受影响。
+const FORCE_DISABLED = true;
+// ───────────────────────────────────────────────────────────────────
+
 import { loadPushVapid, isPushVapidReady } from './pushVapid';
 import { KeepAlive } from './keepAlive';
 import {
@@ -47,9 +57,12 @@ export interface ProactivePushConfig {
 
 export function loadPushConfig(): ProactivePushConfig {
   let enabled = false;
-  try {
-    enabled = localStorage.getItem(ENABLED_STORAGE_KEY) === 'true';
-  } catch { /* ignore */ }
+  // 全局 kill switch：下线后无论 localStorage 里存的是什么，一律当关闭处理。
+  if (!FORCE_DISABLED) {
+    try {
+      enabled = localStorage.getItem(ENABLED_STORAGE_KEY) === 'true';
+    } catch { /* ignore */ }
+  }
   return {
     enabled,
     workerUrl: WORKER_URL.trim().replace(/\/+$/, ''),


### PR DESCRIPTION
设置面板已隐藏，但已开启用户的 proactive_push_enabled_v1 仍持久化在
localStorage 里，藏 UI 改不了落盘状态——客户端照常心跳、Worker 照常发
wake push，导致"被动一直开着"。

在 loadPushConfig() 前加 FORCE_DISABLED 常量，置 true 后一律返回 enabled=false：所有注册/心跳路径都过 isPushConfigReady()，一处全断。 用户下次加载新版即停心跳，Worker 在心跳窗口内自动停发。只关 Worker
加速层，proactiveChat 的本地定时主动消息不受影响。

https://claude.ai/code/session_01UXtrGUxi5HwaRZnGVyyKsk