### PR TITLE
fix(群聊): 群头像/群信息修改退出后不再恢复默认

### DIFF
--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -177,7 +177,7 @@ const GroupMessageItem = React.memo(({
 // --- Main Component ---
 
 const GroupChat: React.FC = () => {
-    const { closeApp, groups, createGroup, deleteGroup, characters, updateCharacter, apiConfig, addToast, userProfile, virtualTime } = useOS();
+    const { closeApp, groups, createGroup, updateGroup, deleteGroup, characters, updateCharacter, apiConfig, addToast, userProfile, virtualTime } = useOS();
     const [view, setView] = useState<'list' | 'chat'>('list');
     const [activeGroup, setActiveGroup] = useState<GroupProfile | null>(null);
     const [messages, setMessages] = useState<Message[]>([]);
@@ -422,13 +422,13 @@ const GroupChat: React.FC = () => {
 
     const handleUpdateGroupInfo = async () => {
         if (!activeGroup) return;
-        const updatedGroup = {
-            ...activeGroup,
+        const updates = {
             name: tempGroupName || activeGroup.name,
             privateContextCap: tempPrivateContextCap,
         };
-        await DB.saveGroup(updatedGroup);
-        setActiveGroup(updatedGroup);
+        // 走 context 的 updateGroup：同步内存 groups + DB，避免退出后读回旧值
+        await updateGroup(activeGroup.id, updates);
+        setActiveGroup({ ...activeGroup, ...updates });
         setModalType('none');
         addToast('群信息已更新', 'success');
     };
@@ -438,9 +438,10 @@ const GroupChat: React.FC = () => {
         if (!file || !activeGroup) return;
         try {
             const base64 = await processImage(file);
-            const updatedGroup = { ...activeGroup, avatar: base64 };
-            await DB.saveGroup(updatedGroup);
-            setActiveGroup(updatedGroup);
+            // 走 context 的 updateGroup：同步内存 groups + DB，
+            // 否则只改了本地 activeGroup，退出回列表/再次进群会读回旧头像（恢复默认）
+            await updateGroup(activeGroup.id, { avatar: base64 });
+            setActiveGroup({ ...activeGroup, avatar: base64 });
             addToast('群头像已修改', 'success');
         } catch (err: any) {
             addToast('图片处理失败', 'error');

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -248,6 +248,7 @@ interface OSContextType {
   // Groups
   groups: GroupProfile[];
   createGroup: (name: string, members: string[]) => void;
+  updateGroup: (id: string, updates: Partial<GroupProfile>) => Promise<void>;
   deleteGroup: (id: string) => void;
 
   // User Profile
@@ -2196,6 +2197,18 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       setGroups(prev => [...prev, newGroup]);
   };
 
+  const updateGroup = async (id: string, updates: Partial<GroupProfile>) => {
+      // 先更新内存中的 groups（列表渲染、再次进群都读这里），再持久化到 DB。
+      // 不更新 context 会导致改了群头像/群名退出后又读回旧值（恢复默认）。
+      let target: GroupProfile | undefined;
+      setGroups(prev => {
+          const updated = prev.map(g => g.id === id ? { ...g, ...updates } : g);
+          target = updated.find(g => g.id === id);
+          return updated;
+      });
+      if (target) await DB.saveGroup(target);
+  };
+
   const deleteGroup = async (id: string) => {
       await DB.deleteGroup(id);
       setGroups(prev => prev.filter(g => g.id !== id));
@@ -3533,6 +3546,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     deleteSong,
     groups,
     createGroup,
+    updateGroup,
     deleteGroup,
     userProfile,
     updateUserProfile,


### PR DESCRIPTION
群头像、群名、私聊上下文上限改了之后退出群聊会读回旧值的根因：
list 视图和再次进群都从 context 的 groups 数组取数据，但
handleGroupAvatarUpload / handleUpdateGroupInfo 只写了 DB 和本地 activeGroup，从没同步 context 的 groups。退出回列表 / 再次点进群时
setActiveGroup 拿到的是 context 里的旧群，头像就"恢复默认"了。

新增 OSContext.updateGroup(id, updates)：同步内存 groups + 持久化 DB （对齐 updateCharacter 的写法），GroupChat 两处改用它。


Claude-Session: https://claude.ai/code/session_015DBN7CHJr9BrMVfd2g6vuv