### PR TITLE
fix: 适配 Claude 返回格式 + thinking 开启时不发采样参数

### DIFF
--- a/apps/CheckPhone.tsx
+++ b/apps/CheckPhone.tsx
@@ -4,7 +4,7 @@ import { DB } from '../utils/db';
 import { CharacterProfile, PhoneEvidence, PhoneCustomApp, PhoneContact, ConvTopic, AiSession, AiServiceKind, TavernCard } from '../types';
 import { ContextBuilder } from '../utils/context';
 import Modal from '../components/os/Modal';
-import { safeResponseJson } from '../utils/safeApi';
+import { safeResponseJson, extractContent, extractJson } from '../utils/safeApi';
 import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import {
     runRealConversation, runNpcConversation, upsertContact, matchRealChar,
@@ -685,14 +685,10 @@ ${realCharRule}
 
             if (!response.ok) throw new Error('API Error');
             const data = await safeResponseJson(response);
-            let content = data.choices[0].message.content;
-            content = content.replace(/```json/g, '').replace(/```/g, '').trim();
-            const firstBracket = content.indexOf('[');
-            const lastBracket = content.lastIndexOf(']');
-            if (firstBracket > -1 && lastBracket > -1) content = content.substring(firstBracket, lastBracket + 1);
-
-            let json = [];
-            try { json = JSON.parse(content); } catch (e) { json = []; }
+            // extractContent + extractJson：兼容 Claude 返回格式（正文在 reasoning_content、
+            // 包 ```json 代码块、夹散文、尾逗号、内层未转义引号…），裸 JSON.parse 解不出来会丢空。
+            const content = extractContent(data);
+            const json = extractJson(content) || [];
 
             const newRecordsToAdd: PhoneEvidence[] = [];
 
@@ -821,7 +817,9 @@ ${realCharRule}
         });
         if (!response.ok) throw new Error('API Error');
         const data = await safeResponseJson(response);
-        return (data.choices?.[0]?.message?.content as string) || '';
+        // 用 extractContent 而非裸读 message.content：兼容 Claude/思考类模型把正文放在
+        // reasoning_content、或正文里夹 <think> 块的情况，否则前端拿到空串（"后台出字前端没内容"）。
+        return extractContent(data);
     };
 
     // 组 context：跟 handleGenerate 一致（含记忆宫殿 + 时间感知 + 最近聊天），让偷看到的 AI 记录贴合真实近况
@@ -901,17 +899,14 @@ ${AI_VENDOR_LORE}
 
             const fullPrompt = `${context}\n\n### [Recent Chat Context]\n${recentMsgs}\n\n### [Task]\n${task}\n请结合「当前时间 / 距离上次联系」和人设，让内容贴合你近期的真实状态。只输出 JSON，不要解释。`;
 
-            let content = (await callLLM(fullPrompt)).replace(/```json/g, '').replace(/```/g, '').trim();
+            const content = await callLLM(fullPrompt);
             const now = Date.now();
             const rid = () => Math.random().toString(36).slice(2, 8);
             const newSessions: AiSession[] = [];
             const newCards: TavernCard[] = [];
 
             if (service === 'tavern') {
-                const s = content.indexOf('{'), e = content.lastIndexOf('}');
-                if (s > -1 && e > -1) content = content.substring(s, e + 1);
-                let obj: any = {};
-                try { obj = JSON.parse(content); } catch { obj = {}; }
+                const obj: any = extractJson(content) || {};
                 // 卡片去重 + 永不顶掉：同名卡复用已有 id（不重建、不覆盖、不挤掉），只新增真正没有过的
                 const nameToId: Record<string, string> = {};
                 for (const c of (targetChar.phoneState?.aiAgent?.cards || [])) nameToId[normName(c.name)] = c.id;
@@ -931,10 +926,8 @@ ${AI_VENDOR_LORE}
                     });
                 }
             } else {
-                const s = content.indexOf('['), e = content.lastIndexOf(']');
-                if (s > -1 && e > -1) content = content.substring(s, e + 1);
-                let arr: any[] = [];
-                try { arr = JSON.parse(content); } catch { arr = []; }
+                const parsed = extractJson(content);
+                const arr: any[] = Array.isArray(parsed) ? parsed : [];
                 for (const sess of arr) {
                     if (!sess?.transcript) continue;
                     newSessions.push({
@@ -1257,10 +1250,8 @@ ${olderText}
 **transcript 写法**：长剧情小说体，第三人称叙事 + 引号对白，动作/神态/心理用 *星号*；"我:" = 你(玩家 ${charName}) 敲进输入框的 RP，"对方:" = AI 扮的「${card.name}」，交替推进，4-6 轮，首轮"对方:"当开场白、**整段以 "我:"(玩家)收尾**（停在等对方回应处）。**"我:"括号外只写故事里所扮角色的动作/对白，不要写你现实里的身体反应（盯屏幕/扔手机/吃东西等）；（全角括号内）= 越过角色直接跟皮下 AI 本体说话（骂它/OOC 提醒/指导怎么演/指出哪段不对）。**
 返回 JSON：{ "title": "剧情标题(12字内)", "transcript": "我: ...\\n对方: ..." }`;
             const fullPrompt = `${context}\n\n### [Recent Chat Context]\n${recentMsgs}\n\n### [Task]\n${task}\n只输出 JSON，不要解释。`;
-            let content = (await callLLM(fullPrompt)).replace(/```json/g, '').replace(/```/g, '').trim();
-            const a = content.indexOf('{'), b = content.lastIndexOf('}');
-            if (a > -1 && b > -1) content = content.substring(a, b + 1);
-            let obj: any = {}; try { obj = JSON.parse(content); } catch { obj = {}; }
+            const content = await callLLM(fullPrompt);
+            const obj: any = extractJson(content) || {};
             if (!obj.transcript) { addToast('没生成出来，再试一次', 'error'); return; }
             const now = Date.now();
             const sess: AiSession = {

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1593,6 +1593,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   reqBody.thinking = { type: 'enabled', budget_tokens: 4000 };
                   reqBody.reasoning_effort = 'medium';
                   reqBody.extra_body = { ...(reqBody.extra_body || {}), thinking: { type: 'enabled', budget_tokens: 4000 } };
+                  // 开思考时不带采样参数: Claude 系在 thinking 启用时只接受 temperature=1，
+                  // 传 0.85 会被 400。删掉用服务端默认；对非 Claude 模型同样安全。
+                  delete reqBody.temperature;
+                  delete reqBody.top_p;
               }
               const data = await safeFetchJson(`${baseUrl}/chat/completions`, {
                   method: 'POST', headers,

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -790,6 +790,12 @@ export const useChatAI = ({
                 baseReqBody.thinking = { type: 'enabled', budget_tokens: 4000 };
                 baseReqBody.reasoning_effort = 'medium';
                 baseReqBody.extra_body = { ...(baseReqBody.extra_body || {}), thinking: { type: 'enabled', budget_tokens: 4000 } };
+                // 开思考时不要带采样参数: Claude 系（含各种中转 claude-*）在 thinking 启用时
+                // 只接受 temperature=1，传 0.85 会被 400 ("temperature may only be set to 1 when
+                // thinking is enabled")。删掉让服务端用默认即可——对其它模型(非 Claude)也安全:
+                // 它们开思考时同样不需要我们指定温度，回退默认不影响行为。
+                delete baseReqBody.temperature;
+                delete baseReqBody.top_p;
             }
             // 流式时显式要求 usage 统计随末尾 chunk 一起返回，否则 token 徽标拿不到数据
             if (userStream) {


### PR DESCRIPTION
查手机·智能体「后台出字但前端没内容」：callLLM 等裸读 message.content +
裸 JSON.parse，遇到 Claude 把正文放进 reasoning_content、包 ```json 代码块、 夹散文/尾逗号时解不出来 → 空。改走仓库现成的 extractContent / extractJson。

thinking 启用时的 HTTP 400 (`temperature may only be set to 1 when thinking is enabled`)：主聊天(useChatAI) 与主动消息(OSContext) 在开思考时删掉 temperature / top_p，让服务端用默认。对非 Claude 模型同样安全。


Claude-Session: https://claude.ai/code/session_019DbMZB9Xc6yGz7xkHzsGE1