### PR TITLE
fix(group): 群聊上下文带出表情包名字，让角色看得见用户发的表情

### DIFF
--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -9,6 +9,7 @@ import { ContextBuilder } from '../utils/context';
 import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import { processGroupNewMessages, deleteGroupMemoriesByGroupId } from '../utils/memoryPalace/groupPipeline';
 import { processImage } from '../utils/file';
+import { stickerNameFromUrl } from '../utils/messageFormat';
 import { DEFAULT_ARCHIVE_PROMPTS } from '../components/chat/ChatConstants';
 import { UsersThree } from '@phosphor-icons/react';
 
@@ -763,7 +764,7 @@ ${recentPrivate || '(暂无私聊)'}
                         content = '[图片]';
                     }
                 } else if (m.type === 'emoji') {
-                    content = '[表情包]';
+                    content = `[表情包: ${stickerNameFromUrl(emojis, rawText.trim())}]`;
                 } else if (m.type === 'transfer') {
                     content = `[发红包: ${m.metadata?.amount}]`;
                 } else if (/^(data:|https?:\/\/)/i.test(rawText.trim())) {
@@ -924,7 +925,9 @@ ${attachedImagesNote}
                 jsonStr = jsonStr.substring(firstBracket, lastBracket + 1);
             }
 
-            let actions = [];
+            // director 解析出的行动数组（形状由 LLM 输出决定，逐字段读取时再各自判型）。
+            // 显式标 any[]：不假装它有精确类型，同时避免 evolving-any 在严格检查下漏报。
+            let actions: any[] = [];
             try {
                 actions = JSON.parse(jsonStr);
                 if (!Array.isArray(actions)) actions = [];

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -3,7 +3,7 @@ import { CharacterProfile, UserProfile, Message, Emoji, EmojiCategory, GroupProf
 import { ContextBuilder } from './context';
 import { DB } from './db';
 import { formatLifeSimResetCardForContext } from './lifeSimChatCard';
-import { normalizeMessageContent } from './messageFormat';
+import { normalizeMessageContent, stickerNameFromUrl } from './messageFormat';
 import { computeCurrentListening, getCurrentSlot } from './charMusicSchedule';
 import { getCharLyricSnippet } from './charLyricCache';
 import { MusicCfg, loadMusicCfgStandalone } from '../context/MusicContext';
@@ -894,7 +894,7 @@ ${xhsEnabled ? `${[notionEnabled, feishuEnabled, notionNotesEnabled].filter(Bool
                     }
                 }
                 else if (m.type === 'emoji') {
-                     const stickerName = emojis.find(e => e.url === m.content)?.name || '未知表情';
+                     const stickerName = stickerNameFromUrl(emojis, m.content);
                      content = `${timeStr} [${m.role === 'user' ? '用户' : '你'} 发送了表情包: ${stickerName}]`;
                 }
                 else if ((m.type as string) === 'chat_forward') {

--- a/utils/messageFormat.sticker.test.ts
+++ b/utils/messageFormat.sticker.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { stickerNameFromUrl } from './messageFormat';
+import { ChatPrompts } from './chatPrompts';
+import type { Emoji } from '../types';
+
+// 锁住「表情包在上下文里看得见名字」的修复。
+//
+// 表情包消息的 content 只存图床 URL，本身不带名字。非识图模型看不到图，只能靠
+// 反查表情名（关键字）才知道对方发了什么表情。私聊主历史一直查名字，但群聊主历史
+// (GroupChat.triggerDirector) 漏查，只给死占位 [表情包]，导致群里角色"看不见"用户
+// 发的表情。修复把查名收口到 stickerNameFromUrl，私聊 / 群聊共用同一个点。
+//
+// 群聊那段序列化内联在 React 组件闭包里、未导出，无法单测；这里改为钉住共用的收口
+// helper 本身 + 私聊集成路径——helper 正确，两条调用路径就都正确。
+
+const DOGE_URL = 'https://img.example/doge.png';
+const emojis: Emoji[] = [{ name: '柴犬贴贴', url: DOGE_URL }];
+
+describe('stickerNameFromUrl 表情名反查', () => {
+    it('URL 命中时返回当初设的表情名', () => {
+        expect(stickerNameFromUrl(emojis, DOGE_URL)).toBe('柴犬贴贴');
+    });
+
+    it('URL 查不到时兜底为 未知表情, 不抛错', () => {
+        expect(stickerNameFromUrl(emojis, 'https://img.example/none.png')).toBe('未知表情');
+        expect(stickerNameFromUrl([], DOGE_URL)).toBe('未知表情');
+    });
+});
+
+describe('buildMessageHistory 私聊表情包带名字', () => {
+    const char = { id: 'c1', name: '小角色' } as any;
+    const userProfile = { name: '我' } as any;
+    const t0 = Date.now() - 60_000;
+
+    it('用户发表情包时上下文带出表情名, 不是光秃秃的占位 (退化即挂)', () => {
+        const history = [
+            { id: 1, charId: 'c1', role: 'user', type: 'emoji', content: DOGE_URL, timestamp: t0 },
+        ] as any[];
+        const { apiMessages } = ChatPrompts.buildMessageHistory(history, 10, char, userProfile, emojis);
+        const userMsg = apiMessages.find((m: any) => m.role === 'user');
+        const content = userMsg!.content as string;
+        expect(content).toContain('柴犬贴贴');
+        expect(content).toContain('发送了表情包');
+    });
+});

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -11,8 +11,17 @@
  * 抽到这里后单点维护。
  */
 
-import type { Message } from '../types';
+import type { Message, Emoji } from '../types';
 import { formatLifeSimResetCardForContext } from './lifeSimChatCard';
+
+/**
+ * 表情包消息的 content 存的是图床 URL，本身不带名字。拼上下文时要靠这个反查出
+ * 当初设的表情名（关键字），非识图模型才能"看见"对方发了什么表情。
+ * 私聊主历史、群聊主历史都从这里取名，避免一处查一处漏（群聊曾漏查，只给 [表情包]）。
+ */
+export function stickerNameFromUrl(emojis: Emoji[], url: string): string {
+    return emojis.find(e => e.url === url)?.name || '未知表情';
+}
 
 /** 仅返回内容体（不加 sender / timestamp）。调用方自行拼外层。 */
 export function normalizeMessageContent(


### PR DESCRIPTION
群聊历史里表情包原本压成无信息的 [表情包]，非识图模型看不到是哪个表情。
把「表情 url → 表情名」反查收口到 messageFormat.stickerNameFromUrl，群聊与 私聊共用，群聊改为输出 [表情包: 名字]。顺带为 GroupChat 里 director actions 的 evolving-any 补显式标注。