### PR TITLE
见面中暂缓投递定时消息 (scheduled messages)

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1138,6 +1138,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
 
           for (const char of characters) {
               try {
+                  // 用户正在 DateApp 里和这个角色见面 —— 角色之前排好的定时消息
+                  // ([schedule_message] 指令) 这轮先压着不投递（不删不读），
+                  // 等用户离开见面界面后，下一轮 5s 检查会自然送达。
+                  if (activeAppRef.current === AppID.Date && activeCharIdScheduleRef.current === char.id) continue;
                   const dueMessages = await DB.getDueScheduledMessages(char.id);
                   if (cancelled) return;
                   if (dueMessages.length > 0) {


### PR DESCRIPTION
角色用 [schedule_message] 指令排好的定时消息由 checkAllSchedules 每 5 秒检查直发，不感知见面状态——用户在 DateApp 见面途中会突然
收到一条对见面毫不知情的"线上消息"，与主动消息是两条独立通道。

处理：用户正在 DateApp 里和该角色见面时，这一轮跳过该角色的
定时消息检查（不删不读），离开见面界面后下一轮检查自然送达。

注：Capacitor 原生端在消息创建时就排了 LocalNotifications 系统
通知，那条 OS 级通知无法拦截，仅 Web 端投递被推迟。

https://claude.ai/code/session_01UbdNQtHxBabaUeATKHsacJ