### PR TITLE
fix(backup): 导出降低内存峰值，手机端不再写出损坏的备份

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -2,9 +2,10 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { useOS } from '../context/OSContext';
 import { Capacitor } from '@capacitor/core';
-import { Filesystem, Directory, Encoding } from '@capacitor/filesystem';
+import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Share } from '@capacitor/share';
 import { safeResponseJson } from '../utils/safeApi';
+import { EXPORT_CHUNK_SIZE, sliceRanges } from '../utils/backupExport';
 import Modal from '../components/os/Modal';
 import { NotionManager, FeishuManager } from '../utils/realtimeContext';
 import { XhsMcpClient } from '../utils/xhsMcpClient';
@@ -327,7 +328,20 @@ const Settings: React.FC = () => {
 
   // For web download link
   const [downloadUrl, setDownloadUrl] = useState<string>('');
-  
+  // 用 ref 跟住当前的 object URL，关弹窗 / 重新导出 / 卸载时都能 revoke 到最新那个，
+  // 不受 state 闭包过期影响。
+  const downloadUrlRef = useRef<string>('');
+  const revokeDownloadUrl = useCallback(() => {
+      if (downloadUrlRef.current) {
+          URL.revokeObjectURL(downloadUrlRef.current);
+          downloadUrlRef.current = '';
+      }
+      setDownloadUrl('');
+  }, []);
+  useEffect(() => () => {
+      if (downloadUrlRef.current) URL.revokeObjectURL(downloadUrlRef.current);
+  }, []);
+
   const [statusMsg, setStatusMsg] = useState('');
   const [testingApi, setTestingApi] = useState(false);
   const [testApiResult, setTestApiResult] = useState<string | null>(null);
@@ -432,38 +446,56 @@ const Settings: React.FC = () => {
           const blob = await exportSystem(mode);
           
           if (Capacitor.isNativePlatform()) {
-              // Convert Blob to Base64 for Native Write
-              const reader = new FileReader();
-              reader.readAsDataURL(blob);
-              reader.onloadend = async () => {
-                  const base64data = String(reader.result);
-                  const fileName = `Sully_Backup_${mode}_${Date.now()}.zip`;
-                  
-                  try {
-                      await Filesystem.writeFile({
-                          path: fileName,
-                          data: base64data, // Filesystem accepts data urls? Or need strip prefix
-                          directory: Directory.Cache,
-                      });
-                      const uriResult = await Filesystem.getUri({
-                          directory: Directory.Cache,
-                          path: fileName,
-                      });
-                      await Share.share({
-                          title: `Sully Backup`,
-                          files: [uriResult.uri],
-                      });
-                  } catch (e) {
-                      console.error("Native write failed", e);
-                      addToast("保存文件失败", "error");
+              // 手机端分片写盘：整包一次性 readAsDataURL 会把几十~上百 MB 的 base64
+              // 一股脑塞进内存，WebView 容易 OOM 闪退。改成按 3MiB 切片，每片转成纯
+              // base64 再 appendFile 追加。先写临时文件，全部写完才改名+分享；中途任何
+              // 一步失败都删掉残片，避免留下一个看着像成功、其实损坏的 .zip。
+              const fileName = `Sully_Backup_${mode}_${Date.now()}.zip`;
+              const tempName = `${fileName}.part`;
+
+              // 读一个 Blob 分片为纯 base64（去掉 data:...;base64, 前缀）。
+              const sliceToBase64 = (slice: Blob): Promise<string> => new Promise((resolve, reject) => {
+                  const reader = new FileReader();
+                  reader.onloadend = () => {
+                      const result = String(reader.result);
+                      const comma = result.indexOf(',');
+                      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+                  };
+                  reader.onerror = () => reject(reader.error || new Error('读取备份分片失败'));
+                  reader.onabort = () => reject(new Error('读取备份分片被中断'));
+                  reader.readAsDataURL(slice);
+              });
+
+              try {
+                  const ranges = sliceRanges(blob.size, EXPORT_CHUNK_SIZE);
+                  for (let i = 0; i < ranges.length; i++) {
+                      const [start, end] = ranges[i];
+                      const base64 = await sliceToBase64(blob.slice(start, end));
+                      if (i === 0) {
+                          await Filesystem.writeFile({ path: tempName, data: base64, directory: Directory.Cache });
+                      } else {
+                          await Filesystem.appendFile({ path: tempName, data: base64, directory: Directory.Cache });
+                      }
                   }
-              };
+                  // 全部分片写盘成功，才把临时文件改名为正式名并分享。
+                  await Filesystem.rename({ from: tempName, to: fileName, directory: Directory.Cache });
+                  const uriResult = await Filesystem.getUri({ directory: Directory.Cache, path: fileName });
+                  await Share.share({ title: `Sully Backup`, files: [uriResult.uri] });
+              } catch (e) {
+                  console.error("Native write failed", e);
+                  // 尽力清掉写了一半的残片，别留下损坏文件。
+                  try { await Filesystem.deleteFile({ path: tempName, directory: Directory.Cache }); } catch { /* ignore */ }
+                  addToast("保存文件失败", "error");
+              }
           } else {
               // Web Download
+              // 上一次导出的 object URL 先 revoke 掉，否则它会一直占着整包内存直到刷新页面。
+              if (downloadUrlRef.current) URL.revokeObjectURL(downloadUrlRef.current);
               const url = URL.createObjectURL(blob);
+              downloadUrlRef.current = url;
               setDownloadUrl(url);
               setShowExportModal(true);
-              
+
               // Auto click
               const a = document.createElement('a');
               a.href = url;
@@ -1968,9 +2000,9 @@ const Settings: React.FC = () => {
       </Modal>
 
       {/* 强制导出 Modal */}
-      <Modal isOpen={showExportModal} title="备份下载" onClose={() => setShowExportModal(false)} footer={
+      <Modal isOpen={showExportModal} title="备份下载" onClose={() => { revokeDownloadUrl(); setShowExportModal(false); }} footer={
           <div className="flex gap-2 w-full">
-               <button onClick={() => setShowExportModal(false)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">关闭</button>
+               <button onClick={() => { revokeDownloadUrl(); setShowExportModal(false); }} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">关闭</button>
           </div>
       }>
           <div className="space-y-4 text-center py-4">

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useEffect, useState, useRef, useCallback } from 'react';
 import { APIConfig, AppID, OSTheme, VirtualTime, CharacterProfile, ChatTheme, Toast, FullBackupData, UserProfile, ApiPreset, GroupProfile, SystemLog, Worldbook, NovelBook, SongSheet, Message, RealtimeConfig, AppearancePreset, CloudBackupConfig, CloudBackupFile } from '../types';
 import { DB } from '../utils/db';
+import { extractImagesInPlace, deepCloneForExport } from '../utils/backupExport';
 import { ProactiveChat } from '../utils/proactiveChat';
 import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { runVRSession } from '../utils/vrWorld/runSession';
@@ -2527,45 +2528,35 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               return obj;
           };
 
-          // Extract Images to ZIP (Recursive) - Used for Media/Theme Mode
-          const processObject = (obj: any): any => {
-              if (obj === null || typeof obj !== 'object') return obj;
-              
-              if (Array.isArray(obj)) {
-                  return obj.map(item => processObject(item));
+          // 把一条 data:image base64 落进 ZIP 的 assets/ 文件夹，返回它的 assets/* 路径。
+          // 同一份 base64 全局只存一份（assetDedupMap 按完整 base64 去重）；无法识别的
+          // data url 原样返回，不动它。
+          const resolveImage = (value: string): string => {
+              try {
+                  const cached = assetDedupMap.get(value);
+                  if (cached) return cached;
+                  const extMatch = value.match(/data:image\/([a-zA-Z0-9]+);base64,/);
+                  if (!extMatch) return value;
+                  const ext = extMatch[1] === 'jpeg' ? 'jpg' : extMatch[1];
+                  const filename = `asset_${Date.now()}_${assetCount++}.${ext}`;
+                  const base64Data = value.split(',')[1];
+                  assetsFolder?.file(filename, base64Data, { base64: true });
+                  const path = `assets/${filename}`;
+                  assetDedupMap.set(value, path);
+                  return path;
+              } catch (e) {
+                  console.warn("Failed to process asset", e);
+                  return value;
               }
+          };
 
-              const newObj: any = {};
-              for (const key in obj) {
-                  if (Object.prototype.hasOwnProperty.call(obj, key)) {
-                      let value = obj[key];
-                      if (typeof value === 'string' && value.startsWith('data:image/')) {
-                          try {
-                              const cached = assetDedupMap.get(value);
-                              if (cached) {
-                                  value = cached;
-                              } else {
-                                  const extMatch = value.match(/data:image\/([a-zA-Z0-9]+);base64,/);
-                                  if (extMatch) {
-                                      const ext = extMatch[1] === 'jpeg' ? 'jpg' : extMatch[1];
-                                      const filename = `asset_${Date.now()}_${assetCount++}.${ext}`;
-                                      const base64Data = value.split(',')[1];
-                                      assetsFolder?.file(filename, base64Data, { base64: true });
-                                      const path = `assets/${filename}`;
-                                      assetDedupMap.set(value, path);
-                                      value = path;
-                                  }
-                              }
-                          } catch (e) {
-                              console.warn("Failed to process asset", e);
-                          }
-                      } else {
-                          value = processObject(value);
-                      }
-                      newObj[key] = value;
-                  }
-              }
-              return newObj;
+          // Extract Images to ZIP (in-place) - Used for Media/Theme Mode.
+          // 原地把 base64 换成 assets/* 路径，不再另建一棵对象树，导出大 store 时峰值内存更省。
+          // 传进来的必须是独立副本：store 数据是 IDB 结构化克隆副本（安全）；theme /
+          // customIcons / appearancePresets 引用了运行态 state，已在上面 backupData 里深拷贝。
+          const processObject = (obj: any): any => {
+              extractImagesInPlace(obj, resolveImage);
+              return obj;
           };
 
           const isRedundantManagedAssetId = (id: string) => (
@@ -2620,6 +2611,12 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           const sparkSocialProfile = await DB.getAsset('spark_social_profile');
           const roomCustomAssets = await DB.getAsset('room_custom_assets_list');
 
+          // theme / customIcons / appearancePresets 直接引用运行态 React state。只有
+          // media/full 会走 processObject 原地改，必须先深拷贝，否则会把正在用的系统主题改坏；
+          // text_only 走 stripBase64（返回新树、不改原对象），直接用引用即可，省掉一次
+          // 可能多达数 MB（壁纸 base64）的克隆。
+          const cloneForInPlace = <T,>(v: T): T => (mode === 'text_only' ? v : deepCloneForExport(v));
+
           const backupData: Partial<FullBackupData> = {
               timestamp: Date.now(),
               version: 3,
@@ -2628,12 +2625,12 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               availableModels: (mode === 'text_only' || mode === 'full') ? availableModels : undefined,
               realtimeConfig: (mode === 'text_only' || mode === 'full') ? realtimeConfig : undefined,
               memoryPalaceConfig: (mode === 'text_only' || mode === 'full') ? memoryPalaceConfig : undefined,
-              theme: theme, // Include theme in all modes (text/media)
+              theme: cloneForInPlace(theme), // Include theme in all modes (text/media)
               customIcons: (mode === 'text_only' || mode === 'media_only' || mode === 'full')
-                  ? { ...customIcons }
+                  ? cloneForInPlace(customIcons)
                   : undefined,
               appearancePresets: (mode === 'text_only' || mode === 'media_only' || mode === 'full')
-                  ? appearancePresets.map(p => ({ ...p }))
+                  ? cloneForInPlace(appearancePresets)
                   : undefined,
               
               socialAppData: (mode === 'text_only' || mode === 'media_only' || mode === 'full') ? {
@@ -2764,14 +2761,15 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           const totalSteps = storesToProcess.length + 3;
           let currentStep = 0;
 
-          // Pre-process specialized image fields (Social App, Theme)
+          // Pre-process specialized image fields (Social App, Theme)。processObject 是
+          // 原地改，所以这里按语句调用、不接返回值，读起来就是「就地处理这个对象」。
           if (mode !== 'text_only') {
-              if (backupData.socialAppData?.userProfile) backupData.socialAppData.userProfile = processObject(backupData.socialAppData.userProfile);
-              if (backupData.socialAppData?.userBg) backupData.socialAppData.userBg = processObject(backupData.socialAppData.userBg);
-              if (backupData.roomCustomAssets) backupData.roomCustomAssets = processObject(backupData.roomCustomAssets);
-              if (backupData.theme) backupData.theme = processObject(backupData.theme);
-              if (backupData.customIcons) backupData.customIcons = processObject(backupData.customIcons);
-              if (backupData.appearancePresets) backupData.appearancePresets = processObject(backupData.appearancePresets);
+              if (backupData.socialAppData?.userProfile) processObject(backupData.socialAppData.userProfile);
+              if (backupData.socialAppData?.userBg) processObject(backupData.socialAppData.userBg);
+              if (backupData.roomCustomAssets) processObject(backupData.roomCustomAssets);
+              if (backupData.theme) processObject(backupData.theme);
+              if (backupData.customIcons) processObject(backupData.customIcons);
+              if (backupData.appearancePresets) processObject(backupData.appearancePresets);
           } else {
               // Strip images for text only
               if (backupData.socialAppData?.userProfile) backupData.socialAppData.userProfile = stripBase64(backupData.socialAppData.userProfile);

--- a/utils/backupExport.test.ts
+++ b/utils/backupExport.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractImagesInPlace, deepCloneForExport, EXPORT_CHUNK_SIZE, sliceRanges } from './backupExport';
+
+const IMG = 'data:image/png;base64,AAAA';
+
+describe('extractImagesInPlace', () => {
+    it('原地把 data:image 字符串换成 resolveImage 的返回值（不另起一棵树）', () => {
+        const root = { a: IMG, nested: { b: IMG }, list: ['x', IMG] };
+        const nestedRef = root.nested;
+        extractImagesInPlace(root, () => 'assets/p.png');
+        expect(root.a).toBe('assets/p.png');
+        expect(root.nested.b).toBe('assets/p.png');
+        expect(root.list[1]).toBe('assets/p.png');
+        // 是原地改：对象引用没变
+        expect(root.nested).toBe(nestedRef);
+    });
+
+    it('非 data:image 字符串和其它原始值原样保留', () => {
+        const root = { keep: 'hello', n: 1, b: true, url: 'https://x/y.png' };
+        extractImagesInPlace(root, () => 'assets/SHOULD_NOT_APPEAR.png');
+        expect(root).toEqual({ keep: 'hello', n: 1, b: true, url: 'https://x/y.png' });
+    });
+
+    it('resolveImage 返回原值时（无法抽取的 data url）字符串保持不变', () => {
+        const root = { a: IMG };
+        extractImagesInPlace(root, (v) => v);
+        expect(root.a).toBe(IMG);
+    });
+
+    it('共享子图只处理一次', () => {
+        const shared = { img: IMG };
+        const root = { left: shared, right: shared };
+        const resolve = vi.fn(() => 'assets/p.png');
+        extractImagesInPlace(root, resolve);
+        // shared.img 这个 data url 只被解析一次
+        expect(resolve).toHaveBeenCalledTimes(1);
+        expect(root.left.img).toBe('assets/p.png');
+        expect(root.right).toBe(root.left);
+    });
+
+    it('遇到自引用循环抛出清楚的错误', () => {
+        const a: any = { img: IMG };
+        a.self = a;
+        expect(() => extractImagesInPlace(a, () => 'assets/p.png')).toThrow(/循环引用/);
+    });
+
+    it('遇到多级循环（a→b→a）也抛错', () => {
+        const a: any = {};
+        const b: any = { back: a };
+        a.next = b;
+        expect(() => extractImagesInPlace(a, () => 'assets/p.png')).toThrow(/循环引用/);
+    });
+
+    it('根是数组时也能遍历', () => {
+        const root: any[] = [IMG, { img: IMG }];
+        extractImagesInPlace(root, () => 'assets/p.png');
+        expect(root[0]).toBe('assets/p.png');
+        expect(root[1].img).toBe('assets/p.png');
+    });
+});
+
+describe('deepCloneForExport', () => {
+    it('深拷贝后改副本不影响原对象', () => {
+        const src = { theme: { wallpaper: IMG, nested: { x: 1 } } };
+        const copy = deepCloneForExport(src);
+        copy.theme.wallpaper = 'changed';
+        copy.theme.nested.x = 999;
+        expect(src.theme.wallpaper).toBe(IMG);
+        expect(src.theme.nested.x).toBe(1);
+    });
+});
+
+describe('sliceRanges / EXPORT_CHUNK_SIZE', () => {
+    it('导出分片大小能被 3 整除（base64 拼接不插入中途补位）', () => {
+        expect(EXPORT_CHUNK_SIZE % 3).toBe(0);
+    });
+
+    it('切出的区间连续且覆盖整段', () => {
+        const ranges = sliceRanges(25, 10);
+        expect(ranges).toEqual([[0, 10], [10, 20], [20, 25]]);
+    });
+
+    it('3 字节对齐的分片：各自 base64 后首尾相接，解码回来就是原始字节', () => {
+        const bytes = new Uint8Array(50).map((_, i) => (i * 37) % 256);
+        const concat = sliceRanges(bytes.length, 9) // 9 % 3 === 0
+            .map(([s, e]) => Buffer.from(bytes.slice(s, e)).toString('base64'))
+            .join('');
+        const decoded = new Uint8Array(Buffer.from(concat, 'base64'));
+        expect(Array.from(decoded)).toEqual(Array.from(bytes));
+    });
+
+    it('非 3 字节对齐的分片会在中途分片塞进 = 补位（这就是必须对齐的原因）', () => {
+        const bytes = new Uint8Array(20).map((_, i) => i);
+        const chunksB64 = sliceRanges(bytes.length, 10) // 10 % 3 !== 0
+            .map(([s, e]) => Buffer.from(bytes.slice(s, e)).toString('base64'));
+        // 非末尾分片带上了 '='，拼起来后整体就无法正确解码
+        expect(chunksB64[0]).toContain('=');
+    });
+});

--- a/utils/backupExport.ts
+++ b/utils/backupExport.ts
@@ -1,0 +1,94 @@
+// 备份导出链路的纯函数小工具。这里刻意不碰 DOM / Capacitor / JSZip，
+// 把两块容易出错的逻辑——「原地抽取素材」和「手机端 3 字节对齐分片」——
+// 拆出来，好在 node 测试环境里单测钉住。
+
+/**
+ * 遍历对象树，把所有 `data:image/...` 字符串原地替换成 `resolveImage` 的返回值
+ * （通常是 `assets/*` 路径；无法抽取时原样返回）。直接改传进来的 `root`，所以
+ * 调用方必须传独立副本：IDB getRawStoreData 拿到的是结构化克隆副本（安全），
+ * 而 theme / customIcons / appearancePresets 这类引用了运行态 React state 的，
+ * 必须先深拷贝再传进来。
+ *
+ * 共享子图（同一对象被多处引用）只处理一次；遇到真正的循环引用直接抛错，
+ * 让问题在这里就带着清楚的提示暴露，而不是拖到后面 JSON.stringify 时报一句
+ * 看不懂的 "circular structure"。
+ */
+export function extractImagesInPlace(
+    root: unknown,
+    resolveImage: (dataUrl: string) => string,
+): void {
+    if (root === null || typeof root !== 'object') return;
+
+    // onPath：当前正在遍历的这条路径上的祖先节点（用来判循环）。
+    // done：已经处理完的节点（共享子图第二次碰到就跳过）。
+    const onPath = new WeakSet<object>();
+    const done = new WeakSet<object>();
+    const stack: object[] = [root as object];
+
+    // 处理一个属性/元素：data:image 字符串原地换成路径，对象/数组入栈续遍历，
+    // 碰到还在当前路径上的节点（回边）即循环引用，抛错。定义一次，不在循环里反复重建。
+    const visit = (container: any, key: string | number, v: unknown) => {
+        if (typeof v === 'string') {
+            if (v.startsWith('data:image/')) container[key] = resolveImage(v);
+        } else if (v !== null && typeof v === 'object') {
+            if (onPath.has(v as object)) throw new Error('备份数据存在循环引用，无法导出');
+            if (!done.has(v as object)) stack.push(v as object);
+        }
+    };
+
+    while (stack.length) {
+        // peek 而不是 pop：第一次见到这个节点时入栈它的孩子并留着自己当「出栈标记」，
+        // 等孩子都处理完再次轮到它时，把它移出 onPath、记为 done。
+        const node = stack[stack.length - 1];
+        if (done.has(node)) { stack.pop(); continue; }
+        if (onPath.has(node)) {
+            stack.pop();
+            onPath.delete(node);
+            done.add(node);
+            continue;
+        }
+        onPath.add(node);
+
+        if (Array.isArray(node)) {
+            for (let i = 0; i < node.length; i++) visit(node, i, node[i]);
+        } else {
+            const obj = node as Record<string, unknown>;
+            for (const key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) visit(obj, key, obj[key]);
+            }
+        }
+    }
+}
+
+/**
+ * 给会被原地改的导出数据做一份独立深拷贝。专门用在那些直接引用了运行态
+ * React state 的值（theme / customIcons / appearancePresets）上，避免原地抽取
+ * 素材时把正在用的系统主题等改坏。
+ */
+export function deepCloneForExport<T>(value: T): T {
+    try {
+        if (typeof structuredClone === 'function') return structuredClone(value);
+    } catch {
+        // 个别老 WebView 没有 structuredClone 或克隆失败，落到 JSON 兜底。
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * 手机端分片导出用的原始分片大小：3MiB，且能被 3 整除。
+ *
+ * 为什么必须是 3 的倍数：base64 每 3 字节编码成 4 个字符，正好填满不带 `=` 补位。
+ * 只要每个非末尾分片的字节数是 3 的倍数，各分片各自 base64 后直接首尾相接，
+ * 解码回来就是原始字节；否则中间会插进 `=` 补位，拼起来再解码就对不上了。
+ */
+export const EXPORT_CHUNK_SIZE = 3 * 1024 * 1024;
+
+/** 把总字节长度切成一串连续的 [start, end) 区间，每段长 `chunkSize`（末段可短）。 */
+export function sliceRanges(total: number, chunkSize: number): Array<[number, number]> {
+    if (chunkSize <= 0) throw new Error('chunkSize must be positive');
+    const ranges: Array<[number, number]> = [];
+    for (let start = 0; start < total; start += chunkSize) {
+        ranges.push([start, Math.min(start + chunkSize, total)]);
+    }
+    return ranges;
+}


### PR DESCRIPTION
## 改了什么

备份「导出」链路的崩溃 / 内存问题，三处修复 + 纯逻辑拆出来配单测。

| 场景 | 改前 | 改后 |
|------|------|------|
| 手机端导出 | 整包一次性转 base64 塞进内存，大备份容易撑爆 WebView 闪退；写入还带了 data url 前缀，可能留下打不开的 .zip | 按 3MiB 分片读取、appendFile 追加；先写临时文件，全部落盘成功才改名 + 分享，中途失败删残片 |
| 导出抽取图片 | 每个 store 都另建一棵对象树，峰值内存翻倍 | 原地处理不再建副本；直接引用运行态外观的 theme/customIcons/appearancePresets 先深拷贝再处理，避免改坏正在用的系统主题 |
| web 导出下载链接 | object URL 从不释放，每导一次漏一个，占着整包内存直到刷新页面 | 重新导出 / 关弹窗 / 组件卸载时及时释放 |

## 其它

- 纯逻辑（原地抽取、深拷贝、3 字节对齐分片）拆到 `utils/backupExport.ts`，配 `backupExport.test.ts`：12 个用例覆盖原地替换、共享子图只处理一次、循环引用必抛错、分片 base64 拼接能还原原始字节。
- `text_only` 模式跳过深拷贝（该模式走 stripBase64 不原地改，省掉一次可能数 MB 的克隆）。

## 没动
- 云端「下载」侧的内存峰值（Range 分块落 OPFS）留作单独一轮。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
