### PR TITLE
feat(settings): 鱼声模型可选，含免费 s2.1-pro-free

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -84,6 +84,7 @@ const Settings: React.FC = () => {
     apiConfig.ttsProvider === 'fishaudio' ? 'fishaudio' : 'minimax'
   );
   const [localFishKey, setLocalFishKey] = useState(apiConfig.fishAudioApiKey || '');
+  const [localFishModel, setLocalFishModel] = useState(apiConfig.fishAudioModel || 's2.1-pro');
   const [showAceStepGuide, setShowAceStepGuide] = useState(false);
   const [otherStatusMsg, setOtherStatusMsg] = useState('');
   // 高级设置（流式/温度）默认折叠 — 大多数用户不需要碰
@@ -375,6 +376,7 @@ const Settings: React.FC = () => {
       setLocalAceStepKey(apiConfig.aceStepApiKey || '');
       setLocalTtsProvider(apiConfig.ttsProvider === 'fishaudio' ? 'fishaudio' : 'minimax');
       setLocalFishKey(apiConfig.fishAudioApiKey || '');
+      setLocalFishModel(apiConfig.fishAudioModel || 's2.1-pro');
   }, [apiConfig]);
 
   const loadPreset = (preset: typeof apiPresets[0]) => {
@@ -425,6 +427,7 @@ const Settings: React.FC = () => {
       aceStepApiKey: localAceStepKey,
       ttsProvider: localTtsProvider,
       fishAudioApiKey: localFishKey,
+      fishAudioModel: localFishModel,
     });
     setOtherStatusMsg('已保存');
     setTimeout(() => setOtherStatusMsg(''), 2000);
@@ -441,9 +444,24 @@ const Settings: React.FC = () => {
       minimaxRegion: localMiniMaxRegion,
       aceStepApiKey: localAceStepKey,
       fishAudioApiKey: localFishKey,
+      fishAudioModel: localFishModel,
       ttsProvider: provider,
     });
     addToast(provider === 'fishaudio' ? '语音生成已切到鱼声 Fish' : '语音生成已切到 MiniMax', 'success');
+  };
+
+  // 选鱼声模型：立即落库（同上，连带草稿一起提交，避免被同步 effect 冲掉）。
+  const selectFishModel = (model: string) => {
+    setLocalFishModel(model);
+    updateApiConfig({
+      minimaxApiKey: localMiniMaxKey,
+      minimaxGroupId: localMiniMaxGroupId,
+      minimaxRegion: localMiniMaxRegion,
+      aceStepApiKey: localAceStepKey,
+      fishAudioApiKey: localFishKey,
+      ttsProvider: localTtsProvider,
+      fishAudioModel: model,
+    });
   };
 
   const fetchModels = async () => {
@@ -1366,7 +1384,24 @@ const Settings: React.FC = () => {
                 <div className="group">
                     <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 block pl-1">鱼声 Fish Audio Key</label>
                     <input type="password" name="fish-api-key" autoComplete="new-password" spellCheck={false} value={localFishKey} onChange={(e) => setLocalFishKey(e.target.value)} placeholder="Fish Audio API Key（fish.audio 控制台签发）" className="w-full bg-white/50 border border-slate-200/60 rounded-xl px-4 py-2.5 text-sm font-mono focus:bg-white transition-all" />
-                    <p className="text-[11px] text-slate-400 mt-1 pl-1">在 <a href="https://fish.audio/zh-CN/developers/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-semibold">fish.audio 开发者页</a> 拿 Key（<span className="text-amber-600 font-medium">需梯子</span>）；默认模型 s2.1-pro。角色音色在「角色 → 语音」里填 reference_id。</p>
+                    <p className="text-[11px] text-slate-400 mt-1 pl-1">在 <a href="https://fish.audio/zh-CN/developers/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-semibold">fish.audio 开发者页</a> 拿 Key（<span className="text-amber-600 font-medium">需梯子</span>）。角色音色在「角色 → 语音」里填 reference_id。</p>
+
+                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-3 mb-1.5 block pl-1">鱼声模型</label>
+                    <select
+                        value={localFishModel}
+                        onChange={(e) => selectFishModel(e.target.value)}
+                        className="w-full bg-white/50 border border-slate-200/60 rounded-xl px-3 py-2.5 text-sm focus:bg-white transition-all"
+                    >
+                        <option value="s2.1-pro-free">s2.1-pro-free —— 免费（同款模型 $0，测试/个人首选）</option>
+                        <option value="s2.1-pro">s2.1-pro —— 付费，质量/延迟更优，生产推荐</option>
+                        <option value="s2-pro">s2-pro —— 上一代，多说话人 / 自然语言控制</option>
+                        <option value="s1">s1 —— 旧版，(圆括号) 情绪标签</option>
+                    </select>
+                    <p className="text-[11px] text-slate-400 mt-1 pl-1">
+                        {localFishModel === 's2.1-pro-free'
+                            ? '免费版：和 s2.1-pro 同一个模型、$0，但不保证 TTFA / DPA，适合自用测试。选了立即生效。'
+                            : '切换立即生效。角色也可在「角色 → 语音」单独覆盖模型（留空则用这里的全局默认）。'}
+                    </p>
                 </div>
 
                 {/* 底部：当前语音引擎二选一 —— radio 样式（不是 tab 切换，配置都在上面，这里只挑用哪家） */}


### PR DESCRIPTION
设置 → 鱼声 Audio 区加模型下拉：s2.1-pro-free（免费，同款模型 $0，测试首选）/ s2.1-pro（付费推荐）/ s2-pro / s1。存 apiConfig.fishAudioModel，切换立即生效（连带 草稿一起 updateApiConfig，不用点保存）；角色可在 voiceProfile.fishModel 单独覆盖。 免费版下给出"不保证 TTFA/DPA、适合自用"的说明。


Claude-Session: https://claude.ai/code/session_01Tkb1qz2koCRoF5T3JrpUZF