### PR TITLE
印象生成改流式 + devDebug 排查工具补强

### DIFF
--- a/apps/Character.tsx
+++ b/apps/Character.tsx
@@ -764,7 +764,12 @@ ${isInitialGeneration ? `
                   model: apiConfig.model,
                   messages: [{ role: "user", content: prompt }],
                   max_tokens: 8000,
-                  temperature: 0.5
+                  temperature: 0.5,
+                  // 印象 prompt 体量大（含完整上下文 + 记忆 + 近期聊天），非流式下要等
+                  // 整段思考链 + JSON 全生成完才返回首字节，常超 60s 撞上中转站空闲超时被
+                  // 掐断（NetworkError）。开流式让连接持续有数据，绕开空闲超时；
+                  // safeResponseJson 会把 SSE 流拼回完整对象，下游 extractContent 无需改动。
+                  stream: true
               })
           }, 0);
           let content = extractContent(data);


### PR DESCRIPTION
## 这次改了啥

一条主线（解决「印象/记忆生成请求等着等着就 NetworkError」），外加一个不相关的小修。

### 主线：绕开非流式长请求的空闲超时

| 改动 | 改前 | 改后 |
|------|------|------|
| 印象生成 | 非流式，要等整段思考链 + JSON 全生成完才返回首字节，常超 60s 撞中转站空闲超时被掐断 | 改 `stream: true`，连接持续有数据绕开空闲超时；`safeResponseJson` 把 SSE 流拼回完整对象，下游 `extractContent` 不用动 |
| API 日志 | 只有 url / body / status | 补「耗时 ms」「请求体大小」两个维度（NetworkError 时耗时 = 等了多久才断，是关键证据） |
| devDebug | 只有 api / instant-push 两类 | 新增 `lifecycle` 类：监听前后台 / 焦点 / 网络状态变化，跟 api 类**对时间线**，判断请求失败是不是切后台 / 锁屏导致 |
| Character 记忆/印象直发 | 几处裸 `fetch`，各自取内容 | 统一走 `safeFetchJson` 接入日志入口，用 `extractContent` 安全取内容并剥离 think 块 |

### 顺带：见面中暂缓投递定时消息

用户正在 DateApp 和某角色见面时，该角色排好的 `[schedule_message]` 这轮先压着不投递（不删不读），离开见面界面后下一轮 5s 检查自然送达。

## 范围

`App.tsx` / `apps/Character.tsx` / `context/OSContext.tsx` / `utils/{devDebug,safeApi,apiCallLog}.ts` / `components/settings/ApiCallLogModal.tsx`，文档 `docs/dev-debug.md` 同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)