### PR TITLE
救援键改为仅在「白框」自定义弹窗开启时出现，平时不显示

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useLayoutEffect, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useOS } from '../context/OSContext';
 import { DB } from '../utils/db';
 import { Message, MessageType, MemoryFragment, Emoji, EmojiCategory, DailySchedule, ScheduleSlot } from '../types';
@@ -2717,6 +2718,26 @@ const Chat: React.FC = () => {
                         </div>
                         <ChromeCssEditor value={char.chromeCustomCss || ''} onChange={(css) => updateCharacter(char.id, { chromeCustomCss: css } as any)} />
                     </div>
+                    {/* 脱离 CSS 控制的救援键：只在「白框」自定义弹窗开着时出现（平时不显示，不丑）。portal 到 body
+                        在聊天 DOM 之外 + id 守护(#sully-safe-reset 特异性高于 *)，连 *{display:none!important} 也盖不掉，
+                        保证你刚粘进坏 CSS 当场崩掉时，这个还原键一定点得到。 */}
+                    {createPortal(
+                        <>
+                            <style>{`#sully-safe-reset{position:fixed!important;top:calc(var(--safe-top) + 6px)!important;left:50%!important;transform:translateX(-50%)!important;visibility:visible!important;opacity:1!important;pointer-events:auto!important;display:flex!important;z-index:2147483647!important;}`}</style>
+                            <button
+                                id="sully-safe-reset"
+                                onClick={() => { updateCharacter(char.id, { chromeCustomCss: '' } as any); addToast('已还原该角色白框', 'success'); }}
+                                style={{
+                                    position: 'fixed', top: 'calc(var(--safe-top) + 6px)', left: '50%', transform: 'translateX(-50%)',
+                                    zIndex: 2147483647, display: 'flex', alignItems: 'center', gap: '4px',
+                                    padding: '5px 12px', borderRadius: '999px',
+                                    background: 'rgba(15,23,42,0.62)', color: '#fff', fontSize: '11px', fontWeight: 700,
+                                    border: '1px solid rgba(255,255,255,0.3)', cursor: 'pointer', boxShadow: '0 2px 10px rgba(0,0,0,0.35)',
+                                }}
+                            >⟲ 还原此角色白框</button>
+                        </>,
+                        document.body,
+                    )}
                 </div>
             )}
 

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -446,7 +446,7 @@ const AppLoadingFallback: React.FC = () => {
 };
 
 const PhoneShell: React.FC = () => {
-  const { theme, isLocked, unlock, activeApp, closeApp, openApp, virtualTime, isDataLoaded, toasts, unreadMessages, characters, handleBack, suspendedCall, resumeCall, activeCharacterId, errorDialog, dismissError, updateCharacter, updateTheme } = useOS();
+  const { theme, isLocked, unlock, activeApp, closeApp, openApp, virtualTime, isDataLoaded, toasts, unreadMessages, characters, handleBack, suspendedCall, resumeCall, activeCharacterId, errorDialog, dismissError } = useOS();
   const useIOSStandaloneLayout = isIOSStandaloneWebApp();
   // 冷启动「世界入场」是否已结束。结束前由 BootSequence 接管整屏（同时取代旧的黑屏 spinner）。
   const [bootDone, setBootDone] = useState(false);
@@ -810,35 +810,6 @@ const PhoneShell: React.FC = () => {
 
           {/* Overlays: Global Mini Player (when music is playing in background) */}
           <GlobalMiniPlayer />
-
-          {/* 白框「脱离 CSS 控制」的救援按钮：当前聊天启用了自定义白框 CSS 时，于外壳层（聊天 DOM 之外）
-              悬浮一个一键还原。全内联样式 + id 守护(#sully-safe-reset，特异性高于 *，连 *{display:none!important}
-              也盖不掉)，确保坏 CSS 把聊天整崩、啥都点不了时，这个按钮永远点得到。 */}
-          {activeApp === AppID.Chat && (() => {
-            const ac = characters.find(c => c.id === activeCharacterId);
-            if (!ac?.chromeCustomCss && !theme.chatChromeCustomCss) return null;
-            return (
-              <>
-                <style>{`#sully-safe-reset{position:fixed!important;top:calc(var(--safe-top) + 6px)!important;left:50%!important;transform:translateX(-50%)!important;visibility:visible!important;opacity:1!important;pointer-events:auto!important;display:flex!important;z-index:2147483647!important;}`}</style>
-                <button
-                  id="sully-safe-reset"
-                  onClick={() => {
-                    if (!window.confirm('还原这个聊天的白框美化？将清空该角色及全局的自定义 CSS（样式写坏卡死时用它救援）。')) return;
-                    if (ac?.chromeCustomCss) updateCharacter(ac.id, { chromeCustomCss: '' } as any);
-                    if (theme.chatChromeCustomCss) updateTheme({ chatChromeCustomCss: '' });
-                  }}
-                  style={{
-                    position: 'fixed', top: 'calc(var(--safe-top) + 6px)', left: '50%', transform: 'translateX(-50%)',
-                    zIndex: 2147483647, display: 'flex', alignItems: 'center', gap: '4px',
-                    padding: '4px 10px', borderRadius: '999px',
-                    background: 'rgba(15,23,42,0.5)', color: '#fff', fontSize: '11px', fontWeight: 700,
-                    border: '1px solid rgba(255,255,255,0.25)', cursor: 'pointer',
-                    boxShadow: '0 2px 8px rgba(0,0,0,0.3)', WebkitBackdropFilter: 'blur(4px)', backdropFilter: 'blur(4px)',
-                  }}
-                >⟲ 还原白框</button>
-              </>
-            );
-          })()}
 
           {/* Overlays: Toasts (Top) */}
           <div className="absolute top-12 left-0 w-full flex flex-col items-center gap-2 pointer-events-none z-[60]">


### PR DESCRIPTION
之前常驻悬浮按钮在正常聊天里也露脸、显丑。改为：只在点开「＋→白框」自定义弹窗时，
才 portal 到 body 悬浮一个脱离 CSS 控制的「⟲ 还原此角色白框」（id 守护，连
*{display:none!important} 也盖不掉）——正好覆盖「粘进坏 CSS 当场崩掉」的时刻。 关掉弹窗即消失。其余兜底（返回键守护、外观一键还原全部）保留。

https://claude.ai/code/session_01PXJsdUn6FqT9QYVDQ4yi8r