### PR TITLE
通话界面键盘弹出不再被顶飞：消费 --keyboard-inset 抬升内容

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -1259,7 +1259,9 @@ const CallApp: React.FC = () => {
             style={{ top: p.top, left: p.left, width: p.s, height: p.s, opacity: 0.5, animationDelay: `${i * 0.4}s`, boxShadow: `0 0 6px ${accentColor}` }} />
         ))}
       </div>
-      <div className="relative z-10 flex flex-col h-full">
+      <div className="relative z-10 flex flex-col h-full" style={{ paddingBottom: 'var(--keyboard-inset, 0px)', transition: 'padding-bottom 0.18s ease-out' }}>
+        {/* keyboard-inset：键盘弹起时把整列内容抬到键盘上方，避免浏览器把界面整体顶飞
+            （Chrome 等浏览器未生效 interactive-widget=resizes-content 时的兜底） */}
       {/* top channel bar */}
       <div className="relative px-5" style={{ paddingTop: 'max(2.25rem, var(--safe-top))' }}>
         <div className="absolute left-5 leading-tight" style={{ top: 'max(2.25rem, var(--safe-top))' }}>


### PR DESCRIPTION
非 iOS（Chrome 等）下整个 app 内层是 fixed inset-0、钉在布局视口上。当浏览器 未生效 interactive-widget=resizes-content（键盘改覆盖模式）时，输入框被键盘 盖住，浏览器为露出它把可视视口整体上顶 → 界面飞走。

iosStandalone.ts 早已算出 --keyboard-inset（键盘遮挡高度）但全项目无人消费。 这里把它接到通话主界面内容容器的 paddingBottom：键盘弹起时整列内容抬到键盘
上方，输入框落入可视区，浏览器无需滚动。resizes-content 生效时 inset≈0，无副作用。

- apps/CallApp.tsx


Claude-Session: https://claude.ai/code/session_01FuvcKdZPyzPMKPeL64chBb