### PR TITLE
fix(call/keyboard): 安卓 Chrome/Edge 键盘避让对齐 PR #260 的全屏方案

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -1366,8 +1366,9 @@ const CallApp: React.FC = () => {
           <div className="mt-1.5 text-lg tabular-nums font-extralight tracking-[0.2em]" style={{ color: accentColor }}>{formatDuration(elapsedSeconds)}</div>
         </div>
       </div>
-      {/* portrait + aura */}
-      <div className="pt-3 pb-1 flex flex-col items-center justify-center">
+      {/* portrait + aura —— 键盘弹起时（body.ios-keyboard-open）整块收起，把可视区让给消息+输入框，
+          避免大头像把输入框顶出键盘上方的可视区（见 index.html 的 .sully-call-hero 规则）。 */}
+      <div className="sully-call-hero pt-3 pb-1 flex flex-col items-center justify-center">
         <div className="relative w-40 h-40">
           <div className={`absolute -inset-3 rounded-full blur-xl ${waveActive ? 'animate-pulse' : ''}`} style={{ background: `radial-gradient(closest-side, ${accentColor}, transparent)`, opacity: waveActive ? 0.8 : 0.4 }} />
           <div className="absolute -inset-1 rounded-full" style={{ boxShadow: `0 0 0 1px ${accentColor}55, inset 0 0 24px ${accentColor}33` }} />
@@ -1481,14 +1482,6 @@ const CallApp: React.FC = () => {
               ref={draftInputRef}
               value={draftInput}
               onChange={(e) => setDraftInput(e.target.value)}
-              onFocus={(e) => {
-                // 和聊天一致：只做一次轻量的「就近滚入可视」，不再手动 scrollTo / 改 padding。
-                const el = e.currentTarget;
-                window.requestAnimationFrame(() => {
-                  if (document.activeElement !== el) return;
-                  try { el.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch {}
-                });
-              }}
               className="flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-white/35"
               placeholder={isListening ? '在听你说……' : sendingBusy ? `${selectedChar?.name || '对方'}正在想……` : `想对${selectedChar?.name || '对方'}说什么？`}
             />

--- a/index.html
+++ b/index.html
@@ -246,6 +246,20 @@
       body.ios-keyboard-open .sully-chat-inputbar {
         padding-bottom: 0;
       }
+      /* 通话页：键盘弹起时收起大头像英雄区（约 300px），把可视区让给消息列表 + 输入框。
+         可视区收到键盘上方后若不收起大头像，会把输入框顶出可视区。用 max-height 过渡平滑收起。 */
+      .sully-call-hero {
+        transition: max-height 0.2s ease-out, opacity 0.2s ease-out, padding 0.2s ease-out;
+        max-height: 420px;
+      }
+      body.ios-keyboard-open .sully-call-hero {
+        max-height: 0;
+        opacity: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        overflow: hidden;
+        pointer-events: none;
+      }
     </style>
   <script type="importmap">
 {

--- a/utils/iosStandalone.ts
+++ b/utils/iosStandalone.ts
@@ -52,6 +52,14 @@ export const isStandaloneDisplayMode = (): boolean => {
 
 export const isIOSStandaloneWebApp = (): boolean => isIOSDevice() && isStandaloneDisplayMode();
 
+// 安卓机（Chrome / Edge 等）。安卓普通浏览器弹软键盘时经常不按 interactive-widget=resizes-content
+// 回流，而是缩小可视区、把整页往上顶（顶栏被切、退出重进才恢复）。需要和 iOS 全屏 PWA 一样，
+// 让 app 高度跟随可视区并锁死外层滚动。
+export const isAndroidDevice = (): boolean => {
+    if (typeof navigator === 'undefined') return false;
+    return /Android/i.test(navigator.userAgent || '');
+};
+
 // 顶部时钟/电量条是否隐藏：外观「隐藏顶部时间栏」开关显式设过就听用户的；没设过(undefined)按平台默认——
 // iOS 全屏 PWA 系统状态栏(真实时间/电量)删不掉，默认隐藏 SullyOS 这条避免双显。
 // 必须用 ?? 而非 ||：显式 false（用户主动要显示）不能被平台默认 true 盖掉。
@@ -101,9 +109,22 @@ const setViewportVars = () => {
         }
     } else {
         stableStandaloneHeight = 0;
+        // obscuredHeight = 被软键盘盖住的高度。安卓浏览器若按 resizes-content 回流，
+        // innerHeight 会跟着缩，obscuredHeight ≈ 0（走无键盘分支，布局自行回流，什么都不用做）；
+        // 若不回流而是缩小可视区/顶起整页，obscuredHeight > 120，进入键盘分支统一避让。
         const obscuredHeight = Math.max(0, innerHeight - viewportHeight - viewportOffsetTop);
-        keyboardInset = obscuredHeight > 120 ? obscuredHeight : 0;
-        fullAppHeight = Math.max(innerHeight, viewportHeight + viewportOffsetTop);
+        const keyboardOpen = obscuredHeight > 120;
+        // 键盘避让统一用「app 高度跟随可视区」，不再靠 keyboard-inset 让各 App 自己叠 padding。
+        keyboardInset = 0;
+        if (keyboardOpen) {
+            // 安卓 Chrome/Edge：app 高度收到键盘上方的可视区，输入框自然落在可视区内；
+            // 再把被浏览器顶起的外层滚动拉回顶部（配合 body.ios-keyboard-open 的 touchmove 锁定），
+            // 界面不再整体上移、退出重进才恢复。
+            fullAppHeight = viewportHeight;
+            if (viewportOffsetTop > 0) window.scrollTo(0, 0);
+        } else {
+            fullAppHeight = Math.max(innerHeight, viewportHeight + viewportOffsetTop);
+        }
     }
 
     document.documentElement.style.setProperty('--app-height', `${fullAppHeight}px`);
@@ -119,6 +140,9 @@ export const installIOSStandaloneWorkaround = () => {
 
     hasInstalledIOSStandaloneWorkaround = true;
     const useStandaloneFixes = isIOSStandaloneWebApp();
+    // iOS 全屏 PWA 与安卓浏览器都需要「聚焦挂 keyboard 类 + 锁外层滚动」这套键盘避让。
+    // 安卓 Chrome/Edge 弹键盘时会把整页顶起，同样靠这套压回去。
+    const useKeyboardFixes = useStandaloneFixes || isAndroidDevice();
     if (useStandaloneFixes) {
         document.documentElement.classList.add('ios-standalone');
         document.body.classList.add('ios-standalone');
@@ -175,7 +199,7 @@ export const installIOSStandaloneWorkaround = () => {
     window.addEventListener('orientationchange', handleSafeAreaChange);
     window.visualViewport?.addEventListener('resize', handleViewportChange);
     window.visualViewport?.addEventListener('scroll', handleViewportChange);
-    if (useStandaloneFixes) {
+    if (useKeyboardFixes) {
         document.addEventListener('focusin', handleFocusIn);
         document.addEventListener('focusout', handleFocusOut);
         document.addEventListener('touchmove', handleTouchMove, { passive: false });


### PR DESCRIPTION
现象：安卓浏览器进通话页点输入框弹键盘，整个界面被顶上去（顶栏 Sully 被切）
且退出重进才恢复，再点又顶。根因是安卓普通浏览器弹软键盘时经常不按
interactive-widget=resizes-content 回流，而是缩小可视区/把整页顶起，而 PR #260 的「app 高度跟随可视区 + 锁外层滚动」这套避让只对 iOS 全屏 PWA 生效，安卓没走到。

把 PR #260 的最终效果扩到安卓 Chrome/Edge：
- utils/iosStandalone.ts：新增 isAndroidDevice()；非 standalone 分支在 obscuredHeight>120（键盘遮挡）时让 --app-height 收到可视区（viewportHeight）， 并把被顶起的外层滚动 scrollTo(0,0) 拉回；聚焦挂 .ios-keyboard-open 类 + touchmove 锁定的处理器改由 useKeyboardFixes(= standalone || 安卓) 装载。
- index.html：新增 .sully-call-hero 规则——键盘弹起时收起通话页大头像英雄区 （约 300px），把可视区让给消息列表+输入框，否则可视区收窄后大头像会把输入框 顶出可视区（聊天没这个大头像所以本来就没事）。
- CallApp：给大头像英雄区加 .sully-call-hero；移除上一版残留的 onFocus scrollIntoView（现由全局 handleFocusIn 统一处理）。

keyboard-inset 兜底彻底退役（无 App 再消费 var(--keyboard-inset)），键盘避让 统一走「app 高度跟随可视区」，和聊天/群聊等其它 App 一致。


Claude-Session: https://claude.ai/code/session_01AwLtBDcPGRKPSbhTtUcBST