### PR TITLE
feat(mini-player): 悬浮球拖动范围限制在安全区内（避开刘海与 home 横条）

### DIFF
--- a/components/os/GlobalMiniPlayer.tsx
+++ b/components/os/GlobalMiniPlayer.tsx
@@ -11,8 +11,13 @@ import { Play, Pause, SkipForward, SkipBack, CaretDown, X } from '@phosphor-icon
 import { useOS } from '../../context/OSContext';
 import { useMusic } from '../../context/MusicContext';
 import { AppID } from '../../types';
-import { readSafeAreaInsets } from '../../utils/iosStandalone';
-import { clampBubblePos, clampExpandedBottom, resolveInsets } from '../../utils/floatingBallBounds';
+import { isIOSStandaloneWebApp, readSafeAreaInsets } from '../../utils/iosStandalone';
+import {
+  clampBubblePos,
+  clampExpandedBottom,
+  resolveInsets,
+  resolveSafeTopInset,
+} from '../../utils/floatingBallBounds';
 
 const STORAGE_KEY = 'globalMiniPlayer.bubblePos.v1';
 const HIDDEN_KEY = 'globalMiniPlayer.hidden.v1';
@@ -40,6 +45,40 @@ const readExpandedBottom = (): number | null => {
   } catch { return null; }
 };
 
+const parsePx = (value: string): number => {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const readSafeTopInset = (): number => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return 0;
+
+  // 优先复用 iosStandalone.ts 写到 :root 的值：iOS standalone 冷启动时 raw env/probe
+  // 可能先给 0，但 --standalone-safe-area-top 已经有 44px 兜底。
+  const standaloneSafeTop = parsePx(
+    window.getComputedStyle(document.documentElement).getPropertyValue('--standalone-safe-area-top'),
+  );
+  if (standaloneSafeTop > 0) return standaloneSafeTop;
+
+  return resolveSafeTopInset({
+    standaloneSafeTop,
+    probedSafeTop: readSafeAreaInsets().top || 0,
+    isIOSStandalone: isIOSStandaloneWebApp(),
+  });
+};
+
+// 把父容器（PhoneShell 外壳）的 padding 与安全区合成球要让出的高度。
+// 只在每次拖拽手势开始（pointerdown）时调一次并缓存进 dragState：
+// safe-area 读取可能触发样式计算 / 探针读取，放进高频 pointermove 会抖。
+const computeInsets = (parent: HTMLElement): { insetTop: number; insetBottom: number } => {
+  const cs = window.getComputedStyle(parent);
+  return resolveInsets({
+    padTop: parseFloat(cs.paddingTop) || 0,
+    padBottom: parseFloat(cs.paddingBottom) || 0,
+    safeTop: readSafeTopInset(),
+  });
+};
+
 const GlobalMiniPlayer: React.FC = () => {
   const { activeApp } = useOS();
   const { current, playing, togglePlay, nextSong, prevSong, progress, duration } = useMusic();
@@ -57,6 +96,8 @@ const GlobalMiniPlayer: React.FC = () => {
     startBottom: number;
     parentH: number;
     selfH: number;
+    insetTop: number;
+    insetBottom: number;
     moved: boolean;
     pointerId: number;
   } | null>(null);
@@ -66,6 +107,7 @@ const GlobalMiniPlayer: React.FC = () => {
     startX: number; startY: number;
     offX: number; offY: number;
     parentW: number; parentH: number;
+    insetTop: number; insetBottom: number;
     moved: boolean;
     pointerId: number | null;
   } | null>(null);
@@ -104,11 +146,14 @@ const GlobalMiniPlayer: React.FC = () => {
     const parentRect = parent.getBoundingClientRect();
     const selfRect = el.getBoundingClientRect();
     const currentBottom = parentRect.bottom - selfRect.bottom;
+    const { insetTop, insetBottom } = computeInsets(parent);
     expandedDragState.current = {
       startY: e.clientY,
       startBottom: currentBottom,
       parentH: parentRect.height,
       selfH: selfRect.height,
+      insetTop,
+      insetBottom,
       moved: false,
       pointerId: e.pointerId,
     };
@@ -121,9 +166,12 @@ const GlobalMiniPlayer: React.FC = () => {
     const dy = e.clientY - ds.startY;
     if (!ds.moved && Math.abs(dy) > DRAG_THRESHOLD) ds.moved = true;
     if (!ds.moved) return;
-    let nextBottom = ds.startBottom - dy;
-    const maxBottom = Math.max(0, ds.parentH - ds.selfH - EDGE_PAD);
-    nextBottom = Math.max(EDGE_PAD, Math.min(maxBottom, nextBottom));
+    const nextBottom = clampExpandedBottom(ds.startBottom - dy, {
+      parentH: ds.parentH,
+      selfH: ds.selfH,
+      insetTop: ds.insetTop,
+      insetBottom: ds.insetBottom,
+    });
     setExpandedBottom(nextBottom);
   }, []);
 
@@ -150,6 +198,7 @@ const GlobalMiniPlayer: React.FC = () => {
     if (!parent) return;
     const parentRect = parent.getBoundingClientRect();
     const bubbleRect = el.getBoundingClientRect();
+    const { insetTop, insetBottom } = computeInsets(parent);
 
     dragState.current = {
       startX: e.clientX,
@@ -158,6 +207,8 @@ const GlobalMiniPlayer: React.FC = () => {
       offY: e.clientY - bubbleRect.top,
       parentW: parentRect.width,
       parentH: parentRect.height,
+      insetTop,
+      insetBottom,
       moved: false,
       pointerId: e.pointerId,
     };
@@ -192,11 +243,17 @@ const GlobalMiniPlayer: React.FC = () => {
     const parent = el.parentElement as HTMLElement | null;
     if (!parent) return;
     const parentRect = parent.getBoundingClientRect();
-    let x = e.clientX - parentRect.left - ds.offX;
-    let y = e.clientY - parentRect.top - ds.offY;
-    x = Math.max(EDGE_PAD, Math.min(ds.parentW - BUBBLE_SIZE - EDGE_PAD, x));
-    y = Math.max(EDGE_PAD, Math.min(ds.parentH - BUBBLE_SIZE - EDGE_PAD, y));
-    setPos({ x, y });
+    const next = clampBubblePos(
+      e.clientX - parentRect.left - ds.offX,
+      e.clientY - parentRect.top - ds.offY,
+      {
+        parentW: ds.parentW,
+        parentH: ds.parentH,
+        insetTop: ds.insetTop,
+        insetBottom: ds.insetBottom,
+      },
+    );
+    setPos(next);
   }, []);
 
   const endDrag = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {

--- a/components/os/GlobalMiniPlayer.tsx
+++ b/components/os/GlobalMiniPlayer.tsx
@@ -11,9 +11,9 @@ import { Play, Pause, SkipForward, SkipBack, CaretDown, X } from '@phosphor-icon
 import { useOS } from '../../context/OSContext';
 import { useMusic } from '../../context/MusicContext';
 import { AppID } from '../../types';
+import { readSafeAreaInsets } from '../../utils/iosStandalone';
+import { clampBubblePos, clampExpandedBottom, resolveInsets } from '../../utils/floatingBallBounds';
 
-const BUBBLE_SIZE = 40;
-const EDGE_PAD = 8;
 const STORAGE_KEY = 'globalMiniPlayer.bubblePos.v1';
 const HIDDEN_KEY = 'globalMiniPlayer.hidden.v1';
 const EXPANDED_BOTTOM_KEY = 'globalMiniPlayer.expandedBottom.v1';

--- a/utils/floatingBallBounds.test.ts
+++ b/utils/floatingBallBounds.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { clampBubblePos, clampExpandedBottom, resolveInsets } from './floatingBallBounds';
+
+// 设备模型：竖屏 iPhone，父容器 390×800，顶部刘海 44、底部 home 条 34。
+const parentW = 390;
+const parentH = 800;
+const insetTop = 44;
+const insetBottom = 34;
+const bubble = 40;
+const pad = 8;
+
+describe('clampBubblePos（折叠小球）', () => {
+  it('拖到底部时停在 home 条上方，不被手势条挡住', () => {
+    const { y } = clampBubblePos(0, 9999, { parentW, parentH, insetTop, insetBottom });
+    // 旧逻辑（不减 insetBottom）会停在 752，球底正好压进 home 条区域；现在应停在更上方
+    expect(y).toBe(parentH - bubble - pad - insetBottom); // 718
+  });
+
+  it('拖到顶部时停在刘海下方，不钻进刘海', () => {
+    const { y } = clampBubblePos(0, -9999, { parentW, parentH, insetTop, insetBottom });
+    expect(y).toBe(pad + insetTop); // 52，而非旧的 8
+  });
+
+  it('横向仍只留 EDGE_PAD（竖屏无左右安全区）', () => {
+    expect(clampBubblePos(-100, 100, { parentW, parentH, insetTop, insetBottom }).x).toBe(pad);
+    expect(clampBubblePos(9999, 100, { parentW, parentH, insetTop, insetBottom }).x).toBe(parentW - bubble - pad);
+  });
+
+  it('无安全区设备退化为纯物理边界', () => {
+    const { x, y } = clampBubblePos(9999, 9999, { parentW, parentH, insetTop: 0, insetBottom: 0 });
+    expect(x).toBe(parentW - bubble - pad);
+    expect(y).toBe(parentH - bubble - pad);
+  });
+});
+
+describe('clampExpandedBottom（展开条）', () => {
+  const selfH = 60;
+
+  it('向下拖到底时离 home 条至少留出安全区 + 间距', () => {
+    const b = clampExpandedBottom(0, { parentH, selfH, insetTop, insetBottom });
+    expect(b).toBe(pad + insetBottom); // 42，而非旧的 8
+  });
+
+  it('向上拖到顶时条顶不钻进刘海', () => {
+    const b = clampExpandedBottom(9999, { parentH, selfH, insetTop, insetBottom });
+    expect(b).toBe(parentH - selfH - pad - insetTop); // 688，而非旧的 732
+  });
+});
+
+describe('resolveInsets（安全区合成）', () => {
+  it('已迁移 App：外壳 paddingTop 为 0，仍用真机刘海兜底，球不进刘海', () => {
+    // 回归守卫：若有人把顶部改成只读 paddingTop，已迁移 App 会重新钻进刘海，这条会挂
+    expect(resolveInsets({ padTop: 0, padBottom: 0, safeTop: 44 }).insetTop).toBe(44);
+  });
+
+  it('未迁移 App：paddingTop 已是刘海高度，取它', () => {
+    expect(resolveInsets({ padTop: 44, padBottom: 34, safeTop: 44 }).insetTop).toBe(44);
+  });
+
+  it('顶部取 padding 与真机刘海的较大值', () => {
+    expect(resolveInsets({ padTop: 50, padBottom: 0, safeTop: 44 }).insetTop).toBe(50);
+    expect(resolveInsets({ padTop: 20, padBottom: 0, safeTop: 44 }).insetTop).toBe(44);
+  });
+
+  it('底部只取 paddingBottom，不叠加真机 safe-bottom（避免已迁移 App 多让）', () => {
+    expect(resolveInsets({ padTop: 0, padBottom: 0, safeTop: 44 }).insetBottom).toBe(0);
+    expect(resolveInsets({ padTop: 0, padBottom: 34, safeTop: 44 }).insetBottom).toBe(34);
+  });
+});

--- a/utils/floatingBallBounds.test.ts
+++ b/utils/floatingBallBounds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { clampBubblePos, clampExpandedBottom, resolveInsets } from './floatingBallBounds';
+import { clampBubblePos, clampExpandedBottom, resolveInsets, resolveSafeTopInset } from './floatingBallBounds';
 
 // 设备模型：竖屏 iPhone，父容器 390×800，顶部刘海 44、底部 home 条 34。
 const parentW = 390;
@@ -65,5 +65,31 @@ describe('resolveInsets（安全区合成）', () => {
   it('底部只取 paddingBottom，不叠加真机 safe-bottom（避免已迁移 App 多让）', () => {
     expect(resolveInsets({ padTop: 0, padBottom: 0, safeTop: 44 }).insetBottom).toBe(0);
     expect(resolveInsets({ padTop: 0, padBottom: 34, safeTop: 44 }).insetBottom).toBe(34);
+  });
+});
+
+describe('resolveSafeTopInset（顶部安全区来源）', () => {
+  it('iOS standalone 冷启动：raw probe 为 0 时复用 CSS 变量兜底', () => {
+    expect(resolveSafeTopInset({
+      standaloneSafeTop: 44,
+      probedSafeTop: 0,
+      isIOSStandalone: true,
+    })).toBe(44);
+  });
+
+  it('CSS 变量还没初始化且 raw probe 仍为 0 时，iOS standalone 继续兜 44px', () => {
+    expect(resolveSafeTopInset({
+      standaloneSafeTop: 0,
+      probedSafeTop: 0,
+      isIOSStandalone: true,
+    })).toBe(44);
+  });
+
+  it('非 iOS standalone 没有安全区读数时保持 0', () => {
+    expect(resolveSafeTopInset({
+      standaloneSafeTop: 0,
+      probedSafeTop: 0,
+      isIOSStandalone: false,
+    })).toBe(0);
   });
 });

--- a/utils/floatingBallBounds.ts
+++ b/utils/floatingBallBounds.ts
@@ -12,6 +12,7 @@
 
 export const DEFAULT_BUBBLE_SIZE = 40;
 export const DEFAULT_EDGE_PAD = 8;
+export const IOS_STANDALONE_TOP_FALLBACK = 44;
 
 const clampRange = (value: number, lo: number, hi: number): number =>
   Math.min(Math.max(value, lo), Math.max(lo, hi));
@@ -55,6 +56,30 @@ export interface RawInsets {
   padBottom: number;
   safeTop: number;
 }
+
+export interface SafeTopInsetInput {
+  standaloneSafeTop: number;
+  probedSafeTop: number;
+  isIOSStandalone: boolean;
+  fallback?: number;
+}
+
+/**
+ * 顶部安全区的来源优先级：
+ * 1. :root 上的 --standalone-safe-area-top（iosStandalone.ts 已带 iOS 冷启动 44px 兜底）
+ * 2. 当前 env/probe 读数
+ * 3. iOS standalone 下最后再兜 44px，防止变量还没初始化时先拖进刘海
+ */
+export const resolveSafeTopInset = ({
+  standaloneSafeTop,
+  probedSafeTop,
+  isIOSStandalone,
+  fallback = IOS_STANDALONE_TOP_FALLBACK,
+}: SafeTopInsetInput): number => {
+  if (standaloneSafeTop > 0) return standaloneSafeTop;
+  if (probedSafeTop > 0) return probedSafeTop;
+  return isIOSStandalone ? fallback : 0;
+};
 
 /**
  * 把外壳 padding 与真机刘海合成球要让出的安全区高度。

--- a/utils/floatingBallBounds.ts
+++ b/utils/floatingBallBounds.ts
@@ -1,0 +1,69 @@
+/**
+ * 全局悬浮球（GlobalMiniPlayer）的拖拽边界计算。
+ *
+ * 抽成纯函数是为了能脱离 DOM 单测：把「球不能拖进 safe area（刘海 / home 条）」这条
+ * 行为钉住，防止以后又退回成只按物理容器尺寸 clamp。
+ *
+ * 坐标系：父容器（PhoneShell 的外壳 div）的 padding box，原点在左上。
+ *  - insetTop    顶部要让出的高度（刘海 / 状态栏），= max(父容器 paddingTop, env safe-top)
+ *  - insetBottom 底部要让出的高度（home 手势条），= 父容器 paddingBottom
+ *    （未迁移 App 外壳用 paddingBottom 让位安全区；已迁移 App 外壳已把底边收回安全区内，paddingBottom 为 0）
+ */
+
+export const DEFAULT_BUBBLE_SIZE = 40;
+export const DEFAULT_EDGE_PAD = 8;
+
+const clampRange = (value: number, lo: number, hi: number): number =>
+  Math.min(Math.max(value, lo), Math.max(lo, hi));
+
+export interface BubbleBoundsInput {
+  parentW: number;
+  parentH: number;
+  insetTop: number;
+  insetBottom: number;
+  bubble?: number;
+  pad?: number;
+}
+
+/** 折叠小球（left/top 定位）：横向只留 EDGE_PAD，纵向额外让出 safe area。 */
+export const clampBubblePos = (
+  x: number,
+  y: number,
+  { parentW, parentH, insetTop, insetBottom, bubble = DEFAULT_BUBBLE_SIZE, pad = DEFAULT_EDGE_PAD }: BubbleBoundsInput,
+): { x: number; y: number } => ({
+  x: clampRange(x, pad, parentW - bubble - pad),
+  y: clampRange(y, pad + insetTop, parentH - bubble - pad - insetBottom),
+});
+
+export interface ExpandedBoundsInput {
+  parentH: number;
+  selfH: number;
+  insetTop: number;
+  insetBottom: number;
+  pad?: number;
+}
+
+/** 展开条（bottom 定位）：bottom 是距父容器底边的距离，越大越靠上。 */
+export const clampExpandedBottom = (
+  bottom: number,
+  { parentH, selfH, insetTop, insetBottom, pad = DEFAULT_EDGE_PAD }: ExpandedBoundsInput,
+): number =>
+  clampRange(bottom, pad + insetBottom, parentH - selfH - pad - insetTop);
+
+export interface RawInsets {
+  padTop: number;
+  padBottom: number;
+  safeTop: number;
+}
+
+/**
+ * 把外壳 padding 与真机刘海合成球要让出的安全区高度。
+ * 顶部取两者较大：未迁移 App 的 paddingTop 已是刘海高度；已迁移 App paddingTop 为 0，靠真机 safe-top 兜底——
+ * 两种 App 都不会让球钻进刘海。
+ * 底部只取 paddingBottom：未迁移 App 即安全区高度，已迁移 App 外壳已把底边收回安全区内（为 0）；
+ * 不叠加真机 safe-bottom（否则已迁移 App 会多让一截、球停得偏高）。
+ */
+export const resolveInsets = ({ padTop, padBottom, safeTop }: RawInsets): { insetTop: number; insetBottom: number } => ({
+  insetTop: Math.max(padTop, safeTop),
+  insetBottom: padBottom,
+});

--- a/utils/iosStandalone.ts
+++ b/utils/iosStandalone.ts
@@ -8,7 +8,7 @@ let cachedBottomInset: number | null = null;
 
 // 用一个隐藏探针同时读取上下安全区：单次插入 + 单次 getComputedStyle（一次 reflow）。
 // env() 在本项目 iOS 全屏 PWA 下偶发返回 0，故需 JS 探测兜底。
-const readSafeAreaInsets = (): { top: number; bottom: number } => {
+export const readSafeAreaInsets = (): { top: number; bottom: number } => {
     if (typeof document === 'undefined' || !document.body) {
         return { top: cachedTopInset ?? 0, bottom: cachedBottomInset ?? 0 };
     }


### PR DESCRIPTION
## 改了什么

把全局悬浮球（迷你播放器）的可拖动范围收进屏幕安全区，松手后不会再卡进刘海或 home 横条下面。

## 改后是怎样

- 小球与展开的播放条，可拖范围夹在「刘海下沿 ~ home 横条上沿」之间，左右各留固定边距
- 安全区高度跟随当前设备动态计算（外壳 padding + 真机刘海），不写死数值
- 边界计算抽成纯函数 `utils/floatingBallBounds`，配单测把行为钉住，防回归

## 涉及文件

| 文件 | 类型 |
|------|------|
| `components/os/GlobalMiniPlayer.tsx` | 改 |
| `utils/floatingBallBounds.ts` | 新增 |
| `utils/floatingBallBounds.test.ts` | 新增 |
| `utils/iosStandalone.ts` | 改 |

## 测试

`pnpm vitest run utils/floatingBallBounds.test.ts` 覆盖边界夹取逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)