### PR TITLE
修掉 CallApp 预先存在的类型报错

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -673,7 +673,7 @@ const CallApp: React.FC = () => {
     }
     const systemPrompt = selectedChar
       ? buildCallPrompt(userName, selectedChar.name, ContextBuilder.buildCoreContext(selectedChar, userProfile, true), voiceLang || undefined)
-      : buildCallPrompt(userName, selectedChar?.name, undefined, voiceLang || undefined);
+      : buildCallPrompt(userName, undefined, undefined, voiceLang || undefined);
     const messages = await buildHistoryMessages(input, skipDbId);
     const chatData = await safeFetchJson(`${baseUrl}/chat/completions`, {
       method: 'POST',


### PR DESCRIPTION
requestAssistantReply 里 selectedChar ? ... : ... 的 else 分支里 selectedChar 已被收窄为空值（never），再访问 selectedChar?.name 触发
"Property 'name' does not exist on type 'never'"。else 分支本就是 selectedChar 为空的情况，name 必为 undefined，直接传 undefined，语义不变。

- apps/CallApp.tsx


Claude-Session: https://claude.ai/code/session_01FuvcKdZPyzPMKPeL64chBb