### PR TITLE
聊天：呼出键盘后顶栏置顶、可视区缩到键盘上方，输入栏贴键盘

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -1261,7 +1261,8 @@ const CallApp: React.FC = () => {
       </div>
       <div className="relative z-10 flex flex-col h-full" style={{ paddingBottom: 'var(--keyboard-inset, 0px)', transition: 'padding-bottom 0.18s ease-out' }}>
         {/* keyboard-inset：键盘弹起时把整列内容抬到键盘上方，避免浏览器把界面整体顶飞
-            （Chrome 等浏览器未生效 interactive-widget=resizes-content 时的兜底） */}
+            （Chrome 等浏览器未生效 interactive-widget=resizes-content 时的兜底）。
+            iOS 全屏 PWA 下 keyboard-inset 恒为 0，键盘避让改由 app 高度跟随可视区统一处理（见 utils/iosStandalone.ts）。 */}
       {/* top channel bar */}
       <div className="relative px-5" style={{ paddingTop: 'max(2.25rem, var(--safe-top))' }}>
         <div className="absolute left-5 leading-tight" style={{ top: 'max(2.25rem, var(--safe-top))' }}>

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -810,7 +810,7 @@ const PhoneShell: React.FC = () => {
           - 已迁移 App（彼方/聊天/群聊/桌面）：自理安全区。外壳直接把底边收回到可见 viewport
             （bottom = --standalone-safe-area-bottom），不让那多出来的 34px 把 App 底部控件压到 home 条上。 */}
       <div
-        className="absolute top-0 left-0 right-0 z-10 overflow-hidden bg-transparent overscroll-none flex flex-col"
+        className="sully-shell-content absolute top-0 left-0 right-0 z-10 overflow-hidden bg-transparent overscroll-none flex flex-col"
         style={
           shellPadsSafeArea
             ? { bottom: 0, paddingTop: 'var(--safe-top)', paddingBottom: 'var(--safe-bottom)' }

--- a/index.html
+++ b/index.html
@@ -218,6 +218,18 @@
       .pb-safe {
         padding-bottom: var(--safe-bottom);
       }
+      /* 软键盘弹出时（iosStandalone 在 body 上挂 .ios-keyboard-open），收掉底部给 home 条留的 safe 间隙，
+         让聊天输入栏直接贴住键盘：① 外壳容器不再把底边钉在 safe 上方，铺到可视区底；② 输入栏收掉自己的 pb-safe 白条。
+         键盘收起后 class 移除，两者各自回到 safe 让位。app 高度跟随可视区由 utils/iosStandalone.ts 处理。 */
+      .sully-chat-inputbar {
+        transition: padding-bottom 0.18s ease-out;
+      }
+      body.ios-keyboard-open .sully-shell-content {
+        bottom: 0 !important;
+      }
+      body.ios-keyboard-open .sully-chat-inputbar {
+        padding-bottom: 0;
+      }
     </style>
   <script type="importmap">
 {

--- a/index.html
+++ b/index.html
@@ -220,7 +220,8 @@
       }
       /* 软键盘弹出时（iosStandalone 在 body 上挂 .ios-keyboard-open），收掉底部给 home 条留的 safe 间隙，
          让聊天输入栏直接贴住键盘：① 外壳容器不再把底边钉在 safe 上方，铺到可视区底；② 输入栏收掉自己的 pb-safe 白条。
-         键盘收起后 class 移除，两者各自回到 safe 让位。app 高度跟随可视区由 utils/iosStandalone.ts 处理。 */
+         键盘收起后 class 移除，两者各自回到 safe 让位。app 高度跟随可视区由 utils/iosStandalone.ts 处理。
+         （外壳 bottom 用 !important 盖过 PhoneShell 给它设的 inline style。） */
       .sully-chat-inputbar {
         transition: padding-bottom 0.18s ease-out;
       }

--- a/utils/iosStandalone.ts
+++ b/utils/iosStandalone.ts
@@ -77,24 +77,34 @@ const setViewportVars = () => {
     const safeInsets = shouldStabilizeHeight ? readSafeAreaInsets() : { top: 0, bottom: 0 };
     const bottomSafeInset = safeInsets.bottom;
     const topSafeInset = shouldStabilizeHeight ? (safeInsets.top > 0 ? safeInsets.top : 44) : 0;
-    const obscuredHeight = Math.max(0, innerHeight - viewportHeight - viewportOffsetTop);
-    const keyboardInset = obscuredHeight > 120 ? obscuredHeight : 0;
-    const nextViewportHeight = Math.max(innerHeight, viewportHeight + viewportOffsetTop);
+
+    let fullAppHeight: number;
+    let keyboardInset: number;
 
     if (shouldStabilizeHeight) {
-        if (!keyboardInset || !stableStandaloneHeight) {
-            stableStandaloneHeight = nextViewportHeight;
+        // 全屏 PWA 没有地址栏，可视高度只在软键盘弹出时变矮。基线取「见过的最大可视高度」。
+        if (!stableStandaloneHeight || viewportHeight > stableStandaloneHeight) {
+            stableStandaloneHeight = viewportHeight;
+        }
+        // 键盘态判据用「可视高度变矮」而非 obscuredHeight：iOS 26 起 standalone 会把 layout viewport 也一起缩，
+        // innerHeight 跟着变矮，obscuredHeight 算出来是 0 而失效。viewportHeight > 150 是对 iOS 偶发脏值的护栏——
+        // 键盘动画期 visualViewport 偶尔报错值，此时退化成「无键盘态」，宁可不避让也不要把布局撑崩成满屏白。
+        const keyboardOpen = viewportHeight > 150 && viewportHeight < stableStandaloneHeight - 100;
+        // 键盘态：app 高度收到当前可视区（home 条已被键盘盖，不再叠加 safe）；无键盘态：基线 + safe（底部给 home 条留位）。
+        fullAppHeight = keyboardOpen ? viewportHeight : stableStandaloneHeight + bottomSafeInset;
+        // standalone 下键盘避让改由「app 高度跟随可视区」统一处理，keyboard-inset 置 0，避免 CallApp 等再叠一层 padding。
+        keyboardInset = 0;
+        // iOS 26 键盘弹出会把整页顶上去（visualViewport.offsetTop > 0），拉回顶部对齐可视区；
+        // 配合 ios-keyboard-open 下的 touchmove 拦截（见 installIOSStandaloneWorkaround），把外层滚动彻底锁死。
+        if (keyboardOpen && viewportOffsetTop > 0) {
+            window.scrollTo(0, 0);
         }
     } else {
         stableStandaloneHeight = 0;
+        const obscuredHeight = Math.max(0, innerHeight - viewportHeight - viewportOffsetTop);
+        keyboardInset = obscuredHeight > 120 ? obscuredHeight : 0;
+        fullAppHeight = Math.max(innerHeight, viewportHeight + viewportOffsetTop);
     }
-
-    const appHeight = shouldStabilizeHeight
-        ? (stableStandaloneHeight || nextViewportHeight)
-        : nextViewportHeight;
-    const fullAppHeight = shouldStabilizeHeight
-        ? appHeight + bottomSafeInset
-        : appHeight;
 
     document.documentElement.style.setProperty('--app-height', `${fullAppHeight}px`);
     document.documentElement.style.setProperty('--visual-viewport-height', `${viewportHeight}px`);
@@ -152,6 +162,15 @@ export const installIOSStandaloneWorkaround = () => {
         }, 180);
     };
 
+    // 键盘弹出时锁死外层滚动：只放行可滚区（消息列表等 .overflow-y-auto）内部滚动，其余 touchmove 一律拦掉。
+    // 不锁的话 iOS 会在输入框聚焦时随手势把整页顶飞（visualViewport.offsetTop 漂移、露出底层色块、闪烁）。
+    const handleTouchMove = (event: TouchEvent) => {
+        if (!document.body.classList.contains('ios-keyboard-open')) return;
+        const target = event.target as Element | null;
+        if (target?.closest?.('.overflow-y-auto')) return;
+        event.preventDefault();
+    };
+
     window.addEventListener('resize', handleSafeAreaChange);
     window.addEventListener('orientationchange', handleSafeAreaChange);
     window.visualViewport?.addEventListener('resize', handleViewportChange);
@@ -159,6 +178,7 @@ export const installIOSStandaloneWorkaround = () => {
     if (useStandaloneFixes) {
         document.addEventListener('focusin', handleFocusIn);
         document.addEventListener('focusout', handleFocusOut);
+        document.addEventListener('touchmove', handleTouchMove, { passive: false });
     }
     setViewportVars();
 

--- a/utils/iosStandalone.ts
+++ b/utils/iosStandalone.ts
@@ -167,7 +167,7 @@ export const installIOSStandaloneWorkaround = () => {
     const handleTouchMove = (event: TouchEvent) => {
         if (!document.body.classList.contains('ios-keyboard-open')) return;
         const target = event.target as Element | null;
-        if (target?.closest?.('.overflow-y-auto')) return;
+        if (target?.closest('.overflow-y-auto')) return;
         event.preventDefault();
     };
 


### PR DESCRIPTION
## 改了什么
iOS 全屏 PWA（加主屏幕打开）下呼出软键盘时的聊天页布局，对齐 Telegram 式体验。

## 改后是怎样
- 顶部联系人栏置顶不动
- 消息可滚范围收到「顶栏以下、键盘以上」，只在这段内滚动
- 输入栏直接贴住键盘，去掉与键盘之间多出的 home 条让位间隙
- 外层滚动锁定，不再被系统把整页顶飞、不再露出底层色块

## 实现
让 app 高度跟随 visualViewport 可视区，键盘态收掉外壳与输入栏的 safe 让位、锁住外层 touchmove（只放行消息列表内部滚动）。对 iOS 26 偶发的视口脏值加护栏，取到异常值时退化为不避让而非把布局撑崩。

涉及 `utils/iosStandalone.ts`、`index.html`、`components/PhoneShell.tsx`；`CallApp` 注释同步说明 standalone 下 keyboard-inset 归零、改由 app 高度统一避让。

🤖 Generated with [Claude Code](https://claude.com/claude-code)