### PR TITLE
fix(date/call): 补 max_tokens，修复见面/通话接 Claude 中转报 502

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -682,6 +682,9 @@ const CallApp: React.FC = () => {
         model: apiConfig.model,
         messages: [{ role: 'system', content: systemPrompt }, ...messages],
         temperature: 0.85,
+        // max_tokens 是 Claude 原生 API 的必填字段；缺了它，OpenAI→Claude 中转会被
+        // 上游打回，包成 502 / bad_response_status_code。与私聊 (useChatAI.ts) 对齐。
+        max_tokens: 8000,
         stream: false,
       }),
     }, 2, 0, { appName: '电话', charId: selectedChar?.id, charName: selectedChar?.name, purpose: '语音通话' });

--- a/apps/DateApp.tsx
+++ b/apps/DateApp.tsx
@@ -105,6 +105,10 @@ const DateApp: React.FC = () => {
                 model: apiConfig.model,
                 messages,
                 temperature,
+                // max_tokens 是 Claude 原生 API 的必填字段；缺了它，糯米机/Csy 等
+                // OpenAI→Claude 中转会被上游打回，再包成 502 / bad_response_status_code。
+                // 与私聊 (useChatAI.ts) 对齐，统一带 8000。
+                max_tokens: 8000,
                 stream: apiConfig.stream ?? false,
             })
         });
@@ -287,23 +291,19 @@ const DateApp: React.FC = () => {
         }
         
         // 2. Prepare Context
-        // 展示用全量（见面记录需要全部 source='date' 消息）
+        // Re-fetch messages. Since we saved the opening in handleEnterSession,
+        // 'allMsgs' will now correctly contain: [History..., Opening, UserMsg]
         const allMsgs = await DB.getMessagesByCharId(char.id, true);
 
         // Update local state for display
         const dateFiltered = allMsgs.filter(m => m.metadata?.source === 'date').sort((a,b) => a.timestamp - b.timestamp);
         setDateMessages(dateFiltered);
 
-        // 发给 LLM 的上下文与 chatapp 对齐：用有界 + 记忆宫殿排除的 getRecentMessagesByCharId
-        // （contextLimit 条、includeProcessed=false），而不是把整段历史一次性塞进请求——
-        // 后者在长历史 / 大 contextLimit 下会一次发出近全量消息（见 919 条），直接撑爆输入上限。
-        const contextMsgs = await DB.getRecentMessagesByCharId(char.id, char.contextLimit || 500);
-
         const emojis = await DB.getEmojis();
         const { messages } = await DatePrompts.buildSessionPayload({
             char,
             userProfile,
-            allMsgs: contextMsgs,
+            allMsgs,
             emojis,
             userText: text,
             variant: 'send',
@@ -333,9 +333,8 @@ const DateApp: React.FC = () => {
         await DB.deleteMessage(lastMsg.id);
         
         // 2. Find the user input that triggered it
-        // 与 handleSendMessage 一致：发给 LLM 的上下文走有界 + 记忆宫殿排除的取数，与 chatapp 对齐
-        const contextMsgs = await DB.getRecentMessagesByCharId(char.id, char.contextLimit || 500);
-        const validMsgs = contextMsgs.filter(m => m.id !== lastMsg.id);
+        const allMsgs = await DB.getMessagesByCharId(char.id, true);
+        const validMsgs = allMsgs.filter(m => m.id !== lastMsg.id);
         const lastUserMsg = validMsgs[validMsgs.length - 1];
         
         if (!lastUserMsg || lastUserMsg.role !== 'user') throw new Error("Context lost");


### PR DESCRIPTION
见面(DateApp)与通话(CallApp)的请求体只发了 model/messages/temperature/stream， 漏了 max_tokens。max_tokens 是 Claude 原生 Messages API 的必填字段，糯米机/Csy 等 OpenAI→Claude 中转在翻译请求时缺这个字段会被上游打回，再包成
502 / bad_response_status_code（表现为「输入超量」但其实与体积无关—— 实测见面 token 比私聊更少照样报错，且换任意 Claude 中转都复现）。

私聊(useChatAI.ts:771)一直带 max_tokens:8000 所以正常。这里与之对齐。

同时回退上一版基于「上下文过大」误判做的 getRecentMessagesByCharId 改动， 恢复见面原本的全量取数（injectMemoryPalace 需要全集），只保留真正的修复。


Claude-Session: https://claude.ai/code/session_01KD7mMjJgZbHYkSiuYFd6vK