### PR TITLE
feat(music): 角色歌单支持长按/选择批量删歌

### DIFF
--- a/apps/music/CharVisitPage.tsx
+++ b/apps/music/CharVisitPage.tsx
@@ -10,15 +10,16 @@
  * - 点歌单进详情（若歌单空，可以一键让 char 搜歌填充）。
  * - 点任一首歌 → 用全局 MusicContext 播放 (沿用 user 的 cookie / 配额)。
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useOS } from '../../context/OSContext';
 import { useMusic, musicApi, toHttps, Song } from '../../context/MusicContext';
 import { CharacterProfile, CharPlaylist, CharPlaylistSong } from '../../types';
 import { CharMusicPersona } from '../../utils/charMusicPersona';
 import { computeCurrentListening } from '../../utils/charMusicSchedule';
+import { removeSongsFromPlaylist } from '../../utils/charPlaylistEdit';
 import { DB } from '../../utils/db';
 import { C, Sparkle, MizuHeader, BokehBg, MiniPlayer } from './MusicUI';
-import { ArrowLeft, MusicNote, Heart, Plus, MagnifyingGlass } from '@phosphor-icons/react';
+import { ArrowLeft, MusicNote, Heart, Plus, MagnifyingGlass, Trash, Check } from '@phosphor-icons/react';
 
 interface Props {
   charId: string;
@@ -62,6 +63,56 @@ const CharVisitPage: React.FC<Props> = ({ charId, onBack, onOpenPlayer }) => {
   const [initializing, setInitializing] = useState(false);
   const [expandedPl, setExpandedPl] = useState<string | null>(null);
   const [fillingPl, setFillingPl] = useState<string | null>(null);
+
+  // 选择模式：长按或点「选择」进入，可勾选多首歌一起删
+  const [selectingPl, setSelectingPl] = useState<string | null>(null);
+  const [selectedSongIds, setSelectedSongIds] = useState<Set<number>>(new Set());
+
+  const enterSelectMode = (plId: string, songId?: number) => {
+    setExpandedPl(plId);
+    setSelectingPl(plId);
+    setSelectedSongIds(songId != null ? new Set([songId]) : new Set());
+  };
+  const exitSelectMode = () => {
+    setSelectingPl(null);
+    setSelectedSongIds(new Set());
+  };
+  const toggleSelected = (songId: number) => {
+    setSelectedSongIds(prev => {
+      const next = new Set(prev);
+      if (next.has(songId)) next.delete(songId); else next.add(songId);
+      return next;
+    });
+  };
+
+  // 长按检测：按住约 0.5s 触发；手指/鼠标移动超过阈值视为滚动，取消长按
+  const lpTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lpFired = useRef(false);
+  const lpStart = useRef<{ x: number; y: number } | null>(null);
+  const clearLongPress = () => {
+    if (lpTimer.current) { clearTimeout(lpTimer.current); lpTimer.current = null; }
+  };
+  const songPressHandlers = (pl: CharPlaylist, song: CharPlaylistSong) => ({
+    onPointerDown: (e: React.PointerEvent) => {
+      if (selectingPl) return; // 已在选择模式，不需要长按
+      lpFired.current = false;
+      lpStart.current = { x: e.clientX, y: e.clientY };
+      clearLongPress();
+      lpTimer.current = setTimeout(() => {
+        lpFired.current = true;
+        enterSelectMode(pl.id, song.id);
+      }, 500);
+    },
+    onPointerMove: (e: React.PointerEvent) => {
+      if (!lpStart.current) return;
+      if (Math.abs(e.clientX - lpStart.current.x) > 10 || Math.abs(e.clientY - lpStart.current.y) > 10) {
+        clearLongPress();
+      }
+    },
+    onPointerUp: clearLongPress,
+    onPointerLeave: clearLongPress,
+    onPointerCancel: clearLongPress,
+  });
 
   const profile = char?.musicProfile;
   const initialized = !!(char && CharMusicPersona.isInitialized(char));
@@ -130,6 +181,23 @@ const CharVisitPage: React.FC<Props> = ({ charId, onBack, onOpenPlayer }) => {
 
   const togglePlaylist = (plId: string) => {
     setExpandedPl(prev => (prev === plId ? null : plId));
+    exitSelectMode(); // 收起或切到别的歌单时，退出选择模式
+  };
+
+  /** 把当前选中的歌从歌单里一起删掉（弹一次确认） */
+  const deleteSelected = (pl: CharPlaylist) => {
+    if (!char || !profile || selectedSongIds.size === 0) return;
+    const n = selectedSongIds.size;
+    const ok = typeof window !== 'undefined'
+      ? window.confirm(`从《${pl.title}》移除选中的 ${n} 首歌？`)
+      : true;
+    if (!ok) return;
+    const nextPlaylists = removeSongsFromPlaylist(profile.playlists, pl.id, selectedSongIds, Date.now());
+    updateCharacter(char.id, {
+      musicProfile: { ...profile, playlists: nextPlaylists, updatedAt: Date.now() },
+    });
+    addToast(`已移除 ${n} 首`, 'success');
+    exitSelectMode();
   };
 
   /** 让 char 用偏爱艺人作为关键词去搜歌 → 自动填充空歌单
@@ -437,23 +505,83 @@ const CharVisitPage: React.FC<Props> = ({ charId, onBack, onOpenPlayer }) => {
                             </button>
                           </div>
                         ) : (
-                          <div className="space-y-1 pt-2">
-                            {pl.songs.map((s, i) => (
-                              <button
-                                key={s.id}
-                                onClick={() => playPlaylistSong(pl, s)}
-                                className="w-full flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-white/40 transition-colors text-left"
-                              >
-                                <span className="text-[10px] w-4 shrink-0" style={{ color: C.faint }}>{i + 1}</span>
-                                <div className="flex-1 min-w-0">
-                                  <div className="text-xs truncate" style={{ color: C.text }}>{s.name}</div>
-                                  <div className="text-[9px] truncate" style={{ color: C.muted }}>{s.artists}</div>
-                                </div>
-                                {s.fee === 1 && (
-                                  <span className="text-[8px] px-1 rounded" style={{ color: C.vip, border: `1px solid ${C.vip}50` }}>VIP</span>
-                                )}
-                              </button>
-                            ))}
+                          <div className="pt-2">
+                            {/* 操作条：平时显示「选择」；选择模式下变成 取消 · 已选 N · 删除 */}
+                            <div className="flex items-center justify-between px-2 pb-1.5">
+                              {selectingPl === pl.id ? (
+                                <>
+                                  <button
+                                    onClick={exitSelectMode}
+                                    className="text-[11px] px-1 py-0.5"
+                                    style={{ color: C.muted }}
+                                  >
+                                    取消
+                                  </button>
+                                  <span className="text-[10px]" style={{ color: C.faint }}>
+                                    已选 {selectedSongIds.size} 首
+                                  </span>
+                                  <button
+                                    onClick={() => deleteSelected(pl)}
+                                    disabled={selectedSongIds.size === 0}
+                                    className="text-[11px] px-1 py-0.5 flex items-center gap-1 disabled:opacity-40"
+                                    style={{ color: C.vip }}
+                                  >
+                                    <Trash size={12} weight="bold" />
+                                    删除
+                                  </button>
+                                </>
+                              ) : (
+                                <>
+                                  <span className="text-[10px]" style={{ color: C.faint }}>{pl.songs.length} 首</span>
+                                  <button
+                                    onClick={() => enterSelectMode(pl.id)}
+                                    className="text-[11px] px-1 py-0.5"
+                                    style={{ color: C.primary }}
+                                  >
+                                    选择
+                                  </button>
+                                </>
+                              )}
+                            </div>
+                            <div className="space-y-1">
+                              {pl.songs.map((s, i) => {
+                                const selecting = selectingPl === pl.id;
+                                const checked = selectedSongIds.has(s.id);
+                                return (
+                                  <button
+                                    key={s.id}
+                                    onClick={() => {
+                                      if (lpFired.current) { lpFired.current = false; return; } // 长按已触发，吞掉这次 click
+                                      if (selecting) { toggleSelected(s.id); return; }
+                                      playPlaylistSong(pl, s);
+                                    }}
+                                    {...songPressHandlers(pl, s)}
+                                    className="w-full flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-white/40 transition-colors text-left"
+                                  >
+                                    {selecting ? (
+                                      <span
+                                        className="w-4 h-4 shrink-0 rounded-full border flex items-center justify-center"
+                                        style={{
+                                          borderColor: checked ? C.primary : C.faint,
+                                          background: checked ? C.primary : 'transparent',
+                                        }}
+                                      >
+                                        {checked && <Check size={10} weight="bold" color="white" />}
+                                      </span>
+                                    ) : (
+                                      <span className="text-[10px] w-4 shrink-0" style={{ color: C.faint }}>{i + 1}</span>
+                                    )}
+                                    <div className="flex-1 min-w-0">
+                                      <div className="text-xs truncate" style={{ color: C.text }}>{s.name}</div>
+                                      <div className="text-[9px] truncate" style={{ color: C.muted }}>{s.artists}</div>
+                                    </div>
+                                    {s.fee === 1 && !selecting && (
+                                      <span className="text-[8px] px-1 rounded" style={{ color: C.vip, border: `1px solid ${C.vip}50` }}>VIP</span>
+                                    )}
+                                  </button>
+                                );
+                              })}
+                            </div>
                           </div>
                         )}
                       </div>
@@ -546,7 +674,7 @@ const CharVisitPage: React.FC<Props> = ({ charId, onBack, onOpenPlayer }) => {
                   background: `${C.sakura}14`,
                   border: `1px solid ${C.sakura}35`,
                 }}
-                title="清空现有音乐人格并重新让 LLM 生成"
+                title="清空后重新生成。"
               >
                 {initializing ? '重新敲门中…' : '重新生成音乐人格'}
               </button>

--- a/utils/charPlaylistEdit.test.ts
+++ b/utils/charPlaylistEdit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { removeSongsFromPlaylist } from './charPlaylistEdit';
+import type { CharPlaylist, CharPlaylistSong } from '../types';
+
+let songSeq = 1;
+const makeSong = (overrides: Partial<CharPlaylistSong> = {}): CharPlaylistSong => ({
+  id: songSeq++,
+  name: `song-${songSeq}`,
+  artists: 'artist',
+  album: 'album',
+  albumPic: '',
+  duration: 200,
+  fee: 0,
+  ...overrides,
+});
+
+const makePlaylist = (id: string, songs: CharPlaylistSong[], updatedAt = 100): CharPlaylist => ({
+  id,
+  title: `pl-${id}`,
+  description: '',
+  coverStyle: 'gradient-01',
+  songs,
+  createdAt: 1,
+  updatedAt,
+});
+
+describe('removeSongsFromPlaylist', () => {
+  it('删掉选中的歌，保留其余', () => {
+    const a = makeSong(), b = makeSong(), c = makeSong();
+    const playlists = [makePlaylist('p1', [a, b, c])];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [b.id], 999);
+
+    expect(result[0].songs.map(s => s.id)).toEqual([a.id, c.id]);
+  });
+
+  it('支持一次删多首', () => {
+    const a = makeSong(), b = makeSong(), c = makeSong(), d = makeSong();
+    const playlists = [makePlaylist('p1', [a, b, c, d])];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', new Set([a.id, c.id]), 999);
+
+    expect(result[0].songs.map(s => s.id)).toEqual([b.id, d.id]);
+  });
+
+  it('只动目标歌单，其它歌单连引用都不变', () => {
+    const p1 = makePlaylist('p1', [makeSong(), makeSong()]);
+    const p2 = makePlaylist('p2', [makeSong()]);
+    const playlists = [p1, p2];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [p1.songs[0].id], 999);
+
+    expect(result[1]).toBe(p2); // 别的歌单原样保留
+  });
+
+  it('删了歌就把目标歌单 updatedAt 更新为 now', () => {
+    const a = makeSong(), b = makeSong();
+    const playlists = [makePlaylist('p1', [a, b], 100)];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [a.id], 777);
+
+    expect(result[0].updatedAt).toBe(777);
+  });
+
+  it('删光所有歌：歌单还在，songs 变空数组', () => {
+    const a = makeSong(), b = makeSong();
+    const playlists = [makePlaylist('p1', [a, b])];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [a.id, b.id], 999);
+
+    expect(result[0].songs).toEqual([]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('songIds 含歌单里没有的 id：安全忽略，只删存在的', () => {
+    const a = makeSong(), b = makeSong();
+    const playlists = [makePlaylist('p1', [a, b])];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [a.id, 99999], 999);
+
+    expect(result[0].songs.map(s => s.id)).toEqual([b.id]);
+  });
+
+  it('空 songIds 是 no-op：按原引用返回，不动 updatedAt', () => {
+    const playlists = [makePlaylist('p1', [makeSong()], 100)];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [], 999);
+
+    expect(result).toBe(playlists);
+  });
+
+  it('目标歌单不存在：按原引用返回', () => {
+    const playlists = [makePlaylist('p1', [makeSong()])];
+
+    const result = removeSongsFromPlaylist(playlists, 'nope', [1, 2, 3], 999);
+
+    expect(result).toBe(playlists);
+  });
+
+  it('选中的 id 都不在歌单里：no-op，按原引用返回', () => {
+    const playlists = [makePlaylist('p1', [makeSong(), makeSong()])];
+
+    const result = removeSongsFromPlaylist(playlists, 'p1', [88888, 99999], 999);
+
+    expect(result).toBe(playlists);
+  });
+});

--- a/utils/charPlaylistEdit.ts
+++ b/utils/charPlaylistEdit.ts
@@ -1,0 +1,41 @@
+/**
+ * 角色歌单的本地编辑操作（纯函数，不碰网络 / 存储）。
+ *
+ * 抽出来单独放，是为了能脱离 React 组件直接做单元测试——
+ * 批量删歌这种"删错一首就糟"的逻辑，靠测试钉住比靠肉眼放心。
+ */
+import { CharPlaylist } from '../types';
+
+/**
+ * 从指定歌单里批量移除若干首歌，返回新的 playlists 数组。
+ *
+ * - 只动 id === playlistId 的那个歌单，其它歌单原样保留（连引用都不变）。
+ * - songIds 里不存在于歌单中的 id 会被安全忽略。
+ * - 真有歌被删掉时，目标歌单的 updatedAt 更新为 now；否则整个数组按原引用返回（no-op）。
+ * - 删光所有歌只会让 songs 变空数组，歌单本身不会被删除。
+ *
+ * @param playlists  当前所有歌单
+ * @param playlistId 目标歌单的本地 id
+ * @param songIds    要删除的歌曲 id 集合
+ * @param now        删除发生的时间戳（注入而非内部取，方便测试）
+ */
+export function removeSongsFromPlaylist(
+  playlists: CharPlaylist[],
+  playlistId: string,
+  songIds: Iterable<number>,
+  now: number,
+): CharPlaylist[] {
+  const idSet = songIds instanceof Set ? songIds : new Set(songIds);
+  if (idSet.size === 0) return playlists;
+
+  let changed = false;
+  const next = playlists.map(pl => {
+    if (pl.id !== playlistId) return pl;
+    const keptSongs = pl.songs.filter(s => !idSet.has(s.id));
+    if (keptSongs.length === pl.songs.length) return pl; // 没删掉任何歌
+    changed = true;
+    return { ...pl, songs: keptSongs, updatedAt: now };
+  });
+
+  return changed ? next : playlists;
+}


### PR DESCRIPTION
## 改之前 → 改之后

拜访角色的「音乐角落」里，歌单展开后每首歌只能点着播放，**没有任何删除入口**——角色加进来的歌删不掉。

改后支持批量删：

| 进选择模式 | 长按任意一首歌（约 0.5s），或点歌单右上角的「选择」按钮 |
|---|---|
| 选歌 | 每行左侧变勾选圈，点一下选/取消（此时点歌不再播放） |
| 删除 | 顶部操作条 `取消 · 已选 N 首 · 删除`，点删除弹一次确认后批量移除 |
| 退出 | 点「取消」、收起歌单、或切到别的歌单都会自动退出 |

长按那首默认选中；空歌单不显示「选择」。只动角色歌单，网易云那边不碰。

## 改了什么

- `utils/charPlaylistEdit.ts` — 新增纯函数 `removeSongsFromPlaylist`，负责从指定歌单批量移除选中歌、其余原样保留。
- `utils/charPlaylistEdit.test.ts` — 9 条单测钉住行为（删多首 / 不误伤别的歌单 / 删光不删歌单 / 忽略不存在的 id / 空选无副作用）。
- `apps/music/CharVisitPage.tsx` — 选择模式状态、长按检测、操作条与勾选 UI；删除复用现有 `updateCharacter` 落库。

## 验证

- `pnpm vitest run utils/charPlaylistEdit.test.ts` → 9 passed
- 目标文件 `tsc --noEmit` 无类型错误
- 触摸交互（长按 / 勾选 / 删除手感）vitest 是 node 环境测不到，需真机或浏览器手动验

🤖 Generated with [Claude Code](https://claude.com/claude-code)