### PR TITLE
fix(music): 中心 Worker 变更后音乐实时跟随（不必刷新）

### DIFF
--- a/context/MusicContext.tsx
+++ b/context/MusicContext.tsx
@@ -13,7 +13,7 @@ import React, {
 } from 'react';
 import { cachedCall as _cachedCall, invalidate as _invalidateCache, clearAll as _clearAllCache } from '../utils/musicCache';
 import { DB } from '../utils/db';
-import { getProxyWorkerUrl, DEFAULT_PROXY_WORKER } from '../utils/proxyWorker';
+import { getProxyWorkerUrl, DEFAULT_PROXY_WORKER, PROXY_WORKER_CHANGED_EVENT } from '../utils/proxyWorker';
 import type { PostProcessMusicHooks } from '../utils/applyAssistantPostProcessing';
 
 /* ───────────── 类型 ───────────── */
@@ -364,6 +364,20 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       return next;
     });
     saveCfg(next);
+  }, []);
+
+  // 中心配置（设置 → 自定义网络代理）变了 → 重读音乐 cfg，让"跟随中心"的地址实时切过去。
+  // 音乐 cfg 是挂载时快照进 state 的，不重读就只能等下次刷新页面；地址真的变了才清缓存重拉。
+  useEffect(() => {
+    const onProxyChanged = () => {
+      setCfgState(prev => {
+        const next = loadCfg();
+        if (next.workerUrl !== prev.workerUrl) _clearAllCache();
+        return next;
+      });
+    };
+    window.addEventListener(PROXY_WORKER_CHANGED_EVENT, onProxyChanged);
+    return () => window.removeEventListener(PROXY_WORKER_CHANGED_EVENT, onProxyChanged);
   }, []);
 
   const initialState = useMemo(loadState, []);

--- a/utils/proxyWorker.ts
+++ b/utils/proxyWorker.ts
@@ -49,18 +49,36 @@ export const getProxyWorkerUrl = (): string => {
 /**
  * 写入自定义 worker 地址。传空、或传的就是默认地址 → 清掉本地存储（回到默认）。
  * 非法地址（不以 http(s):// 开头）直接忽略，由调用方负责校验提示。
+ * 写入成功后广播一个自定义事件，让"启动时快照配置"的消费者（如音乐播放器）能实时跟随。
  */
 export const setProxyWorkerUrl = (url: string): void => {
   try {
     const trimmed = normalize(url || '');
     if (!trimmed || trimmed === DEFAULT_PROXY_WORKER) {
       localStorage.removeItem(LS_KEY);
+      notifyProxyWorkerChanged();
       return;
     }
     if (!/^https?:\/\//i.test(trimmed)) return;
     localStorage.setItem(LS_KEY, trimmed);
+    notifyProxyWorkerChanged();
   } catch {
     /* localStorage 不可用就当默认处理 */
+  }
+};
+
+/**
+ * 中心 Worker 地址变更事件。同一标签页内改 localStorage 不会触发原生 'storage' 事件，
+ * 所以用这个自定义事件通知那些"只在挂载时读一次配置"的模块（目前是音乐播放器）实时刷新。
+ */
+export const PROXY_WORKER_CHANGED_EVENT = 'sully:proxy-worker-changed';
+const notifyProxyWorkerChanged = (): void => {
+  try {
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new Event(PROXY_WORKER_CHANGED_EVENT));
+    }
+  } catch {
+    /* 非浏览器环境（测试 / SSR）忽略 */
   }
 };
 


### PR DESCRIPTION
问题：音乐 cfg 在挂载时快照进 React state，且无 storage 监听，所以改了
中心配置后当场不重读，仍用启动时的旧地址（叠加缓存键不含 workerUrl，
表现为"填错地址音乐还能用"）。网易云本身确实走 worker，只是没实时切。

修复：
- setProxyWorkerUrl 写入后广播自定义事件 PROXY_WORKER_CHANGED_EVENT （同标签页改 localStorage 不触发原生 storage 事件）
- MusicProvider 监听该事件 → 重读 cfg（跑迁移）；workerUrl 真变了才清 音乐缓存重拉，避免命中旧 worker 的缓存

其余功能本就在请求时现取 getProxyWorkerUrl()，无需此处理。


Claude-Session: https://claude.ai/code/session_01Wbe1Mxqf68StLNpdefKNWh