### PR TITLE
fix(tts): 静态部署(github.io)鱼声走 sfworker 代理绕 CORS

### DIFF
--- a/utils/fishAudioTts.ts
+++ b/utils/fishAudioTts.ts
@@ -15,6 +15,7 @@ import { CharacterProfile, APIConfig } from '../types';
 import { Capacitor, CapacitorHttp } from '@capacitor/core';
 import { hashTtsParams, getCachedTts, saveCachedTts } from './ttsCache';
 import { normalizeApiKey } from './minimaxApiKey';
+import { getProxyWorkerUrl } from './proxyWorker';
 import type { TtsResult } from './minimaxTts';
 
 const FISH_PROXY_PATH = '/api/fishaudio/tts';
@@ -319,10 +320,21 @@ const fishFetchAudio = async (
     return base64ToBlob(String(response.data || ''));
   }
 
-  const url = shouldBypassWebProxy() ? FISH_UPSTREAM : FISH_PROXY_PATH;
+  // 静态部署（github.io / file:）没有 /api serverless 代理，直连 api.fish.audio 会被浏览器
+  // CORS 挡（Fish 不发 ACAO 头）。走项目通用 sfworker 代理 /fishaudio/tts（带 CORS 头）。
+  // model 放 query，避免自定义 model 头触发预检失败；只留 Authorization（worker 已允许）。
+  let url: string;
+  let headers: Record<string, string>;
+  if (shouldBypassWebProxy()) {
+    url = `${getProxyWorkerUrl()}/fishaudio/tts?model=${encodeURIComponent(model)}`;
+    headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` };
+  } else {
+    url = FISH_PROXY_PATH;
+    headers = jsonHeaders;
+  }
   const res = await fetch(url, {
     method: 'POST',
-    headers: jsonHeaders,
+    headers,
     body: JSON.stringify(payload),
   });
   if (!res.ok) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -2709,6 +2709,39 @@ export default {
       }
     }
 
+    // ========== 鱼声 Fish Audio TTS 代理 (静态部署绕 CORS, 纯透传) ==========
+    // 前端 POST /fishaudio/tts?model=s2.1-pro  + Authorization: Bearer <fish key>
+    // body = { text, reference_id, format, ... }；返回二进制音频(mp3)。
+    // model 走 query：避免自定义 'model' header 触发 CORS 预检失败。
+    // Worker 不读不存 key，只做 CORS + 转发 https://api.fish.audio/v1/tts。
+    if (url.pathname === '/fishaudio/tts') {
+      if (request.method !== 'POST') {
+        return jsonResponse({ error: 'Method not allowed' }, { status: 405, origin });
+      }
+      const auth = request.headers.get('Authorization');
+      if (!auth) {
+        return jsonResponse({ error: 'Missing Authorization header (Fish API key)' }, { status: 401, origin });
+      }
+      const model = (url.searchParams.get('model') || 's2.1-pro').trim();
+      try {
+        const upstream = await fetch('https://api.fish.audio/v1/tts', {
+          method: 'POST',
+          headers: {
+            'Authorization': auth,
+            'Content-Type': request.headers.get('Content-Type') || 'application/json',
+            'model': model,
+          },
+          body: await request.text(),
+        });
+        const respHeaders = new Headers(corsHeaders(origin));
+        respHeaders.set('Content-Type', upstream.headers.get('Content-Type') || 'audio/mpeg');
+        respHeaders.set('Access-Control-Expose-Headers', 'Content-Length, Content-Type');
+        return new Response(upstream.body, { status: upstream.status, headers: respHeaders });
+      } catch (e) {
+        return jsonResponse({ error: 'Fish Audio upstream fetch failed', detail: String(e && e.message || e) }, { status: 502, origin });
+      }
+    }
+
     // ========== 麦当劳 MCP 代理 (浏览器 CORS 兜底, 纯透传) ==========
     // 前端 POST /mcp/mcd  + Authorization: Bearer <user_mcp_token>
     // body 即 MCP JSON-RPC 报文 (initialize / tools/list / tools/call ...)


### PR DESCRIPTION
github.io 是静态托管、没有 /api serverless 代理，之前回退直连 api.fish.audio 被浏览器 CORS 挡（Fish 不发 ACAO 头）。本地 pnpm dev 有 vite 代理所以没事。

- worker/index.js 新增 /fishaudio/tts 路由：转发到 api.fish.audio/v1/tts，二进制音频 带 CORS 头回传；model 走 query 避免自定义头触发预检；worker 不读不存 key
- fishAudioTts.fishFetchAudio：静态部署(github.io/file:)分支改为走 getProxyWorkerUrl()/fishaudio/tts（而非直连上游）。dev/vercel 仍走 /api 代理， native 仍直连
- 附带好处：经 Cloudflare worker 转发，github.io 用户连 Fish 也不需要梯子（worker 在墙外）

注意：默认/自建 worker 需重新部署带上这条新路由才能生效。


Claude-Session: https://claude.ai/code/session_01Tkb1qz2koCRoF5T3JrpUZF