### PR TITLE
fix(xhs): 让角色也能看到用户分享的小红书笔记评论

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -876,14 +876,27 @@ const Chat: React.FC = () => {
                     if (mcpUrl && realtimeConfig?.xhsMcpConfig?.enabled) {
                         try {
                             const noteUrl = `https://www.xiaohongshu.com/explore/${noteId}${xsecToken ? `?xsec_token=${xsecToken}&xsec_source=pc_share` : ''}`;
-                            const result = await XhsMcpClient.getNoteDetail(mcpUrl, noteUrl, xsecToken);
+                            // loadAllComments：和角色自己浏览笔记 (XHS_DETAIL) 一致地把评论区也抓回来，
+                            // 否则 user 分享的笔记只有标题/正文，角色读不到评论（char 分享给 user 的却能看到）。
+                            const result = await XhsMcpClient.getNoteDetail(mcpUrl, noteUrl, xsecToken, { loadAllComments: true });
                             if (isDevDebugAvailable()) console.log('[卡片调试] 小红书抓取 result =', result);
                             if (result.success && result.data) {
                                 // bridge(Lite) 返回 { data: { note, comments } }；MCP 可能直接是 note —— 逐层解包。
-                                const noteObj = (result.data as any)?.data?.note || (result.data as any)?.note || result.data;
+                                const dataRoot = (result.data as any)?.data || result.data;
+                                const noteObj = dataRoot?.note || (result.data as any)?.note || result.data;
                                 const fetched = normalizeNote(noteObj);
                                 // 抓到的字段补全基础卡；id/标题/token 保底，标题优先文案标题（更完整可读）。
                                 note = { ...note, ...fetched, noteId: fetched.noteId || note.noteId, title: titleFromText || fetched.title || note.title, xsecToken: fetched.xsecToken || xsecToken };
+                                // normalizeNote 只保留笔记基础字段会丢掉评论 —— 单独解包评论挂回卡片，
+                                // 让角色读 context 时也能看到评论区（与 char 浏览/分享笔记对齐）。
+                                const rawComments = dataRoot?.comments?.list || dataRoot?.comments
+                                    || (noteObj as any)?.comments?.list || (noteObj as any)?.comments || [];
+                                const comments = (Array.isArray(rawComments) ? rawComments : []).map((c: any) => ({
+                                    author: c.userInfo?.nickname || c.nickname || c.userName || c.author || '匿名',
+                                    content: c.content || '',
+                                    likes: c.likeCount || c.like_count || c.likes || 0,
+                                })).filter((c: any) => c.content).slice(0, 15);
+                                if (comments.length) note.comments = comments;
                             }
                         } catch (e) {
                             console.warn('XHS link fetch via MCP failed (已用文案兜底):', e);

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -881,7 +881,13 @@ ${userProfile.name} 给你反馈时，别当成约束，当成信任——ta 在
                 else if ((m.type as string) === 'xhs_card') {
                     const note = m.metadata?.xhsNote || {};
                     const sender = m.role === 'user' ? '用户' : '你';
-                    content = `${timeStr} [${sender}分享了小红书笔记]\n标题: ${note.title || '无标题'}\n作者: ${note.author || '未知'}\n赞: ${note.likes || 0}\n简介: ${note.desc || '无'}\n${m.role === 'user' ? '(请根据你的性格对这个帖子发表看法)' : ''}`;
+                    // 评论区：user 分享笔记时也带上评论（抓取于建卡时），让角色像浏览笔记一样能看到评论，
+                    // 不再出现「char 分享的能看评论、user 分享的看不到」的不对称。
+                    const noteComments = Array.isArray(note.comments) ? note.comments : [];
+                    const commentsLine = noteComments.length
+                        ? `\n热评: ${noteComments.slice(0, 15).map((c: any) => `${c.author || '匿名'}: ${c.content}`).join(' | ')}`
+                        : '';
+                    content = `${timeStr} [${sender}分享了小红书笔记]\n标题: ${note.title || '无标题'}\n作者: ${note.author || '未知'}\n赞: ${note.likes || 0}\n简介: ${note.desc || '无'}${commentsLine}\n${m.role === 'user' ? '(请根据你的性格对这个帖子发表看法)' : ''}`;
                 }
                 else if ((m.type as string) === 'vr_card') {
                     // vr_card：你自己进入 VR 社交游戏《彼方》时留下的动态。

--- a/utils/messageFormat.cards.test.ts
+++ b/utils/messageFormat.cards.test.ts
@@ -19,6 +19,23 @@ describe('normalizeMessageContent · xhs_card', () => {
     expect(out).toContain('今天画了花岗岩版');
   });
 
+  it('有评论时把评论区也喂给角色（user 分享的笔记也能看到评论）', () => {
+    const out = normalizeMessageContent(
+      mk('xhs_card', '睡不够', { xhsNote: {
+        title: '睡不够', desc: '今天画了花岗岩版', author: '某人',
+        comments: [
+          { author: '路人甲', content: '太好笑了', likes: 12 },
+          { author: '路人乙', content: '同款', likes: 3 },
+        ],
+      } }),
+      'Char', '我',
+    );
+    expect(out).toContain('评论区');
+    expect(out).toContain('路人甲');
+    expect(out).toContain('太好笑了');
+    expect(out).toContain('路人乙');
+  });
+
   it('只有文案标题(无 MCP/没抓到正文)时给标题并明示别瞎编', () => {
     const out = normalizeMessageContent(
       mk('xhs_card', '睡不够', { xhsNote: { title: '睡不够', desc: '', author: '' } }),

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -155,7 +155,12 @@ export function normalizeMessageContent(
         const author = (note.author || '').trim();
         const authorPart = author ? `（作者：${author}）` : '';
         const head = `[小红书笔记] ${userName}分享了一篇小红书笔记${title ? `《${title}》` : ''}${authorPart}`;
-        if (desc) return `${head}\n笔记正文：\n${desc}`;
+        // 评论区：建卡时抓到的评论一并喂给角色（含归档/记忆宫殿场景），与浏览笔记时的可见性对齐。
+        const comments = Array.isArray(note.comments) ? note.comments : [];
+        const commentsPart = comments.length
+            ? `\n评论区：\n${comments.slice(0, 15).map((c: any) => `· ${c.author || '匿名'}：${c.content}`).join('\n')}`
+            : '';
+        if (desc) return `${head}\n笔记正文：\n${desc}${commentsPart}`;
         // 只有标题（没部署 MCP / 没抓到正文）：角色至少知道是哪篇笔记，但别假装读过正文。
         if (title) return `${head}\n（注：只拿到了笔记标题，正文/图片没抓到——要读完整内容需部署小红书功能。别假装读过正文。）`;
         return `${head}\n（注：这篇笔记的内容没能获取到。）`;


### PR DESCRIPTION
此前 char 浏览/分享笔记走 XHS_DETAIL（loadAllComments），评论会进 context； 但 user 在聊天里分享小红书链接走 Chat.tsx 解析路径，getNoteDetail 没传 loadAllComments，且 normalizeNote 只保留笔记基础字段会丢掉评论，喂给角色的 chatPrompts/messageFormat 也不含评论行 —— 导致「char 分享的能看评论、user 分享的看不到」的不对称。

- Chat.tsx: 抓详情时传 loadAllComments，单独解包评论挂回 xhsNote.comments
- chatPrompts.ts / messageFormat.ts: xhs_card 渲染时带上评论区
- 补 messageFormat.cards 测试覆盖评论场景


Claude-Session: https://claude.ai/code/session_01NhSH7dLyfDkhfjJ3KFUhrk