### PR TITLE
[codex] Add standard worldbook support

### DIFF
--- a/apps/Character.tsx
+++ b/apps/Character.tsx
@@ -20,6 +20,7 @@ import { resolveMiniMaxApiKey } from '../utils/minimaxApiKey';
 import { normalizeUserImpression } from '../utils/impression';
 import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import { COMMON_TIMEZONES } from '../utils/timezone';
+import { toMountedWorldbook } from '../utils/worldbook';
 
 const CharacterCard: React.FC<{
     char: CharacterProfile;
@@ -242,12 +243,7 @@ const Character: React.FC = () => {
       }
 
       // CACHE THE CONTENT, include category
-      const newBookEntry = { 
-          id: book.id, 
-          title: book.title, 
-          content: book.content,
-          category: book.category 
-      };
+      const newBookEntry = toMountedWorldbook(book);
       handleChange('mountedWorldbooks', [...currentBooks, newBookEntry]);
       setShowWorldbookModal(false);
       addToast(`已挂载: ${book.title}`, 'success');
@@ -265,12 +261,7 @@ const Character: React.FC = () => {
 
       for (const book of booksToMount) {
           if (!currentBooks.some(b => b.id === book.id)) {
-              newEntries.push({
-                  id: book.id,
-                  title: book.title,
-                  content: book.content,
-                  category: book.category
-              });
+              newEntries.push(toMountedWorldbook(book));
               addedCount++;
           }
       }
@@ -920,6 +911,7 @@ ${isInitialGeneration ? `
                   const category = wb.category && wb.category.trim() ? wb.category : fallbackCategory;
                   wb.category = category;
                   await addWorldbook({
+                      ...wb,
                       id: wb.id,
                       title: wb.title || '未命名设定',
                       content: wb.content || '',

--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -686,7 +686,7 @@ ${logText.substring(0, 10000)}
             // 1. 共享场景块（用户档案 + 共有世界书 + 共有 worldview）
             //    每个角色都"看见"的舞台只描述一次，避免按成员数 N 倍复制。
             //    每个角色的人设/印象/记忆仍保持完整，不做任何压缩。
-            const sharedScene = ContextBuilder.buildGroupSharedScene(groupMembers, userProfile);
+            const sharedScene = ContextBuilder.buildGroupSharedScene(groupMembers, userProfile, currentMsgs);
 
             let context = `【系统：群聊模拟器配置】
 当前群名: "${activeGroup.name}"
@@ -707,7 +707,7 @@ ${sharedScene.text}`;
                     skipWorldview: sharedScene.worldviewIsShared,
                     skipWorldbookIds: sharedScene.sharedWorldbookIds,
                     headerOverride: `[Group Member Profile: ${member.name}]`,
-                });
+                }, { worldbookMessages: currentMsgs });
                 // Get private gap string
                 const privateGapInfo = await getPrivateTimeGap(member.id);
 

--- a/apps/WorldbookApp.tsx
+++ b/apps/WorldbookApp.tsx
@@ -1,8 +1,16 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { useOS } from '../context/OSContext';
-import { Worldbook } from '../types';
+import { Worldbook, WorldbookDepthRole, WorldbookPosition, WorldbookSelectiveLogic } from '../types';
 import Modal from '../components/os/Modal';
-import { DiamondsFour, BookOpen } from '@phosphor-icons/react';
+import { DiamondsFour, BookOpen, DownloadSimple, UploadSimple } from '@phosphor-icons/react';
+import {
+    parseStandardWorldbook,
+    serializeStandardWorldbook,
+    splitWorldbookKeywords,
+    WORLDBOOK_POSITION_DESCRIPTIONS,
+    WORLDBOOK_POSITION_LABELS,
+    WORLDBOOK_ROLE_LABELS,
+} from '../utils/worldbook';
 
 const WorldbookApp: React.FC = () => {
     const { closeApp, worldbooks, addWorldbook, updateWorldbook, deleteWorldbook, addToast } = useOS();
@@ -21,6 +29,21 @@ const WorldbookApp: React.FC = () => {
     const [tempContent, setTempContent] = useState('');
     const [tempCategory, setTempCategory] = useState('');
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const importRef = useRef<HTMLInputElement>(null);
+    const [tempEnabled, setTempEnabled] = useState(true);
+    const [tempConstant, setTempConstant] = useState(true);
+    const [tempKeywords, setTempKeywords] = useState('');
+    const [tempSecondaryKeywords, setTempSecondaryKeywords] = useState('');
+    const [tempSelectiveLogic, setTempSelectiveLogic] = useState<WorldbookSelectiveLogic>(0);
+    const [tempPosition, setTempPosition] = useState<WorldbookPosition>(1);
+    const [tempDepth, setTempDepth] = useState(4);
+    const [tempRole, setTempRole] = useState<WorldbookDepthRole>(0);
+    const [tempOrder, setTempOrder] = useState(100);
+    const [tempScanDepth, setTempScanDepth] = useState(4);
+    const [tempUseProbability, setTempUseProbability] = useState(false);
+    const [tempProbability, setTempProbability] = useState(100);
+    const [tempCaseSensitive, setTempCaseSensitive] = useState(false);
+    const [tempWholeWords, setTempWholeWords] = useState(false);
 
     // Grouping Logic
     const groupedBooks = useMemo(() => {
@@ -46,6 +69,20 @@ const WorldbookApp: React.FC = () => {
         setTempTitle('');
         setTempContent('');
         setTempCategory(''); // Default empty
+        setTempEnabled(true);
+        setTempConstant(true);
+        setTempKeywords('');
+        setTempSecondaryKeywords('');
+        setTempSelectiveLogic(0);
+        setTempPosition(1);
+        setTempDepth(4);
+        setTempRole(0);
+        setTempOrder(100);
+        setTempScanDepth(4);
+        setTempUseProbability(false);
+        setTempProbability(100);
+        setTempCaseSensitive(false);
+        setTempWholeWords(false);
         setIsEditing(true);
     };
 
@@ -54,6 +91,20 @@ const WorldbookApp: React.FC = () => {
         setTempTitle(book.title);
         setTempContent(book.content);
         setTempCategory(book.category || '');
+        setTempEnabled(!book.disable);
+        setTempConstant(book.constant ?? !(book.key && book.key.length > 0));
+        setTempKeywords((book.key || []).join(', '));
+        setTempSecondaryKeywords((book.keysecondary || []).join(', '));
+        setTempSelectiveLogic(book.selectiveLogic ?? 0);
+        setTempPosition(book.position ?? 1);
+        setTempDepth(book.depth ?? 4);
+        setTempRole(book.role ?? 0);
+        setTempOrder(book.order ?? 100);
+        setTempScanDepth(book.scanDepth ?? 4);
+        setTempUseProbability(book.useProbability === true);
+        setTempProbability(book.probability ?? 100);
+        setTempCaseSensitive(book.caseSensitive === true);
+        setTempWholeWords(book.matchWholeWords === true);
         setIsEditing(true);
     };
 
@@ -64,12 +115,36 @@ const WorldbookApp: React.FC = () => {
         }
 
         const category = tempCategory.trim() || '未分类设定 (General)';
+        const primaryKeywords = splitWorldbookKeywords(tempKeywords);
+        const secondaryKeywords = splitWorldbookKeywords(tempSecondaryKeywords);
+        if (!tempConstant && primaryKeywords.length === 0) {
+            addToast('关键词触发模式至少需要一个主要关键词', 'error');
+            return;
+        }
+        const entryConfig = {
+            disable: !tempEnabled,
+            constant: tempConstant,
+            key: tempConstant ? [] : primaryKeywords,
+            keysecondary: tempConstant ? [] : secondaryKeywords,
+            selective: !tempConstant && secondaryKeywords.length > 0,
+            selectiveLogic: tempSelectiveLogic,
+            position: tempPosition,
+            depth: Math.max(0, Math.floor(tempDepth || 0)),
+            role: tempRole,
+            order: Number.isFinite(tempOrder) ? tempOrder : 100,
+            scanDepth: Math.max(0, Math.floor(tempScanDepth || 0)),
+            useProbability: tempUseProbability,
+            probability: Math.max(0, Math.min(100, tempProbability || 0)),
+            caseSensitive: tempCaseSensitive,
+            matchWholeWords: tempWholeWords,
+        };
 
         if (editingBook) {
             await updateWorldbook(editingBook.id, {
                 title: tempTitle,
                 content: tempContent,
-                category: category
+                category: category,
+                ...entryConfig,
             });
             addToast('已保存 (同步至相关角色)', 'success');
         } else {
@@ -78,6 +153,7 @@ const WorldbookApp: React.FC = () => {
                 title: tempTitle,
                 content: tempContent,
                 category: category,
+                ...entryConfig,
                 createdAt: Date.now(),
                 updatedAt: Date.now()
             };
@@ -85,6 +161,39 @@ const WorldbookApp: React.FC = () => {
             addToast('新书已创建', 'success');
         }
         setIsEditing(false);
+    };
+
+    const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const category = file.name.replace(/\.json$/i, '').trim() || '导入世界书';
+            const imported = parseStandardWorldbook(text, category);
+            for (const book of imported) await addWorldbook(book);
+            addToast(`已导入 ${imported.length} 条世界书条目`, 'success');
+            setExpandedCategory(category);
+        } catch (error: any) {
+            addToast(error?.message || '世界书导入失败', 'error');
+        } finally {
+            if (importRef.current) importRef.current.value = '';
+        }
+    };
+
+    const handleExportGroup = (event: React.MouseEvent, category: string, books: Worldbook[]) => {
+        event.stopPropagation();
+        const json = serializeStandardWorldbook(books);
+        const blob = new Blob([json], { type: 'application/json;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const safeName = category.replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_').trim() || 'worldbook';
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = `${safeName}.json`;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+        addToast(`已导出「${category}」共 ${books.length} 条`, 'success');
     };
 
     const requestDelete = (e: React.MouseEvent, book: Worldbook) => {
@@ -120,35 +229,41 @@ const WorldbookApp: React.FC = () => {
     // EDIT MODAL (Full Screen Overlay Style)
     if (isEditing) {
         return (
-            <div className="h-full w-full bg-slate-50 flex flex-col font-sans animate-fade-in">
-                <div className="bg-white/80 backdrop-blur-md border-b border-slate-200 shrink-0 z-20" style={{ paddingTop: 'var(--safe-top)' }}>
-                    <div className="h-16 flex items-center justify-between px-4">
-                        <button onClick={() => setIsEditing(false)} className="px-3 py-1 text-slate-500 font-bold text-sm">取消</button>
-                        <span className="font-bold text-slate-800">{editingBook ? '编辑条目' : '新建条目'}</span>
-                        <button onClick={handleSave} className="px-4 py-1.5 bg-indigo-500 text-white rounded-full text-xs font-bold shadow-md active:scale-95 transition-transform">保存</button>
+            <div className="h-full w-full bg-[#f5f6fa] flex flex-col font-sans animate-fade-in">
+                <div className="bg-white/90 backdrop-blur-xl border-b border-slate-200/70 shrink-0 z-20" style={{ paddingTop: 'var(--safe-top)' }}>
+                    <div className="h-16 max-w-2xl mx-auto w-full flex items-center justify-between px-5">
+                        <button onClick={() => setIsEditing(false)} className="px-3 py-2 -ml-3 rounded-xl text-slate-500 font-semibold text-sm hover:bg-slate-100 active:scale-95 transition-all">取消</button>
+                        <div className="text-center">
+                            <div className="text-[10px] font-bold tracking-[0.16em] text-indigo-400 uppercase">Worldbook</div>
+                            <div className="text-sm font-bold text-slate-800 mt-0.5">{editingBook ? '编辑条目' : '新建条目'}</div>
+                        </div>
+                        <button onClick={handleSave} className="px-4 py-2 -mr-1 bg-indigo-500 text-white rounded-xl text-xs font-bold shadow-sm shadow-indigo-200 active:scale-95 transition-all hover:bg-indigo-600">保存</button>
                     </div>
                 </div>
 
-                <div className="flex-1 overflow-y-auto p-6 space-y-6">
-                    <div className="space-y-4">
-                        <div>
-                            <label className="text-xs font-bold text-slate-400 uppercase mb-2 block tracking-wider">标题 (Title)</label>
+                <div className="flex-1 overflow-y-auto">
+                    <div className="w-full max-w-2xl mx-auto px-5 py-5 pb-10 space-y-4">
+                        <div className="bg-white rounded-[1.5rem] border border-slate-200/70 p-5 shadow-sm shadow-slate-200/40 space-y-4">
+                            <div>
+                                <div className="text-[11px] font-bold tracking-[0.14em] text-indigo-500 uppercase">基础信息</div>
+                                <p className="text-[10px] text-slate-400 mt-1">用于识别、整理和挂载这条世界书。</p>
+                            </div>
+                            <div>
+                            <label className="text-xs font-bold text-slate-500 mb-2 block">标题</label>
                             <input 
                                 value={tempTitle}
                                 onChange={e => setTempTitle(e.target.value)}
                                 placeholder="例如: 魔法体系、公司背景..." 
-                                className="w-full text-lg font-bold text-slate-800 bg-white border border-slate-200 rounded-xl px-4 py-3 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 transition-all"
+                                className="w-full text-base font-bold text-slate-800 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
                             />
-                        </div>
-
-                        <div>
-                            <label className="text-xs font-bold text-slate-400 uppercase mb-2 block tracking-wider">分组 (Group)</label>
-                            <div className="relative">
-                                <input 
+                            </div>
+                            <div>
+                                <label className="text-xs font-bold text-slate-500 mb-2 block">分组</label>
+                                <input
                                     value={tempCategory}
                                     onChange={e => setTempCategory(e.target.value)}
-                                    placeholder="例如: 世界观、人物、地理..." 
-                                    className="w-full text-sm text-slate-700 bg-white border border-slate-200 rounded-xl px-4 py-3 outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 transition-all"
+                                    placeholder="例如: 世界观、人物、地理..."
+                                    className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
                                     list="category-suggestions"
                                 />
                                 <datalist id="category-suggestions">
@@ -156,17 +271,190 @@ const WorldbookApp: React.FC = () => {
                                         <option key={cat} value={cat} />
                                     ))}
                                 </datalist>
+                                <p className="text-[10px] text-slate-400 mt-1.5 px-1">同名条目会自动归入已有分组。</p>
                             </div>
-                            <p className="text-[10px] text-slate-400 mt-1 pl-1">输入相同名称可自动归入已有分组。</p>
                         </div>
 
-                        <div>
-                            <label className="text-xs font-bold text-slate-400 uppercase mb-2 block tracking-wider">设定内容 (Content)</label>
+                        <div className="bg-white rounded-[1.5rem] border border-slate-200/70 p-5 shadow-sm shadow-slate-200/40 space-y-5">
+                            <div className="flex items-center justify-between gap-4">
+                                <div>
+                                    <div className="text-xs font-bold text-slate-700">启用条目</div>
+                                    <p className="text-[10px] text-slate-400 mt-1">关闭后保留内容，但不会注入提示词。</p>
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => setTempEnabled(value => !value)}
+                                    className={`relative inline-flex w-12 h-7 shrink-0 items-center rounded-full p-1 transition-colors duration-200 focus:outline-none focus:ring-4 focus:ring-indigo-100 ${tempEnabled ? 'bg-indigo-500' : 'bg-slate-200'}`}
+                                    aria-pressed={tempEnabled}
+                                >
+                                    <span className={`block w-5 h-5 rounded-full bg-white shadow-sm ring-1 ring-black/5 transition-transform duration-200 ${tempEnabled ? 'translate-x-5' : 'translate-x-0'}`} />
+                                </button>
+                            </div>
+
+                            <div className="border-t border-slate-100 pt-4">
+                                <label className="text-[11px] font-bold text-slate-400 uppercase mb-2 block tracking-[0.12em]">触发方式</label>
+                                <label className="flex items-center gap-3 py-2 cursor-pointer select-none">
+                                    <input
+                                        type="checkbox"
+                                        checked={!tempConstant}
+                                        onChange={e => setTempConstant(!e.target.checked)}
+                                        className="w-4 h-4 accent-indigo-500"
+                                    />
+                                    <span className="text-sm font-semibold text-slate-700">启用关键词触发</span>
+                                </label>
+                                <p className={`text-[10px] leading-relaxed mt-1 pl-7 ${tempConstant ? 'text-slate-400' : 'text-indigo-500'}`}>
+                                    {tempConstant
+                                        ? '未勾选：不检查关键词，这条世界书会始终生效。'
+                                        : '已勾选：只有主要关键词命中时才生效；未填写关键词将无法保存。'}
+                                </p>
+                            </div>
+
+                            {!tempConstant && (
+                                <div className="space-y-4 animate-fade-in">
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-400 mb-2 block">主要关键词</label>
+                                        <input
+                                            value={tempKeywords}
+                                            onChange={e => setTempKeywords(e.target.value)}
+                                            placeholder="多个关键词用逗号或换行分隔"
+                                            className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-400 mb-2 block">辅助关键词（可选）</label>
+                                        <input
+                                            value={tempSecondaryKeywords}
+                                            onChange={e => setTempSecondaryKeywords(e.target.value)}
+                                            placeholder="用于进一步限制触发条件"
+                                            className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                        />
+                                    </div>
+                                    {splitWorldbookKeywords(tempSecondaryKeywords).length > 0 && (
+                                        <div>
+                                            <label className="text-xs font-bold text-slate-400 mb-2 block">辅助关键词条件</label>
+                                            <select
+                                                value={tempSelectiveLogic}
+                                                onChange={e => setTempSelectiveLogic(Number(e.target.value) as WorldbookSelectiveLogic)}
+                                                className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                            >
+                                                <option value={0}>至少匹配一个</option>
+                                                <option value={3}>全部匹配</option>
+                                                <option value={2}>全部不能匹配</option>
+                                                <option value={1}>不能全部匹配</option>
+                                            </select>
+                                        </div>
+                                    )}
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <label className="flex items-center gap-2 text-xs text-slate-600">
+                                            <input type="checkbox" checked={tempCaseSensitive} onChange={e => setTempCaseSensitive(e.target.checked)} className="accent-indigo-500" />
+                                            区分大小写
+                                        </label>
+                                        <label className="flex items-center gap-2 text-xs text-slate-600">
+                                            <input type="checkbox" checked={tempWholeWords} onChange={e => setTempWholeWords(e.target.checked)} className="accent-indigo-500" />
+                                            完整词匹配
+                                        </label>
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-400 mb-2 block">扫描最近消息数</label>
+                                        <input
+                                            type="number"
+                                            min={0}
+                                            value={tempScanDepth}
+                                            onChange={e => setTempScanDepth(Number(e.target.value))}
+                                            className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="bg-white rounded-[1.5rem] border border-slate-200/70 p-5 shadow-sm shadow-slate-200/40 space-y-4">
+                            <div>
+                                <div className="text-[11px] font-bold tracking-[0.14em] text-indigo-500 uppercase">注入设置</div>
+                                <p className="text-[10px] text-slate-400 mt-1">控制条目在提示词中的位置和优先级。</p>
+                            </div>
+                            <div>
+                                <label className="text-xs font-bold text-slate-500 mb-2 block">注入位置</label>
+                                <select
+                                    value={tempPosition}
+                                    onChange={e => setTempPosition(Number(e.target.value) as WorldbookPosition)}
+                                    className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                >
+                                    {(Object.entries(WORLDBOOK_POSITION_LABELS) as [string, string][]).map(([value, label]) => (
+                                        <option key={value} value={value}>
+                                            {label}{value === '1' ? '（默认 · 旧版位置）' : ''}
+                                        </option>
+                                    ))}
+                                </select>
+                                <p className="text-[10px] leading-relaxed text-slate-400 mt-2 px-1">
+                                    {WORLDBOOK_POSITION_DESCRIPTIONS[tempPosition]}
+                                </p>
+                            </div>
+
+                            {tempPosition === 4 && (
+                                <div className="grid grid-cols-2 gap-3 animate-fade-in">
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-400 mb-2 block">消息深度</label>
+                                        <input
+                                            type="number"
+                                            min={0}
+                                            value={tempDepth}
+                                            onChange={e => setTempDepth(Number(e.target.value))}
+                                            className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                        />
+                                        <p className="text-[10px] text-slate-400 mt-1 px-1">0 最靠近最新消息，数字越大越往前。</p>
+                                    </div>
+                                    <div>
+                                        <label className="text-xs font-bold text-slate-400 mb-2 block">消息角色</label>
+                                        <select
+                                            value={tempRole}
+                                            onChange={e => setTempRole(Number(e.target.value) as WorldbookDepthRole)}
+                                            className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                        >
+                                            {(Object.entries(WORLDBOOK_ROLE_LABELS) as [string, string][]).map(([value, label]) => (
+                                                <option key={value} value={value}>{label}</option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                </div>
+                            )}
+
+                            <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label className="text-xs font-bold text-slate-400 mb-2 block">插入顺序</label>
+                                    <input
+                                        type="number"
+                                        value={tempOrder}
+                                        onChange={e => setTempOrder(Number(e.target.value))}
+                                        className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="flex items-center gap-2 text-xs font-bold text-slate-400 mb-2">
+                                        <input type="checkbox" checked={tempUseProbability} onChange={e => setTempUseProbability(e.target.checked)} className="accent-indigo-500" />
+                                        使用概率
+                                    </label>
+                                    <input
+                                        type="number"
+                                        min={0}
+                                        max={100}
+                                        disabled={!tempUseProbability}
+                                        value={tempProbability}
+                                        onChange={e => setTempProbability(Number(e.target.value))}
+                                        className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all disabled:opacity-40"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="bg-white rounded-[1.5rem] border border-slate-200/70 p-5 shadow-sm shadow-slate-200/40">
+                            <div className="text-[11px] font-bold tracking-[0.14em] text-indigo-500 uppercase">设定内容</div>
+                            <p className="text-[10px] text-slate-400 mt-1 mb-3">支持 Markdown；这里只填写实际需要注入模型的内容。</p>
                             <textarea 
                                 value={tempContent}
                                 onChange={e => setTempContent(e.target.value)}
                                 placeholder="在此输入详细的设定内容，支持 Markdown 格式..." 
-                                className="w-full h-80 bg-white border border-slate-200 rounded-xl p-4 text-sm text-slate-700 leading-relaxed resize-none outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-100 transition-all font-mono"
+                                className="w-full h-80 bg-slate-50/80 border border-slate-200 rounded-2xl p-4 text-sm text-slate-700 leading-relaxed resize-none outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all font-mono"
                             />
                         </div>
                     </div>
@@ -193,9 +481,19 @@ const WorldbookApp: React.FC = () => {
                         <span className="font-bold text-slate-700 text-lg tracking-wide flex items-center gap-2">
                             <DiamondsFour size={18} className="text-indigo-500" /> 世界书
                         </span>
-                        <button onClick={handleCreate} className="w-9 h-9 bg-indigo-500 text-white rounded-full shadow-lg shadow-indigo-200 flex items-center justify-center active:scale-90 transition-transform hover:bg-indigo-600">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
-                        </button>
+                        <div className="flex items-center gap-2">
+                            <input ref={importRef} type="file" className="hidden" onChange={handleImport} />
+                            <button
+                                onClick={() => importRef.current?.click()}
+                                className="w-9 h-9 bg-white/80 text-indigo-500 border border-white rounded-full shadow-sm flex items-center justify-center active:scale-90 transition-transform"
+                                title="导入标准世界书"
+                            >
+                                <UploadSimple size={18} weight="bold" />
+                            </button>
+                            <button onClick={handleCreate} className="w-9 h-9 bg-indigo-500 text-white rounded-full shadow-lg shadow-indigo-200 flex items-center justify-center active:scale-90 transition-transform hover:bg-indigo-600">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -225,6 +523,13 @@ const WorldbookApp: React.FC = () => {
                             </div>
                             <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider group-hover:text-indigo-600 transition-colors">{category}</h3>
                             <span className="text-[9px] bg-white/50 px-1.5 rounded text-slate-400 border border-white/50">{books.length}</span>
+                            <button
+                                onClick={(event) => handleExportGroup(event, category, books)}
+                                className="ml-auto p-2 -my-2 rounded-full text-slate-400 hover:text-indigo-600 hover:bg-white/70 active:scale-90 transition-all"
+                                title="导出该组为标准世界书"
+                            >
+                                <DownloadSimple size={16} weight="bold" />
+                            </button>
                         </div>
 
                         {/* Group Items */}
@@ -243,6 +548,14 @@ const WorldbookApp: React.FC = () => {
                                             </div>
                                             <div className="text-[10px] text-slate-400 font-mono pl-3.5">
                                                 Updated: {new Date(book.updatedAt).toLocaleDateString()}
+                                            </div>
+                                            <div className="flex flex-wrap gap-1.5 mt-2 pl-3.5">
+                                                <span className={`text-[9px] px-2 py-0.5 rounded-full font-bold ${book.disable ? 'bg-slate-200 text-slate-500' : 'bg-indigo-50 text-indigo-500'}`}>
+                                                    {book.disable ? '已停用' : (book.constant ?? !(book.key && book.key.length > 0)) ? '常驻' : '关键词'}
+                                                </span>
+                                                <span className="text-[9px] px-2 py-0.5 rounded-full bg-white/70 text-slate-400">
+                                                    {WORLDBOOK_POSITION_LABELS[book.position ?? 1]}
+                                                </span>
                                             </div>
                                         </div>
                                         

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -27,6 +27,7 @@ import { LocalNotifications } from '@capacitor/local-notifications';
 import { Capacitor } from '@capacitor/core';
 import { formatBytes } from '../utils/format';
 import { isEmotionEvalSkipped } from '../utils/devDebug';
+import { toMountedWorldbook } from '../utils/worldbook';
 // 备份用：把存在 localStorage 的本机配置随导出一起带走（键名须与 importFullData 对齐）
 import { exportPostOfficeLocal } from '../utils/vrWorld/postOffice';
 import { exportWorldHomeLocal } from '../utils/worldHome/localBackup';
@@ -2255,12 +2256,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               if (char.mountedWorldbooks?.some(m => m.id === id)) {
                   const newMounted = char.mountedWorldbooks.map(m =>
                       m.id === id
-                          ? {
-                              id: fullUpdatedWb.id,
-                              title: fullUpdatedWb.title,
-                              content: fullUpdatedWb.content,
-                              category: fullUpdatedWb.category,
-                            }
+                          ? toMountedWorldbook(fullUpdatedWb)
                           : m
                   );
                   const newChar = { ...char, mountedWorldbooks: newMounted };

--- a/types.ts
+++ b/types.ts
@@ -831,7 +831,40 @@ export interface DreamLog {
     script?: DreamScript;   // 完整快照 → 可原样重看
 }
 
-export interface Worldbook {
+export type WorldbookPosition = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type WorldbookDepthRole = 0 | 1 | 2;
+export type WorldbookSelectiveLogic = 0 | 1 | 2 | 3;
+
+export interface WorldbookEntryConfig {
+    /** Primary activation keywords. Empty for constant entries. */
+    key?: string[];
+    /** Optional secondary activation keywords. */
+    keysecondary?: string[];
+    /** Always active when true; legacy SullyOS entries default to true. */
+    constant?: boolean;
+    selective?: boolean;
+    selectiveLogic?: WorldbookSelectiveLogic;
+    order?: number;
+    position?: WorldbookPosition;
+    disable?: boolean;
+    probability?: number;
+    useProbability?: boolean;
+    depth?: number;
+    role?: WorldbookDepthRole | null;
+    scanDepth?: number | null;
+    caseSensitive?: boolean | null;
+    matchWholeWords?: boolean | null;
+    sourceUid?: number;
+}
+
+export interface MountedWorldbook extends WorldbookEntryConfig {
+    id: string;
+    title: string;
+    content: string;
+    category?: string;
+}
+
+export interface Worldbook extends WorldbookEntryConfig {
     id: string;
     title: string;
     content: string; 
@@ -1906,7 +1939,7 @@ export interface CharacterProfile {
   writerPersona?: string;
   writerPersonaGeneratedAt?: number;
 
-  mountedWorldbooks?: { id: string; title: string; content: string; category?: string }[];
+  mountedWorldbooks?: MountedWorldbook[];
 
   impression?: UserImpression;
 

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -165,7 +165,14 @@ export const ChatPrompts = {
 
         // 记忆宫殿检索结果现在从 char.memoryPalaceInjection 读取，由 buildCoreContext 统一注入
         const coreT0 = performance.now();
-        let baseSystemPrompt = ContextBuilder.buildCoreContext(char, userProfile, true);
+        let baseSystemPrompt = ContextBuilder.buildCoreContext(
+            char,
+            userProfile,
+            true,
+            undefined,
+            undefined,
+            { worldbookMessages: currentMsgs },
+        );
         timings.buildCoreContext = Math.round(performance.now() - coreT0);
 
         // 情绪底色（buffInjection）已移入 ContextBuilder.buildCoreContext()，所有 App 统一注入

--- a/utils/chatRequestPayload.ts
+++ b/utils/chatRequestPayload.ts
@@ -23,6 +23,7 @@ import { buildLuckinMiniAppContextBlock, buildLuckinChatSystemBlock } from './lu
 import type { LuckinMiniAppSnapshot, LuckinChatState } from './luckinToolBridge';
 import type { MusicCfg, Song, LyricLine, MusicPlaybackSnapshot } from '../context/MusicContext';
 import { isPromptBuildSkipped } from './devDebug';
+import { injectWorldbookDepthEntries, resolveWorldbookEntries } from './worldbook';
 
 export interface UserListeningContext {
     songName: string;
@@ -266,6 +267,16 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
 
     // ── 8. 剥离历史里旧的双语标签 ─────────────────────────
     const cleanedApiMessages = cleanApiMessages(apiMessages);
+    const resolvedWorldbookEntries = resolveWorldbookEntries(
+        char.mountedWorldbooks || [],
+        cleanedApiMessages,
+        char.name,
+        userProfile.name,
+    );
+    const messagesWithWorldbookDepth = injectWorldbookDepthEntries(
+        cleanedApiMessages,
+        resolvedWorldbookEntries.filter(entry => entry.position === 4),
+    );
 
     // ── 9. 麦当劳小程序上下文（在 cleanedApiMessages 之后追加到 systemPrompt） ──
     const mcdActive = !!mcdMiniSnap?.open;
@@ -297,7 +308,7 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
     // ── 10. 组装 fullMessages + 末尾双语 reminder ─────────
     const fullMessages: Array<{ role: string; content: any }> = [
         { role: 'system', content: systemPrompt },
-        ...cleanedApiMessages,
+        ...messagesWithWorldbookDepth,
     ];
     if (bilingualActive) {
         fullMessages.push({
@@ -308,7 +319,7 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
 
     return {
         systemPrompt,
-        cleanedApiMessages,
+        cleanedApiMessages: messagesWithWorldbookDepth,
         fullMessages,
         flags: { bilingualActive, mcdActive, luckinActive, luckinChatActive, htmlActive, thinkingActive, promptBuildSkipped: false },
     };

--- a/utils/context.ts
+++ b/utils/context.ts
@@ -3,6 +3,12 @@ import { CharacterProfile, UserProfile, DailySchedule } from '../types';
 import { normalizeUserImpression } from './impression';
 import { getFlowNarrativeKey, isScheduleFeatureOn } from './scheduleGenerator';
 import { resolveCharTimeZone, nowInTimeZone, tzAwarenessNote, interactionGapNote } from './timezone';
+import {
+    formatWorldbookSection,
+    resolveWorldbookEntries,
+    splitWorldbookSections,
+    type WorldbookScanMessage,
+} from './worldbook';
 
 /**
  * Memory Central
@@ -112,9 +118,21 @@ export const ContextBuilder = {
             lastInteractionTs?: number;
             /** 抑制整段时间感知（当前时间/时差/距上次联系）。见面纯架空（dateTimeAwarenessEnabled=false）时用。 */
             skipTimeAwareness?: boolean;
+            /** Recent messages used to activate keyword-based worldbook entries. */
+            worldbookMessages?: WorldbookScanMessage[];
         },
     ): string => {
-        let context = `${groupOptions?.headerOverride ?? '[System: Roleplay Configuration]'}\n\n`;
+        const skipBookIds = groupOptions?.skipWorldbookIds;
+        const filteredBooks = (char.mountedWorldbooks || []).filter(wb => !skipBookIds || !skipBookIds.has(wb.id));
+        const worldbookSections = splitWorldbookSections(resolveWorldbookEntries(
+            filteredBooks,
+            timeOptions?.worldbookMessages || [],
+            char.name,
+            user.name,
+        ));
+
+        let context = formatWorldbookSection(worldbookSections.beforeCharacter, '世界书 · 角色设定前');
+        context += `${groupOptions?.headerOverride ?? '[System: Roleplay Configuration]'}\n\n`;
 
         // 1. 核心身份 (Identity)
         context += `### 你的身份 (Character)\n`;
@@ -166,30 +184,9 @@ export const ContextBuilder = {
             context += `### 世界观与设定 (World Settings)\n${char.worldview}\n\n`;
         }
 
-        // [NEW] 挂载的世界书 (Mounted Worldbooks) - GROUPED BY CATEGORY
-        // 群聊场景下：共享世界书已被 buildGroupSharedScene 提取到顶部场景块，这里跳过去重 ID
-        const skipBookIds = groupOptions?.skipWorldbookIds;
-        const filteredBooks = (char.mountedWorldbooks || []).filter(wb => !skipBookIds || !skipBookIds.has(wb.id));
-        if (filteredBooks.length > 0) {
-            context += `### 扩展设定集 (Worldbooks)\n`;
-
-            // Group books by category
-            const groupedBooks: Record<string, typeof filteredBooks> = {};
-            filteredBooks.forEach(wb => {
-                const cat = wb.category || '通用设定 (General)';
-                if (!groupedBooks[cat]) groupedBooks[cat] = [];
-                groupedBooks[cat].push(wb);
-            });
-
-            // Output grouped content
-            Object.entries(groupedBooks).forEach(([category, books]) => {
-                context += `#### [${category}]\n`;
-                books.forEach(wb => {
-                    context += `**Title: ${wb.title}**\n${wb.content}\n---\n`;
-                });
-                context += `\n`;
-            });
-        }
+        context += formatWorldbookSection(worldbookSections.afterCharacter, '扩展设定集 (Worldbooks)');
+        context += formatWorldbookSection(worldbookSections.beforeExamples, '世界书 · 示例消息前');
+        context += formatWorldbookSection(worldbookSections.afterExamples, '世界书 · 示例消息后');
 
         // 3. 用户画像 (User Profile)
         // 群聊场景下：用户画像已在共享场景块顶部，这里跳过避免重复
@@ -294,6 +291,9 @@ export const ContextBuilder = {
             console.log(`🎭 [Context] Active buffs:`, JSON.stringify(char.activeBuffs || [], null, 2));
         }
 
+        context += formatWorldbookSection(worldbookSections.authorsNoteTop, '世界书 · 作者注释顶部');
+        context += formatWorldbookSection(worldbookSections.authorsNoteBottom, '世界书 · 作者注释底部');
+
         // 7. 表达底线 (Anti-Filler) —— 全 App 通用的精简版防套话提示。
         // 模型八股（空泛感慨、万能句式）是"没话找话"时的填充物，这里只做正向引导
         // （去挖具体素材），不列任何禁语——把禁语写进提示词反而会激活它（粉色大象）。
@@ -340,6 +340,7 @@ export const ContextBuilder = {
     buildGroupSharedScene: (
         members: CharacterProfile[],
         user: UserProfile,
+        worldbookMessages: WorldbookScanMessage[] = [],
     ): {
         text: string;
         sharedWorldbookIds: Set<string>;
@@ -390,22 +391,8 @@ export const ContextBuilder = {
             text += `### 共有世界观 (Shared World Settings)\n${members[0].worldview!.trim()}\n\n`;
         }
 
-        if (sharedBooks.length > 0) {
-            text += `### 共有扩展设定集 (Shared Worldbooks)\n`;
-            const groupedBooks: Record<string, typeof sharedBooks> = {};
-            sharedBooks.forEach(wb => {
-                const cat = wb.category || '通用设定 (General)';
-                if (!groupedBooks[cat]) groupedBooks[cat] = [];
-                groupedBooks[cat].push(wb);
-            });
-            Object.entries(groupedBooks).forEach(([category, books]) => {
-                text += `#### [${category}]\n`;
-                books.forEach(wb => {
-                    text += `**Title: ${wb.title}**\n${wb.content}\n---\n`;
-                });
-                text += `\n`;
-            });
-        }
+        const resolvedSharedBooks = resolveWorldbookEntries(sharedBooks, worldbookMessages, '', user.name);
+        text += formatWorldbookSection(resolvedSharedBooks, '共有扩展设定集 (Shared Worldbooks)');
 
         return { text, sharedWorldbookIds, worldviewIsShared };
     },

--- a/utils/worldbook.test.ts
+++ b/utils/worldbook.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import type { MountedWorldbook } from '../types';
+import {
+    injectWorldbookDepthEntries,
+    isWorldbookEntryActive,
+    parseStandardWorldbook,
+    resolveWorldbookEntries,
+    serializeStandardWorldbook,
+    splitWorldbookSections,
+    toMountedWorldbook,
+} from './worldbook';
+
+const book = (overrides: Partial<MountedWorldbook> = {}): MountedWorldbook => ({
+    id: 'book-1',
+    title: '测试条目',
+    content: '{{char}} 在 {{user}} 提到月亮时会想起故乡。',
+    category: '测试',
+    ...overrides,
+});
+
+describe('worldbook activation', () => {
+    it('keeps legacy entries constantly active after character definitions', () => {
+        const resolved = resolveWorldbookEntries([book()], [], '阿澈', '小雨');
+        expect(resolved).toHaveLength(1);
+        expect(resolved[0].position).toBe(1);
+        expect(resolved[0].content).toContain('阿澈 在 小雨');
+    });
+
+    it('activates keyword entries only when the recent scan buffer matches', () => {
+        const keywordBook = book({ constant: false, key: ['月亮'], scanDepth: 2 });
+        expect(isWorldbookEntryActive(keywordBook, [{ content: '今晚有月亮' }])).toBe(true);
+        expect(isWorldbookEntryActive(keywordBook, [{ content: '今晚下雨' }])).toBe(false);
+    });
+
+    it('respects secondary keyword logic and disabled state', () => {
+        const selectiveBook = book({
+            constant: false,
+            key: ['学校'],
+            keysecondary: ['老师', '同学'],
+            selective: true,
+            selectiveLogic: 3,
+        });
+        expect(isWorldbookEntryActive(selectiveBook, [{ content: '学校里的老师和同学' }])).toBe(true);
+        expect(isWorldbookEntryActive(selectiveBook, [{ content: '学校里的老师' }])).toBe(false);
+        expect(isWorldbookEntryActive({ ...selectiveBook, disable: true }, [{ content: '学校里的老师和同学' }])).toBe(false);
+    });
+});
+
+describe('worldbook positions', () => {
+    it('splits standard positions and injects at-depth entries using their role', () => {
+        const resolved = resolveWorldbookEntries([
+            book({ id: 'before', position: 0 }),
+            book({ id: 'depth', position: 4, depth: 1, role: 1 }),
+        ]);
+        const sections = splitWorldbookSections(resolved);
+        expect(sections.beforeCharacter.map(entry => entry.book.id)).toEqual(['before']);
+
+        const messages = injectWorldbookDepthEntries(
+            [{ role: 'user', content: '一' }, { role: 'assistant', content: '二' }],
+            sections.atDepth,
+        );
+        expect(messages.map(message => message.role)).toEqual(['user', 'user', 'assistant']);
+        expect(messages[1].content).toContain('{{char}}');
+    });
+});
+
+describe('standard worldbook import', () => {
+    it('converts entries into a SullyOS category without losing activation metadata', () => {
+        const imported = parseStandardWorldbook(JSON.stringify({
+            entries: {
+                0: {
+                    uid: 7,
+                    comment: '月亮设定',
+                    content: '月亮是蓝色的。',
+                    key: ['月亮'],
+                    keysecondary: [],
+                    constant: false,
+                    selective: false,
+                    order: 120,
+                    position: 4,
+                    depth: 2,
+                    role: 0,
+                    disable: false,
+                    probability: 80,
+                    useProbability: true,
+                },
+            },
+        }), '导入测试', 1234);
+
+        expect(imported).toHaveLength(1);
+        expect(imported[0]).toMatchObject({
+            title: '月亮设定',
+            category: '导入测试',
+            key: ['月亮'],
+            constant: false,
+            position: 4,
+            depth: 2,
+            role: 0,
+            order: 120,
+            probability: 80,
+            useProbability: true,
+            sourceUid: 7,
+        });
+    });
+
+    it('exports a whole group as a standard worldbook that can be imported again', () => {
+        const source = [{
+            ...book({
+                id: 'export-1',
+                title: '导出条目',
+                content: '导出内容',
+                constant: false,
+                key: ['导出'],
+                position: 4,
+                depth: 3,
+                role: 2,
+            }),
+            category: '导出组',
+            createdAt: 1,
+            updatedAt: 1,
+        }];
+
+        const json = serializeStandardWorldbook(source);
+        const raw = JSON.parse(json);
+        expect(raw.entries['0']).toMatchObject({
+            comment: '导出条目',
+            key: ['导出'],
+            position: 4,
+            depth: 3,
+            role: 2,
+        });
+
+        const imported = parseStandardWorldbook(json, '重新导入', 2);
+        expect(imported[0]).toMatchObject({
+            title: '导出条目',
+            content: '导出内容',
+            key: ['导出'],
+            position: 4,
+            depth: 3,
+            role: 2,
+        });
+    });
+});
+
+describe('mounted worldbook synchronization', () => {
+    it('copies edited activation and injection settings into the character mount cache', () => {
+        const mounted = toMountedWorldbook({
+            ...book({
+                constant: false,
+                key: ['月亮'],
+                keysecondary: ['夜晚'],
+                selective: true,
+                selectiveLogic: 0,
+                position: 4,
+                depth: 2,
+                role: 1,
+                disable: true,
+                order: 180,
+                scanDepth: 6,
+                useProbability: true,
+                probability: 75,
+            }),
+            category: '同步测试',
+            createdAt: 1,
+            updatedAt: 2,
+        });
+
+        expect(mounted).toMatchObject({
+            constant: false,
+            key: ['月亮'],
+            keysecondary: ['夜晚'],
+            selective: true,
+            position: 4,
+            depth: 2,
+            role: 1,
+            disable: true,
+            order: 180,
+            scanDepth: 6,
+            useProbability: true,
+            probability: 75,
+        });
+        expect(mounted).not.toHaveProperty('createdAt');
+        expect(mounted).not.toHaveProperty('updatedAt');
+    });
+});

--- a/utils/worldbook.ts
+++ b/utils/worldbook.ts
@@ -1,0 +1,342 @@
+import type {
+    MountedWorldbook,
+    Worldbook,
+    WorldbookDepthRole,
+    WorldbookPosition,
+    WorldbookSelectiveLogic,
+} from '../types';
+
+export type WorldbookLike = Worldbook | MountedWorldbook;
+
+export interface WorldbookScanMessage {
+    role?: string;
+    content: unknown;
+}
+
+export interface ResolvedWorldbookEntry {
+    book: WorldbookLike;
+    content: string;
+    position: WorldbookPosition;
+    order: number;
+}
+
+export interface WorldbookSystemSections {
+    beforeCharacter: ResolvedWorldbookEntry[];
+    afterCharacter: ResolvedWorldbookEntry[];
+    authorsNoteTop: ResolvedWorldbookEntry[];
+    authorsNoteBottom: ResolvedWorldbookEntry[];
+    atDepth: ResolvedWorldbookEntry[];
+    beforeExamples: ResolvedWorldbookEntry[];
+    afterExamples: ResolvedWorldbookEntry[];
+}
+
+export const WORLDBOOK_POSITION_LABELS: Record<WorldbookPosition, string> = {
+    0: '角色设定前',
+    1: '角色设定后',
+    2: '作者注释顶部',
+    3: '作者注释底部',
+    4: '聊天记录指定深度',
+    5: '示例消息前',
+    6: '示例消息后',
+};
+
+export const WORLDBOOK_POSITION_DESCRIPTIONS: Record<WorldbookPosition, string> = {
+    0: '适合放全局规则、基础背景；会出现在角色身份与性格设定之前。',
+    1: '适合一般世界观、人物与地点设定；这是旧版世界书一直使用的默认位置。',
+    2: '适合放写作方向、语气或节奏要求；位于作者注释内容顶部。',
+    3: '适合放作者注释后的补充与强调；比顶部内容更靠后。',
+    4: '适合临时状态、近期事件或强提醒；按深度和角色插入聊天记录。',
+    5: '适合放阅读示例对话前需要先知道的说明。',
+    6: '适合放示例对话结束后的补充说明。',
+};
+
+export const WORLDBOOK_ROLE_LABELS: Record<WorldbookDepthRole, string> = {
+    0: 'System',
+    1: 'User',
+    2: 'Assistant',
+};
+
+const clamp = (value: unknown, min: number, max: number, fallback: number): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.min(max, Math.max(min, parsed)) : fallback;
+};
+
+const asStringArray = (value: unknown): string[] => {
+    if (!Array.isArray(value)) return [];
+    return value.map(item => String(item).trim()).filter(Boolean);
+};
+
+export const splitWorldbookKeywords = (value: string): string[] => (
+    value.split(/[,，\n]/).map(item => item.trim()).filter(Boolean)
+);
+
+export const toMountedWorldbook = (book: Worldbook): MountedWorldbook => ({
+    id: book.id,
+    title: book.title,
+    content: book.content,
+    category: book.category,
+    key: book.key ? [...book.key] : undefined,
+    keysecondary: book.keysecondary ? [...book.keysecondary] : undefined,
+    constant: book.constant,
+    selective: book.selective,
+    selectiveLogic: book.selectiveLogic,
+    order: book.order,
+    position: book.position,
+    disable: book.disable,
+    probability: book.probability,
+    useProbability: book.useProbability,
+    depth: book.depth,
+    role: book.role,
+    scanDepth: book.scanDepth,
+    caseSensitive: book.caseSensitive,
+    matchWholeWords: book.matchWholeWords,
+    sourceUid: book.sourceUid,
+});
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const keywordMatches = (
+    text: string,
+    keyword: string,
+    caseSensitive: boolean,
+    wholeWords: boolean,
+): boolean => {
+    if (!keyword) return false;
+    if (!wholeWords) {
+        return caseSensitive
+            ? text.includes(keyword)
+            : text.toLocaleLowerCase().includes(keyword.toLocaleLowerCase());
+    }
+    const flags = caseSensitive ? 'u' : 'iu';
+    const escaped = escapeRegExp(keyword);
+    return new RegExp(`(^|[^\\p{L}\\p{N}_])${escaped}(?=$|[^\\p{L}\\p{N}_])`, flags).test(text);
+};
+
+const messageText = (message: WorldbookScanMessage): string => {
+    if (typeof message.content === 'string') return message.content;
+    if (Array.isArray(message.content)) {
+        return message.content
+            .map(part => (typeof part === 'string' ? part : (part as any)?.text || ''))
+            .filter(Boolean)
+            .join('\n');
+    }
+    return '';
+};
+
+const scanTextForBook = (book: WorldbookLike, messages: WorldbookScanMessage[]): string => {
+    const depth = Math.max(0, Math.floor(book.scanDepth ?? 4));
+    if (depth === 0) return '';
+    return messages.slice(-depth).map(messageText).filter(Boolean).join('\n');
+};
+
+const secondaryConditionPasses = (
+    book: WorldbookLike,
+    text: string,
+    caseSensitive: boolean,
+    wholeWords: boolean,
+): boolean => {
+    if (!book.selective) return true;
+    const secondary = book.keysecondary || [];
+    if (secondary.length === 0) return true;
+    const matches = secondary.map(key => keywordMatches(text, key, caseSensitive, wholeWords));
+    const logic: WorldbookSelectiveLogic = book.selectiveLogic ?? 0;
+    if (logic === 1) return !matches.every(Boolean);
+    if (logic === 2) return !matches.some(Boolean);
+    if (logic === 3) return matches.every(Boolean);
+    return matches.some(Boolean);
+};
+
+export const isWorldbookEntryActive = (
+    book: WorldbookLike,
+    messages: WorldbookScanMessage[] = [],
+): boolean => {
+    if (book.disable) return false;
+
+    const primary = book.key || [];
+    const isConstant = book.constant ?? primary.length === 0;
+    const text = scanTextForBook(book, messages);
+    const caseSensitive = book.caseSensitive === true;
+    const wholeWords = book.matchWholeWords === true;
+
+    if (!isConstant) {
+        if (primary.length === 0) return false;
+        if (!primary.some(key => keywordMatches(text, key, caseSensitive, wholeWords))) return false;
+        if (!secondaryConditionPasses(book, text, caseSensitive, wholeWords)) return false;
+    }
+
+    if (book.useProbability) {
+        const probability = clamp(book.probability, 0, 100, 100);
+        if (probability <= 0) return false;
+        if (probability < 100 && Math.random() * 100 >= probability) return false;
+    }
+
+    return true;
+};
+
+export const expandWorldbookMacros = (content: string, charName: string, userName: string): string => {
+    let expanded = content;
+    if (charName) expanded = expanded.replace(/{{\s*char\s*}}/gi, charName);
+    if (userName) expanded = expanded.replace(/{{\s*user\s*}}/gi, userName);
+    return expanded;
+};
+
+export const resolveWorldbookEntries = (
+    books: WorldbookLike[] = [],
+    messages: WorldbookScanMessage[] = [],
+    charName = '',
+    userName = '',
+): ResolvedWorldbookEntry[] => books
+    .filter(book => isWorldbookEntryActive(book, messages))
+    .map(book => ({
+        book,
+        content: expandWorldbookMacros(book.content || '', charName, userName),
+        position: book.position ?? 1,
+        order: Number.isFinite(book.order) ? Number(book.order) : 100,
+    }))
+    .filter(entry => entry.content.trim())
+    .sort((a, b) => a.order - b.order);
+
+export const splitWorldbookSections = (entries: ResolvedWorldbookEntry[]): WorldbookSystemSections => ({
+    beforeCharacter: entries.filter(entry => entry.position === 0),
+    afterCharacter: entries.filter(entry => entry.position === 1),
+    authorsNoteTop: entries.filter(entry => entry.position === 2),
+    authorsNoteBottom: entries.filter(entry => entry.position === 3),
+    atDepth: entries.filter(entry => entry.position === 4),
+    beforeExamples: entries.filter(entry => entry.position === 5),
+    afterExamples: entries.filter(entry => entry.position === 6),
+});
+
+export const formatWorldbookSection = (
+    entries: ResolvedWorldbookEntry[],
+    heading: string,
+): string => {
+    if (entries.length === 0) return '';
+    let output = `### ${heading}\n`;
+    let lastLegacyCategory = '';
+    for (const entry of entries) {
+        // SillyTavern comments are editor-only and are not part of the prompt.
+        if (entry.book.sourceUid === undefined) {
+            const category = entry.book.category || '通用设定 (General)';
+            if (category !== lastLegacyCategory) {
+                output += `#### [${category}]\n`;
+                lastLegacyCategory = category;
+            }
+            output += `**Title: ${entry.book.title}**\n`;
+        }
+        output += `${entry.content.trim()}\n---\n`;
+    }
+    return `${output}\n`;
+};
+
+export const injectWorldbookDepthEntries = <T extends WorldbookScanMessage>(
+    messages: T[],
+    entries: ResolvedWorldbookEntry[],
+): Array<T | { role: string; content: string }> => {
+    if (entries.length === 0) return [...messages];
+    const buckets = new Map<number, ResolvedWorldbookEntry[]>();
+    for (const entry of entries) {
+        const depth = Math.max(0, Math.floor(entry.book.depth ?? 4));
+        const index = Math.max(0, messages.length - depth);
+        const bucket = buckets.get(index) || [];
+        bucket.push(entry);
+        buckets.set(index, bucket);
+    }
+
+    const result: Array<T | { role: string; content: string }> = [];
+    for (let index = 0; index <= messages.length; index += 1) {
+        const bucket = buckets.get(index) || [];
+        for (const entry of bucket) {
+            const roleValue = entry.book.role ?? 0;
+            const role = roleValue === 1 ? 'user' : roleValue === 2 ? 'assistant' : 'system';
+            result.push({ role, content: entry.content.trim() });
+        }
+        if (index < messages.length) result.push(messages[index]);
+    }
+    return result;
+};
+
+export const serializeStandardWorldbook = (books: WorldbookLike[]): string => {
+    const usedUids = new Set<number>();
+    const entries: Record<string, Record<string, unknown>> = {};
+
+    books.forEach((book, index) => {
+        let uid = Number.isFinite(book.sourceUid) ? Number(book.sourceUid) : index;
+        while (usedUids.has(uid)) uid += 1;
+        usedUids.add(uid);
+
+        const primary = book.key || [];
+        const secondary = book.keysecondary || [];
+        const position = book.position ?? 1;
+        entries[String(index)] = {
+            uid,
+            key: [...primary],
+            keysecondary: [...secondary],
+            comment: book.title,
+            content: book.content,
+            constant: book.constant ?? primary.length === 0,
+            selective: book.selective ?? secondary.length > 0,
+            selectiveLogic: book.selectiveLogic ?? 0,
+            order: book.order ?? 100,
+            position,
+            disable: book.disable === true,
+            probability: book.probability ?? 100,
+            useProbability: book.useProbability === true,
+            depth: book.depth ?? 4,
+            role: position === 4 ? (book.role ?? 0) : null,
+            scanDepth: book.scanDepth ?? null,
+            caseSensitive: book.caseSensitive ?? null,
+            matchWholeWords: book.matchWholeWords ?? null,
+            displayIndex: index,
+        };
+    });
+
+    return JSON.stringify({ entries }, null, 2);
+};
+
+export const parseStandardWorldbook = (
+    rawText: string,
+    category: string,
+    now = Date.now(),
+): Worldbook[] => {
+    const parsed = JSON.parse(rawText);
+    if (!parsed || typeof parsed !== 'object' || !parsed.entries || typeof parsed.entries !== 'object') {
+        throw new Error('不是受支持的标准世界书文件：缺少 entries');
+    }
+    const rawEntries = Array.isArray(parsed.entries)
+        ? parsed.entries
+        : Object.values(parsed.entries);
+
+    const books = rawEntries.flatMap((value: any, index: number): Worldbook[] => {
+        if (!value || typeof value !== 'object' || typeof value.content !== 'string') return [];
+        const uid = Number.isFinite(Number(value.uid)) ? Number(value.uid) : index;
+        const position = clamp(value.position, 0, 6, 1) as WorldbookPosition;
+        const rawRole = value.role == null ? null : clamp(value.role, 0, 2, 0) as WorldbookDepthRole;
+        return [{
+            id: `wb-${now}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+            title: String(value.comment || value.name || `条目 ${uid + 1}`),
+            content: value.content,
+            category,
+            createdAt: now,
+            updatedAt: now,
+            key: asStringArray(value.key),
+            keysecondary: asStringArray(value.keysecondary),
+            constant: value.constant === true,
+            selective: value.selective === true,
+            selectiveLogic: clamp(value.selectiveLogic, 0, 3, 0) as WorldbookSelectiveLogic,
+            order: Number.isFinite(Number(value.order)) ? Number(value.order) : 100,
+            position,
+            disable: value.disable === true,
+            probability: clamp(value.probability, 0, 100, 100),
+            useProbability: value.useProbability === true,
+            depth: Math.max(0, Math.floor(clamp(value.depth, 0, 999, 4))),
+            role: rawRole,
+            scanDepth: value.scanDepth == null ? null : Math.max(0, Math.floor(clamp(value.scanDepth, 0, 999, 4))),
+            caseSensitive: value.caseSensitive == null ? null : value.caseSensitive === true,
+            matchWholeWords: value.matchWholeWords == null ? null : value.matchWholeWords === true,
+            sourceUid: uid,
+        }];
+    });
+
+    if (books.length === 0) throw new Error('世界书里没有可导入的有效条目');
+    return books;
+};


### PR DESCRIPTION
## What changed
- add standard `entries` worldbook import and group-level standard JSON export
- support constant and keyword activation, secondary-key logic, probability, enable/disable state, order, prompt position, depth, and message role
- preserve legacy worldbook behavior and synchronize edited settings to mounted character caches
- route character-position entries through `ContextBuilder` and depth entries through chat message assembly
- refine the worldbook editor UI with clearer activation controls, position guidance, and a fixed toggle layout

## Why
SullyOS previously stored worldbooks as flat always-on content, so standard lorebook files could not retain activation or insertion semantics.

## Impact
Existing unmounted and legacy worldbooks retain their previous behavior. Standard files can now be imported, edited, mounted, and exported by group without losing the supported metadata.

## Validation
- `vitest run`: 525 tests passed
- `utils/worldbook.test.ts`: 7 tests passed after the final UI/export changes
- Vite production build passed