### PR TITLE
fix(active-msg): 主动消息按角色可见性过滤表情包，避免发出绑定给其他角色的表情

### DIFF
--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -1,5 +1,6 @@
 import { ActiveMsg2InboxMessage, APIConfig, RealtimeConfig, UserProfile } from '../types';
 import { DB } from './db';
+import { ChatPrompts } from './chatPrompts';
 import { ActiveMsgStore } from './activeMsgStore';
 import {
   applyAssistantPostProcessing,
@@ -134,7 +135,15 @@ const processInboxMessageWithPostProcessing = async (message: ActiveMsg2InboxMes
 
   const userProfile: UserProfile = (await DB.getUserProfile())
     ?? { name: 'User', avatar: '', bio: '' };
-  const emojis = await DB.getEmojis();
+  // 按角色可见性过滤表情包：后处理落库时靠 emojis.find(e => e.name === name) 反查 URL，
+  // 若传全量表情，名字冲突时会把 A 的 [[SEND_EMOJI: x]] 匹配到 B 名下的同名表情，导致
+  // A 发出绑定给 B 的表情包。本地聊天路径喂的是 aiVisibleEmojis（已过滤），主动消息路径
+  // 之前漏了这步，这里复用同一套过滤收口（与 activeMsgClient.buildCompletePrompt 对齐）。
+  const { emojis } = ChatPrompts.filterVisibleEmojis(
+    await DB.getEmojis(),
+    await DB.getEmojiCategories(),
+    message.charId,
+  );
   const contextMsgs = await DB.getRecentMessagesByCharId(message.charId, 200);
 
   const apiConfig = loadApiConfigFromLocalStorage();


### PR DESCRIPTION
主动消息(Active Msg)落库路径 processInboxMessageWithPostProcessing 之前用全量 DB.getEmojis() 喂给 applyAssistantPostProcessing。后处理靠 emojis.find(e => e.name === name) 反查表情 URL，名字冲突时会把 A 输出的 [[SEND_EMOJI: x]] 匹配到 B 名下的同名表情， 导致 A 发出绑定给 B 的表情包。

本地聊天路径喂的是已过滤的 aiVisibleEmojis；提示词路径 activeMsgClient.buildCompletePrompt 也已用 ChatPrompts.filterVisibleEmojis 过滤。此处对落库路径收口到同一套过滤，三条路径行为对齐。


Claude-Session: https://claude.ai/code/session_01Ss9qHcjjLXrxPKCyC63sbE