### PR TITLE
备份：导出/导入纳入家园本机配置 + 瑞幸 token

### DIFF
--- a/apps/WorldHomeApp.tsx
+++ b/apps/WorldHomeApp.tsx
@@ -28,10 +28,11 @@ import { worldTimeLabel, isNightWorld, houseOf, NARRATIVE_STYLES, buildNpcRollPr
 import { SIM_CHAPTER_DAYS, SIM_CHAPTER_CLOCKS } from '../utils/worldHome/chapters';
 import { dmThreadsOf, groupThreadOf } from '../utils/worldHome/threads';
 import { safeFetchJson } from '../utils/safeApi';
+import { WORLD_API_KEY, WORLD_CUSTOM_STYLE_KEY } from '../utils/worldHome/localBackup';
 import type { WorldProfile, WorldEpisode, WorldHomeMode, WorldTimeMode, WorldHouse, WorldThread, WorldNarrativeStyle, CharacterProfile, WorldCharBeat, APIConfig, ApiPreset } from '../types';
 
-/** 自定义文风的本地收藏（localStorage，跨世界复用）。 */
-const CUSTOM_STYLE_KEY = 'world_custom_styles';
+/** 自定义文风的本地收藏 / 家园全局 API 的 localStorage key —— 与备份工具共用同一组，避免漂移。 */
+const CUSTOM_STYLE_KEY = WORLD_CUSTOM_STYLE_KEY;
 const loadSavedStyles = (): string[] => {
     try { const s = localStorage.getItem(CUSTOM_STYLE_KEY); return s ? JSON.parse(s) : []; } catch { return []; }
 };
@@ -40,7 +41,6 @@ const persistSavedStyles = (list: string[]) => {
 };
 
 /** 家园全局 API（所有世界共用一份；不设=跟随全局聊天默认）。存 localStorage。 */
-const WORLD_API_KEY = 'world_home_api';
 const loadWorldApi = (): { baseUrl: string; apiKey: string; model: string } | null => {
     try { const s = localStorage.getItem(WORLD_API_KEY); const c = s ? JSON.parse(s) : null; return c?.baseUrl ? c : null; } catch { return null; }
 };

--- a/types.ts
+++ b/types.ts
@@ -2374,6 +2374,8 @@ export interface FullBackupData {
     worlds?: WorldProfile[];                   // 家园·世界定义
     worldEpisodes?: WorldEpisode[];            // 家园·演绎历史
     vrPostOffice?: Record<string, string>;     // 邮局本机配置：身份 deviceId / 后端地址（存 localStorage）
+    worldHomeLocal?: Record<string, string>;   // 家园本机配置：全局 API + 文风收藏（存 localStorage）
+    luckinLocal?: Record<string, string>;      // 瑞幸：token + 启用状态（存 localStorage）
     songs?: SongSheet[]; // Songwriting app data
     
     // Bank Data

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -11,6 +11,8 @@ import {
     WorldProfile, WorldEpisode
 } from '../types';
 import { exportPostOfficeLocal, importPostOfficeLocal } from './vrWorld/postOffice';
+import { exportLuckinLocal, importLuckinLocal } from './luckinMcpClient';
+import { exportWorldHomeLocal, importWorldHomeLocal } from './worldHome/localBackup';
 
 const DB_NAME = 'AetherOS_Data';
 const DB_VERSION = 64; // Bumped: v64 ensure worlds / world_episodes stores exist（v63 漏建：已到 v63 的库不会再触发 upgrade，补一版重建）
@@ -2284,6 +2286,8 @@ export const DB = {
           vrPostOffice: exportPostOfficeLocal(), // 邮局本机配置（身份/后端地址，存 localStorage）
           worlds,
           worldEpisodes,
+          worldHomeLocal: exportWorldHomeLocal(), // 家园本机配置：全局 API + 文风收藏（存 localStorage）
+          luckinLocal: exportLuckinLocal(),       // 瑞幸 token + 启用状态（存 localStorage）
       };
   },
 
@@ -2409,6 +2413,8 @@ export const DB = {
           (data as any).vrPostOffice !== undefined,
           data.worlds !== undefined,
           data.worldEpisodes !== undefined,
+          (data as any).worldHomeLocal !== undefined,
+          (data as any).luckinLocal !== undefined,
           data.pixelHomeAssets !== undefined,
           data.pixelHomeLayouts !== undefined,
           data.userProfile !== undefined,
@@ -2692,6 +2698,14 @@ export const DB = {
           await clearAndAdd(STORE_WORLD_EPISODES, data.worldEpisodes, '家园演绎历史', false);
           data.worldEpisodes = undefined as any;
       }, data.worldEpisodes?.length || 0);
+      await runSection('家园本机配置', (data as any).worldHomeLocal !== undefined, async () => {
+          importWorldHomeLocal((data as any).worldHomeLocal); // 全局 API + 文风收藏
+          (data as any).worldHomeLocal = undefined;
+      }, 1);
+      await runSection('瑞幸配置', (data as any).luckinLocal !== undefined, async () => {
+          importLuckinLocal((data as any).luckinLocal); // token + 启用状态
+          (data as any).luckinLocal = undefined;
+      }, 1);
       await runSection('歌曲', data.songs !== undefined, async () => {
           await clearAndAdd(STORE_SONGS, data.songs, '歌曲', false);
           data.songs = undefined as any;

--- a/utils/luckinMcpClient.ts
+++ b/utils/luckinMcpClient.ts
@@ -88,6 +88,23 @@ export const isLuckinConfigured = (): boolean => {
     return isLuckinEnabled() && getLuckinToken().length > 0;
 };
 
+// ── 备份用：把瑞幸的 token + 启用状态随「设置 → 导出/导入备份」一起带走（存 localStorage） ──
+export function exportLuckinLocal(): Record<string, string> | undefined {
+    try {
+        const out: Record<string, string> = {};
+        const tk = localStorage.getItem(MCP_TOKEN_KEY); if (tk) out[MCP_TOKEN_KEY] = tk;
+        const en = localStorage.getItem(MCP_ENABLED_KEY); if (en) out[MCP_ENABLED_KEY] = en;
+        return Object.keys(out).length ? out : undefined;
+    } catch { return undefined; }
+}
+export function importLuckinLocal(data: Record<string, string> | null | undefined): void {
+    if (!data || typeof data !== 'object') return;
+    try {
+        if (typeof data[MCP_TOKEN_KEY] === 'string') localStorage.setItem(MCP_TOKEN_KEY, data[MCP_TOKEN_KEY]);
+        if (typeof data[MCP_ENABLED_KEY] === 'string') localStorage.setItem(MCP_ENABLED_KEY, data[MCP_ENABLED_KEY]);
+    } catch { /* ignore */ }
+}
+
 // ========== JSON-RPC 会话状态 (内存, 进程级) ==========
 
 let requestIdCounter = 0;

--- a/utils/worldHome/localBackup.ts
+++ b/utils/worldHome/localBackup.ts
@@ -1,0 +1,25 @@
+/**
+ * 家园存在 localStorage 里的本机配置（随「设置 → 导出/导入备份」一起带走）：
+ *   - world_home_api：家园全局 API（所有世界共用的覆盖）
+ *   - world_custom_styles：用户收藏的自定义文风（跨世界复用）
+ * 这两份不在 IndexedDB，所以必须单独走备份，否则换设备 / 导入后会丢。
+ */
+export const WORLD_API_KEY = 'world_home_api';
+export const WORLD_CUSTOM_STYLE_KEY = 'world_custom_styles';
+
+export function exportWorldHomeLocal(): Record<string, string> | undefined {
+    try {
+        const out: Record<string, string> = {};
+        const api = localStorage.getItem(WORLD_API_KEY); if (api) out[WORLD_API_KEY] = api;
+        const styles = localStorage.getItem(WORLD_CUSTOM_STYLE_KEY); if (styles) out[WORLD_CUSTOM_STYLE_KEY] = styles;
+        return Object.keys(out).length ? out : undefined;
+    } catch { return undefined; }
+}
+
+export function importWorldHomeLocal(data: Record<string, string> | null | undefined): void {
+    if (!data || typeof data !== 'object') return;
+    try {
+        if (typeof data[WORLD_API_KEY] === 'string') localStorage.setItem(WORLD_API_KEY, data[WORLD_API_KEY]);
+        if (typeof data[WORLD_CUSTOM_STYLE_KEY] === 'string') localStorage.setItem(WORLD_CUSTOM_STYLE_KEY, data[WORLD_CUSTOM_STYLE_KEY]);
+    } catch { /* ignore */ }
+}


### PR DESCRIPTION
家园 worlds/演绎历史本就在 DB 备份里，但 localStorage 里的东西没被带走。补上：
- 家园全局 API + 文风收藏（world_home_api / world_custom_styles）→ 抽到 utils/worldHome/localBackup.ts，WorldHomeApp 与备份共用同一组 key（不再漂移）。
- 瑞幸 token + 启用状态（luckinMcpClient 加 export/import）。 FullBackupData 增 worldHomeLocal / luckinLocal；导出对象、导入分区、分区计数都接上。 现在「设置→导出/导入」会一并带走它们，换设备/导入后文风收藏和瑞幸 token 不再丢。