### PR TITLE
fix(music): MizuHeader 自理顶部安全区，避免与系统状态栏重叠

### DIFF
--- a/apps/music/MusicUI.tsx
+++ b/apps/music/MusicUI.tsx
@@ -92,7 +92,7 @@ export const MizuHeader: React.FC<{
   right?: React.ReactNode;
 }> = ({ title, onBack, onClose, right }) => (
   <div className="flex items-center justify-between px-4 h-12 shrink-0 shizuku-glass-strong relative z-20"
-    style={{ borderBottom: `1px solid rgba(255,255,255,0.3)` }}>
+    style={{ borderBottom: `1px solid rgba(255,255,255,0.3)`, paddingTop: 'var(--safe-top)', boxSizing: 'content-box' }}>
     <button
       className="w-8 h-8 flex items-center justify-center rounded-full transition-all"
       style={{ color: C.primary }}


### PR DESCRIPTION
未来音楽（网易云）App 已在 SELF_SAFE_AREA_APPS 名单里，外壳不再统一让位
安全区，但通用顶栏 MizuHeader 一直没接管 --safe-top，导致 iPhone 刘海/状态栏 机型上顶栏与系统状态栏重叠、点不到返回/关闭按钮。

给 MizuHeader 加 paddingTop: var(--safe-top)，并用 box-sizing: content-box 保住 h-12(48px) 可点高度（Tailwind preflight 默认 border-box 会把内容压进刘海）。 与本 App 内歌词对轴浮层既有写法一致，一处修复覆盖播放页/搜索/设置/我的/登录/拜访
所有子页。


Claude-Session: https://claude.ai/code/session_01QRRtksJWkuiU6cPZBVfxUy