### PR TITLE
feat(backup): v2 分片格式，消除大账号导出 RangeError 硬崩

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -3,6 +3,8 @@ import React, { createContext, useContext, useEffect, useState, useRef, useCallb
 import { APIConfig, AppID, OSTheme, VirtualTime, CharacterProfile, ChatTheme, Toast, FullBackupData, UserProfile, ApiPreset, GroupProfile, SystemLog, Worldbook, NovelBook, SongSheet, Message, RealtimeConfig, AppearancePreset, CloudBackupConfig, CloudBackupFile } from '../types';
 import { DB } from '../utils/db';
 import { extractImagesInPlace, deepCloneForExport } from '../utils/backupExport';
+import { writeV2Backup, assembleV2Backup, type BackupManifest, type ZipFileWriter, type ZipFileReader } from '../utils/backupFormat';
+import { encodeVectorsForBackup } from '../utils/memoryPalace/db';
 import { ProactiveChat } from '../utils/proactiveChat';
 import { VRScheduler } from '../utils/vrWorld/scheduler';
 import { runVRSession } from '../utils/vrWorld/runSession';
@@ -42,14 +44,15 @@ const normalizeProactiveAiContent = (raw: string): string => {
 
 
 type JSZipFileLike = {
-  async: (type: 'string' | 'base64') => Promise<string>;
+  async(type: 'string' | 'base64'): Promise<string>;
+  async(type: 'uint8array'): Promise<Uint8Array>;
 };
 
 type JSZipLike = {
   folder: (name: string) => { file: (name: string, data: string, options?: { base64?: boolean }) => void } | null;
   file: {
     (name: string): JSZipFileLike | null;
-    (name: string, data: string, options?: { base64?: boolean }): void;
+    (name: string, data: string | Uint8Array, options?: { base64?: boolean }): void;
   };
   generateAsync: (
     options: {
@@ -2832,6 +2835,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               return result;
           };
 
+          // 向量二进制旁路（#2）：memory_vectors 归一化拼成 bin + 索引（逻辑在 encodeVectorsForBackup，
+          // 那边有 ensureFloat32 统一 Uint8Array / Float32Array / 遗留 number[] 三态），导出收尾交给
+          // writeV2Backup 落进 zip——不进 backupData、不当普通数组分片，避开 number[] 进 JSON 的膨胀。
+          let vectorPayload: ReturnType<typeof encodeVectorsForBackup> | undefined;
+
           for (const storeName of storesToProcess) {
               currentStep++;
               setSysOperation({
@@ -2843,6 +2851,14 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               let rawData = await DB.getRawStoreData(storeName);
               let processedData: any;
 
+              // 向量旁路：归一化拼 bin + 索引，不进 backupData（writeV2Backup 收尾落 zip）。直接跳过
+              // 下面的图片处理 / switch（向量无图、无 image base64）。
+              if (storeName === 'memory_vectors') {
+                  vectorPayload = encodeVectorsForBackup(Array.isArray(rawData) ? rawData : []);
+                  await new Promise(resolve => setTimeout(resolve, 10));
+                  continue;
+              }
+
               // --- MODE SPECIFIC FILTERING ---
 
               if (storeName === 'assets' && Array.isArray(rawData)) {
@@ -2853,29 +2869,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               }
 
               // Fast path: stores with no image data skip expensive recursive traversal
+              // （memory_vectors 已在上面走二进制旁路 continue 掉，这里只剩其它无图 store）
               if (noImageStores.has(storeName)) {
-                  if (storeName === 'memory_vectors' && Array.isArray(rawData)) {
-                      // 向量在 IndexedDB 里是 Uint8Array（Float32 原始字节）或老
-                      // number[]，JSON.stringify 没法序列化 Uint8Array（结果是 {}）
-                      // 所以这里统一解码成 plain number[]，让备份能 JSON 圆规一周。
-                      // 重做时 MemoryVectorDB.saveMany 会把 number[] 重新压回
-                      // Uint8Array，磁盘还是省的。
-                      processedData = rawData.map((v: any) => {
-                          if (!v || !v.vector) return v;
-                          let arr: number[];
-                          if (v.vector instanceof Uint8Array) {
-                              const f32 = new Float32Array(v.vector.buffer, v.vector.byteOffset, v.vector.byteLength >>> 2);
-                              arr = Array.from(f32);
-                          } else if (v.vector instanceof Float32Array) {
-                              arr = Array.from(v.vector);
-                          } else {
-                              arr = v.vector;
-                          }
-                          return { ...v, vector: arr };
-                      });
-                  } else {
-                      processedData = rawData;
-                  }
+                  processedData = rawData;
               } else if (mode === 'text_only') {
                   processedData = Array.isArray(rawData) && rawData.length > 200
                       ? await processArrayChunked(rawData, stripBase64)
@@ -2970,7 +2966,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   case 'tracker_entries': backupData.trackerEntries = processedData; break;
                   case 'hotnews_snapshots': backupData.hotNewsSnapshots = processedData; break;
                   case 'memory_nodes': backupData.memoryNodes = processedData; break;
-                  case 'memory_vectors': backupData.memoryVectors = processedData; break;
+                  // memory_vectors 走二进制旁路（上面已 continue），不在此 switch 落 backupData
                   case 'memory_links': backupData.memoryLinks = processedData; break;
                   case 'topic_boxes': backupData.topicBoxes = processedData; break;
                   case 'anticipations': backupData.anticipations = processedData; break;
@@ -3003,50 +2999,23 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           // 卡在 95% 干等。level 9 压几十 MB 数据可能要好几秒。
           setSysOperation({ status: 'processing', message: '正在生成压缩包（最高压缩级别）...', progress: 70 });
 
-          // --- MEMORY-OPTIMIZED INCREMENTAL SERIALIZATION ---
-          // Instead of JSON.stringify(entire backupData) which doubles peak memory,
-          // we serialize large arrays separately and build the JSON incrementally.
-          const largeArrayKeys = ['characters', 'messages', 'assets', 'galleryImages',
-              'savedEmojis', 'memoryNodes', 'memoryVectors', 'memoryLinks',
-              'socialPosts', 'diaries', 'worldbooks', 'novels', 'xhsActivities',
-              'bankTransactions', 'quizSessions', 'guidebookSessions',
-              'topicBoxes', 'anticipations', 'eventBoxes', 'roomCustomAssets', 'mediaAssets',
-              'customThemes', 'appearancePresets', 'courses', 'games', 'songs',
-              'roomTodos', 'roomNotes', 'tasks', 'anniversaries', 'groups',
-              'savedJournalStickers', 'emojiCategories', 'xhsStockImages',
-              'scheduledMessages', 'handbooks', 'trackers', 'trackerEntries', 'hotNewsSnapshots',
-              'dailySchedules', 'memoryBatches', 'pixelHomeAssets', 'pixelHomeLayouts',
-              'worldEpisodes'] as const;
-
-          // Build metadata (small fields) separately
-          const metadata: Record<string, any> = {};
-          const largeKeySet = new Set(largeArrayKeys as readonly string[]);
-          for (const key of Object.keys(backupData)) {
-              if (!largeKeySet.has(key)) {
-                  metadata[key] = (backupData as any)[key];
-              }
-          }
-
-          // Build JSON string incrementally: "{metadata..., largeKey1:[...], largeKey2:[...]}"
-          const metaStr = JSON.stringify(metadata);
-          const jsonParts: string[] = [metaStr.slice(0, -1)]; // Remove trailing '}'
-
-          let addedLarge = false;
-          for (const key of largeArrayKeys) {
-              const value = (backupData as any)[key];
-              if (value === undefined || value === null) continue;
-              jsonParts.push(`${addedLarge || metaStr.length > 2 ? ',' : ''}"${key}":${JSON.stringify(value)}`);
-              addedLarge = true;
-              // Release reference immediately to allow GC
-              (backupData as any)[key] = undefined;
-              // Yield to let GC run
-              await new Promise(r => setTimeout(r, 0));
-          }
-          jsonParts.push('}');
-
-          zip.file("data.json", jsonParts.join(''));
-          // Release parts
-          jsonParts.length = 0;
+          // --- v2 分片序列化（替代老的单根 data.json）---
+          // 不再把所有数据拼成一根 data.json：单根字符串逼近 ~512M 会确定性 RangeError。
+          // 改成每个数组字段分片写进 stores/<field>.NNN.json、其余非数组字段进 metadata.json、
+          // 收尾写 manifest.json 当导入契约。导入端按 manifest 把各片拼回与这里完全相同的 data
+          // 对象，喂给原封不动的 importFullData——还原语义（clear-and-add / merge / 单例 /
+          // media_only 补丁……）不在这里重写。详见 utils/backupFormat.ts。
+          await writeV2Backup(
+              zip as unknown as ZipFileWriter,
+              backupData as Record<string, any>,
+              {
+                  mode,
+                  createdAt: Date.now(),
+                  assetCount,
+                  vectors: vectorPayload,
+                  onYield: () => new Promise<void>(r => setTimeout(r, 0)),
+              },
+          );
 
           // 进度提示：每 ~5% 更新一次（避免高频 React 重渲染），同时让进度
           // 条从 70% 平滑爬到 99%，用户能确切看到"在动"。
@@ -3160,12 +3129,37 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   const JSZip = await loadJSZip();
                   const loadedZip = await JSZip.loadAsync(fileOrJson);
                   zip = loadedZip;
-                  const dataFile = loadedZip.file("data.json");
-                  if (!dataFile) throw new Error("损坏的备份包: 缺少 data.json");
-                  let jsonStr = await dataFile.async("string");
                   totalAssetFiles = countZipAssetFiles(loadedZip);
-                  data = JSON.parse(jsonStr);
-                  jsonStr = '';
+                  const manifestFile = loadedZip.file("manifest.json");
+                  if (manifestFile) {
+                      // v2：manifest 驱动的分片备份。assembleV2Backup 只读 zip、组装内存对象，
+                      // 校验不过直接抛错——此时 importFullData 还没调，DB 一字未动。
+                      let manifest: BackupManifest;
+                      try {
+                          manifest = JSON.parse(await manifestFile.async("string"));
+                      } catch {
+                          throw new Error("损坏的备份包：manifest.json 解析失败");
+                      }
+                      data = await assembleV2Backup(
+                          loadedZip as unknown as ZipFileReader,
+                          manifest,
+                          {
+                              onYield: () => new Promise<void>(r => setTimeout(r, 0)),
+                              onShardProgress: (field, idx, total) => {
+                                  showImportProgress('parsing', '正在解析备份分片...',
+                                      5 + Math.floor((idx / Math.max(1, total)) * 25),
+                                      { current: `分片 ${field}` });
+                              },
+                          },
+                      ) as FullBackupData;
+                  } else {
+                      // v1（老备份）：单根 data.json，原样保留，老备份永远打得开。
+                      const dataFile = loadedZip.file("data.json");
+                      if (!dataFile) throw new Error("损坏的备份包: 缺少 data.json");
+                      let jsonStr = await dataFile.async("string");
+                      data = JSON.parse(jsonStr);
+                      jsonStr = '';
+                  }
               }
           }
 

--- a/utils/backupFormat.test.ts
+++ b/utils/backupFormat.test.ts
@@ -106,6 +106,17 @@ describe('backupFormat v2 往返', () => {
         expect(manifest.stores.messages.parts).toBeGreaterThanOrEqual(2);
     });
 
+    it('数组含 undefined 空洞：count 记实际写入数，不让被跳过的空洞触发条数误判 abort（G1）', async () => {
+        const zip = new FakeZip();
+        // JSON.stringify(undefined) === undefined，导出时该元素被跳过
+        const arr = [{ id: 1 }, undefined, { id: 3 }];
+        const manifest = await writeV2Backup(zip, { messages: arr }, {});
+        // count 必须是「实际写入的 2 条」而非 arr.length(3)，否则导入端条数自洽校验会误判损坏
+        expect(manifest.stores.messages.count).toBe(2);
+        const data = await assembleV2Backup(zip, manifest); // 旧写法（count=3）会在这里抛 count-mismatch
+        expect(data.messages).toEqual([{ id: 1 }, { id: 3 }]);
+    });
+
     it('单条超硬上限：干净报错中止，不退回 RangeError', async () => {
         const zip = new FakeZip();
         const limits: ShardLimits = { maxLen: 100, maxItems: 10, hardMaxLen: 500 };

--- a/utils/backupFormat.test.ts
+++ b/utils/backupFormat.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import {
+    writeV2Backup, assembleV2Backup, shardFileName,
+    BACKUP_FORMAT_VERSION, type BackupManifest, type ShardLimits,
+} from './backupFormat';
+
+// 这组用例锁住 v2 分片格式的「写 → 读」往返与各档校验。核心契约：
+//   导入端拼出的 data 必须与导出端喂进去的 backupData 逐字段一致（数组照旧、非数组照旧），
+//   这样它喂给原封不动的 importFullData 时，还原行为就和 v1 完全一样。
+// 失败档（缺片 / 条数不符 / 版本不符 / 非数组 / 单条超大）必须在「拼数据之前/导出中途」
+// 干净报错，绝不退回 RangeError、绝不静默少数据。
+
+// 内存假 zip：同时实现 ZipFileWriter / ZipFileReader，支持文本与二进制（Uint8Array）。
+class FakeFile {
+    constructor(private content: string | Uint8Array) {}
+    async(type: 'string'): Promise<string>;
+    async(type: 'uint8array'): Promise<Uint8Array>;
+    async(type: 'string' | 'uint8array'): Promise<string | Uint8Array> {
+        if (type === 'uint8array') {
+            return Promise.resolve(this.content instanceof Uint8Array ? this.content : new TextEncoder().encode(String(this.content)));
+        }
+        return Promise.resolve(typeof this.content === 'string' ? this.content : new TextDecoder().decode(this.content));
+    }
+}
+class FakeZip {
+    files = new Map<string, string | Uint8Array>();
+    file(name: string): FakeFile | null;
+    file(name: string, data: string | Uint8Array, options?: { base64?: boolean }): void;
+    file(name: string, data?: string | Uint8Array): FakeFile | null | void {
+        if (data === undefined) {
+            if (!this.files.has(name)) return null;
+            return new FakeFile(this.files.get(name)!);
+        }
+        this.files.set(name, data);
+    }
+}
+
+const sampleBackup = () => ({
+    // 非数组字段 → metadata.json
+    timestamp: 123,
+    version: 3,
+    theme: { name: 'dark', wallpaper: 'assets/asset_1.png' },
+    userProfile: { name: '楪', avatar: 'assets/asset_2.png' },
+    lifeSimState: null,                 // 单例空 → null，仍要原样带回（v1 语义：清目标）
+    apiConfig: undefined,               // undefined 字段 → JSON 丢弃，导入端拿不到（与 v1 一致）
+    // 数组字段 → 分片
+    messages: [{ id: 1, t: 'a' }, { id: 2, t: 'b' }, { id: 3, t: 'c' }],
+    galleryImages: [],                  // 空数组 → count 0、parts 0，导入端必须拼回 []
+    memoryNodes: [{ id: 'n1' }],
+});
+
+describe('backupFormat v2 往返', () => {
+    it('写 → 读：每个字段与原 backupData 逐字段一致（数组照旧、非数组照旧）', async () => {
+        const zip = new FakeZip();
+        const src = sampleBackup();
+        const manifest = await writeV2Backup(zip, { ...src, messages: [...src.messages], galleryImages: [], memoryNodes: [...src.memoryNodes] }, { mode: 'full', createdAt: 999, assetCount: 2 });
+
+        expect(manifest.formatVersion).toBe(BACKUP_FORMAT_VERSION);
+        expect(manifest.mode).toBe('full');
+        expect(manifest.assetCount).toBe(2);
+        // 数组字段都进了 manifest.stores（含空数组 count 0）
+        expect(manifest.stores.messages).toEqual({ parts: 1, count: 3 });
+        expect(manifest.stores.galleryImages).toEqual({ parts: 0, count: 0 });
+        expect(manifest.stores.memoryNodes).toEqual({ parts: 1, count: 1 });
+        // 非数组字段不进 stores
+        expect(manifest.stores.theme).toBeUndefined();
+        expect(manifest.stores.userProfile).toBeUndefined();
+
+        const data = await assembleV2Backup(zip, manifest);
+        expect(data.messages).toEqual(src.messages);
+        expect(data.galleryImages).toEqual([]);              // 空数组拼回 []，不是 undefined
+        expect(data.memoryNodes).toEqual(src.memoryNodes);
+        expect(data.theme).toEqual(src.theme);
+        expect(data.userProfile).toEqual(src.userProfile);
+        expect(data.lifeSimState).toBe(null);                // null 原样带回
+        expect('apiConfig' in data).toBe(false);             // undefined 字段被 JSON 丢弃，导入端没有
+        expect(data.timestamp).toBe(123);
+    });
+
+    it('大数组按 maxItems 分多片，拼回顺序不乱、不漏不重', async () => {
+        const zip = new FakeZip();
+        const messages = Array.from({ length: 23 }, (_, i) => ({ id: i, body: `m${i}` }));
+        const limits: ShardLimits = { maxLen: 1 << 30, maxItems: 5, hardMaxLen: 1 << 30 };
+        const manifest = await writeV2Backup(zip, { messages: [...messages] }, { limits });
+
+        expect(manifest.stores.messages.parts).toBe(5); // 23/5 → 5 片（5,5,5,5,3）
+        expect(manifest.stores.messages.count).toBe(23);
+        // 每片文件都在
+        for (let p = 0; p < 5; p++) expect(zip.files.has(shardFileName('messages', p))).toBe(true);
+
+        const data = await assembleV2Backup(zip, manifest);
+        expect(data.messages).toEqual(messages); // 顺序 + 内容完全一致
+    });
+
+    it('单条超软上限：该条独占一片（Finding 5），仍能完整往返', async () => {
+        const zip = new FakeZip();
+        const big = { id: 'big', blob: 'x'.repeat(2000) };
+        const items = [{ id: 'a' }, big, { id: 'c' }];
+        // maxLen 设 1000：big 条 ~2000 长度，独占一片；前后小条各自成片
+        const limits: ShardLimits = { maxLen: 1000, maxItems: 9999, hardMaxLen: 1 << 30 };
+        const manifest = await writeV2Backup(zip, { messages: items }, { limits });
+        const data = await assembleV2Backup(zip, manifest);
+        expect(data.messages).toEqual(items);
+        expect(manifest.stores.messages.count).toBe(3);
+        expect(manifest.stores.messages.parts).toBeGreaterThanOrEqual(2);
+    });
+
+    it('单条超硬上限：干净报错中止，不退回 RangeError', async () => {
+        const zip = new FakeZip();
+        const limits: ShardLimits = { maxLen: 100, maxItems: 10, hardMaxLen: 500 };
+        await expect(
+            writeV2Backup(zip, { messages: [{ id: 'x', blob: 'y'.repeat(1000) }] }, { limits })
+        ).rejects.toThrow(/单条记录过大/);
+        // 没写出 manifest（中途抛错）
+        expect(zip.files.has('manifest.json')).toBe(false);
+    });
+});
+
+describe('backupFormat v2 校验档（写库前 abort，DB 未动）', () => {
+    it('缺分片文件 → abort', async () => {
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { messages: [{ id: 1 }, { id: 2 }] }, {});
+        zip.files.delete(shardFileName('messages', 0)); // 人为删掉一片
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/没有|找不到|中止导入/);
+    });
+
+    it('条数与 manifest 不符 → abort', async () => {
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { messages: [{ id: 1 }, { id: 2 }] }, {});
+        const tampered: BackupManifest = { ...manifest, stores: { ...manifest.stores, messages: { parts: 1, count: 99 } } };
+        await expect(assembleV2Backup(zip, tampered)).rejects.toThrow(/对不上|中止导入/);
+    });
+
+    it('formatVersion 不是 2（如未来 v3）→ abort，不拿 v2 parser 硬解', async () => {
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { messages: [{ id: 1 }] }, {});
+        const v3: BackupManifest = { ...manifest, formatVersion: 3 };
+        await expect(assembleV2Backup(zip, v3)).rejects.toThrow(/不支持的备份格式版本/);
+    });
+
+    it('分片内容不是数组 → abort', async () => {
+        const zip = new FakeZip();
+        zip.file('metadata.json', '{}');
+        zip.file(shardFileName('messages', 0), '{"not":"an array"}');
+        const manifest: BackupManifest = { formatVersion: 2, stores: { messages: { parts: 1, count: 1 } } };
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/不是数组/);
+    });
+
+    it('缺 metadata.json → abort', async () => {
+        const zip = new FakeZip();
+        const manifest: BackupManifest = { formatVersion: 2, stores: {} };
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/metadata\.json/);
+    });
+});
+
+// 向量二进制旁路：构造 Float32 字节拼成的 bin + 索引，喂给 writeV2Backup 的 vectors 选项。
+function makeVectorPayload(vecs: Array<{ memoryId: string; charId: string; values: number[]; model?: string }>) {
+    const index: any[] = [];
+    const parts: Uint8Array[] = [];
+    let offset = 0;
+    for (const v of vecs) {
+        const f32 = new Float32Array(v.values);
+        const bytes = new Uint8Array(f32.buffer, f32.byteOffset, f32.byteLength);
+        parts.push(bytes);
+        index.push({ memoryId: v.memoryId, charId: v.charId, dimensions: f32.length, model: v.model, byteOffset: offset, byteLength: bytes.byteLength });
+        offset += bytes.byteLength;
+    }
+    const bin = new Uint8Array(offset);
+    let p = 0;
+    for (const part of parts) { bin.set(part, p); p += part.byteLength; }
+    return { bin, index };
+}
+
+describe('backupFormat v2 向量二进制旁路', () => {
+    it('向量写 bin → 读回：逐值一致、维度保留、每条 vector 是独立 buffer 的 Uint8Array', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([
+            { memoryId: 'm1', charId: 'c1', values: [0.1, 0.2, 0.3, 0.4], model: 'embed-test' },
+            { memoryId: 'm2', charId: 'c1', values: [1, 2, 3, 4] },
+            { memoryId: 'm3', charId: 'c2', values: [-0.5, 0.5, -0.25, 0.25] },
+        ]);
+        const manifest = await writeV2Backup(zip, { memoryNodes: [{ id: 'm1' }] }, { vectors: payload });
+        expect(manifest.vectors).toEqual({ count: 3, byteLength: 3 * 4 * 4 });
+        // 向量不进 stores（走旁路）
+        expect(manifest.stores.memoryVectors).toBeUndefined();
+
+        const data = await assembleV2Backup(zip, manifest);
+        expect(data.memoryVectors).toHaveLength(3);
+        const v1 = data.memoryVectors[0];
+        expect(v1.memoryId).toBe('m1');
+        expect(v1.charId).toBe('c1');
+        expect(v1.model).toBe('embed-test');
+        expect(v1.dimensions).toBe(4);
+        // vector 是 Uint8Array，且 buffer 紧贴自己的 byteLength（证明是 slice 独立 buffer，不是整 bin 的 subarray 视图）
+        expect(v1.vector).toBeInstanceOf(Uint8Array);
+        expect(v1.vector.byteLength).toBe(16);
+        expect(v1.vector.buffer.byteLength).toBe(16);
+        // 逐值还原
+        const back = new Float32Array(v1.vector.buffer, v1.vector.byteOffset, v1.vector.byteLength >>> 2);
+        expect(Array.from(back)).toEqual([
+            expect.closeTo(0.1, 6), expect.closeTo(0.2, 6), expect.closeTo(0.3, 6), expect.closeTo(0.4, 6),
+        ]);
+        // 第二条整数值精确
+        const back2 = new Float32Array(data.memoryVectors[1].vector.buffer, data.memoryVectors[1].vector.byteOffset, 4);
+        expect(Array.from(back2)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('向量 byteLength 与维度对不上 → abort', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([{ memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] }]);
+        payload.index[0].dimensions = 5; // 谎称 5 维但只有 16 字节（4 维）
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/维度对不上|中止导入/);
+    });
+
+    it('向量条数与 manifest 不符 → abort', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([{ memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] }]);
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        const tampered: BackupManifest = { ...manifest, vectors: { count: 99, byteLength: manifest.vectors!.byteLength } };
+        await expect(assembleV2Backup(zip, tampered)).rejects.toThrow(/向量条数.*不符|中止导入/);
+    });
+
+    it('向量 bin 字节数与 manifest 不符 → abort', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([{ memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] }]);
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        const tampered: BackupManifest = { ...manifest, vectors: { count: 1, byteLength: 9999 } };
+        await expect(assembleV2Backup(zip, tampered)).rejects.toThrow(/bin 字节数.*不符|中止导入/);
+    });
+
+    it('声明了向量但缺 bin 文件 → abort', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([{ memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] }]);
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        zip.files.delete('stores/memory_vectors.bin');
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/缺 index\/bin|中止导入/);
+    });
+
+    // codex 二审 finding：坏 byteOffset 会被 slice 钳制成空/截断字节、组装却照样过 → 写库前必须挡住
+    it('向量 byteOffset 越过 bin 末尾 → abort（不被 slice 静默钳制）', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([
+            { memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] },
+            { memoryId: 'm2', charId: 'c1', values: [5, 6, 7, 8] },
+        ]);
+        payload.index[1].byteOffset = payload.bin.byteLength; // 指到 bin 末尾之外
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/越过 bin 末尾|中止导入/);
+    });
+
+    it('向量 byteOffset 为负数 → abort', async () => {
+        const zip = new FakeZip();
+        const payload = makeVectorPayload([{ memoryId: 'm1', charId: 'c1', values: [1, 2, 3, 4] }]);
+        payload.index[0].byteOffset = -4;
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/偏移\/长度\/维度非法|中止导入/);
+    });
+});
+
+// FakeZip 只验逻辑，验不到真 JSZip 的二进制编码 + generateAsync/loadAsync 实际行为。
+// 这条用真 JSZip 跑完整往返，钉死「bin 直写 Uint8Array、读回 async('uint8array') 字节无损」。
+describe('backupFormat v2 真实 JSZip 二进制往返', () => {
+    it('真 JSZip：写 bin + 分片 + metadata → generateAsync → loadAsync → 读 manifest → 完整还原', async () => {
+        const zip = new JSZip();
+        const payload = makeVectorPayload([
+            { memoryId: 'm1', charId: 'c1', values: [0.1, 0.2, 0.3, 0.4], model: 'e' },
+            { memoryId: 'm2', charId: 'c2', values: [1, 2, 3, 4] },
+        ]);
+        await writeV2Backup(zip as any, {
+            messages: [{ id: 1, t: 'a' }, { id: 2, t: 'b' }],
+            theme: { name: 'dark' },
+        }, { vectors: payload, mode: 'full' });
+
+        // 真正打包成字节，再原样解回来（模拟落盘 → 重新导入）
+        const bytes = await zip.generateAsync({ type: 'uint8array' });
+        const loaded = await JSZip.loadAsync(bytes);
+        // manifest 从 zip 里读（不是用内存里的），走和导入端一模一样的路径
+        const manifest = JSON.parse(await loaded.file('manifest.json')!.async('string'));
+        const data = await assembleV2Backup(loaded as any, manifest);
+
+        expect(data.messages).toEqual([{ id: 1, t: 'a' }, { id: 2, t: 'b' }]);
+        expect(data.theme).toEqual({ name: 'dark' });
+        expect(data.memoryVectors).toHaveLength(2);
+        expect(data.memoryVectors[0].vector).toBeInstanceOf(Uint8Array);
+        expect(data.memoryVectors[0].vector.byteLength).toBe(16);
+        const back = new Float32Array(data.memoryVectors[0].vector.buffer, data.memoryVectors[0].vector.byteOffset, 4);
+        expect(Array.from(back)).toEqual([
+            expect.closeTo(0.1, 6), expect.closeTo(0.2, 6), expect.closeTo(0.3, 6), expect.closeTo(0.4, 6),
+        ]);
+        const back2 = new Float32Array(data.memoryVectors[1].vector.buffer, data.memoryVectors[1].vector.byteOffset, 4);
+        expect(Array.from(back2)).toEqual([1, 2, 3, 4]);
+    });
+});

--- a/utils/backupFormat.ts
+++ b/utils/backupFormat.ts
@@ -107,6 +107,7 @@ export async function writeV2Backup(
         let buf: string[] = [];
         let bufLen = 0;
         let parts = 0;
+        let writtenCount = 0; // 实际写进分片的条数：可能 < arr.length（下面会跳过序列化成 undefined 的空洞）
         const flush = () => {
             if (buf.length === 0) return;
             zip.file(shardFileName(field, parts), '[' + buf.join(',') + ']');
@@ -134,13 +135,16 @@ export async function writeV2Backup(
             if (s.length >= limits.maxLen && buf.length > 0) flush();
             buf.push(s);
             bufLen += s.length;
+            writtenCount++;
             if (bufLen >= limits.maxLen || buf.length >= limits.maxItems) {
                 flush();
                 if (onYield) await onYield();
             }
         }
         flush();
-        manifestStores[field] = { parts, count: arr.length };
+        // count 用「实际写入条数」而非 arr.length：上面跳过了序列化成 undefined 的空洞，若仍按
+        // arr.length 记，导入端「拼出条数 === count」自洽校验会对一个本来合法的备份误判损坏 abort。
+        manifestStores[field] = { parts, count: writtenCount };
     };
 
     // 一遍扫 backupData：数组字段分片（写完释放），其余非数组字段进 metadata。

--- a/utils/backupFormat.ts
+++ b/utils/backupFormat.ts
@@ -1,0 +1,316 @@
+// v2 备份格式：分片读写的纯逻辑，刻意不碰 React / DOM / Capacitor，只依赖一个最小的
+// zip 读写接口，好在 node 测试环境里拿真 jszip 单测往返。
+//
+// 设计主线（见 notes/backup-streaming-refactor-plan.md）：
+//   导出端先按 v1 老逻辑把所有数据攒进一个 backupData 对象（角色/消息/单例/设置……，
+//   特殊分支一字不改）；这里只负责「换一种存法」——把其中的数组字段分片写进
+//   stores/<field>.NNN.json，其余非数组字段（主题/设置/单例对象等）整进 metadata.json，
+//   收尾写一份 manifest.json 当导入契约。
+//   导入端读 manifest，把各片拼回「与 v1 完全相同的 data 对象」，再喂给原封不动的
+//   importFullData——还原语义（clear-and-add / merge / 单例 / media_only 补丁……）全部
+//   留在 importFullData 里，这里不重写，所以不会出现「两套语义彼此漂移」。
+//
+// 为什么单根 data.json 会崩：对单个超大数组或整包做 JSON.stringify，文本长度逼近 JS
+// 单字符串 ~512M（2^29）上限会确定性抛 RangeError。分片后每片字符串长度有界，永不触上限。
+
+export const BACKUP_FORMAT_VERSION = 2;
+
+/** 分片阈值。注意这里的「Len」量的是 JS 字符串长度（UTF-16 码元数），正是 RangeError 盯的那个量，
+ *  不是 UTF-8 字节数——用它当阈值刚好守住「单根字符串别逼近 512M」。 */
+export interface ShardLimits {
+    /** 单片字符串长度软上限：攒到这个长度就 flush 一片 */
+    maxLen: number;
+    /** 单片条数软上限：攒到这么多条就 flush 一片（防超多小记录挤进一片） */
+    maxItems: number;
+    /** 单条记录序列化硬上限：单条就超它 → 干净报错中止导出，绝不退回 RangeError */
+    hardMaxLen: number;
+}
+
+export const DEFAULT_SHARD_LIMITS: ShardLimits = {
+    maxLen: 32 * 1024 * 1024,        // 32M 码元，远低于 ~512M 上限
+    maxItems: 5000,
+    hardMaxLen: 256 * 1024 * 1024,   // 256M 码元
+};
+
+/** 向量 bin 的索引项：每条向量在 memory_vectors.bin 里的位置 + 重建所需元数据 */
+export interface VectorIndexEntry {
+    memoryId: string;
+    charId: string;
+    dimensions: number;
+    model?: string;
+    byteOffset: number;
+    byteLength: number;
+}
+
+export interface BackupManifest {
+    formatVersion: number;
+    mode?: string;
+    createdAt?: number;
+    /** key = backupData 字段名（如 messages / galleryImages / memoryNodes），value = 分片数 + 总条数 */
+    stores: Record<string, { parts: number; count: number }>;
+    /** 向量走二进制旁路（memory_vectors.bin + .index.json），不进 stores。无向量时省略。 */
+    vectors?: { count: number; byteLength: number };
+    assetCount?: number;
+}
+
+/** 写端：往 zip 里塞文本文件，或二进制（Uint8Array）文件。二进制直写，绝不经 base64 大字符串。 */
+export interface ZipFileWriter {
+    file(name: string, data: string | Uint8Array, options?: { base64?: boolean }): void;
+}
+
+/** 读端：按名取文件，能按类型 async 出文本或字节；取不到返回 null */
+export interface ZipFileReader {
+    file(name: string): {
+        async(type: 'string'): Promise<string>;
+        async(type: 'uint8array'): Promise<Uint8Array>;
+    } | null;
+}
+
+/** 向量 bin / index 在 zip 里的固定文件名 */
+export const VECTOR_BIN_FILE = 'stores/memory_vectors.bin';
+export const VECTOR_INDEX_FILE = 'stores/memory_vectors.index.json';
+
+/** 分片文件名：stores/<field>.NNN.json。写读两端用同一个公式，靠数字下标对齐，不靠文件名字典序。 */
+export function shardFileName(field: string, index: number): string {
+    return `stores/${field}.${String(index).padStart(3, '0')}.json`;
+}
+
+export interface WriteV2Options {
+    mode?: string;
+    createdAt?: number;
+    assetCount?: number;
+    limits?: ShardLimits;
+    /** React 端传 `() => new Promise(r => setTimeout(r, 0))` 让出主线程；测试端可不传 */
+    onYield?: () => Promise<void>;
+    /** 向量二进制旁路：调用方（OSContext）已把 memory_vectors 归一化拼成 bin + index 时传进来。
+     *  写进 memory_vectors.bin（二进制直写）+ .index.json，并在 manifest.vectors 记 count/byteLength。
+     *  传了这个就不要再把 memoryVectors 放进 backupData（否则会被当普通数组又分片一遍）。 */
+    vectors?: { bin: Uint8Array; index: VectorIndexEntry[] };
+}
+
+/**
+ * 把已攒好的 backupData 写成 v2 分片布局，返回 manifest。
+ *
+ * 会「消费」backupData：数组字段写完即把该字段置 undefined 释放引用，方便大数组尽早被 GC。
+ * 调用方不应在调用后再读 backupData。
+ */
+export async function writeV2Backup(
+    zip: ZipFileWriter,
+    backupData: Record<string, any>,
+    options: WriteV2Options = {},
+): Promise<BackupManifest> {
+    const limits = options.limits || DEFAULT_SHARD_LIMITS;
+    const onYield = options.onYield;
+    const manifestStores: Record<string, { parts: number; count: number }> = {};
+
+    const shardArrayField = async (field: string, arr: any[]) => {
+        let buf: string[] = [];
+        let bufLen = 0;
+        let parts = 0;
+        const flush = () => {
+            if (buf.length === 0) return;
+            zip.file(shardFileName(field, parts), '[' + buf.join(',') + ']');
+            parts++;
+            buf = [];
+            bufLen = 0;
+        };
+        for (let i = 0; i < arr.length; i++) {
+            let s: string;
+            try {
+                s = JSON.stringify(arr[i]);
+            } catch (e: any) {
+                throw new Error(`备份序列化失败（${field} 第 ${i} 条）：${e?.message || e}`);
+            }
+            // JSON.stringify(undefined) === undefined；跳过空洞（putItems 释放后的占位等不会进这里，
+            // 但 backupData 的稀疏数组保险起见跳过），保持与 v1「JSON 丢弃 undefined」一致。
+            if (s === undefined) continue;
+            if (s.length > limits.hardMaxLen) {
+                throw new Error(
+                    `备份中有单条记录过大（${field}，约 ${Math.round(s.length / 1048576)}M 字符），` +
+                    `超出安全上限，已中止导出以免生成损坏的备份包。`,
+                );
+            }
+            // 单条就超软上限：先把已攒的 flush 掉，让这条独占一片（Finding 5）
+            if (s.length >= limits.maxLen && buf.length > 0) flush();
+            buf.push(s);
+            bufLen += s.length;
+            if (bufLen >= limits.maxLen || buf.length >= limits.maxItems) {
+                flush();
+                if (onYield) await onYield();
+            }
+        }
+        flush();
+        manifestStores[field] = { parts, count: arr.length };
+    };
+
+    // 一遍扫 backupData：数组字段分片（写完释放），其余非数组字段进 metadata。
+    const metaFields: Record<string, any> = {};
+    for (const key of Object.keys(backupData)) {
+        const value = backupData[key];
+        if (Array.isArray(value)) {
+            await shardArrayField(key, value);
+            backupData[key] = undefined; // 释放引用，已落 zip
+        } else {
+            metaFields[key] = value;
+        }
+    }
+
+    zip.file('metadata.json', JSON.stringify(metaFields));
+
+    // 向量二进制旁路：bin 直写 Uint8Array（不经 base64，bin 多大都不会撞字符串上限），
+    // index 是小 JSON。manifest.vectors 记 count/byteLength 供导入端校验。
+    let vectorsMeta: { count: number; byteLength: number } | undefined;
+    if (options.vectors) {
+        zip.file(VECTOR_BIN_FILE, options.vectors.bin);
+        zip.file(VECTOR_INDEX_FILE, JSON.stringify(options.vectors.index));
+        vectorsMeta = { count: options.vectors.index.length, byteLength: options.vectors.bin.byteLength };
+    }
+
+    const manifest: BackupManifest = {
+        formatVersion: BACKUP_FORMAT_VERSION,
+        mode: options.mode,
+        createdAt: options.createdAt,
+        stores: manifestStores,
+        vectors: vectorsMeta,
+        assetCount: options.assetCount,
+    };
+    zip.file('manifest.json', JSON.stringify(manifest));
+    return manifest;
+}
+
+export interface AssembleV2Options {
+    /** React 端传让出主线程的函数；测试端可不传 */
+    onYield?: () => Promise<void>;
+    /** 进度回调：当前字段、已处理字段序号、字段总数 */
+    onShardProgress?: (field: string, fieldIndex: number, fieldTotal: number) => void;
+}
+
+/**
+ * 读 v2 备份，把各分片拼回「与 v1 完全相同的 data 对象」。
+ *
+ * 全程只读 zip、组装内存对象，不碰数据库——所以任何校验不过直接抛错时，DB 一字未动，
+ * 调用方应在调用 importFullData 之前先 await 本函数。
+ *
+ * 校验三档（都在写库前）：① formatVersion 严格等于 2；② manifest 声明的每个分片文件都在
+ * （缺则 abort）；③ 每字段组装后条数 === manifest count、每片必须是数组（抓我们自己导出的 bug，
+ * 不是防用户篡改）。素材文件 assets/* 不进这道硬边界——缺图维持 warn+skip（缺图只可能来自
+ * 篡改，真丢了也无从恢复，为它拒绝整个导入没意义）。
+ */
+export async function assembleV2Backup(
+    zip: ZipFileReader,
+    manifest: BackupManifest,
+    options: AssembleV2Options = {},
+): Promise<Record<string, any>> {
+    if (!manifest || typeof manifest !== 'object') {
+        throw new Error('损坏的备份包：manifest.json 无法解析。');
+    }
+    if (manifest.formatVersion !== BACKUP_FORMAT_VERSION) {
+        throw new Error(
+            `不支持的备份格式版本：${manifest.formatVersion}（本版本只能导入 formatVersion ` +
+            `${BACKUP_FORMAT_VERSION} 的备份），已中止导入（数据未改动）。`,
+        );
+    }
+
+    const metaFile = zip.file('metadata.json');
+    if (!metaFile) throw new Error('损坏的备份包：有 manifest 但缺 metadata.json，已中止导入（数据未改动）。');
+    let data: Record<string, any>;
+    try {
+        data = JSON.parse(await metaFile.async('string'));
+    } catch {
+        throw new Error('损坏的备份包：metadata.json 解析失败，已中止导入（数据未改动）。');
+    }
+
+    const stores = manifest.stores || {};
+    const fields = Object.keys(stores);
+
+    // 先一遍校验所有声明的分片文件都在（缺则 abort，此时还没拼任何数据、DB 未动）
+    for (const field of fields) {
+        const { parts } = stores[field];
+        for (let p = 0; p < parts; p++) {
+            const name = shardFileName(field, p);
+            if (!zip.file(name)) {
+                throw new Error(`损坏的备份包：manifest 声明了 ${name} 但 zip 里没有，已中止导入（数据未改动）。`);
+            }
+        }
+    }
+
+    // 逐字段逐片拼回完整数组；parse 完一片即释放该片字符串；组装后条数必须等于 manifest count
+    for (let fi = 0; fi < fields.length; fi++) {
+        const field = fields[fi];
+        const { parts, count } = stores[field];
+        const arr: any[] = [];
+        for (let p = 0; p < parts; p++) {
+            const name = shardFileName(field, p);
+            let str = await zip.file(name)!.async('string');
+            let chunk: any;
+            try {
+                chunk = JSON.parse(str);
+            } catch {
+                throw new Error(`损坏的备份包：${name} 解析失败，已中止导入（数据未改动）。`);
+            }
+            str = ''; // 释放该片字符串
+            if (!Array.isArray(chunk)) {
+                throw new Error(`损坏的备份包：${name} 不是数组，已中止导入（数据未改动）。`);
+            }
+            for (const item of chunk) arr.push(item);
+            if (options.onYield) await options.onYield();
+        }
+        if (arr.length !== count) {
+            throw new Error(
+                `损坏的备份包：${field} 实际拼出 ${arr.length} 条、manifest 声明 ${count} 条，对不上，` +
+                `已中止导入（数据未改动）。`,
+            );
+        }
+        data[field] = arr;
+        options.onShardProgress?.(field, fi, fields.length);
+    }
+
+    // 向量二进制旁路：从 bin + index 重建 MemoryVector[]，塞进 data.memoryVectors，
+    // 跟其它 store 一样走那一次 importFullData（clear-once），不走 saveMany 旁路。
+    if (manifest.vectors) {
+        const idxFile = zip.file(VECTOR_INDEX_FILE);
+        const binFile = zip.file(VECTOR_BIN_FILE);
+        if (!idxFile || !binFile) {
+            throw new Error('损坏的备份包：manifest 声明了向量但缺 index/bin 文件，已中止导入（数据未改动）。');
+        }
+        let index: VectorIndexEntry[];
+        try {
+            index = JSON.parse(await idxFile.async('string'));
+        } catch {
+            throw new Error('损坏的备份包：memory_vectors.index.json 解析失败，已中止导入（数据未改动）。');
+        }
+        const bin = await binFile.async('uint8array');
+        if (!Array.isArray(index) || index.length !== manifest.vectors.count) {
+            throw new Error('损坏的备份包：向量条数与 manifest 不符，已中止导入（数据未改动）。');
+        }
+        if (bin.byteLength !== manifest.vectors.byteLength) {
+            throw new Error('损坏的备份包：向量 bin 字节数与 manifest 不符，已中止导入（数据未改动）。');
+        }
+        const okInt = (n: unknown): n is number => Number.isSafeInteger(n) && (n as number) >= 0;
+        const vectors = index.map((e) => {
+            // 偏移/长度/维度必须是非负安全整数，且字节区间落在 bin 内。少了这道校验，坏 byteOffset
+            // 会被 Uint8Array.slice() 钳制成空/截断的字节（不报错），组装照样过，importFullData 清旧
+            // 存新 → 本该 abort 的损坏变成丢数据。这里把它挡在写库前（也顺带抓自家 offset 算错的 bug）。
+            if (!okInt(e.byteOffset) || !okInt(e.byteLength) || !okInt(e.dimensions)) {
+                throw new Error(`损坏的备份包：向量 ${e.memoryId} 的偏移/长度/维度非法，已中止导入（数据未改动）。`);
+            }
+            if (e.byteLength !== e.dimensions * 4) {
+                throw new Error(`损坏的备份包：向量 ${e.memoryId} 的字节数与维度对不上，已中止导入（数据未改动）。`);
+            }
+            if (e.byteOffset + e.byteLength > bin.byteLength) {
+                throw new Error(`损坏的备份包：向量 ${e.memoryId} 的字节区间越过 bin 末尾，已中止导入（数据未改动）。`);
+            }
+            // slice 切出独立 buffer（不是 subarray 视图）：否则 IndexedDB 结构化克隆会把整根 bin
+            // 给每条向量各复制一遍。importFullData 的 memory_vectors 段对 Uint8Array 形态原样存。
+            const vector = bin.slice(e.byteOffset, e.byteOffset + e.byteLength);
+            if (vector.byteLength !== e.byteLength) {
+                throw new Error(`损坏的备份包：向量 ${e.memoryId} 切片长度异常，已中止导入（数据未改动）。`);
+            }
+            return { memoryId: e.memoryId, charId: e.charId, dimensions: e.dimensions, model: e.model, vector };
+        });
+        data.memoryVectors = vectors;
+        options.onShardProgress?.('memoryVectors', fields.length, fields.length + 1);
+    }
+
+    return data;
+}

--- a/utils/backupRoundtrip.test.ts
+++ b/utils/backupRoundtrip.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DB, openDB } from './db';
+import { encodeVectorsForBackup } from './memoryPalace/db';
+import { writeV2Backup, assembleV2Backup, shardFileName, type ShardLimits } from './backupFormat';
+
+// fake-indexeddb 已通过 test-setup.ts 注入。
+// 这组用例走「真实链路」：writeV2Backup → assembleV2Backup → DB.importFullData，钉死 v2 改造
+// 里最危险的几个数据完整性 finding。和 backupFormat.test.ts（纯格式往返）不同，这里验证的是
+// 「拼回的 data 喂给原封不动的 importFullData 后，落库行为和 v1 一致、且分片不引入丢数据」。
+
+class FakeFile {
+    constructor(private content: string | Uint8Array) {}
+    async(type: 'string'): Promise<string>;
+    async(type: 'uint8array'): Promise<Uint8Array>;
+    async(type: 'string' | 'uint8array'): Promise<string | Uint8Array> {
+        if (type === 'uint8array') {
+            return Promise.resolve(this.content instanceof Uint8Array ? this.content : new TextEncoder().encode(String(this.content)));
+        }
+        return Promise.resolve(typeof this.content === 'string' ? this.content : new TextDecoder().decode(this.content));
+    }
+}
+class FakeZip {
+    files = new Map<string, string | Uint8Array>();
+    file(name: string): FakeFile | null;
+    file(name: string, data: string | Uint8Array, options?: { base64?: boolean }): void;
+    file(name: string, data?: string | Uint8Array): FakeFile | null | void {
+        if (data === undefined) {
+            if (!this.files.has(name)) return null;
+            return new FakeFile(this.files.get(name)!);
+        }
+        this.files.set(name, data);
+    }
+}
+
+const SMALL_SHARDS = (maxItems: number): ShardLimits => ({ maxLen: 1 << 30, maxItems, hardMaxLen: 1 << 30 });
+
+async function seedStore(name: string, records: any[]): Promise<void> {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(name, 'readwrite');
+        const store = tx.objectStore(name);
+        store.clear();
+        for (const r of records) store.put(r);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+beforeEach(async () => {
+    // 清掉本组会断言/写入的 store，避免 importFullData 跨用例残留串味
+    for (const s of ['gallery', 'themes', 'user_profile', 'characters', 'messages', 'memory_vectors']) {
+        await seedStore(s, []);
+    }
+});
+
+/** 把存储形态的向量记录读回（vector 是 Uint8Array）解码成 number[]，逐值比对用 */
+function vecValues(v: any): number[] {
+    const u8: Uint8Array = v.vector;
+    const f32 = new Float32Array(u8.buffer, u8.byteOffset, u8.byteLength >>> 2);
+    return Array.from(f32);
+}
+
+describe('v2 真实链路：分片 → 组装 → importFullData', () => {
+    it('跨分片 clear-and-add：所有片的数据都落库、不只剩最后一片（Finding 1）', async () => {
+        await seedStore('gallery', [{ id: 'old', url: 'old' }]);
+        const items = Array.from({ length: 5 }, (_, i) => ({ id: `g${i}`, url: `u${i}` }));
+
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { galleryImages: items }, { limits: SMALL_SHARDS(2) });
+        expect(manifest.stores.galleryImages.parts).toBe(3); // 5/2 → 3 片，确保真跨片
+
+        const data = await assembleV2Backup(zip, manifest);
+        await DB.importFullData(data as any);
+
+        const ids = (await DB.getRawStoreData('gallery')).map((g: any) => g.id).sort();
+        // 旧 'old' 被 clear、5 条全部还原（老的「逐片喂 importFullData」写法只会剩最后一片 → 这里会挂）
+        expect(ids).toEqual(['g0', 'g1', 'g2', 'g3', 'g4']);
+    });
+
+    it('media_only 补丁：文字角色字段 + 文字消息存活，只有媒体被更新（R4·F1）', async () => {
+        await seedStore('characters', [{ id: 'c1', name: 'Alice', bio: 'text-bio', avatar: 'old-avatar' }]);
+        await seedStore('messages', [{ id: 1, charId: 'c1', type: 'text', content: 'hello' }]);
+
+        // media_only 形状：没有 characters 字段（关键！），只有 mediaAssets + 过滤后的 image 消息
+        const backupData = {
+            mediaAssets: [{ charId: 'c1', avatar: 'new-avatar', backgrounds: {} }],
+            messages: [{ id: 2, charId: 'c1', type: 'image', content: 'img' }],
+        };
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, backupData, {});
+        const data = await assembleV2Backup(zip, manifest);
+        expect('characters' in data).toBe(false); // 没有 characters → importFullData 走 patch、不破坏性清
+
+        await DB.importFullData(data as any);
+
+        const c1 = (await DB.getRawStoreData('characters')).find((c: any) => c.id === 'c1');
+        expect(c1.name).toBe('Alice');        // 文字字段存活
+        expect(c1.bio).toBe('text-bio');      // 文字字段存活
+        expect(c1.avatar).toBe('new-avatar'); // 媒体被 patch
+        // 老文字消息 id1 没被清，新 image id2 加上（patch/merge，不 clear）
+        const msgIds = (await DB.getRawStoreData('messages')).map((m: any) => m.id).sort();
+        expect(msgIds).toEqual([1, 2]);
+    });
+
+    it('空数组按 shape 还原：clear-and-add 清、merge 不动、单例省略不动（test 9）', async () => {
+        await seedStore('gallery', [{ id: 'gold', url: 'x' }]);          // clear-and-add 目标
+        await seedStore('themes', [{ id: 'told', name: 'old-theme' }]);  // merge 目标
+        await seedStore('user_profile', [{ id: 'me', name: 'OldUser' }]); // 单例目标
+
+        // galleryImages 空数组（clear-and-add → 清）、customThemes 空数组（merge → 不动）、
+        // 不含 userProfile（单例省略 → 不动）
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { galleryImages: [], customThemes: [] }, {});
+        const data = await assembleV2Backup(zip, manifest);
+        await DB.importFullData(data as any);
+
+        expect(await DB.getRawStoreData('gallery')).toEqual([]);                                    // 被清
+        expect((await DB.getRawStoreData('themes')).map((t: any) => t.id)).toEqual(['told']);       // merge 空 → 保留
+        expect((await DB.getRawStoreData('user_profile')).map((u: any) => u.name)).toEqual(['OldUser']); // 省略 → 保留
+    });
+
+    it('formatVersion 3 在组装阶段 abort，DB 未发生任何写（test 12）', async () => {
+        await seedStore('gallery', [{ id: 'keep', url: 'x' }]);
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { galleryImages: [{ id: 'new' }] }, {});
+        const v3 = { ...manifest, formatVersion: 3 };
+        await expect(assembleV2Backup(zip, v3)).rejects.toThrow(/不支持的备份格式版本/);
+        // 从没调用 importFullData → gallery 原样
+        expect((await DB.getRawStoreData('gallery')).map((g: any) => g.id)).toEqual(['keep']);
+    });
+
+    it('缺分片在组装阶段 abort，DB 未发生任何写（test 8）', async () => {
+        await seedStore('gallery', [{ id: 'keep', url: 'x' }]);
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { galleryImages: [{ id: 'a' }, { id: 'b' }] }, { limits: SMALL_SHARDS(1) });
+        zip.files.delete(shardFileName('galleryImages', 1)); // 删掉第二片
+        await expect(assembleV2Backup(zip, manifest)).rejects.toThrow(/中止导入/);
+        expect((await DB.getRawStoreData('gallery')).map((g: any) => g.id)).toEqual(['keep']);
+    });
+});
+
+describe('v2 真实链路：向量二进制旁路', () => {
+    it('向量 clear-once：目标独有的旧向量被清、备份的向量落库、逐值一致（test 10 + 二进制往返）', async () => {
+        // 目标已有 vA、vB（存储形态 Uint8Array）
+        const toU8 = (vals: number[]) => { const f = new Float32Array(vals); return new Uint8Array(f.buffer, f.byteOffset, f.byteLength); };
+        await seedStore('memory_vectors', [
+            { memoryId: 'vA', charId: 'c1', dimensions: 4, vector: toU8([9, 9, 9, 9]) },
+            { memoryId: 'vB', charId: 'c1', dimensions: 4, vector: toU8([8, 8, 8, 8]) },
+        ]);
+
+        // 备份只含 vA（新值）+ vC，不含 vB
+        const payload = encodeVectorsForBackup([
+            { memoryId: 'vA', charId: 'c1', vector: toU8([1, 2, 3, 4]) },
+            { memoryId: 'vC', charId: 'c2', vector: toU8([5, 6, 7, 8]) },
+        ]);
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { memoryNodes: [{ id: 'n1' }] }, { vectors: payload });
+        const data = await assembleV2Backup(zip, manifest);
+        await DB.importFullData(data as any);
+
+        const stored = await DB.getRawStoreData('memory_vectors');
+        const byId = new Map(stored.map((v: any) => [v.memoryId, v]));
+        // vB 被清（走 importFullData 的 clearStore，不是 saveMany upsert 旁路）
+        expect([...byId.keys()].sort()).toEqual(['vA', 'vC']);
+        // 逐值一致，且 vA 是新值不是旧值
+        expect(vecValues(byId.get('vA'))).toEqual([1, 2, 3, 4]);
+        expect(vecValues(byId.get('vC'))).toEqual([5, 6, 7, 8]);
+        // 落库形态是 Uint8Array（紧凑存储）
+        expect(byId.get('vA').vector).toBeInstanceOf(Uint8Array);
+    });
+
+    it('遗留 number[] 向量导出 v2、再导入逐值一致（R4·F4 / test 18）', async () => {
+        // 老数据：vector 还是 raw number[]（未迁移成 Uint8Array）
+        await seedStore('memory_vectors', [
+            { memoryId: 'legacy1', charId: 'c1', dimensions: 4, vector: [0.11, 0.22, 0.33, 0.44] },
+        ]);
+
+        // 导出走和 OSContext 完全相同的归一化函数
+        const raw = await DB.getRawStoreData('memory_vectors');
+        const payload = encodeVectorsForBackup(raw);
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, {}, { vectors: payload });
+        expect(manifest.vectors).toEqual({ count: 1, byteLength: 16 });
+
+        await seedStore('memory_vectors', []); // 清空目标，证明是从备份还原
+        const data = await assembleV2Backup(zip, manifest);
+        await DB.importFullData(data as any);
+
+        const stored = await DB.getRawStoreData('memory_vectors');
+        expect(stored).toHaveLength(1);
+        expect(stored[0].memoryId).toBe('legacy1');
+        const vals = vecValues(stored[0]);
+        expect(vals).toEqual([
+            expect.closeTo(0.11, 6), expect.closeTo(0.22, 6), expect.closeTo(0.33, 6), expect.closeTo(0.44, 6),
+        ]);
+    });
+});

--- a/utils/db.backupChunked.test.ts
+++ b/utils/db.backupChunked.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DB, openDB } from './db';
+
+// fake-indexeddb 已通过 test-setup.ts 注入。
+// 这组用例锁住 #1「游标分批读」(getStoreDataChunked) 的契约：分批读出的结果集必须与
+// getRawStoreData 的整表 getAll 完全一致（条数、顺序、内容），且回调可以是 async、批边界
+// 不漏不重。这是给 v2 流式导出当地基的回归守卫——读法换了但数据一条都不能少。
+
+// gallery store keyPath 'id'，直接拿 raw 事务塞数据，避开上层方法的额外语义。
+async function seedGallery(records: any[]): Promise<void> {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('gallery', 'readwrite');
+        const store = tx.objectStore('gallery');
+        store.clear();
+        for (const r of records) store.put(r);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
+async function collectChunked(storeName: string, batchSize?: number): Promise<any[]> {
+    const out: any[] = [];
+    await DB.getStoreDataChunked(storeName, batch => { out.push(...batch); }, batchSize);
+    return out;
+}
+
+beforeEach(async () => {
+    await seedGallery([]);
+});
+
+describe('getStoreDataChunked（游标分批读）', () => {
+    it('结果集与 getRawStoreData 的 getAll 完全一致（条数/顺序/内容）', async () => {
+        // 乱序写入，验证两种读法都按主键升序、彼此一致
+        const ids = [37, 5, 128, 1, 999, 64, 2, 500, 88, 7];
+        await seedGallery(ids.map(id => ({ id, url: `img_${id}`, tag: id % 2 ? 'odd' : 'even' })));
+
+        const viaGetAll = await DB.getRawStoreData('gallery');
+        const viaCursor = await collectChunked('gallery', 4); // batchSize < 总数，强制多批
+
+        expect(viaCursor).toHaveLength(viaGetAll.length);
+        expect(viaCursor).toEqual(viaGetAll); // 逐条深比，顺序也必须一致
+        // 主键升序：1,2,5,7,37,...
+        expect(viaCursor.map((r: any) => r.id)).toEqual([1, 2, 5, 7, 37, 64, 88, 128, 500, 999]);
+    });
+
+    it('空表：onBatch 一次都不调，正常结束', async () => {
+        let calls = 0;
+        await DB.getStoreDataChunked('gallery', () => { calls++; });
+        expect(calls).toBe(0);
+    });
+
+    it('批边界：总数正好是 batchSize 整数倍，不漏不重不多跑空批', async () => {
+        await seedGallery(Array.from({ length: 200 }, (_, i) => ({ id: i + 1, url: `u${i}` })));
+        const batches: number[] = [];
+        await DB.getStoreDataChunked('gallery', batch => { batches.push(batch.length); }, 50);
+        // 200 / 50 = 4 个满批，不该多出一个空批
+        expect(batches).toEqual([50, 50, 50, 50]);
+        const all = await collectChunked('gallery', 50);
+        expect(all).toHaveLength(200);
+        expect(new Set(all.map((r: any) => r.id)).size).toBe(200); // 无重复
+    });
+
+    it('batchSize 大于总数：一批读完', async () => {
+        await seedGallery(Array.from({ length: 30 }, (_, i) => ({ id: i + 1 })));
+        const batches: number[] = [];
+        await DB.getStoreDataChunked('gallery', batch => { batches.push(batch.length); }, 200);
+        expect(batches).toEqual([30]);
+    });
+
+    it('回调是 async（中途 await 让出主线程）也不丢数据、不报事务失活', async () => {
+        await seedGallery(Array.from({ length: 120 }, (_, i) => ({ id: i + 1, url: `u${i}` })));
+        const out: any[] = [];
+        await DB.getStoreDataChunked('gallery', async batch => {
+            await new Promise(r => setTimeout(r, 0)); // 跨过事务自动提交点
+            out.push(...batch);
+        }, 40);
+        expect(out).toHaveLength(120);
+        expect(out.map((r: any) => r.id)).toEqual(Array.from({ length: 120 }, (_, i) => i + 1));
+    });
+
+    it('store 不存在：直接返回，不抛错', async () => {
+        await expect(
+            DB.getStoreDataChunked('__nonexistent_store__', () => { throw new Error('不该被调用'); })
+        ).resolves.toBeUndefined();
+    });
+});

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -2185,6 +2185,65 @@ export const DB = {
       });
   },
 
+  /**
+   * 游标分批读整表：每攒够 batchSize 条回调一次 onBatch(batch)，回调内消费完即释放，
+   * 绝不像 getRawStoreData 那样把整表一次性 getAll 进内存。导出大 store 时用它，把读取
+   * 峰值从「整个 store」降到「一个 batch」。
+   *
+   * 实现要点——每批一个独立 readonly 事务，按主键升序续读（顺序与 getAll 完全一致）：
+   * IDB 事务在控制权回到事件循环、且没有挂起请求时会自动提交关闭。onBatch 可能是 async
+   * （要 await 写分片 / 让出主线程），await 必然跨过这个提交点把事务关掉，之后再 cursor
+   * .continue() 就会抛 TransactionInactiveError。所以这里先在一个事务内用游标攒满一批、
+   * 让事务自然关闭，await onBatch 消费完，再用 lowerBound(lastKey, true) 开下一个事务从
+   * 断点续读。这是 memoryPalace/db.ts 的 scanAndMigrateLegacy 同款分批事务做法。
+   *
+   * ⚠ 一致性语义（接进导出前必读）：分批跨多个事务 ≠ getAll 的单事务快照。store 静止时
+   * 两者结果一致；但若批次之间有并发写入，key 大于断点的新记录会被带进来、已扫过 key 上的
+   * 增删改会漏掉或读到陈旧值——拼出来的可能是内部不一致的 store。getRawStoreData 的单次
+   * getAll 至少是「每个 store 自带一致快照」。所以把本函数接进备份导出时，必须先保证导出
+   * 期间 store 静止（暂停写入 / 加导出锁），否则要接受「活动中导出 = 尽力而为快照」并补一条
+   * 批间改动的回归测试。当前备份导出仍走 getRawStoreData，未用本函数，此约束留给后续接入时兑现。
+   */
+  getStoreDataChunked: async (
+      storeName: string,
+      onBatch: (batch: any[]) => void | Promise<void>,
+      batchSize = 200,
+  ): Promise<void> => {
+      const db = await openDB();
+      if (!db.objectStoreNames.contains(storeName)) return;
+
+      let lastKey: IDBValidKey | null = null;
+      for (;;) {
+          const { batch, newLastKey, done } = await new Promise<{
+              batch: any[]; newLastKey: IDBValidKey | null; done: boolean;
+          }>((resolve, reject) => {
+              const tx = db.transaction(storeName, 'readonly');
+              const store = tx.objectStore(storeName);
+              const range = lastKey !== null ? IDBKeyRange.lowerBound(lastKey, true) : undefined;
+              const req = store.openCursor(range);
+              const collected: any[] = [];
+              let bLast: IDBValidKey | null = lastKey;
+              let bDone = false;
+              req.onsuccess = () => {
+                  const cursor = req.result;
+                  if (!cursor) { bDone = true; return; } // 走到末尾
+                  if (collected.length >= batchSize) return; // 攒够这批，停 continue 等事务关闭
+                  collected.push(cursor.value);
+                  bLast = cursor.primaryKey;
+                  cursor.continue();
+              };
+              req.onerror = () => reject(req.error);
+              tx.oncomplete = () => resolve({ batch: collected, newLastKey: bLast, done: bDone });
+              tx.onerror = () => reject(tx.error || new Error('getStoreDataChunked tx failed'));
+              tx.onabort = () => reject(tx.error || new Error('getStoreDataChunked tx aborted'));
+          });
+
+          if (batch.length > 0) await onBatch(batch);
+          lastKey = newLastKey;
+          if (done) break;
+      }
+  },
+
   exportFullData: async (): Promise<Partial<FullBackupData>> => {
       const db = await openDB();
       

--- a/utils/memoryPalace/db.ts
+++ b/utils/memoryPalace/db.ts
@@ -11,6 +11,7 @@ import type {
     EventBox,
 } from './types';
 import { bm25Index } from './bm25Index';
+import type { VectorIndexEntry as VectorBackupIndexEntry } from '../backupFormat';
 
 // ─── Store 名称常量 ────────────────────────────────────
 
@@ -202,6 +203,39 @@ export function ensureFloat32(vec: number[] | Float32Array | Uint8Array): Float3
     }
     // 旧 number[] 路径
     return new Float32Array(vec);
+}
+
+/**
+ * 把 memory_vectors 的原始记录归一化成「Float32 原始字节拼成的一根 bin + 索引」，供 v2 备份的
+ * 向量二进制旁路使用（见 utils/backupFormat.ts）。vector 可能是 Uint8Array（已迁移）/ Float32Array /
+ * 遗留 number[]，必须先过 ensureFloat32 统一——遗留 number[] 不归一化直接当字节读会写出无效数据（R4·F4）。
+ * dimensions 用实际 f32 长度，钉死 byteLength === dimensions*4 不变量（导入端据此校验）。
+ */
+export function encodeVectorsForBackup(
+    rawVectors: Array<{ memoryId?: string; charId?: string; dimensions?: number; model?: string; vector?: unknown }>,
+): { bin: Uint8Array; index: VectorBackupIndexEntry[] } {
+    const index: VectorBackupIndexEntry[] = [];
+    const parts: Uint8Array[] = [];
+    let offset = 0;
+    for (const v of rawVectors) {
+        if (!v || !v.vector || !v.memoryId) continue;
+        const f32 = ensureFloat32(v.vector as number[] | Float32Array | Uint8Array);
+        const bytes = new Uint8Array(f32.buffer, f32.byteOffset, f32.byteLength);
+        parts.push(bytes);
+        index.push({
+            memoryId: v.memoryId,
+            charId: (v.charId ?? '') as string,
+            dimensions: f32.length,
+            model: v.model,
+            byteOffset: offset,
+            byteLength: bytes.byteLength,
+        });
+        offset += bytes.byteLength;
+    }
+    const bin = new Uint8Array(offset);
+    let p = 0;
+    for (const part of parts) { bin.set(part, p); p += part.byteLength; }
+    return { bin, index };
 }
 
 /** 编码为 IndexedDB 存储形态（Uint8Array of Float32 raw bytes） */

--- a/utils/webdavClient.test.ts
+++ b/utils/webdavClient.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { uploadBackup } from './webdavClient';
+import type { CloudBackupConfig } from '../types';
+
+// 这条锁住 #5 的大小预检：经 Worker 代理上传（web 路径）时，备份 blob 超体积上限必须在发起上传
+// 前就给可执行报错（提示改用本地导出 / GitHub），而不是傻等几十秒上行后才失败。
+// node 测试环境非 native，走 web 分支；超限会在创建 XMLHttpRequest 之前 resolve，所以这里无需 XHR。
+
+const config: CloudBackupConfig = {
+    webdavUrl: 'https://example.invalid/dav',
+    remotePath: '/backups',
+    username: 'u',
+    password: 'p',
+} as CloudBackupConfig;
+
+describe('uploadBackup 大小预检（#5）', () => {
+    it('超过 Worker 上传上限：直接报错且提示改用本地导出 / GitHub，不发起上传', async () => {
+        // 只读 blob.size，造一个声明超大的假 blob，避免真分配几百 MB
+        const oversized = { size: 200 * 1024 * 1024 } as Blob;
+        const res = await uploadBackup(config, oversized, 'backup.zip');
+        expect(res.ok).toBe(false);
+        expect(res.message).toMatch(/超过云端代理上传上限/);
+        expect(res.message).toMatch(/本地导出|GitHub/);
+    });
+});

--- a/utils/webdavClient.ts
+++ b/utils/webdavClient.ts
@@ -17,6 +17,17 @@ import { CloudBackupConfig, CloudBackupFile } from '../types';
 
 const WORKER_URL = 'https://sullymeow.ccwu.cc';
 
+// 经 CF Worker 代理上传（web 路径）的请求体上限。Cloudflare Worker 免费版单次请求体约 100MB，
+// 超了会被 Worker/平台直接拒（返回 413 之类），且大请求体上行还可能撞 ~42s 上行超时。所以在发起
+// 上传前先按 blob 大小预检：超限直接给可执行的报错（改用本地导出 / GitHub），别让用户傻等几十秒
+// 才失败。备份 blob 已是压缩 zip，gzip 上行无意义，这里只做大小闸。
+// 注：native 路径（CapacitorHttp 直连上游 WebDAV，不过 Worker）不受此限，上游各家容量不一，
+// 由响应状态兜底；native 端把整个 blob 读进 ArrayBuffer 的额外拷贝是已知内存开销，彻底解需改
+// 「先落临时文件再按路径 PUT」，列为 follow-up。
+const WORKER_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+const formatMiB = (bytes: number): string => `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+
 const isNative = (): boolean => {
     try {
         return Capacitor.isNativePlatform();
@@ -180,6 +191,7 @@ export const uploadBackup = async (
     const mapStatus = (s: number) => {
         if (s === 200 || s === 201 || s === 204) return { ok: true, message: '上传成功' };
         if (s === 401) return { ok: false, message: '认证失败' };
+        if (s === 413) return { ok: false, message: `备份文件 ${formatMiB(blob.size)} 超出云端上传上限，请改用「本地导出」或「GitHub 备份」` };
         if (s === 507) return { ok: false, message: '云端空间不足' };
         return { ok: false, message: `上传失败 (${s})` };
     };
@@ -202,6 +214,15 @@ export const uploadBackup = async (
     }
 
     return new Promise((resolve) => {
+        // 大小预检：经 Worker 代理的上传超体积上限时，直接给可执行报错，不发起注定失败的上传。
+        if (blob.size > WORKER_MAX_UPLOAD_BYTES) {
+            resolve({
+                ok: false,
+                message: `备份文件 ${formatMiB(blob.size)} 超过云端代理上传上限（约 ${formatMiB(WORKER_MAX_UPLOAD_BYTES)}），请改用「本地导出」或「GitHub 备份」`,
+            });
+            return;
+        }
+
         const url = buildProxyUrl(buildFullUrl(config.webdavUrl, remotePath));
         const auth = buildAuthHeader(config);
 


### PR DESCRIPTION
## 改了啥 → 现在啥样

备份导出原先把全部数据拼成**一根** `data.json` 字符串，重度账号文本逼近 ~512M JS 单字符串上限会**确定性 `RangeError` 硬崩**。本 PR 改为 v2 分片格式：

| | 改之前 | 改之后 |
|---|---|---|
| 导出 | 全部拼成一根 `data.json` | 每个数组字段分片写 `stores/<field>.NNN.json`，其余进 `metadata.json`，`manifest.json` 当导入契约 |
| 导入 | 整串 `JSON.parse` | 按 manifest 把各片拼回**与原来完全相同的 `data` 对象**，喂给**原封不动的 `importFullData`** |
| 还原语义 | 在 importFullData | **没动**——clear-and-add / merge / 单例 / media_only 补丁全部复用，只换「怎么存」 |

核心设计：v2 只改**序列化**，忠实复刻 v1 的 `backupData` 对象；还原语义仍是 `importFullData` 这一处真相源，不写第二套、不会漂移。

## 具体改动

- **分片格式**：消除单根大字符串 → 永不触 RangeError；去掉旧的 `join('')` 整包翻倍
- **向量二进制**：`memory_vectors` 不再 number[] 进 JSON（~5× 膨胀 + 解码副本），改写进 `memory_vectors.bin`（直写 Uint8Array）+ 索引；遗留 number[] 先归一化；导入端 `slice` 切独立 buffer，避免结构化克隆把整根 bin 复制 N 遍
- **游标分批读** `getStoreDataChunked`：导出读取地基（**本轮未接入导出**，留 follow-up；接入需先处理导出期并发写的快照一致性）
- **导入分片组装**：复用既有逐 50 条 `putItems` + 素材回填，调一次 `importFullData`
- **WebDAV**：上传前体积预检 + 413 映射成可读报错（超 Worker 上限提示改用本地导出 / GitHub）
- **写库前三档校验**：版本严格 `=== 2` / 缺片 / 条数不符 / 向量越界 → **abort 且 DB 一字未动**
- **向后兼容**：老备份（无 `manifest.json`）原样走 v1 路径

## 测试

26 条回归守卫，**全量 456 通过**：格式往返（含真 JSZip 端到端）、跨片 clear-and-add 不丢数据、media_only 不误清文字、空 store 按 shape 还原、向量二进制往返、clear-once、遗留 number[]、向量越界 abort、WebDAV 预检。经两轮 codex adversarial-review，findings 已全部 disposition。

> 注：OSContext 的 export/import 接线属 React 胶水，单测不覆盖，已手动跑过完整往返（导出→导入→校对 + v1 备份兼容）验证。

## 一个单向门

v2 起导出是新布局：**老版本 App 打不开新备份**（新→旧不兼容）；新版 App 能打开老备份（旧→新兼容保留）。

## Follow-up（不在本轮）

- 游标流式读接入导出（砍构建峰值 ~O(整包) → O(单片) + 处理并发快照一致性）
- WebDAV 临时文件上传（native 端绕开整包 ArrayBuffer 拷贝）
- 消息/相册保留策略（产品决策）

🤖 Generated with [Claude Code](https://claude.com/claude-code)