### PR TITLE
家园群聊/私聊：生成去重 + 点按即可编辑删除

### DIFF
--- a/apps/WorldHomeApp.tsx
+++ b/apps/WorldHomeApp.tsx
@@ -179,7 +179,7 @@ const ChibiFigure: React.FC<{ char: CharacterProfile; size?: number; bob?: boole
 // 跨轮累积的真实会话：A 发的和 B 的回应交替出现）
 // ============================================================
 
-/** 会话气泡流：自己右绿、对方左白带头像，剧情时间变化处插分隔条。长按某条气泡可编辑/删除。 */
+/** 会话气泡流：自己右绿、对方左白带头像，剧情时间变化处插分隔条。点按某条气泡可编辑/删除。 */
 const ThreadBubbles: React.FC<{
     thread: WorldThread;
     selfId: string;
@@ -191,20 +191,6 @@ const ThreadBubbles: React.FC<{
     const avatarOf = (id: string) => members.find(m => m.id === id)?.avatar;
     const emojiOf = (id: string) => npcs.find(n => n.id === id)?.emoji || '🙂';
     const isNpc = (id: string) => npcs.some(n => n.id === id);
-    // 长按 ~500ms 触发编辑；手指移动超过 10px（在滚动）就取消
-    const pressRef = useRef<{ timer: ReturnType<typeof setTimeout>; x: number; y: number } | null>(null);
-    const endPress = () => { if (pressRef.current) { clearTimeout(pressRef.current.timer); pressRef.current = null; } };
-    const startPress = (e: React.PointerEvent, m: WorldChatMessage) => {
-        if (!onPick) return;
-        endPress();
-        const x = e.clientX, y = e.clientY;
-        const timer = setTimeout(() => { endPress(); onPick(m); }, 500);
-        pressRef.current = { timer, x, y };
-    };
-    const movePress = (e: React.PointerEvent) => {
-        const s = pressRef.current;
-        if (s && (Math.abs(e.clientX - s.x) > 10 || Math.abs(e.clientY - s.y) > 10)) endPress();
-    };
     const els: React.ReactNode[] = [];
     let lastTime = '';
     thread.messages.forEach(m => {
@@ -228,14 +214,10 @@ const ThreadBubbles: React.FC<{
                 )}
                 <div className={`max-w-[78%] ${mine ? 'items-end' : 'items-start'} flex flex-col`}>
                     {!mine && showNames && <div className="text-[8.5px] text-white/45 font-bold mb-0.5 px-1">{m.fromName}{isNpc(m.fromId) ? ' · NPC' : ''}</div>}
-                    <div className={`px-2.5 py-1.5 text-[11px] leading-[1.5] shadow-sm ${onPick ? 'select-none' : ''} ${mine
+                    <div role={onPick ? 'button' : undefined} onClick={onPick ? () => onPick(m) : undefined}
+                        className={`px-2.5 py-1.5 text-[11px] leading-[1.5] shadow-sm ${onPick ? 'cursor-pointer active:opacity-80 transition-opacity' : ''} ${mine
                         ? 'rounded-2xl rounded-br-md bg-gradient-to-br from-emerald-400 to-emerald-500 text-white'
-                        : 'rounded-2xl rounded-bl-md bg-white/95 text-slate-800'}`}
-                        onPointerDown={onPick ? e => startPress(e, m) : undefined}
-                        onPointerMove={onPick ? movePress : undefined}
-                        onPointerUp={onPick ? endPress : undefined}
-                        onPointerLeave={onPick ? endPress : undefined}
-                        onPointerCancel={onPick ? endPress : undefined}>
+                        : 'rounded-2xl rounded-bl-md bg-white/95 text-slate-800'}`}>
                         {m.text}
                     </div>
                 </div>
@@ -442,7 +424,7 @@ const PhoneModal: React.FC<{
                                                         <button onClick={() => setDmOpenId(null)} className="flex items-center gap-1 text-[11px] font-bold text-white/80 active:scale-95 transition-transform">
                                                             <CaretRight size={12} weight="bold" className="rotate-180" />{otherName}
                                                         </button>
-                                                        {onEditContent && <span className="text-[8px] text-white/35">长按消息可编辑/删除</span>}
+                                                        {onEditContent && <span className="text-[8px] text-white/35">点按消息可编辑/删除</span>}
                                                     </div>
                                                     {folded && (
                                                         <button onClick={() => setDmExpanded(true)} className="w-full text-[10px] font-bold py-1.5 rounded-full bg-white/10 text-white/60 active:scale-95 transition-transform">
@@ -491,7 +473,7 @@ const PhoneModal: React.FC<{
                                         const shownGroup = folded ? { ...group, messages: group.messages.slice(-FOLD) } : group;
                                         return (
                                             <div className="space-y-1.5">
-                                                <div className="text-center text-[9px] text-white/40 font-bold pb-1">「{group.name}」 · {group.memberIds.length} 人{world.npcs.length > 0 ? ` + ${world.npcs.length} NPC` : ''}{onEditContent ? ' · 长按消息可编辑/删除' : ''}</div>
+                                                <div className="text-center text-[9px] text-white/40 font-bold pb-1">「{group.name}」 · {group.memberIds.length} 人{world.npcs.length > 0 ? ` + ${world.npcs.length} NPC` : ''}{onEditContent ? ' · 点按消息可编辑/删除' : ''}</div>
                                                 {folded && (
                                                     <button onClick={() => setGroupExpanded(true)} className="w-full text-[10px] font-bold py-1.5 rounded-full bg-white/10 text-white/60 active:scale-95 transition-transform">
                                                         展开更早的 {group.messages.length - FOLD} 条

--- a/utils/worldHome/threads.ts
+++ b/utils/worldHome/threads.ts
@@ -37,6 +37,25 @@ function pushMsg(thread: WorldThread, msg: WorldChatMessage) {
     if (thread.messages.length > THREAD_CAP) thread.messages = thread.messages.slice(-THREAD_CAP);
 }
 
+/** 去重归一化：去掉所有空白再比，避免「同一句只差换行/空格」漏判。 */
+const normLine = (s: string): string => s.replace(/\s+/g, '').trim();
+
+/**
+ * 同一发送者在近 window 条里是否已发过一模一样的内容。
+ * 用来挡住模型偶尔把上一轮的私聊/群聊原样再冒一遍——同一句在不同时间反复刷屏。
+ * 空白内容也判为「重复」直接丢弃。
+ */
+export function isDuplicateLine(thread: WorldThread, fromId: string, text: string, window = 60): boolean {
+    const n = normLine(text);
+    if (!n) return true;
+    const start = Math.max(0, thread.messages.length - window);
+    for (let i = thread.messages.length - 1; i >= start; i--) {
+        const m = thread.messages[i];
+        if (m.fromId === fromId && normLine(m.text) === n) return true;
+    }
+    return false;
+}
+
 /**
  * 把一个角色 beat 里的手机消息落进线程（dm → 私聊线程；group → 世界群聊）。
  * 在每个角色演绎完后立刻调用——链式后续角色才能在同一轮里收到。
@@ -63,6 +82,7 @@ export function applyBeatToThreads(
             threads.push(thread);
         }
         for (const line of dm.lines) {
+            if (isDuplicateLine(thread, beat.charId, line)) continue;
             pushMsg(thread, { id: genId('wm'), fromId: beat.charId, fromName: beat.charName, text: line, round, storyTime, timestamp: now });
         }
     }
@@ -71,6 +91,7 @@ export function applyBeatToThreads(
     if (groupLines.length > 0) {
         const group = threads.find(t => t.id === GROUP_THREAD_ID)!;
         for (const line of groupLines) {
+            if (isDuplicateLine(group, beat.charId, line)) continue;
             pushMsg(group, { id: genId('wm'), fromId: beat.charId, fromName: beat.charName, text: line, round, storyTime, timestamp: now });
         }
     }
@@ -90,6 +111,7 @@ export function applyNpcGroupLines(
     for (const l of lines) {
         const npc = world.npcs.find(n => n.name === l.name);
         if (!npc) continue; // 只收真实存在的 NPC 的发言
+        if (isDuplicateLine(group, npc.id, l.line)) continue;
         pushMsg(group, { id: genId('wm'), fromId: npc.id, fromName: npc.name, text: l.line, round, storyTime, timestamp: now });
     }
 }
@@ -117,6 +139,7 @@ export function applyNpcDms(
         }
         for (const line of dm.lines) {
             if (!line) continue;
+            if (isDuplicateLine(thread, npc.id, line)) continue;
             pushMsg(thread, { id: genId('wm'), fromId: npc.id, fromName: npc.name, text: line, round, storyTime, timestamp: now });
         }
     }

--- a/utils/worldHome/worldHome.test.ts
+++ b/utils/worldHome/worldHome.test.ts
@@ -371,6 +371,18 @@ describe('世界消息线程（交替传递）', () => {
         expect(group.messages.map(m => m.fromName)).toEqual(['老板娘', '小满']);
     });
 
+    it('群聊/私聊去重：同一发送者把上一轮的话原样再发一遍会被丢掉（只差空白也算）', () => {
+        const world = mkWorld({ npcs: [{ id: 'n1', name: '老板娘', persona: '面包店' }] });
+        ensureThreads(world);
+        // 第1轮：小满在群里说「今天天气真好」
+        applyBeatToThreads(world, { charId: 'a', charName: '小满', location: 'x', narrative: 'y', mood: 'z', phone: { group: ['今天天气真好'] } }, members, 1, '第1天白天');
+        // 第2轮：小满又把同一句（只差空白）原样发一遍 → 丢弃；NPC 重复冒泡同句也丢
+        applyBeatToThreads(world, { charId: 'a', charName: '小满', location: 'x', narrative: 'y', mood: 'z', phone: { group: [' 今天天气真好 ', '换个新话题'] } }, members, 2, '第1天夜晚');
+        applyNpcGroupLines(world, [{ name: '老板娘', line: '新出炉的栗子包！' }, { name: '老板娘', line: '新出炉的栗子包！' }], 2, '第1天夜晚');
+        const group = groupThreadOf(world)!;
+        expect(group.messages.map(m => m.text)).toEqual(['今天天气真好', '换个新话题', '新出炉的栗子包！']);
+    });
+
     it('formatThreadForPrompt：本轮消息标【刚刚】，历史消息标剧情时间', () => {
         const world = mkWorld();
         applyBeatToThreads(world, { charId: 'a', charName: '小满', location: 'x', narrative: 'y', mood: 'z', phone: { dms: [{ to: '阿岚', lines: ['老消息'] }] } }, members, 1, '第1天白天');


### PR DESCRIPTION
- 群聊/私聊也做落库去重：同一发送者把上一轮的话原样再冒一遍（含只差空白 的）直接丢弃，覆盖角色发言与 NPC 冒泡/回私信——解决"群聊不同时间刷出一样 的消息"。
- 聊天消息的编辑/删除由长按改为点按：长按在可滚动列表里会被浏览器的 pointercancel 打断、触屏上经常失效，点按更稳也更好发现；提示文案同步改为 "点按消息可编辑/删除"。


Claude-Session: https://claude.ai/code/session_0144zA9XAFNTdymbdRPbyA7m