### PR TITLE
fix(db): VersionError 时回退到不带版本号打开, 避免现有版本偏高时整库报错

### DIFF
--- a/utils/db.test.ts
+++ b/utils/db.test.ts
@@ -63,6 +63,31 @@ describe('openDB 失效自愈', () => {
   });
 });
 
+// 现有版本高于当前 build 的 DB_VERSION 时 (用户先跑过更新的 build / 另一 tab 升过级 /
+// SW 缓存了更新的 bundle), 带 DB_VERSION 打开会抛 VersionError —— 旧逻辑直接 reject,
+// 整个 origin 的 IndexedDB 全挂 (SYSTEM ERROR、美化读不出来、线下进不去)。修复后回退到
+// 「不带版本号打开」, 连到现有更高版本 (store 是超集, 读写兼容)。
+describe('openDB 版本回退 (现有版本高于当前 build)', () => {
+  it('遇到 VersionError 时不带版本号回退打开, 不再整库报错', async () => {
+    await DB.deleteDB(); // 复位 + 清掉单例连接
+
+    // 裸开一条「比 DB_VERSION 更高」的连接建库后关闭, 制造现有版本偏高的现场
+    const hi = await new Promise<IDBDatabase>((resolve, reject) => {
+      const r = indexedDB.open('AetherOS_Data', 999);
+      r.onsuccess = () => resolve(r.result);
+      r.onerror = () => reject(r.error);
+    });
+    hi.close();
+
+    // openDB 带 DB_VERSION(<999) 打开 → VersionError → 回退到不带版本号 → 连到 v999
+    const db = await openDB();
+    expect(db).toBeTruthy();
+    expect(db.version).toBe(999);
+
+    await DB.deleteDB(); // 收尾, 避免污染后续用例
+  });
+});
+
 describe('DB.deleteDB', () => {
   it('删库前先关掉单例连接, 不被本页自己的连接 block', async () => {
     await openDB(); // 建立单例连接

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -106,10 +106,41 @@ export const openDB = (): Promise<IDBDatabase> => {
     let settled = false;
 
     request.onerror = () => {
-        console.error("DB Open Error:", request.error);
+        const err = request.error;
+        // 版本回退兜底: 浏览器里已存在「比当前 build 的 DB_VERSION 更高」的版本时
+        // (用户先跑过更新的 build / 另一个 tab 升过级 / SW 缓存了更新的 bundle),
+        // 带 DB_VERSION 打开会抛 VersionError("lower version than existing")。
+        // 旧逻辑直接 reject → 整个 origin 的 IndexedDB 读写全挂: SYSTEM ERROR、
+        // 美化(themes 存在库里)读不出来、线下(LifeSim)进不去。其实更高版本的 store
+        // 只是当前 schema 的超集, 不带版本号打开就能连到现有版本、读写完全兼容,
+        // 不需要也不能降级建表。所以这里回退到「不带版本号 open」一次而不是报死。
+        if (err?.name === 'VersionError') {
+            console.warn('[DB] open VersionError —— 现有版本高于当前 build, 回退到不带版本号打开');
+            settled = true; // 原 request 已终结 (VersionError 后不会再 onsuccess), 标记以防迟到回调
+            const fb = indexedDB.open(DB_NAME); // 不带版本号 = 连到现有(更高)版本, 不触发 upgrade
+            fb.onsuccess = () => {
+                const db = fb.result;
+                // 与正常路径一致地挂上失效自愈回调 (另一 tab 升级 / 浏览器强关连接)。
+                db.onversionchange = () => {
+                    db.close();
+                    if (dbPromise === promise) dbPromise = null;
+                };
+                db.onclose = () => {
+                    if (dbPromise === promise) dbPromise = null;
+                };
+                resolve(db);
+            };
+            fb.onerror = () => {
+                console.error("DB Open Error (versionless fallback):", fb.error);
+                if (dbPromise === promise) dbPromise = null;
+                reject(fb.error);
+            };
+            return;
+        }
+        console.error("DB Open Error:", err);
         if (dbPromise === promise) dbPromise = null; // 打开失败别把 rejected promise 缓存住
         settled = true;
-        reject(request.error);
+        reject(err);
     };
 
     request.onsuccess = () => {


### PR DESCRIPTION
浏览器里已存在比当前 build 更高的 DB 版本时 (用户先跑过更新的 build /
另一个 tab 升过级 / SW 缓存了更新的 bundle), indexedDB.open(name, DB_VERSION) 会抛 VersionError("lower version than existing")。旧逻辑直接 reject, 导致整个 origin 的 IndexedDB 读写全挂 —— 表现为 SYSTEM ERROR、美化(themes)读不出来、 线下(LifeSim)进不去且反复闪退。

更高版本的 store 只是当前 schema 的超集, 不带版本号打开即可连到现有版本、
读写完全兼容。openDB 在收到 VersionError 时回退到 indexedDB.open(name)(无版本号) 一次, 并照常挂上失效自愈回调。补一条 db.test.ts 用例锁住该回退路径。