### PR TITLE
开机文案改为「欢迎回家！」

### DIFF
--- a/components/os/BootSequence.tsx
+++ b/components/os/BootSequence.tsx
@@ -211,11 +211,11 @@ const BootSequence: React.FC<Props> = ({ dataReady, wallpaper, onDone }) => {
             transformOrigin: 'center',
             animation: cinematic ? 'bootLineIn 900ms ease-out 1100ms both' : 'bootLineIn 400ms ease-out 200ms both',
           }} />
-          <div className="mt-3 text-[11px] text-white/80" style={{
-            letterSpacing: '0.34em',
+          <div className="mt-3 text-[12px] text-white/85" style={{
+            letterSpacing: '0.3em',
             animation: cinematic ? 'bootSoftIn 1200ms ease-out 1250ms both' : 'bootSoftIn 500ms ease-out 250ms both',
           }}>
-            进入你的小世界
+            欢迎回家！
           </div>
         </div>
       </div>


### PR DESCRIPTION
放弃随机角色台词方案（会引入开机期 DB 读取），直接把开机序列的「进入你的小世界」
改成静态「欢迎回家！」——零开销、不读任何数据、不影响开机速度。

https://claude.ai/code/session_01PXJsdUn6FqT9QYVDQ4yi8r