### PR TITLE
feat(memory-palace): 整合回忆超长改二次压缩，不再硬截断丢尾部

### DIFF
--- a/utils/memoryPalace/eventBoxCompression.ts
+++ b/utils/memoryPalace/eventBoxCompression.ts
@@ -19,7 +19,8 @@ import type { EventBox, MemoryNode, EmbeddingConfig, MemoryRoom, RemoteVectorCon
 import {
     EVENT_BOX_COMPRESSION_THRESHOLD,
     EVENT_BOX_SEAL_THRESHOLD,
-    EVENT_BOX_SUMMARY_TARGET_CHARS,
+    EVENT_BOX_SUMMARY_TARGET_MIN_CHARS,
+    EVENT_BOX_SUMMARY_TARGET_MAX_CHARS,
     EVENT_BOX_SUMMARY_HARD_MAX_CHARS,
 } from './types';
 import { EventBoxDB, MemoryNodeDB } from './db';
@@ -27,6 +28,7 @@ import type { LightLLMConfig } from './pipeline';
 import { vectorizeAndStore } from './vectorStore';
 import { bulkSetArchived } from './supabaseVector';
 import { safeFetchJson, extractJson } from '../safeApi';
+import { enforceSummaryLengthBudget } from './summaryLengthBudget';
 
 const VALID_ROOMS: MemoryRoom[] = [
     'living_room', 'bedroom', 'study', 'user_room',
@@ -146,7 +148,7 @@ async function callCompressionLLM(
 
 **要求（严格遵守）**：
 1. **第一人称**（用「我」），从 ${charName} 的视角写。${userLabel} 用名字直接称呼。
-2. **字数目标 ${EVENT_BOX_SUMMARY_TARGET_CHARS} 字以内，绝对上限 ${EVENT_BOX_SUMMARY_HARD_MAX_CHARS} 字**。紧凑、务实、不口水。
+2. **字数目标 ${EVENT_BOX_SUMMARY_TARGET_MIN_CHARS}-${EVENT_BOX_SUMMARY_TARGET_MAX_CHARS} 字，绝对上限 ${EVENT_BOX_SUMMARY_HARD_MAX_CHARS} 字**。紧凑、务实、不口水。
 3. **只保留关键信息**：具体人物、动作、对象、场景、转折、情绪。**去掉所有语气填充、修辞铺陈、重复感慨**（如「真是的」、「怎么说呢」、「不过话说回来」等）。事实先行。
 4. **带时间点但不冗余**：每件事标一次日期就够（「3 月 20 日…4 月 5 日…」），不要每句都重复时间。
 5. **连贯但简洁**：不套「起因/经过/结果」模板，但要让读者能按顺序看懂事情怎么发展的。
@@ -162,7 +164,7 @@ async function callCompressionLLM(
 
 严格 JSON，不要 markdown 包裹（content 里的引用一律用「」/《》/'，不要用 "）：
 {
-  "content": "（紧凑的第一人称回忆，${EVENT_BOX_SUMMARY_TARGET_CHARS}字内）",
+  "content": "（紧凑的第一人称回忆，${EVENT_BOX_SUMMARY_TARGET_MIN_CHARS}-${EVENT_BOX_SUMMARY_TARGET_MAX_CHARS}字）",
   "name": "...",
   "tags": ["...", "..."],
   "room": "...",
@@ -215,11 +217,16 @@ async function callCompressionLLM(
                 return null;
             }
         }
-        // 硬截断安全网：LLM 超限时截断并追加提示，避免单盒 summary 无限膨胀
+        // 长度兜底：超过硬上限时，先让模型把这段二次压缩回目标区间（不丢信息），
+        // 压不动或二次压缩失败才退回硬截断保证有界。详见 enforceSummaryLengthBudget。
         let content = String(parsed.content);
         if (content.length > EVENT_BOX_SUMMARY_HARD_MAX_CHARS) {
-            console.warn(`🗜️ [Compression] LLM summary ${content.length} 字超过硬上限 ${EVENT_BOX_SUMMARY_HARD_MAX_CHARS}，截断`);
-            content = content.slice(0, EVENT_BOX_SUMMARY_HARD_MAX_CHARS) + '……';
+            console.warn(`🗜️ [Compression] LLM summary ${content.length} 字超过硬上限 ${EVENT_BOX_SUMMARY_HARD_MAX_CHARS}，尝试二次压缩`);
+            content = await enforceSummaryLengthBudget(
+                content,
+                (t) => recompressSummary(t, EVENT_BOX_SUMMARY_TARGET_MAX_CHARS, llmConfig, charName),
+                EVENT_BOX_SUMMARY_HARD_MAX_CHARS,
+            );
         }
         return {
             content,
@@ -231,6 +238,53 @@ async function callCompressionLLM(
         };
     } catch (err: any) {
         console.error(`🗜️ [Compression] LLM 调用失败: ${err?.message || err}`);
+        return null;
+    }
+}
+
+// ─── 整合回忆长度兜底：超限二次压缩，压不动才硬截断 ──────────
+
+/**
+ * 让模型把过长的整合回忆压缩回 targetMaxChars 字内（纯文本输出，不走 JSON）。
+ * 失败返回 null，由 enforceSummaryLengthBudget 决定兜底。
+ */
+async function recompressSummary(
+    text: string,
+    targetMaxChars: number,
+    llmConfig: LightLLMConfig,
+    charName: string,
+): Promise<string | null> {
+    const systemPrompt = `你是 ${charName}。下面这段第一人称回忆写得太长了。请在**不丢关键信息**（具体人物、地点、事件、转折、情绪）的前提下，把它压缩到 ${targetMaxChars} 字以内。
+要求：保持第一人称（「我」）、连贯通顺；只删语气填充和重复铺陈，不删事实；引用一律用「」《》或单引号，不要用半角双引号。
+直接输出压缩后的回忆正文，不要解释、不要 JSON、不要 markdown 包裹。`;
+    try {
+        const data = await safeFetchJson(
+            `${llmConfig.baseUrl.replace(/\/+$/, '')}/chat/completions`,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${llmConfig.apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: llmConfig.model,
+                    messages: [
+                        { role: 'system', content: systemPrompt },
+                        { role: 'user', content: text },
+                    ],
+                    temperature: 0.3,
+                    max_tokens: 4000,
+                    stream: false,
+                }),
+            },
+            2, 0, { appName: '记忆宫殿', purpose: '事件压缩-二次压缩' }
+        );
+        const reply = (data.choices?.[0]?.message?.content || '').trim();
+        // 模型偶尔仍会裹 ``` 代码块，剥掉常见包裹
+        const cleaned = reply.replace(/^```[a-zA-Z]*\n?/, '').replace(/\n?```$/, '').trim();
+        return cleaned || null;
+    } catch (err: any) {
+        console.warn(`🗜️ [Compression] 二次压缩 LLM 调用失败: ${err?.message || err}`);
         return null;
     }
 }

--- a/utils/memoryPalace/eventBoxSummaryBudget.test.ts
+++ b/utils/memoryPalace/eventBoxSummaryBudget.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+    EVENT_BOX_SUMMARY_TARGET_MIN_CHARS,
+    EVENT_BOX_SUMMARY_TARGET_MAX_CHARS,
+    EVENT_BOX_SUMMARY_HARD_MAX_CHARS,
+} from './types';
+import { enforceSummaryLengthBudget } from './summaryLengthBudget';
+
+describe('EventBox summary 字数预算', () => {
+    it('目标区间下界小于上界', () => {
+        expect(EVENT_BOX_SUMMARY_TARGET_MIN_CHARS).toBeLessThan(EVENT_BOX_SUMMARY_TARGET_MAX_CHARS);
+    });
+
+    // 回归守卫：硬截断线必须高于目标上界，给「模型数不准字数」留缓冲。
+    // 若砍线 ≤ 目标上界，模型瞄着目标上界写、稍微超一点就会被硬截断拼上「……」——
+    // 这正是整合回忆末尾省略号的根因。砍线和目标上界不能一起往下压到同一个值。
+    it('硬截断线高于目标上界（留缓冲，避免模型稍超就被砍出「……」）', () => {
+        expect(EVENT_BOX_SUMMARY_HARD_MAX_CHARS).toBeGreaterThan(EVENT_BOX_SUMMARY_TARGET_MAX_CHARS);
+    });
+});
+
+describe('enforceSummaryLengthBudget — 超限二次压缩兜底', () => {
+    const HARD = 900;
+    const ELLIPSIS = '……';
+
+    it('未超限：原样返回，且不触发二次压缩', async () => {
+        const text = 'a'.repeat(500);
+        let called = false;
+        const out = await enforceSummaryLengthBudget(text, async () => { called = true; return null; }, HARD);
+        expect(out).toBe(text);
+        expect(called).toBe(false);
+    });
+
+    it('超限 + 二次压缩达标：采用压缩结果，不留省略号', async () => {
+        const text = 'a'.repeat(1000);
+        const out = await enforceSummaryLengthBudget(text, async () => 'b'.repeat(600), HARD);
+        expect(out).toBe('b'.repeat(600));
+        expect(out.endsWith(ELLIPSIS)).toBe(false);
+    });
+
+    it('超限 + 二次压缩后仍超：取更短者做基底，硬截断兜底', async () => {
+        const text = 'a'.repeat(1000);
+        // 二次压缩压到 950，仍 > 900 → 用 950 这份做基底截断
+        const out = await enforceSummaryLengthBudget(text, async () => 'b'.repeat(950), HARD);
+        expect(out.startsWith('b'.repeat(HARD))).toBe(true);
+        expect(out.endsWith(ELLIPSIS)).toBe(true);
+        expect(out.length).toBe(HARD + ELLIPSIS.length);
+    });
+
+    it('超限 + 二次压缩失败(null)：回退硬截断原文', async () => {
+        const text = 'a'.repeat(1000);
+        const out = await enforceSummaryLengthBudget(text, async () => null, HARD);
+        expect(out).toBe('a'.repeat(HARD) + ELLIPSIS);
+    });
+});

--- a/utils/memoryPalace/summaryLengthBudget.ts
+++ b/utils/memoryPalace/summaryLengthBudget.ts
@@ -1,0 +1,20 @@
+/**
+ * 整合回忆长度兜底（纯逻辑，无外部依赖，便于单测）。
+ *
+ * content 超过硬上限时：
+ *   1. 先用 recompress 让模型二次压缩；压到硬上限内就采用（不丢信息、无「……」）。
+ *   2. 二次压缩失败 / 压完仍超 → 取更短的那份做基底，硬截断 +「……」保证绝对有界。
+ *
+ * recompress 由调用方注入（真实路径是 LLM 调用），单测时换成假实现即可不碰网络。
+ */
+export async function enforceSummaryLengthBudget(
+    content: string,
+    recompress: (text: string) => Promise<string | null>,
+    hardMaxChars: number,
+): Promise<string> {
+    if (content.length <= hardMaxChars) return content;
+    const recompressed = await recompress(content);
+    if (recompressed && recompressed.length <= hardMaxChars) return recompressed;
+    const base = recompressed && recompressed.length < content.length ? recompressed : content;
+    return base.slice(0, hardMaxChars) + '……';
+}

--- a/utils/memoryPalace/types.ts
+++ b/utils/memoryPalace/types.ts
@@ -171,9 +171,11 @@ export const EVENT_BOX_LIVE_HARD_CAP = 15;
 /** 盒内事件总数（archived + live）达到此值后封盒，之后的相关记忆另开新盒 */
 export const EVENT_BOX_SEAL_THRESHOLD = 12;
 
-/** summary 目标字数（prompt 引导）+ 硬上限（超过强制截断） */
-export const EVENT_BOX_SUMMARY_TARGET_CHARS = 500;
-export const EVENT_BOX_SUMMARY_HARD_MAX_CHARS = 800;
+/** summary 目标字数区间（prompt 引导，让模型尽量落在区间内）+ 硬上限（超过强制截断兜底）。
+ *  目标上界低于硬上限，给「模型数不准字数」留缓冲——模型瞄着上界写、稍微超一点也不会被砍出「……」。 */
+export const EVENT_BOX_SUMMARY_TARGET_MIN_CHARS = 400;
+export const EVENT_BOX_SUMMARY_TARGET_MAX_CHARS = 700;
+export const EVENT_BOX_SUMMARY_HARD_MAX_CHARS = 900;
 
 // ─── 旧话题盒（已废弃，代码路径已摘除，类型保留以兼容残留数据读取） ──
 


### PR DESCRIPTION
## 改了什么

事件盒「整合回忆」过长时，原先超过硬上限会直接截断、末尾拼「……」，丢掉尾部内容——而且向量化和上下文注入用的都是截断版，被砍的细节在召回层面调不回来。

## 改后怎样

| | 改之前 | 改之后 |
|---|---|---|
| 字数目标 | 500 字以内 | 400-700 字 |
| 硬上限 | 800 | 900 |
| 超限处理 | 直接砍 +「……」 | 先二次压缩回区间；压不动或失败才硬截断兜底 |

- 超 900 字时先让模型把这段再压一轮（信息浓缩不丢），压回 900 内即采用；只有压不动或调用失败才退回硬截断保证有界。
- 字数目标改成区间、硬上限抬高，给模型「数不准字数」留缓冲。

## 影响范围
- 纯前端逻辑（记忆压缩在前端跑），不涉及 worker。
- 只对之后的压缩生效；已存在的截断版 summary 不会自动重生成。
- 超限时多一次 LLM 调用（仅模型写飞超 900 时触发）。

## 测试
新增 `eventBoxSummaryBudget.test.ts`，6 个用例全过：
- 2 个钉住「硬截断线 > 目标上界」的回归守卫
- 4 个覆盖兜底分支：不超限 / 二次压缩达标 / 压完仍超 / 压缩失败

🤖 Generated with [Claude Code](https://claude.com/claude-code)