### PR TITLE
fix(chat): render <语音 emotion="…"> voice tags (don't leak literal tag)

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -314,7 +314,7 @@ const Chat: React.FC = () => {
                 // parseVoiceOutput already sanitized it (whitelisted sound tags only).
                 spokenText = voiceTagContent;
                 // originalText = text OUTSIDE the voice tag (the display/Chinese text)
-                const textOutsideTag = msg.content.replace(/<[语語]音>[\s\S]*?<\/[语語]音>/g, '').trim();
+                const textOutsideTag = msg.content.replace(/<[语語]音[^>]*>[\s\S]*?<\/[语語]音>/g, '').trim();
                 originalText = textOutsideTag ? cleanTextForTts(textOutsideTag) : '';
                 // If voice lang is set and no Chinese text outside the tag, translate spoken text back to Chinese
                 if (voiceLang && !originalText && spokenText) {

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -2187,7 +2187,7 @@ const MessageItem = React.memo(({
         // Residual action/system tags that may have leaked through
         .replace(/\[\[(?:ACTION|RECALL|SEARCH|DIARY|READ_DIARY|FS_DIARY|FS_READ_DIARY|SEND_EMOJI|DIARY_START|DIARY_END|FS_DIARY_START|FS_DIARY_END)[:\s][\s\S]*?\]\]/g, '')
         .replace(/\[schedule_message[^\]]*\]/g, '')
-        .replace(/<[语語]音>[\s\S]*?<\/[语語]音>/g, '')  // strip <语音>...</语音> voice tags
+        .replace(/<[语語]音[^>]*>[\s\S]*?<\/[语語]音>/g, '')  // strip <语音 ...>...</语音> voice tags (tolerate emotion attr)
         .replace(/^\s*---\s*$/gm, '')                // standalone --- lines
         .replace(/``+/g, '')                          // empty/stray backtick pairs
         .replace(/(^|\s)`(\s|$)/gm, '$1$2')         // lone backticks at boundaries
@@ -2211,11 +2211,11 @@ const MessageItem = React.memo(({
     const showTranslateButton = translationEnabled && hasBilingual && langBContent;
 
     // Check if raw content has a <语音> tag (voice-only message that hasn't been TTS'd yet)
-    const hasVoiceTag = !isUser && /<[语語]音>[\s\S]*?<\/[语語]音>/.test(m.content);
+    const hasVoiceTag = !isUser && /<[语語]音[^>]*>[\s\S]*?<\/[语語]音>/.test(m.content);
     // Spoken text inside the <语音> tag — lets the placeholder bar offer a 转文字 toggle
     // even when no audio was synthesized (e.g. character has no MiniMax voice configured),
     // so fake voice messages stay readable just like real ones.
-    const voiceTagText = hasVoiceTag ? (m.content.match(/<[语語]音>([\s\S]*?)<\/[语語]音>/)?.[1]?.trim() || '') : '';
+    const voiceTagText = hasVoiceTag ? (m.content.match(/<[语語]音[^>]*>([\s\S]*?)<\/[语語]音>/)?.[1]?.trim() || '') : '';
     const hasVoiceContent = voiceData?.url || voiceLoading || hasVoiceTag;
     // Don't render empty bubbles (e.g. messages that were just "---"), unless voice data exists or pending
     if (!displayContent && !hasVoiceContent) return null;

--- a/public/instant-worker.deno.bundle.js
+++ b/public/instant-worker.deno.bundle.js
@@ -2354,7 +2354,7 @@ var replaceSendEmoji = (t) => t.replace(/\[\[SEND_EMOJI:\s*(.+?)\]\]/g, "[\u8868
 var replaceEmojiReverseTag = (t) => t.replace(/\[(?:你|User|用户|System|[\w一-龥]+)\s*发送了表情包[:：]\s*(.*?)\]/g, "[\u8868\u60C5\uFF1A$1]");
 var replaceHtmlBlocks = (t) => t.replace(/\[html\][\s\S]*?\[\/html\]/gi, "[HTML \u5361\u7247]");
 var replaceTranslationForBanner = (t) => t.replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, "$1").replace(/<译文>[\s\S]*?<\/译文>/g, "").replace(/<\/?(?:翻译|原文)>/g, "");
-var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
+var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2405,7 +2405,7 @@ function sanitizeIntoSegments(text) {
         preview: (_raw, match) => (match[1] || "").trim() || "[\u7FFB\u8BD1]"
       },
       {
-        pattern: /<(语音|語音)>([\s\S]*?)<\/\1>/,
+        pattern: /<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/,
         preview: (_raw, match) => (match[2] || "").trim() || "[\u8BED\u97F3]"
       }
     ]

--- a/utils/sanitize.test.ts
+++ b/utils/sanitize.test.ts
@@ -370,6 +370,13 @@ describe('sanitizeIntoSegments', () => {
     ]);
   });
 
+  it('<语音 emotion="…"> 带情绪属性也整块保留 + banner 取内部文字', () => {
+    const segs = sanitizeIntoSegments('<语音 emotion="sad">Hello world</语音>');
+    expect(segs).toEqual([
+      { raw: '<语音 emotion="sad">Hello world</语音>', sanitized: 'Hello world' },
+    ]);
+  });
+
   it('<语音> 多行内容 → 整块单 segment, 不被 chunkText 按 \\n 切碎', () => {
     const input = '前面文字\n<语音>\nWait...\nare you serious?\n</语音>\n后面文字';
     const segs = sanitizeIntoSegments(input);

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -131,7 +131,7 @@ const replaceTranslationForBanner = (t: string): string =>
 
 /** `<语音>...</语音>` → 内部文字 (banner 用; segment 路径里有 sentinel 保护跳过这条) */
 const replaceVoiceForBanner = (t: string): string =>
-  t.replace(/<(语音|語音)>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || '').trim());
+  t.replace(/<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || '').trim());
 
 /**
  * 翻译块只保留原文.
@@ -308,7 +308,7 @@ export function sanitizeIntoSegments(text: string): Segment[] {
         preview: (_raw: string, match: RegExpMatchArray) => (match[1] || '').trim() || '[翻译]',
       },
       {
-        pattern: /<(语音|語音)>([\s\S]*?)<\/\1>/,
+        pattern: /<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/,
         preview: (_raw: string, match: RegExpMatchArray) => (match[2] || '').trim() || '[语音]',
       },
     ],

--- a/worker/instant-push/worker.bundle.js
+++ b/worker/instant-push/worker.bundle.js
@@ -2354,7 +2354,7 @@ var replaceSendEmoji = (t) => t.replace(/\[\[SEND_EMOJI:\s*(.+?)\]\]/g, "[\u8868
 var replaceEmojiReverseTag = (t) => t.replace(/\[(?:你|User|用户|System|[\w一-龥]+)\s*发送了表情包[:：]\s*(.*?)\]/g, "[\u8868\u60C5\uFF1A$1]");
 var replaceHtmlBlocks = (t) => t.replace(/\[html\][\s\S]*?\[\/html\]/gi, "[HTML \u5361\u7247]");
 var replaceTranslationForBanner = (t) => t.replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, "$1").replace(/<译文>[\s\S]*?<\/译文>/g, "").replace(/<\/?(?:翻译|原文)>/g, "");
-var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
+var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2405,7 +2405,7 @@ function sanitizeIntoSegments(text) {
         preview: (_raw, match) => (match[1] || "").trim() || "[\u7FFB\u8BD1]"
       },
       {
-        pattern: /<(语音|語音)>([\s\S]*?)<\/\1>/,
+        pattern: /<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/,
         preview: (_raw, match) => (match[2] || "").trim() || "[\u8BED\u97F3]"
       }
     ]

--- a/worker/instant-push/worker.deno.bundle.js
+++ b/worker/instant-push/worker.deno.bundle.js
@@ -2354,7 +2354,7 @@ var replaceSendEmoji = (t) => t.replace(/\[\[SEND_EMOJI:\s*(.+?)\]\]/g, "[\u8868
 var replaceEmojiReverseTag = (t) => t.replace(/\[(?:你|User|用户|System|[\w一-龥]+)\s*发送了表情包[:：]\s*(.*?)\]/g, "[\u8868\u60C5\uFF1A$1]");
 var replaceHtmlBlocks = (t) => t.replace(/\[html\][\s\S]*?\[\/html\]/gi, "[HTML \u5361\u7247]");
 var replaceTranslationForBanner = (t) => t.replace(/<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, "$1").replace(/<译文>[\s\S]*?<\/译文>/g, "").replace(/<\/?(?:翻译|原文)>/g, "");
-var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
+var replaceVoiceForBanner = (t) => t.replace(/<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/g, (_m, _tag, inner) => (inner || "").trim());
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2405,7 +2405,7 @@ function sanitizeIntoSegments(text) {
         preview: (_raw, match) => (match[1] || "").trim() || "[\u7FFB\u8BD1]"
       },
       {
-        pattern: /<(语音|語音)>([\s\S]*?)<\/\1>/,
+        pattern: /<(语音|語音)[^>]*>([\s\S]*?)<\/\1>/,
         preview: (_raw, match) => (match[2] || "").trim() || "[\u8BED\u97F3]"
       }
     ]


### PR DESCRIPTION
语音消息的解析层 (minimaxTts.ts VOICE_TAG_RE) 已支持 emotion 属性，但 显示/剥离层的几处正则只匹配裸 <语音> 标签，遇到 <语音 emotion="sad">
就匹配失败：标签不被剥离，原样渲染进气泡 → 用户看到一整串
`<语音 emotion="sad">…</语音>` 文本。

统一把这些裸标签正则改成容忍属性的 `<语音[^>]*>`（与 minimaxTts.ts
对齐）：
- components/chat/MessageItem.tsx: stripJunk 剥离 / hasVoiceTag 探测 / voiceTagText 提取（聊天气泡渲染，本次报告的主因）
- apps/Chat.tsx: 手动 TTS 取「标签外文字」
- utils/sanitize.ts: replaceVoiceForBanner + segment protect 正则 （instant-push 通知 banner 路径）
- 重新生成 worker bundles 同步上述改动
- 新增 sanitize.test.ts 回归用例：带 emotion 属性仍整块保留 + banner 取内部文字


Claude-Session: https://claude.ai/code/session_012WoVXgsVrcWevshbmUzC9f