### PR TITLE
fix(xhs): 角色小红书开关关闭时不再注入提示词/调用功能

### DIFF
--- a/utils/agenticTools.ts
+++ b/utils/agenticTools.ts
@@ -46,10 +46,9 @@ export function resolveXhsConfig(char: CharacterProfile, realtimeConfig?: Realti
     const loggedInNickname = mcpConfig?.loggedInNickname;
     const userXsecToken = mcpConfig?.userXsecToken;
 
-    if (char.xhsEnabled !== undefined) {
-        return { enabled: !!char.xhsEnabled && mcpAvailable, mcpUrl, loggedInUserId, loggedInNickname, userXsecToken };
-    }
-    return { enabled: !!(realtimeConfig?.xhsEnabled) && mcpAvailable, mcpUrl, loggedInUserId, loggedInNickname, userXsecToken };
+    // 必须由角色自己的开关显式打开（UI 默认关闭）；不回退到全局 realtimeConfig.xhsEnabled，
+    // 与 chatPrompts.ts 的提示词注入门控保持一致。
+    return { enabled: !!char.xhsEnabled && mcpAvailable, mcpUrl, loggedInUserId, loggedInNickname, userXsecToken };
 }
 
 export interface AgenticToolCtx {

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -346,11 +346,11 @@ ${uname} 的化身正挂在《彼方》的【${roomName}】${act ? `，状态写
         const notionEnabled = !!(realtimeConfig?.notionEnabled && realtimeConfig?.notionApiKey && realtimeConfig?.notionDatabaseId);
         const notionNotesEnabled = !!(realtimeConfig?.notionEnabled && realtimeConfig?.notionApiKey && realtimeConfig?.notionNotesDatabaseId);
         const feishuEnabled = !!(realtimeConfig?.feishuEnabled && realtimeConfig?.feishuAppId && realtimeConfig?.feishuAppSecret && realtimeConfig?.feishuBaseId && realtimeConfig?.feishuTableId);
-        // Per-character XHS override: MCP-only
+        // Per-character XHS: 必须由角色自己的开关显式打开（UI 默认关闭）。
+        // 不再回退到全局 realtimeConfig.xhsEnabled —— 否则配置了 lite/MCP 后，
+        // 即使角色开关显示为关，未显式设置过(undefined)的角色仍会收到小红书提示词。
         const mcpXhsAvailable = !!(realtimeConfig?.xhsMcpConfig?.enabled && realtimeConfig?.xhsMcpConfig?.serverUrl);
-        const xhsEnabled = char.xhsEnabled !== undefined
-            ? !!(char.xhsEnabled && mcpXhsAvailable)
-            : !!(realtimeConfig?.xhsEnabled && mcpXhsAvailable);
+        const xhsEnabled = !!(char.xhsEnabled && mcpXhsAvailable);
 
         baseSystemPrompt += `### 聊天 App 行为规范 (Chat App Rules)
             **严格注意，你正在手机聊天，无论之前是什么模式，哪怕上一句话你们还面对面在一起，当前，你都是已经处于线上聊天状态了，请不要输出你的行为**


### PR DESCRIPTION
修复 bug：配置全局小红书 lite/MCP 后，即使角色 chat-app 设置里的
小红书开关显示为关闭，角色仍会收到小红书提示词并调用相关功能。

根因：门控逻辑用 `char.xhsEnabled !== undefined` 判断，未显式设置过 开关的角色 (undefined) 会回退到全局 realtimeConfig.xhsEnabled。但 UI 默认把 undefined 显示为「关」，造成「显示关闭却仍生效」的错位。

改为以角色自身开关为准：仅当 char.xhsEnabled 显式为 true 且 MCP/lite 已配置时才启用，与 UI 显示保持一致。同步修改 chatPrompts.ts 的提示词
注入门控与 agenticTools.ts 的 resolveXhsConfig（功能执行门控）。


Claude-Session: https://claude.ai/code/session_01TrRcBXwXPMBT1mPnfKwKe5