### PR TITLE
fix(memory-palace): 副 API 不再推荐国产模型 / 硅基流动，改为中性措辞

### DIFF
--- a/apps/MemoryPalaceApp.tsx
+++ b/apps/MemoryPalaceApp.tsx
@@ -2509,7 +2509,7 @@ export default function MemoryPalaceApp() {
                         <div>
                             <label className={labelClass}>BASE URL</label>
                             <input type="text" value={lightUrl} onChange={e => setLightUrl(e.target.value)}
-                                placeholder="https://api.siliconflow.cn/v1" className={inputClass} />
+                                placeholder="https://..." className={inputClass} />
                         </div>
                         <div>
                             <label className={labelClass}>API KEY</label>
@@ -2519,9 +2519,10 @@ export default function MemoryPalaceApp() {
                         <div>
                             <label className={labelClass}>MODEL</label>
                             <input type="text" value={lightModel} onChange={e => setLightModel(e.target.value)}
-                                placeholder="deepseek-ai/DeepSeek-V2.5" className={inputClass} />
+                                placeholder="一个便宜的对话模型名" className={inputClass} />
                             <div style={{ fontSize: 10, color: '#9ca3af', marginTop: 4, paddingLeft: 4 }}>
-                                推荐: deepseek-ai/DeepSeek-V2.5 · Qwen/Qwen2.5-7B-Instruct · GLM-4-Flash
+                                填任意一家便宜的<b>对话模型</b>即可（按主 API 一样的填法），自己挑就好。
+                                注意：这里要的是跑后台文字任务的<b>对话</b>模型，<b>不是</b> embedding 向量模型——别填到下面 Embedding 区才该用的那类。
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
记忆宫殿「副 API」(lightLLM, 跑后台文字任务) 之前 placeholder 指向硅基流动 URL + deepseek-ai/DeepSeek-V2.5，推荐文案还列了 DeepSeek/Qwen/GLM 等国产模型，导致很多用户 把硅基流动的模型填到这里。硅基流动适合的是 embedding，不适合当对话模型。

改为：
- placeholder 中性化（URL 用 https://...，MODEL 用通用提示）
- 推荐文案不再指向任何具体模型，只说"填任意便宜的对话模型即可，自己挑"
- 明确提示这里要的是对话模型而非 embedding 向量模型，避免误填

Embedding / Rerank 区继续推荐硅基流动（其擅长场景），不动。


Claude-Session: https://claude.ai/code/session_01Ss9qHcjjLXrxPKCyC63sbE