### PR TITLE
fix(chat): 翻译模式下引用回复不再吞掉用户的实际回复

### DIFF
--- a/utils/chatPrompts.quote.test.ts
+++ b/utils/chatPrompts.quote.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { ChatPrompts } from './chatPrompts';
+import { cleanApiMessages } from './chatRequestPayload';
+
+// 锁住「翻译模式下引用回复, 角色只看到引用、看不到用户实际回复」的修复。
+//
+// 链路: 双语 char 消息存储为 `原文\n%%BILINGUAL%%\n译文`; 用户引用它时 replyTo.content
+// 是完整双语串。buildMessageHistory 把引用拼成
+//   [用户引用了你之前说的「<摘要60字>」，并回复了 ↓]\n<用户回复>
+// 修复前摘要原样截取 → %%BILINGUAL%% 混进引用头 → cleanApiMessages 在标记处整条截断
+// → 「并回复了 ↓」和用户回复全被吃掉, 模型只看到半截引用头。
+// 修复后摘要先剥双语标记、只取原文侧, 截断不再波及用户回复。
+
+const char = { id: 'c1', name: '小角色' } as any;
+const userProfile = { name: '我' } as any;
+
+const BI_CONTENT = 'こんにちは、元気？\n%%BILINGUAL%%\n你好，最近好吗？';
+const USER_REPLY = '我的实际回复内容，不能被吞掉';
+
+const t0 = Date.now() - 60_000;
+const makeHistory = () => ([
+    { id: 1, charId: 'c1', role: 'assistant', type: 'text', content: BI_CONTENT, timestamp: t0 },
+    {
+        id: 2, charId: 'c1', role: 'user', type: 'text', content: USER_REPLY, timestamp: t0 + 1000,
+        replyTo: { id: 1, content: BI_CONTENT, name: '小角色' },
+    },
+] as any[]);
+
+describe('buildMessageHistory 引用双语消息', () => {
+    it('引用摘要只取原文侧, 不把 %%BILINGUAL%% 混进引用头', () => {
+        const { apiMessages } = ChatPrompts.buildMessageHistory(makeHistory(), 10, char, userProfile, []);
+        const userMsg = apiMessages.find((m: any) => m.role === 'user');
+        expect(userMsg).toBeTruthy();
+        const content = userMsg!.content as string;
+        expect(content).toContain('こんにちは、元気？');
+        expect(content).toContain(USER_REPLY);
+        expect(content.toLowerCase()).not.toContain('%%bilingual%%');
+    });
+
+    it('引用头 + 用户回复经 cleanApiMessages 后完整保留 (修复前回复被截掉)', () => {
+        const { apiMessages } = ChatPrompts.buildMessageHistory(makeHistory(), 10, char, userProfile, []);
+        const cleaned = cleanApiMessages(apiMessages);
+        const userMsg = cleaned.find((m: any) => m.role === 'user');
+        const content = userMsg!.content as string;
+        expect(content).toContain('引用了');
+        expect(content).toContain(USER_REPLY);
+    });
+
+    it('双语 assistant 消息本体仍在标记处截断只留原文 (既有行为不回归)', () => {
+        const { apiMessages } = ChatPrompts.buildMessageHistory(makeHistory(), 10, char, userProfile, []);
+        const cleaned = cleanApiMessages(apiMessages);
+        const aiMsg = cleaned.find((m: any) => m.role === 'assistant');
+        const content = aiMsg!.content as string;
+        expect(content).toContain('こんにちは、元気？');
+        expect(content).not.toContain('你好，最近好吗？');
+    });
+
+    it('引用内容是 <翻译> XML 形态时也剥干净、只留原文', () => {
+        const xmlBi = '<翻译>\n<原文>おはよう</原文>\n<译文>早上好</译文>\n</翻译>';
+        const history = [
+            { id: 1, charId: 'c1', role: 'assistant', type: 'text', content: xmlBi, timestamp: t0 },
+            {
+                id: 2, charId: 'c1', role: 'user', type: 'text', content: USER_REPLY, timestamp: t0 + 1000,
+                replyTo: { id: 1, content: xmlBi, name: '小角色' },
+            },
+        ] as any[];
+        const { apiMessages } = ChatPrompts.buildMessageHistory(history, 10, char, userProfile, []);
+        const userMsg = apiMessages.find((m: any) => m.role === 'user');
+        const content = userMsg!.content as string;
+        expect(content).toContain('おはよう');
+        expect(content).toContain(USER_REPLY);
+        expect(content).not.toContain('<翻译>');
+        expect(content).not.toContain('<译文>');
+    });
+});

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -764,7 +764,19 @@ ${xhsEnabled ? `${[notionEnabled, feishuEnabled, notionNotesEnabled].filter(Bool
                     // 引用回复：把"被引用的原话"做成独立的上下文框，用户的新回复另起一行突出出来。
                     // 旧格式 [回复 "引用前50字..."]: 回复 会把引用和回复挤在一行，引用往往比回复长得多，
                     // 模型注意力被引用淹没、只对引用做反应而忽略真正的新消息（即"对方只看到引用看不到回复"）。
-                    const rawQuote = typeof m.replyTo.content === 'string' ? m.replyTo.content : '';
+                    let rawQuote = typeof m.replyTo.content === 'string' ? m.replyTo.content : '';
+                    // 双语消息存储为 `原文\n%%BILINGUAL%%\n译文` —— 引用摘要只取原文侧。
+                    // 关键：绝不能让 %%BILINGUAL%% 标记混进引用头。下游 cleanApiMessages 会把整条
+                    // 消息在该标记处截断，用户引用双语消息时「并回复了 ↓」和用户的实际回复会被
+                    // 一起截掉（= 翻译模式下"角色只看到引用、看不到回复"）。
+                    if (/%%BILINGUAL%%/i.test(rawQuote)) {
+                        const sides = rawQuote.split(/%%BILINGUAL%%/i).map(s => s.trim());
+                        rawQuote = sides.find(s => !!s) || '';
+                    }
+                    rawQuote = rawQuote
+                        .replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, '$1')
+                        .replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '')
+                        .trim();
                     const quoted = rawQuote.length > 60 ? rawQuote.slice(0, 60) + '…' : rawQuote;
                     // name 记的是被引用消息的说话人：char.name = 用户在回复 char 本人之前的话；'我' = 用户引用自己。
                     const whose = m.replyTo.name === char.name ? '你之前说的' : (m.replyTo.name === '我' ? '自己说的' : (m.replyTo.name || '对方') + '说的');

--- a/utils/chatRequestPayload.ts
+++ b/utils/chatRequestPayload.ts
@@ -122,7 +122,12 @@ function deriveListeningFromSnapshot(
     return { userListeningContext, isListeningTogether, musicCfg: cfg };
 }
 
-function cleanApiMessages(apiMessages: Array<{ role: string; content: any }>): Array<{ role: string; content: any }> {
+/**
+ * 剥离历史里旧的双语标签: `%%BILINGUAL%%` 形态整条在标记处截断 (只留原文侧),
+ * `<翻译>` XML 形态只留 <原文>。导出仅为单测 — 引用头绝不能混入 %%BILINGUAL%%
+ * (见 chatPrompts.buildMessageHistory 的引用摘要清洗), 否则截断会吃掉用户的实际回复。
+ */
+export function cleanApiMessages(apiMessages: Array<{ role: string; content: any }>): Array<{ role: string; content: any }> {
     return apiMessages.map((msg: any) => {
         if (typeof msg.content !== 'string') return msg;
         let c: string = msg.content;


### PR DESCRIPTION
双语 char 消息存储为 `原文\n%%BILINGUAL%%\n译文`。用户引用它回复时,
buildMessageHistory 把完整双语串原样截 60 字做引用摘要, %%BILINGUAL%% 标记随之混进引用头; 下游 cleanApiMessages 按双语形态约定在标记处整条
截断 — 「并回复了 ↓」和用户的实际回复一起被吃掉, 模型只看到半截引用头
(= 用户反馈"角色只看到引用、看不到我的回复")。只在原文侧短于 60 字时
触发, 所以表现为"大多数情况"。

修复: 引用摘要构造时先剥双语标记 — %%BILINGUAL%% 形态取原文侧 (原文空
则取译文侧), <翻译> XML 形态只留 <原文> — 再截 60 字, 标记不再进入引用
头。cleanApiMessages 截断语义不变 (双语 assistant 消息本体仍只留原文), 导出仅为单测。

https://claude.ai/code/session_011BkHxKxMQaaKvVdSLAsLrL