### PR TITLE
devDebug 加 lifecycle 捕获类，api 日志补耗时与请求体大小

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,8 +7,14 @@ import BuildBadge from './components/BuildBadge';
 import DevDebugPanel from './components/DevDebugPanel';
 import VRBroadcast from './components/VRBroadcast';
 import { isIOSStandaloneWebApp } from './utils/iosStandalone';
+import { installDevDebugLifecycleCapture } from './utils/devDebug';
 
 const App: React.FC = () => {
+  React.useEffect(() => {
+    // 常驻监听前后台 / 焦点 / 网络事件；抓不抓由 devDebug 的 lifecycle 类勾选决定
+    installDevDebugLifecycleCapture();
+  }, []);
+
   const useAbsoluteShell = typeof window !== 'undefined' && isIOSStandaloneWebApp();
   const shellClassName = useAbsoluteShell
     ? 'fixed inset-0 w-full h-full bg-transparent overflow-hidden'

--- a/components/settings/ApiCallLogModal.tsx
+++ b/components/settings/ApiCallLogModal.tsx
@@ -144,6 +144,9 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                                     <div className="col-span-2">
                                         <Field label="模型" value={e.model} mono />
                                     </div>
+                                    {e.durationMs != null && (
+                                        <Field label="耗时" value={e.durationMs >= 1000 ? `${(e.durationMs / 1000).toFixed(1)}s` : `${e.durationMs}ms`} />
+                                    )}
                                     {(e.totalTokens != null || e.promptTokens != null || e.completionTokens != null) && (
                                         <div className="col-span-2 flex items-baseline gap-1.5 min-w-0">
                                             <span className="text-[10px] text-slate-400 shrink-0">Token</span>

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -727,9 +727,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           const [resource, config] = args;
           
           const urlStr = String(resource);
-          
+          const fetchStartedAt = Date.now();
+
           try {
               const response = await originalFetch(...args);
+              const durationMs = Date.now() - fetchStartedAt;
 
               // 「API 调用记录」统一记录入口：所有 /chat/completions（裸 fetch + safeFetchJson
               // 内部 fetch 都会经过这里）都记一笔。meta 优先取调用方挂在 init 上的 __sullyMeta
@@ -746,10 +748,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                       usageClone.text().then((t) => {
                           let parsed: any = undefined;
                           try { parsed = JSON.parse(t); } catch { /* 流式/非 JSON：无 usage，照样记 */ }
-                          recordApiCall({ url: urlStr, body, status, ok, response: parsed, meta });
-                      }).catch(() => recordApiCall({ url: urlStr, body, status, ok, meta }));
+                          recordApiCall({ url: urlStr, body, status, ok, response: parsed, meta, durationMs });
+                      }).catch(() => recordApiCall({ url: urlStr, body, status, ok, meta, durationMs }));
                   } else {
-                      recordApiCall({ url: urlStr, body, status, ok, meta });
+                      recordApiCall({ url: urlStr, body, status, ok, meta, durationMs });
                   }
               }
 
@@ -783,7 +785,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           } catch (err: any) {
               // Network Failure
               if (urlStr.includes('/chat/completions')) {
-                  recordApiCall({ url: urlStr, body: (config as any)?.body, ok: false, meta: (config as any)?.__sullyMeta });
+                  recordApiCall({ url: urlStr, body: (config as any)?.body, ok: false, meta: (config as any)?.__sullyMeta, durationMs: Date.now() - fetchStartedAt });
               }
               setSystemLogs(prev => [{
                   id: `log-${Date.now()}`,

--- a/docs/dev-debug.md
+++ b/docs/dev-debug.md
@@ -61,6 +61,7 @@ isDevDebugAvailable()  // utils/devDebug.ts
 | `skipEmotionEval` | `context/OSContext.tsx:1436`、`hooks/useChatAI.ts:439 / 685` |
 | 捕获类 `api` | `utils/safeApi.ts`（调 `appendDevDebugApiLog`，普通聊天直发 + Character 的记忆精炼/归档/导入/批量总结/印象生成，凡走 `safeFetchJson` 的 chat completions 都算） |
 | 捕获类 `instant-push` | `utils/activeMsgRuntime.ts`、`utils/instantPushClient.ts`（调 `appendDevDebugInstantPushLog`） |
+| 捕获类 `lifecycle` | `utils/devDebug.ts` 自带的 `installDevDebugLifecycleCapture()`（`App.tsx` 启动时挂一次，监听器常驻、抓不抓走门禁） |
 | 总开关 `captureEnabled` | `utils/devDebug.ts` 的 `isCaptureEnabled()` 闸门——关掉时所有捕获类都不抓 |
 
 ---
@@ -130,8 +131,9 @@ sullyos.devDebug.log.v1.<branch>        ← 分类捕获日志（各类混存，
 | `skipPromptBuild` | 行为 | 只发聊天历史，不注入 system prompt | 双语 / MCD / HTML / thinking 等增强全部关掉 |
 | `skipEmotionEval` | 行为 | 主回复照常，但不跑本地 / Instant Push 的 emotion eval | 关掉后情绪不更新 |
 | `captureEnabled`<br>（记录日志·总开关） | 行为 | 日志录制总闸：关掉时所有捕获类都不抓 | 默认关；关掉只是停录，**不清**已抓日志 |
-| 捕获类 `api` | 捕获 | 抓所有走 `safeFetchJson`（`safeApi`）的 chat completions 请求 + 响应：普通聊天直发，外加 Character 里的记忆精炼/强制归档/导入清洗/批量总结/印象生成 | 取消勾选只停此后抓取，**不清**已有日志 |
+| 捕获类 `api` | 捕获 | 抓所有走 `safeFetchJson`（`safeApi`）的 chat completions 请求 + 响应：普通聊天直发，外加 Character 里的记忆精炼/强制归档/导入清洗/批量总结/印象生成。每条带 `durationMs`（最后一次 attempt 从发起到成功/报错的耗时）和 `requestChars`（请求体字符数，messages 折叠后靠它看体积） | 取消勾选只停此后抓取，**不清**已有日志 |
 | 捕获类 `instant-push` | 捕获 | 抓 instant push 通道：经 worker 的 LLM 交换 + SSE 投递结果（超时/收到/失败） | 同上，取消勾选不清日志 |
+| 捕获类 `lifecycle` | 捕获 | 抓页面前后台/焦点/网络状态变化：`visibilitychange`、`focus`/`blur`、`pagehide`/`pageshow`（含 bfcache `persisted` 标记）、`online`/`offline`、`freeze`/`resume`（Chromium 系）。跟 api 类对时间线用——API 报错前后紧挨着 `visibilitychange → hidden`，基本就是切后台/锁屏把 fetch 冻死的 | 同上，取消勾选不清日志 |
 | `exposeLogDetail`<br>（记录完整内容） | 抓取 | 关（默认）：`messages` 聊天历史数组整组换成一句 `…共 N 项（已折叠）`；开：整段存 | 影响**抓取 / 存储**；要完整须复现前打开，已抓的折叠版不可还原 |
 
 捕获日志：各类**混存在一个数组**里、每条带 `category`，全局最多留 **100 条 / 1 MB**（先到先淘汰）。因为长文本在写入时就折叠了（见第九节），实际存的是瘦身版、很省空间，1 MB 基本撑不爆、轻松存满 100 条；导出（复制 / 下载）默认导全部、自动带上当前分支 + commit，并对密钥字段脱敏。

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -50,6 +50,8 @@ export interface ApiCallLogEntry extends ApiCallMeta {
     completionTokens?: number;
     /** 总 token（total_tokens） */
     totalTokens?: number;
+    /** 请求从发起到响应 / 报错的耗时 ms（NetworkError 类失败时 = 等了多久才断） */
+    durationMs?: number;
 }
 
 const PRESETS_STORAGE_KEY = 'os_api_presets';
@@ -148,6 +150,7 @@ export function recordApiCall(input: {
     ok: boolean;
     response?: unknown;
     meta?: ApiCallMeta;
+    durationMs?: number;
 }): void {
     try {
         const baseUrl = deriveBaseUrl(input.url);
@@ -166,6 +169,7 @@ export function recordApiCall(input: {
             promptTokens: usage.prompt,
             completionTokens: usage.completion,
             totalTokens: usage.total,
+            durationMs: input.durationMs,
             appId: meta.appId,
             appName: meta.appName,
             charId: meta.charId,

--- a/utils/devDebug.ts
+++ b/utils/devDebug.ts
@@ -4,8 +4,9 @@
 //   2. 在 DEV_DEBUG_CAPTURE_CATEGORIES 加一行（面板会自动多出一个开关）
 //   3. 写一个语义化的 appendDevDebugXxxLog 薄封装（见文件末尾 appendDevDebugApiLog / appendDevDebugInstantPushLog）
 // 其余存储 / 脱敏 / 限容 / 导出逻辑全部通用，不用改。
-// 分类按「来源通道」切：api = 普通聊天直发模型；instant-push = 经 worker 的通道事件。
-export type DevDebugCaptureCategory = 'api' | 'instant-push';
+// 分类按「来源通道」切：api = 普通聊天直发模型；instant-push = 经 worker 的通道事件；
+// lifecycle = 页面前后台/网络状态变化（排查「请求等着等着就 NetworkError」时跟 api 类对时间线）。
+export type DevDebugCaptureCategory = 'api' | 'instant-push' | 'lifecycle';
 
 export interface DevDebugCaptureCategoryMeta {
     key: DevDebugCaptureCategory;
@@ -25,6 +26,11 @@ export const DEV_DEBUG_CAPTURE_CATEGORIES: DevDebugCaptureCategoryMeta[] = [
         key: 'instant-push',
         title: 'IP',
         detail: 'Instant Push 通道：经 worker 的 LLM 交换 + SSE 投递结果（超时 / 收到 / 失败）。',
+    },
+    {
+        key: 'lifecycle',
+        title: '前后台',
+        detail: '页面前后台 / 焦点 / 网络状态变化（visibilitychange、focus/blur、pagehide/pageshow、online/offline、freeze/resume），用来跟 api 类对时间线，判断请求失败是不是切后台导致的。',
     },
 ];
 
@@ -413,6 +419,19 @@ export interface DevDebugHttpLogInput {
     requestBody?: unknown;
     response?: unknown;
     error?: unknown;
+    /** 本次请求从发起到成功 / 报错的耗时 ms（重试场景 = 最后一次 attempt 的耗时）。 */
+    durationMs?: number;
+}
+
+/** 请求体字符数：messages 折叠后日志里看不出请求多大，这个数字补上「体积」维度。 */
+function measureRequestChars(body: unknown): number | undefined {
+    if (body === undefined || body === null) return undefined;
+    if (typeof body === 'string') return body.length;
+    try {
+        return JSON.stringify(body)?.length;
+    } catch {
+        return undefined;
+    }
 }
 
 /** 通用 HTTP 日志薄封装；按 category 落到对应类别，请求体 / 错误统一整形。 */
@@ -425,6 +444,8 @@ function appendDevDebugHttpLog(category: DevDebugCaptureCategory, input: DevDebu
             url: input.url,
             method: input.method,
             status: input.status,
+            durationMs: input.durationMs,
+            requestChars: measureRequestChars(input.requestBody),
             request: parseRequestBody(input.requestBody),
             response: input.response,
             error: input.error
@@ -445,6 +466,47 @@ export function appendDevDebugApiLog(input: DevDebugHttpLogInput): void {
 /** instant-push 类：经 worker 的通道事件（消费点 activeMsgRuntime / instantPushClient）。 */
 export function appendDevDebugInstantPushLog(input: DevDebugHttpLogInput): void {
     appendDevDebugHttpLog('instant-push', input);
+}
+
+// ===== lifecycle 类：页面前后台 / 焦点 / 网络状态变化 =====
+// 用途：跟 api 类条目对时间线。比如某条 API 在 NetworkError 前后紧挨着
+// 「visibilitychange → hidden」，基本可以断定是切后台 / 锁屏把 fetch 冻死的。
+// 监听器常驻（事件本身低频、回调零成本），抓不抓由 appendDevDebugLog 的
+// isCaptureEnabled('lifecycle') 门禁决定——没勾时回调直接 return。
+
+let lifecycleCaptureInstalled = false;
+
+function appendLifecycleEvent(event: string, extra?: Record<string, unknown>): void {
+    appendDevDebugLog('lifecycle', {
+        label: `[lifecycle] ${event}`,
+        data: {
+            event,
+            visibility: typeof document !== 'undefined' ? document.visibilityState : 'n/a',
+            online: typeof navigator !== 'undefined' ? navigator.onLine : undefined,
+            ...extra,
+        },
+    });
+}
+
+/** 安装 lifecycle 事件捕获（幂等，App 启动时挂一次）。 */
+export function installDevDebugLifecycleCapture(): void {
+    if (lifecycleCaptureInstalled) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    lifecycleCaptureInstalled = true;
+
+    document.addEventListener('visibilitychange', () => {
+        appendLifecycleEvent(`visibilitychange → ${document.visibilityState}`);
+    });
+    window.addEventListener('focus', () => appendLifecycleEvent('window focus'));
+    window.addEventListener('blur', () => appendLifecycleEvent('window blur'));
+    // pagehide.persisted = true 表示进了 bfcache（页面被冻结而非销毁）
+    window.addEventListener('pagehide', (e) => appendLifecycleEvent('pagehide', { persisted: (e as PageTransitionEvent).persisted }));
+    window.addEventListener('pageshow', (e) => appendLifecycleEvent('pageshow', { persisted: (e as PageTransitionEvent).persisted }));
+    window.addEventListener('online', () => appendLifecycleEvent('online'));
+    window.addEventListener('offline', () => appendLifecycleEvent('offline'));
+    // Page Lifecycle API（Chromium 系才有）：freeze = 后台冻结，resume = 解冻
+    document.addEventListener('freeze', () => appendLifecycleEvent('freeze'));
+    document.addEventListener('resume', () => appendLifecycleEvent('resume'));
 }
 
 export interface DevDebugLogger {

--- a/utils/safeApi.ts
+++ b/utils/safeApi.ts
@@ -167,6 +167,7 @@ export async function safeFetchJson(
             }
             attemptOptions = { ...metaOptions, signal: ac.signal };
         }
+        const attemptStartedAt = Date.now();
         try {
             const response = await fetch(url, attemptOptions);
             if (timeoutHandle) clearTimeout(timeoutHandle);
@@ -195,6 +196,7 @@ export async function safeFetchJson(
                     status: response.status,
                     requestBody: options.body,
                     response: data,
+                    durationMs: Date.now() - attemptStartedAt,
                 });
             }
             return data;
@@ -228,6 +230,7 @@ export async function safeFetchJson(
                     status: lastStatus,
                     requestBody: options.body,
                     error: e,
+                    durationMs: Date.now() - attemptStartedAt,
                 });
             }
             throw e;


### PR DESCRIPTION
## 背景

排查用户反馈的「印象追加失败：API 调用记录成功但前端 NetworkError」时，现有日志缺两个关键维度：请求等了多久才挂、报错时页面是否发生了前后台切换。没有这两个信息，无法区分三个竞争假设（中间层空闲超时 / 切后台冻结 fetch / 请求体过大被拒）。

## 改动

| 改动 | 改后效果 |
|------|---------|
| 新捕获类 `lifecycle`（前后台） | 调试面板多一个「前后台」checkbox，记录 visibilitychange / focus / blur / pagehide / pageshow（含 bfcache persisted）/ online / offline / freeze / resume，与 api 类条目对时间线 |
| api 类日志补 `durationMs` | 每条请求带「发起到成功/报错的耗时」，一眼区分立刻失败 vs 超时失败 |
| api 类日志补 `requestChars` | messages 折叠后仍能看出请求体积，验证「prompt 过大」假设 |
| 「设置 → API 调用记录」记录并展示耗时 | 用户侧列表每条显示「耗时 3.2s」 |

监听器由 App 启动时挂一次（幂等），未勾选类别时回调零成本。`docs/dev-debug.md` 已同步。

## 测试

- `pnpm vitest run`：281 passed / 0 failed
- `tsc --noEmit`：本次修改的 7 个文件无新增错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)