### PR TITLE
fix(dateapp): 见面模式上下文取数对齐 chatapp，避免输入超量

### DIFF
--- a/apps/DateApp.tsx
+++ b/apps/DateApp.tsx
@@ -287,19 +287,23 @@ const DateApp: React.FC = () => {
         }
         
         // 2. Prepare Context
-        // Re-fetch messages. Since we saved the opening in handleEnterSession,
-        // 'allMsgs' will now correctly contain: [History..., Opening, UserMsg]
+        // 展示用全量（见面记录需要全部 source='date' 消息）
         const allMsgs = await DB.getMessagesByCharId(char.id, true);
-        
+
         // Update local state for display
         const dateFiltered = allMsgs.filter(m => m.metadata?.source === 'date').sort((a,b) => a.timestamp - b.timestamp);
         setDateMessages(dateFiltered);
+
+        // 发给 LLM 的上下文与 chatapp 对齐：用有界 + 记忆宫殿排除的 getRecentMessagesByCharId
+        // （contextLimit 条、includeProcessed=false），而不是把整段历史一次性塞进请求——
+        // 后者在长历史 / 大 contextLimit 下会一次发出近全量消息（见 919 条），直接撑爆输入上限。
+        const contextMsgs = await DB.getRecentMessagesByCharId(char.id, char.contextLimit || 500);
 
         const emojis = await DB.getEmojis();
         const { messages } = await DatePrompts.buildSessionPayload({
             char,
             userProfile,
-            allMsgs,
+            allMsgs: contextMsgs,
             emojis,
             userText: text,
             variant: 'send',
@@ -329,8 +333,9 @@ const DateApp: React.FC = () => {
         await DB.deleteMessage(lastMsg.id);
         
         // 2. Find the user input that triggered it
-        const allMsgs = await DB.getMessagesByCharId(char.id, true);
-        const validMsgs = allMsgs.filter(m => m.id !== lastMsg.id);
+        // 与 handleSendMessage 一致：发给 LLM 的上下文走有界 + 记忆宫殿排除的取数，与 chatapp 对齐
+        const contextMsgs = await DB.getRecentMessagesByCharId(char.id, char.contextLimit || 500);
+        const validMsgs = contextMsgs.filter(m => m.id !== lastMsg.id);
         const lastUserMsg = validMsgs[validMsgs.length - 1];
         
         if (!lastUserMsg || lastUserMsg.role !== 'user') throw new Error("Context lost");


### PR DESCRIPTION
见面 session 路径用 getMessagesByCharId(charId, true)（全量、 includeProcessed=true）加载历史，唯一兜底是 buildDateHistory 里的 slice(-contextLimit)。在长历史 + 大 contextLimit（默认 1000）下，这等于 把整段历史（实测 919 条）一次性塞进单次请求，直接撑爆模型输入上限 →
上游返回 502 / bad_response_status_code（即「输入超量」）。私聊正常， 是因为它走有界 + 记忆宫殿排除的 getRecentMessagesByCharId。

handleSendMessage / handleReroll 改为与 chatapp 一致：发给 LLM 的上下文 用 getRecentMessagesByCharId(charId, char.contextLimit || 500) （includeProcessed=false），全量历史仅保留给见面记录展示。
这样 buildDateHistory 与 injectMemoryPalace 拿到的窗口都与私聊对齐。


Claude-Session: https://claude.ai/code/session_01KD7mMjJgZbHYkSiuYFd6vK