### PR TITLE
家园：观测重 roll 后支持手动补发到聊天 + 清理过期朋友圈评论

### DIFF
--- a/apps/WorldHomeApp.tsx
+++ b/apps/WorldHomeApp.tsx
@@ -23,7 +23,7 @@ import {
 import { DB } from '../utils/db';
 import { getChibi } from '../utils/vrWorld/chibi';
 import { WorldScheduler } from '../utils/worldHome/scheduler';
-import { isWorldRunning } from '../utils/worldHome/engine';
+import { isWorldRunning, injectWorldCard } from '../utils/worldHome/engine';
 import { worldTimeLabel, isNightWorld, houseOf, NARRATIVE_STYLES, buildNpcRollPrompt, parseRolledNpcs, realObserveTarget } from '../utils/worldHome/prompts';
 import { SIM_CHAPTER_DAYS, SIM_CHAPTER_CLOCKS } from '../utils/worldHome/chapters';
 import { dmThreadsOf, groupThreadOf } from '../utils/worldHome/threads';
@@ -40,7 +40,8 @@ import type { WorldProfile, WorldEpisode, WorldHomeMode, WorldTimeMode, WorldHou
 type WHEditTarget =
     | { type: 'post'; round: number; charId: string; idx: number }
     | { type: 'memo'; round: number; charId: string; idx: number }
-    | { type: 'msg'; threadId: string; msgId: string };
+    | { type: 'msg'; threadId: string; msgId: string }
+    | { type: 'comment'; key: string; idx: number };
 
 /** 自定义文风的本地收藏 / 家园全局 API 的 localStorage key —— 与备份工具共用同一组，避免漂移。 */
 const CUSTOM_STYLE_KEY = WORLD_CUSTOM_STYLE_KEY;
@@ -390,7 +391,15 @@ const PhoneModal: React.FC<{
                                                             {rx && rx.comments.length > 0 && (
                                                                 <div className="mt-1.5 rounded-lg bg-slate-50 px-2.5 py-1.5 space-y-1">
                                                                     {rx.comments.map((c, ci) => (
-                                                                        <p key={ci} className="text-[10.5px] leading-snug text-slate-600"><span className="font-bold text-slate-700">{c.from}</span>：{c.text}</p>
+                                                                        <div key={ci} className="group flex items-start gap-1">
+                                                                            <p className="flex-1 text-[10.5px] leading-snug text-slate-600"><span className="font-bold text-slate-700">{c.from}</span>：{c.text}</p>
+                                                                            {onEditContent && (
+                                                                                <button onClick={() => onEditContent({ type: 'comment', key: f.key, idx: ci }, null)}
+                                                                                    className="shrink-0 mt-px text-slate-300 active:text-rose-500 active:scale-90 transition" title="删除这条评论">
+                                                                                    <X size={11} weight="bold" />
+                                                                                </button>
+                                                                            )}
+                                                                        </div>
                                                                     ))}
                                                                 </div>
                                                             )}
@@ -992,7 +1001,8 @@ const ResidentDayCard: React.FC<{
     onPhone: () => void;
     onDirective: (impulseText: string, text: string) => void;
     onReroll?: () => void;
-}> = ({ char, beat: b, t, world, onPhone, onDirective, onReroll }) => {
+    onInject?: () => void;
+}> = ({ char, beat: b, t, world, onPhone, onDirective, onReroll, onInject }) => {
     const [open, setOpen] = useState(false);
     if (!b) {
         return (
@@ -1103,10 +1113,19 @@ const ResidentDayCard: React.FC<{
                             ))}
                         </div>
                     )}
-                    {onReroll && (
-                        <button onClick={onReroll} className={`mt-1 flex items-center gap-1 text-[10px] font-bold px-2.5 py-1 rounded-lg border ${t.chip} active:scale-95 transition-transform`}>
-                            <Sparkle size={11} weight="fill" className="text-violet-500" />重演这一段
-                        </button>
+                    {(onReroll || onInject) && (
+                        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                            {onReroll && (
+                                <button onClick={onReroll} className={`flex items-center gap-1 text-[10px] font-bold px-2.5 py-1 rounded-lg border ${t.chip} active:scale-95 transition-transform`}>
+                                    <Sparkle size={11} weight="fill" className="text-violet-500" />重演这一段
+                                </button>
+                            )}
+                            {onInject && (
+                                <button onClick={onInject} className={`flex items-center gap-1 text-[10px] font-bold px-2.5 py-1 rounded-lg border ${t.chip} active:scale-95 transition-transform`} title="把这段观测补发到和 ta 的聊天里（重 roll 后保底用）">
+                                    <PaperPlaneTilt size={11} weight="fill" className="text-sky-500" />发到聊天
+                                </button>
+                            )}
+                        </div>
                     )}
                 </div>
             )}
@@ -1201,6 +1220,20 @@ const WorldView: React.FC<{
         setRerollTarget(null); setRerollDir('');
     };
 
+    // 手动把某角色最新一拍补发到「和 ta 的聊天」（保底）：重 roll 后不会自动注入 world_card，
+    // 删掉旧卡片想换上新观测、或当时漏注入时，点这里补一张进上下文与记忆。
+    const injectBeatToChat = async (charId: string) => {
+        if (!latest) { addToast('还没有可发送的观测', 'error'); return; }
+        const beat = latest.beats.find(b => b.charId === charId);
+        if (!beat) { addToast('这一轮 ta 还没演出来', 'error'); return; }
+        try {
+            await injectWorldCard(world, beat, latest.round, latest.storyTime);
+            addToast(`已把这段观测发到和 ${beat.charName} 的聊天里`, 'success');
+        } catch {
+            addToast('发送失败，稍后再试', 'error');
+        }
+    };
+
     // 拜访视图的住房编排：配置的小屋 + 没分配的成员各自独居
     const visitHouses = useMemo(() => {
         const out: { house: WorldHouse; residents: CharacterProfile[] }[] = [];
@@ -1225,6 +1258,19 @@ const WorldView: React.FC<{
 
     /** 编辑/删除手机里的生成内容（动态/备忘落 episode；私聊/群聊落 world.threads）。newText=null 表示删除。 */
     const applyContentEdit = async (target: WHEditTarget, newText: string | null) => {
+        if (target.type === 'comment') {
+            // 朋友圈评论删除：feedReactions[key].comments 按下标删一条；删空了就把整条反应去掉
+            const rx = world.feedReactions?.[target.key];
+            if (!rx) return;
+            const comments = rx.comments.filter((_, i) => i !== target.idx);
+            const fr = { ...world.feedReactions };
+            if (comments.length === 0 && !rx.likes) delete fr[target.key];
+            else fr[target.key] = { ...rx, comments };
+            await DB.saveWorld({ ...world, feedReactions: fr, updatedAt: Date.now() });
+            onWorldUpdated();
+            addToast('已删除', 'success');
+            return;
+        }
         if (target.type === 'post' || target.type === 'memo') {
             const ep = episodes.find(e => e.round === target.round);
             const beat = ep?.beats.find(b => b.charId === target.charId);
@@ -1552,6 +1598,7 @@ const WorldView: React.FC<{
                                                     onPhone={() => setPhoneView({ ownerId: r.id })}
                                                     onDirective={(impulseText, text) => sendDirective(r.id, impulseText, text)}
                                                     onReroll={latest?.beats.some(b => b.charId === r.id) ? () => { setRerollDir(''); setRerollTarget({ charId: r.id, charName: r.name }); } : undefined}
+                                                    onInject={world.timeMode !== 'sim' && world.injectToChat !== false && latest?.beats.some(b => b.charId === r.id) ? () => injectBeatToChat(r.id) : undefined}
                                                 />
                                             ))}
                                         </div>

--- a/utils/worldHome/engine.ts
+++ b/utils/worldHome/engine.ts
@@ -215,6 +215,39 @@ function buildCardContent(world: WorldProfile, storyTime: string, beat: WorldCha
     return lines.join('\n');
 }
 
+/** 组装某一拍的 world_card metadata（与彼方 vr_card 同构，注入聊天 / 进记忆用）。 */
+export function buildWorldCardMeta(world: WorldProfile, beat: WorldCharBeat, round: number, storyTime: string): WorldCardMeta {
+    return {
+        worldCard: true,
+        worldId: world.id,
+        worldName: world.name,
+        mode: world.mode,
+        round,
+        storyTime,
+        location: beat.location,
+        mood: beat.mood,
+        narrative: beat.narrative,
+        statusPanel: beat.statusPanel,
+        timeline: beat.timeline,
+        memo: beat.memo,
+        impulse: beat.impulse,
+        phonePosts: beat.phone?.posts,
+        phoneGroup: beat.phone?.group,
+    };
+}
+
+/**
+ * 把某一拍作为 world_card 注入这名角色的 1v1 聊天（进上下文与记忆）。
+ * 自动演绎、单拍补发都走这里——保证格式一致，也方便 UI 做「手动发送保底」。
+ */
+export async function injectWorldCard(world: WorldProfile, beat: WorldCharBeat, round: number, storyTime: string): Promise<void> {
+    await DB.saveMessage({
+        charId: beat.charId, role: 'assistant', type: 'world_card',
+        content: buildCardContent(world, storyTime, beat),
+        metadata: buildWorldCardMeta(world, beat, round, storyTime),
+    });
+}
+
 export async function runWorldEpisode(deps: WorldEpisodeDeps): Promise<WorldEpisodeResult> {
     const { world, characters, apiConfig, userProfile, groups, realtimeConfig, memoryPalaceConfig, trigger } = deps;
 
@@ -452,28 +485,8 @@ export async function runWorldEpisode(deps: WorldEpisodeDeps): Promise<WorldEpis
         // ── 4. world_card 注入各成员 1v1 聊天（与彼方 vr_card 同构；sim 模式不进记忆，跳过） ──
         if (entersMemory) {
             for (const beat of beats) {
-                const meta: WorldCardMeta = {
-                    worldCard: true,
-                    worldId: world.id,
-                    worldName: world.name,
-                    mode: world.mode,
-                    round: episode.round,
-                    storyTime,
-                    location: beat.location,
-                    mood: beat.mood,
-                    narrative: beat.narrative,
-                    statusPanel: beat.statusPanel,
-                    timeline: beat.timeline,
-                    memo: beat.memo,
-                    impulse: beat.impulse,
-                    phonePosts: beat.phone?.posts,
-                    phoneGroup: beat.phone?.group,
-                };
                 try {
-                    await DB.saveMessage({
-                        charId: beat.charId, role: 'assistant', type: 'world_card',
-                        content: buildCardContent(world, storyTime, beat), metadata: meta,
-                    });
+                    await injectWorldCard(world, beat, episode.round, storyTime);
                 } catch (e) {
                     console.error(`[WorldHome] card inject failed for ${beat.charName}:`, e);
                 }
@@ -585,23 +598,31 @@ export async function rerollWorldCharBeat(
         };
         await DB.saveWorldEpisode(updatedEp);
 
+        // 重演会换掉这一拍的动态，但点赞/评论按 `round_charId_idx` 关联——不清掉旧反应，
+        // 上一次的评论就会原样挂到新动态上（评论对不上号）。这里把这名角色这一轮的反应全抹掉；
+        // 重演不再跑 NPC 引擎，新动态先没有互动也好过挂错评论。
+        let worldDirty = false;
+        if (world.feedReactions) {
+            const prefix = `${episode.round}_${charId}_`;
+            const kept = Object.fromEntries(Object.entries(world.feedReactions).filter(([k]) => !k.startsWith(prefix)));
+            if (Object.keys(kept).length !== Object.keys(world.feedReactions).length) {
+                world.feedReactions = kept;
+                worldDirty = true;
+            }
+        }
+
         // 仅当之前是「失败缺这拍」时补副作用，避免对已有拍重复加好感/重复消息
         if (!hadBeat) {
             applyBeatToThreads(world, beat, members, episode.round, episode.storyTime);
             collectSeeds(world, beat, episode.round, episode.storyTime);
             applyRelationshipDeltas(world, [beat], members);
-            await DB.saveWorld({ ...world, threads: world.threads, seeds: world.seeds, relationships: world.relationships, updatedAt: Date.now() });
+            worldDirty = true;
             if (world.timeMode !== 'sim' && world.injectToChat !== false) {
-                const meta: WorldCardMeta = {
-                    worldCard: true, worldId: world.id, worldName: world.name, mode: world.mode,
-                    round: episode.round, storyTime: episode.storyTime, location: beat.location, mood: beat.mood,
-                    narrative: beat.narrative, statusPanel: beat.statusPanel, timeline: beat.timeline, memo: beat.memo,
-                    impulse: beat.impulse, phonePosts: beat.phone?.posts, phoneGroup: beat.phone?.group,
-                };
-                try {
-                    await DB.saveMessage({ charId: beat.charId, role: 'assistant', type: 'world_card', content: buildCardContent(world, episode.storyTime, beat), metadata: meta });
-                } catch { /* ignore */ }
+                try { await injectWorldCard(world, beat, episode.round, episode.storyTime); } catch { /* ignore */ }
             }
+        }
+        if (worldDirty) {
+            await DB.saveWorld({ ...world, threads: world.threads, seeds: world.seeds, relationships: world.relationships, feedReactions: world.feedReactions, updatedAt: Date.now() });
         }
         dispatch('world-episode-done', { worldId: world.id, episodeId: updatedEp.id, storyTime: episode.storyTime, round: episode.round });
         return { ok: true, episode: updatedEp };


### PR DESCRIPTION
小屋家园系统两处体验修复：

1. 手动「发到聊天」保底：重 roll 一拍时为避免重复加好感/重复消息， 不会自动再注入 world_card。但用户删掉旧观测卡片想换上新观测时就 没法进上下文了。现在每个角色的当轮演绎下方加「发到聊天」按钮， 手动把这段观测补发进 1v1 聊天（进上下文与记忆）。注入逻辑抽出 injectWorldCard，自动演绎与手动补发共用，保证格式一致。

2. 重 roll 后清掉过期朋友圈评论：点赞/评论按 round_charId_idx 关联， 重演换掉动态后旧评论会原样挂到新动态上（对不上号）。现在重演时 抹掉这名角色这一轮的 feedReactions——重演不再跑 NPC 引擎，新动态 先没有互动也好过挂错评论。

3. 朋友圈评论现在可手动删除（此前只能删动态/群聊，评论删不掉）： 手机动态里每条评论加删除按钮，删空且无赞时整条反应一并清掉。


Claude-Session: https://claude.ai/code/session_01KtNZkHZ8h8kaLMva3tGAtp