### PR TITLE
feat(proxy): 可选「本站同源代理」绕过 CORS（Vercel 等带后端部署）

### DIFF
--- a/api/llm-proxy.ts
+++ b/api/llm-proxy.ts
@@ -1,0 +1,122 @@
+/**
+ * 通用 OpenAI 兼容 LLM 同源代理（Vercel Serverless）。
+ *
+ * 为什么要它：
+ *   纯前端在浏览器里直连第三方 API，受同源策略约束——对方不返回
+ *   Access-Control-Allow-Origin（如 Pioneer）就会被 CORS 预检挡死。
+ *   而「浏览器 → 本站 /api/llm-proxy（同源，不跨域）→ 第三方（服务器到服务器，没有 CORS）」
+ *   这条链路第一段不跨域、第二段没 CORS，于是任何没开 CORS 的源都能用。
+ *   这跟 api/minimax/* 是同一思路，只是做成「转发到客户端指定 base_url」的通用版。
+ *
+ * 客户端约定：
+ *   - 把真正要打的完整上游地址放在请求头 `x-llm-target`
+ *     （例：https://api.pioneer.ai/v1/chat/completions）。
+ *   - 鉴权头（Authorization / X-API-Key）、Content-Type、Accept 原样带上，这里透传。
+ *   - method / body 原样转发。响应流式透传回去（status、content-type 保留）。
+ *
+ * 安全：只允许公网 http(s) 目标，挡掉 loopback / 私网 / link-local，避免被当成 SSRF 跳板。
+ */
+
+// 单次最长执行时间放宽到 60s（Hobby 计划上限），给长文本生成留余量。
+export const config = { maxDuration: 60 };
+
+function setCors(res: any) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,X-API-Key,X-LLM-Target,Accept');
+}
+
+// 拒绝内网/环回/链路本地目标，避免 SSRF。
+function isUnsafeTarget(parsed: URL): boolean {
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return true;
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.local') || host.endsWith('.internal')) return true;
+  if (host === '::1' || host === '0.0.0.0') return true;
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = Number(v4[1]); const b = Number(v4[2]);
+    if (a === 127 || a === 10 || a === 0) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+  }
+  if (/^f[cd][0-9a-f]{2}:/i.test(host) || /^fe[89ab][0-9a-f]:/i.test(host)) return true;
+  return false;
+}
+
+export default async function handler(req: any, res: any) {
+  setCors(res);
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.status(405).json({ error: 'Method Not Allowed' });
+    return;
+  }
+
+  const targetRaw = typeof req.headers['x-llm-target'] === 'string' ? req.headers['x-llm-target'] : '';
+  if (!targetRaw) {
+    res.status(400).json({ error: 'Missing X-LLM-Target header' });
+    return;
+  }
+
+  let target: URL;
+  try {
+    target = new URL(targetRaw);
+  } catch {
+    res.status(400).json({ error: 'Invalid X-LLM-Target URL' });
+    return;
+  }
+  if (isUnsafeTarget(target)) {
+    res.status(400).json({ error: 'Target host not allowed' });
+    return;
+  }
+
+  // 透传鉴权/内容头，丢掉 host/origin/cookie 等会干扰上游的。
+  const fwdHeaders: Record<string, string> = {};
+  const auth = req.headers['authorization'];
+  const xApiKey = req.headers['x-api-key'];
+  const accept = req.headers['accept'];
+  if (typeof auth === 'string' && auth) fwdHeaders['Authorization'] = auth;
+  if (typeof xApiKey === 'string' && xApiKey) fwdHeaders['X-API-Key'] = xApiKey;
+  if (typeof accept === 'string' && accept) fwdHeaders['Accept'] = accept;
+
+  // body：Vercel 已把 JSON body 解析成对象，转发时重新序列化（LLM 接口都是 JSON）。
+  let body: string | undefined;
+  if (req.method === 'POST') {
+    fwdHeaders['Content-Type'] = 'application/json';
+    if (req.body !== undefined && req.body !== null) {
+      body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+    }
+  }
+
+  try {
+    const upstream = await fetch(target.toString(), {
+      method: req.method,
+      headers: fwdHeaders,
+      body,
+    });
+
+    res.status(upstream.status);
+    const ct = upstream.headers.get('content-type');
+    if (ct) res.setHeader('Content-Type', ct);
+
+    // 流式透传：边收边写，既支持 SSE 流，也避开缓冲式响应体大小上限。
+    if (upstream.body && typeof (upstream.body as any).getReader === 'function') {
+      const reader = (upstream.body as any).getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(Buffer.from(value));
+      }
+      res.end();
+    } else {
+      const buf = Buffer.from(await upstream.arrayBuffer());
+      res.end(buf);
+    }
+  } catch (err: any) {
+    res.status(502).json({ error: `Upstream fetch failed: ${err?.message || 'unknown'}` });
+  }
+}

--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -71,6 +71,7 @@ const Settings: React.FC = () => {
   const [localUrl, setLocalUrl] = useState(apiConfig.baseUrl);
   const [localModel, setLocalModel] = useState(apiConfig.model);
   const [localStream, setLocalStream] = useState<boolean>(apiConfig.stream === true);
+  const [localUseProxy, setLocalUseProxy] = useState<boolean>(apiConfig.useProxy === true);
   const [localTemperature, setLocalTemperature] = useState<number>(
     typeof apiConfig.temperature === 'number' ? apiConfig.temperature : 0.85
   );
@@ -414,6 +415,7 @@ const Settings: React.FC = () => {
       model: localModel,
       stream: localStream,
       temperature: localTemperature,
+      useProxy: localUseProxy,
     });
     setStatusMsg('配置已保存');
     setTimeout(() => setStatusMsg(''), 2000);
@@ -1207,6 +1209,19 @@ const Settings: React.FC = () => {
                                     <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${localStream ? 'translate-x-4' : 'translate-x-0.5'}`} />
                                 </button>
                             </div>
+                            <div className="flex items-center justify-between">
+                                <div className="pr-2">
+                                    <span className="text-[10px] text-slate-400">通过本站代理 (绕过 CORS)</span>
+                                    <p className="text-[9px] text-slate-300 mt-0.5">源不开 CORS（如 Pioneer）直连报 Failed to fetch 时打开。仅 Vercel 等带后端的部署有效，GitHub Pages 纯静态无效；原生 App 无需开。</p>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => setLocalUseProxy(v => !v)}
+                                    className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors flex-shrink-0 ${localUseProxy ? 'bg-slate-400' : 'bg-slate-200'}`}
+                                >
+                                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${localUseProxy ? 'translate-x-4' : 'translate-x-0.5'}`} />
+                                </button>
+                            </div>
                             <div>
                                 <div className="flex items-center justify-between">
                                     <span className="text-[10px] text-slate-400">温度 (Temperature)</span>
@@ -1246,7 +1261,7 @@ const Settings: React.FC = () => {
                         </span>
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-slate-400 flex-shrink-0"><path fillRule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" /></svg>
                     </button>
-                    <p className="text-[11px] text-slate-400 mt-1 pl-1">「刷新模型列表」失败多为浏览器跨域（CORS）所致——服务端能拉到、浏览器拉不到。这时点上方直接手动填模型名 / 训练作业 ID 即可。</p>
+                    <p className="text-[11px] text-slate-400 mt-1 pl-1">「刷新模型列表」失败多为浏览器跨域（CORS）所致——服务端能拉到、浏览器拉不到。可打开上面的「通过本站代理」开关（Vercel 等部署）重试，或点上方直接手动填模型名 / 训练作业 ID。</p>
                 </div>
                 
                 <button onClick={handleSaveApi} className="w-full py-3 rounded-2xl font-bold text-white shadow-lg shadow-primary/20 bg-primary active:scale-95 transition-all mt-2">

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -14,7 +14,7 @@ import { runWorldEpisode, rerollWorldCharBeat } from '../utils/worldHome/engine'
 import { ChatParser } from '../utils/chatParser';
 import { safeFetchJson } from '../utils/safeApi';
 import { recordApiCall, setApiCallAmbientContext } from '../utils/apiCallLog';
-import { shouldRouteViaNativeHttp, nativeHttpFetch } from '../utils/nativeHttpFetch';
+import { shouldRouteViaNativeHttp, nativeHttpFetch, shouldRouteViaWebProxy, buildWebProxyArgs, setLlmWebProxyEnabled } from '../utils/nativeHttpFetch';
 import { INSTALLED_APPS } from '../constants';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
@@ -743,12 +743,21 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           const urlStr = String(resource);
           const fetchStartedAt = Date.now();
 
-          // 原生 App（Capacitor）：LLM 类接口改走 CapacitorHttp 原生 HTTP，天然绕开 WebView
-          // 的 CORS——服务端没开 CORS 的源（如 Pioneer）在打包后的 App 里也能直连，无需代理。
-          // 纯网页版 shouldRouteViaNativeHttp 恒为 false，行为完全不变。日志/记录逻辑照旧。
-          const runFetch = shouldRouteViaNativeHttp(urlStr)
-              ? () => nativeHttpFetch(resource, config)
-              : () => originalFetch(...args);
+          // LLM 接口分流（聊天/模型列表等）：
+          //  1) 原生 App（Capacitor）→ 走 CapacitorHttp 原生 HTTP，天然绕开 WebView 的 CORS；
+          //  2) 网页 + 开了「本站代理」→ 改打同源 /api/llm-proxy（Vercel 等带后端的部署），
+          //     由服务端转发上游，绕过浏览器 CORS；
+          //  3) 其余 → 原样直连。
+          // 三者都不命中时（纯静态网页 / 未开代理）行为完全不变。日志/记录仍按真实上游 urlStr 记。
+          let runFetch: () => Promise<Response>;
+          if (shouldRouteViaNativeHttp(urlStr)) {
+              runFetch = () => nativeHttpFetch(resource, config);
+          } else if (shouldRouteViaWebProxy(urlStr)) {
+              const [proxyUrl, proxyInit] = buildWebProxyArgs(resource, config);
+              runFetch = () => originalFetch(proxyUrl, proxyInit);
+          } else {
+              runFetch = () => originalFetch(...args);
+          }
 
           try {
               const response = await runFetch();
@@ -1417,6 +1426,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   useEffect(() => {
     setTtsProvider(apiConfig.ttsProvider);
   }, [apiConfig.ttsProvider]);
+  // 同步「本站代理」开关，让全局 fetch 拦截器决定 LLM 请求是否改打 /api/llm-proxy。
+  useEffect(() => {
+    setLlmWebProxyEnabled(apiConfig.useProxy);
+  }, [apiConfig.useProxy]);
   const userProfileRef = useRef(userProfile);
   userProfileRef.current = userProfile;
   const groupsRef = useRef(groups);

--- a/types.ts
+++ b/types.ts
@@ -180,6 +180,10 @@ export interface APIConfig {
   stream?: boolean;
   // Per-API temperature for chat / 约会 main calls. Missing → 0.85.
   temperature?: number;
+  // 通过本站同源 Serverless 代理（/api/llm-proxy）转发聊天/模型列表请求，绕过浏览器 CORS。
+  // 仅对带后端的部署（Vercel 等）有效；GitHub Pages 纯静态没有 /api，开了也没用。
+  // 缺省 → false（直连）。只在源不开 CORS（如 Pioneer）时才需要打开。
+  useProxy?: boolean;
 }
 
 export interface InstantPushConfig {

--- a/utils/nativeHttpFetch.ts
+++ b/utils/nativeHttpFetch.ts
@@ -36,6 +36,45 @@ export function shouldRouteViaNativeHttp(url: string): boolean {
   return LLM_ENDPOINT_TAIL.test(url);
 }
 
+// ---- Web 同源代理（Vercel 等带后端的部署）----
+// 纯前端被 CORS 挡时，可改打本站 /api/llm-proxy（同源，不跨域），由服务端转发到上游。
+// 这是个全局开关，由 OSContext 跟随 apiConfig.useProxy 同步（参考 setMinimaxRegion 的写法）。
+let webProxyEnabled = false;
+
+export function setLlmWebProxyEnabled(enabled: boolean | undefined | null): void {
+  webProxyEnabled = !!enabled;
+}
+
+/** 本站代理端点（同源）。Vercel serverless：api/llm-proxy.ts。 */
+export const LLM_WEB_PROXY_PATH = '/api/llm-proxy';
+
+/**
+ * 是否把这个请求改走本站同源代理。
+ * 条件：非原生（原生走 CapacitorHttp 就够了）、开关打开、绝对 http(s) 的 LLM 端点，
+ * 且不是本站代理自身（防自我递归）。
+ */
+export function shouldRouteViaWebProxy(url: string): boolean {
+  if (isNativeRuntime()) return false;
+  if (!webProxyEnabled) return false;
+  if (!/^https?:\/\//i.test(url)) return false;
+  if (url.includes(LLM_WEB_PROXY_PATH)) return false;
+  return LLM_ENDPOINT_TAIL.test(url);
+}
+
+/**
+ * 把对上游的 fetch 改写成对本站 /api/llm-proxy 的 fetch：
+ * 上游真实地址放进 X-LLM-Target 头，鉴权/内容头原样保留，method/body 不变。
+ */
+export function buildWebProxyArgs(
+  resource: RequestInfo | URL,
+  config?: RequestInit,
+): [string, RequestInit] {
+  const target = String(resource);
+  const headers = headersToObject(config?.headers);
+  headers['X-LLM-Target'] = target;
+  return [LLM_WEB_PROXY_PATH, { ...(config || {}), headers }];
+}
+
 function headersToObject(headers: HeadersInit | undefined): Record<string, string> {
   const out: Record<string, string> = {};
   if (!headers) return out;


### PR DESCRIPTION
GitHub Pages 纯静态没后端，被 CORS 挡死无解；但 Vercel 能跑 Serverless 函数 （项目已有 api/minimax/*）。浏览器→本站 /api/llm-proxy（同源不跨域）→上游 （服务器到服务器无 CORS），即可让 Pioneer 这类不开 CORS 的源在网页版也能用，
不依赖 Cloudflare worker、不funnel 到他人额度。

- api/llm-proxy.ts：通用 OpenAI 兼容转发函数。上游地址走 X-LLM-Target 头，透传 Authorization/X-API-Key/Content-Type，流式透传响应；带 SSRF 防护（挡内网/环回）
- nativeHttpFetch.ts：新增 web 代理路由判定与改写（setLlmWebProxyEnabled / shouldRouteViaWebProxy / buildWebProxyArgs），复用 LLM 端点识别
- OSContext 全局 fetch 拦截器统一分流：原生→CapacitorHttp；网页+开关→本站代理； 否则直连。跟随 apiConfig.useProxy 同步开关
- 新增 APIConfig.useProxy + 设置页「通过本站代理」开关，默认关（直连、零函数调用、 零成本）；只在源不开 CORS 时才需打开


Claude-Session: https://claude.ai/code/session_012qGXKWncRaagLn9D2BQPvS