### PR TITLE
chore(worker): bump INSTANT_WORKER_VERSION & worker package

### DIFF
--- a/utils/instantWorkerVersion.ts
+++ b/utils/instantWorkerVersion.ts
@@ -9,4 +9,4 @@
 // Bump this whenever worker/instant-push/src/* gets a behavior change that
 // requires users to redeploy their worker. Use YYYY-MM-DD; the frontend
 // compares strings directly.
-export const INSTANT_WORKER_VERSION = '2026-06-01';
+export const INSTANT_WORKER_VERSION = '2026-06-10';

--- a/worker/instant-push/package.json
+++ b/worker/instant-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sullyos-instant-push-worker",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "description": "SullyOS Instant Push — Cloudflare Worker (deploy-from-git entry, agentic-loop enabled).",


### PR DESCRIPTION
…age 0.9.2

amsg-* 全家桶刚 bump 到 stable（client 2.5.0 / instant 0.9.1 / server 2.5.1 / sw 2.3.1），用户需要重新部署 worker。bump 这个常量后前端会自动给已部署的用户弹"Worker 需要更新"提示。

worker/instant-push 的 package.json 版本号也跟着走到 0.9.2，给部署人一眼能区分。