### PR TITLE
fix(date): 见面「继续上次」崩溃自愈，打破 iOS WebKit 反复闪退死循环

### DIFF
--- a/apps/DateApp.tsx
+++ b/apps/DateApp.tsx
@@ -12,6 +12,7 @@ import { safeResponseJson } from '../utils/safeApi';
 import Modal from '../components/os/Modal';
 import DateSession from '../components/date/DateSession';
 import DateSettings from '../components/date/DateSettings';
+import { armDateResumeAttempt, clearDateResumeAttempt, takeCrashedDateResume } from '../utils/dateSessionRecovery';
 import { BookOpen, Sparkle, CaretLeft, GearSix } from '@phosphor-icons/react';
 
 const DateApp: React.FC = () => {
@@ -100,6 +101,20 @@ const DateApp: React.FC = () => {
         }
     }, [char, mode]);
 
+    // 见面「继续上次」崩溃自愈：若上次恢复会话时把 iOS WebKit 内容进程撑崩了
+    // (表现为反复灰屏/白屏「此网页反复出现问题」，非可捕获的 JS 异常)，那份重快照
+    // 的哨兵会残留到本次进见面。这里检出后丢弃有毒的 savedDateState（仅清恢复快照，
+    // 消息历史不动），避免用户永久卡在闪退死循环里。只在 DateApp 挂载时跑一次。
+    useEffect(() => {
+        const crashedCharId = takeCrashedDateResume();
+        if (!crashedCharId) return;
+        const crashed = characters.find(c => c.id === crashedCharId);
+        if (crashed?.savedDateState) {
+            updateCharacter(crashedCharId, { savedDateState: undefined });
+            addToast('上次见面异常退出，已清理存档，可重新开始', 'info');
+        }
+    }, []); // 仅挂载时检查一次
+
     // --- Navigation Helpers ---
     const handleBack = () => {
         if (mode === 'peek') {
@@ -144,6 +159,9 @@ const DateApp: React.FC = () => {
 
     const handleResumeSession = () => {
         if (!pendingSessionChar) return;
+        // 恢复尝试开始前先武装崩溃哨兵：若这份重快照在 iOS 上把内容进程撑崩，
+        // 哨兵会残留到下次进见面被检出并清理（见挂载时的自愈 effect）。
+        armDateResumeAttempt(pendingSessionChar.id);
         setActiveCharacterId(pendingSessionChar.id);
         setMode('session');
         setPendingSessionChar(null);
@@ -152,6 +170,8 @@ const DateApp: React.FC = () => {
 
     const handleStartNewSession = () => {
         if (!pendingSessionChar) return;
+        // 新会话没有恢复快照可重放，撤销任何残留哨兵。
+        clearDateResumeAttempt();
         updateCharacter(pendingSessionChar.id, { savedDateState: undefined });
         startPeek(pendingSessionChar);
         setPendingSessionChar(null);
@@ -447,6 +467,8 @@ const DateApp: React.FC = () => {
     };
 
     const onExitSession = (finalState: DateState) => {
+        // 用户主动保存并退出 = 干净退出，撤销恢复哨兵。
+        clearDateResumeAttempt();
         if (char) {
             updateCharacter(char.id, { savedDateState: finalState });
             addToast('进度已保存', 'success');

--- a/components/date/DateSession.tsx
+++ b/components/date/DateSession.tsx
@@ -6,6 +6,7 @@ import { DB } from '../../utils/db';
 import DateSettings from './DateSettings';
 import ObserveHUD from './ObserveHUD';
 import { extractObservation, hasObservation } from '../../utils/datePrompts';
+import { clearDateResumeAttempt } from '../../utils/dateSessionRecovery';
 import { cleanTextForTts, VALID_EMOTIONS } from '../../utils/minimaxTts';
 import { synthesizeSpeech, characterHasVoice } from '../../utils/ttsRouter';
 import { resolveTtsProvider } from '../../utils/ttsProvider';
@@ -346,14 +347,15 @@ const DateSession: React.FC<DateSessionProps> = ({
     // Initialization
     useEffect(() => {
         if (initialState) {
-            // Resume
-            setBgImage(initialState.bgImage);
-            setCurrentSprite(initialState.currentSprite);
-            setCurrentText(initialState.currentText);
-            setDisplayedText(initialState.currentText);
-            setDialogueQueue(initialState.dialogueQueue);
-            setDialogueBatch(initialState.dialogueBatch);
-            setIsNovelMode(initialState.isNovelMode);
+            // Resume — 防御性回填：老快照 / 落库竞态可能缺字段，缺数组兜底成 []，
+            // 否则后续 dialogueQueue.length 等取值会抛异常连累整个会话渲染。
+            setBgImage(initialState.bgImage || '');
+            setCurrentSprite(initialState.currentSprite || '');
+            setCurrentText(initialState.currentText || '');
+            setDisplayedText(initialState.currentText || '');
+            setDialogueQueue(Array.isArray(initialState.dialogueQueue) ? initialState.dialogueQueue : []);
+            setDialogueBatch(Array.isArray(initialState.dialogueBatch) ? initialState.dialogueBatch : []);
+            setIsNovelMode(!!initialState.isNovelMode);
         } else {
             // New Session - pick initial sprite from active skin set or default sprites
             const s = (() => {
@@ -584,10 +586,19 @@ const DateSession: React.FC<DateSessionProps> = ({
         // Periodic auto-save every 30s
         const interval = setInterval(saveStateToDB, 30000);
 
+        // 见面「继续上次」崩溃自愈：只要会话稳定挂载并渲染了一小段时间没崩，
+        // 就撤销 DateApp 在恢复前武装的哨兵——证明这份快照能安全加载。若 iOS WebKit
+        // 在此之前把内容进程撑崩（进程级崩溃，不会跑下面的卸载 cleanup），哨兵留存，
+        // 下次进见面即被检出并丢弃这份有毒快照。新会话（无 initialState）无哨兵，clear 为空操作。
+        const settleTimer = setTimeout(() => clearDateResumeAttempt(), 2500);
+
         return () => {
             window.removeEventListener('beforeunload', handleBeforeUnload);
             document.removeEventListener('visibilitychange', handleVisibilityChange);
             clearInterval(interval);
+            clearTimeout(settleTimer);
+            // 干净卸载（SPA 内导航离开会话）= 非崩溃，撤销哨兵。
+            clearDateResumeAttempt();
             // 卸载时只把进度直接落库，绝不调用 onExit。onExit 会执行「用户主动退出」的
             // 导航（setMode('select') + 弹「进度已保存」），而卸载在很多非用户意图的场景
             // 都会发生 —— 尤其 React.StrictMode (dev) 的「挂载→卸载→重挂载」探测：

--- a/utils/dateSessionRecovery.test.ts
+++ b/utils/dateSessionRecovery.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+    armDateResumeAttempt,
+    clearDateResumeAttempt,
+    takeCrashedDateResume,
+} from './dateSessionRecovery';
+
+// 锁住见面「继续上次」崩溃自愈的两段式护栏:
+// arm(恢复开始) → clear(恢复成功/干净退出); 若进程在两者之间被 iOS WebKit 杀掉,
+// 哨兵残留, 下次 take 读到 = 上次恢复崩了 → 调用方丢弃有毒的 savedDateState。
+//
+// 测试环境是 node (无 sessionStorage)，用 Map 后端的 stub 模拟，与 chunkLoadRecovery.test.ts 一致。
+
+const KEY = 'sullyos_date_resume_attempt';
+
+const stubSessionStorage = () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal('sessionStorage', {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, String(v)); },
+        removeItem: (k: string) => { store.delete(k); },
+        clear: () => { store.clear(); },
+    });
+    return store;
+};
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+describe('dateSessionRecovery 两段式护栏', () => {
+    it('arm 后正常 clear（恢复成功）→ 再进见面无残留', () => {
+        stubSessionStorage();
+        armDateResumeAttempt('char-1');
+        clearDateResumeAttempt();
+        expect(takeCrashedDateResume()).toBeNull();
+    });
+
+    it('arm 后没 clear（进程崩溃）→ 下次进见面检出崩溃的 charId', () => {
+        stubSessionStorage();
+        armDateResumeAttempt('char-42');
+        // 模拟崩溃 + reload：sessionStorage 在同一 tab 会话内留存，哨兵仍在
+        expect(takeCrashedDateResume()).toBe('char-42');
+    });
+
+    it('take 只读一次：读到后自动清除，第二次返回 null', () => {
+        stubSessionStorage();
+        armDateResumeAttempt('char-7');
+        expect(takeCrashedDateResume()).toBe('char-7');
+        expect(takeCrashedDateResume()).toBeNull();
+    });
+
+    it('从未 arm → take 返回 null（正常全新进入不误伤）', () => {
+        stubSessionStorage();
+        expect(takeCrashedDateResume()).toBeNull();
+    });
+
+    it('后一次 arm 覆盖前一次的 charId', () => {
+        stubSessionStorage();
+        armDateResumeAttempt('char-a');
+        armDateResumeAttempt('char-b');
+        expect(takeCrashedDateResume()).toBe('char-b');
+    });
+
+    it('哨兵内容损坏（非法 JSON）→ take 安全返回 null，不抛异常，并清除', () => {
+        const store = stubSessionStorage();
+        store.set(KEY, '{not valid json');
+        expect(() => takeCrashedDateResume()).not.toThrow();
+        expect(store.has(KEY)).toBe(false);
+    });
+
+    it('哨兵缺 charId 字段 → take 返回 null', () => {
+        const store = stubSessionStorage();
+        store.set(KEY, JSON.stringify({ at: 123 }));
+        expect(takeCrashedDateResume()).toBeNull();
+    });
+
+    it('sessionStorage 不可用时静默降级，不影响调用方', () => {
+        // 不 stub sessionStorage → 访问抛 ReferenceError → 内部 catch
+        expect(() => armDateResumeAttempt('char-x')).not.toThrow();
+        expect(() => clearDateResumeAttempt()).not.toThrow();
+        expect(takeCrashedDateResume()).toBeNull();
+    });
+});

--- a/utils/dateSessionRecovery.ts
+++ b/utils/dateSessionRecovery.ts
@@ -1,0 +1,64 @@
+/**
+ * 见面(DateApp)「恢复上次进度」崩溃自愈 — 打破 iOS WebKit 反复闪退死循环
+ *
+ * 触发场景 (用户报障: iOS Edge 见面时突然闪退, 之后刷新重进反复灰屏/白屏):
+ *  - 见面会话每 30s / 切后台 / 关页面时会把当前 DateState 直接落库 (savedDateState);
+ *  - 若这份快照本身很重 (大图立绘/背景 + 大量历史消息 + 阅读模式全量渲染),
+ *    在内存吃紧的 iOS WebKit 上「继续上次」会把整个内容进程撑爆 (OOM) 或触发
+ *    看门狗超时 —— 浏览器直接杀进程, 表现为「此网页反复出现问题」而非 JS 异常。
+ *
+ * 关键: 这类进程级崩溃 **不是** 能被 React ErrorBoundary 捕获的 JS 异常, 而且崩溃前
+ * 那份 savedDateState 已经落库 —— 重进见面点「继续上次」会原样重放同一份重快照,
+ * 于是每次都崩, 用户被永久锁死在这个功能里 (只能清站点数据才能自救)。
+ *
+ * 自愈思路 (两段式, 参考 chunkLoadRecovery 的 sessionStorage 护栏):
+ *  1) 恢复「尝试」开始时 (点「继续上次」) → armDateResumeAttempt(charId) 写哨兵;
+ *  2) 会话成功挂载并稳定渲染一小段时间后 → clearDateResumeAttempt() 撤哨兵 (证明这份快照能安全加载)。
+ * 若进程在 1) 与 2) 之间被杀, 哨兵不会被清除 (进程崩溃不会跑 React 卸载逻辑),
+ * 于是下次进见面时 takeCrashedDateResume() 读到残留哨兵 = 上次恢复崩了 →
+ * 调用方丢弃这份有毒的 savedDateState (仅清恢复快照, 不动消息历史), 让用户重新开始。
+ *
+ * 为什么用 sessionStorage: 整页 reload (刷新 / WebKit 崩溃后重载) 仍在同一 tab 会话内,
+ * 哨兵得以留存被检出; 正常关标签页后自然清空, 不会误伤下次全新打开。
+ */
+
+const RESUME_SENTINEL_KEY = 'sullyos_date_resume_attempt';
+
+/** 恢复尝试开始: 记下正在恢复哪个角色的见面会话 */
+export const armDateResumeAttempt = (charId: string): void => {
+    try {
+        sessionStorage.setItem(RESUME_SENTINEL_KEY, JSON.stringify({ charId, at: Date.now() }));
+    } catch {
+        // sessionStorage 不可用: 没法防死循环, 但也不影响正常功能 —— 静默降级
+    }
+};
+
+/** 恢复成功 / 干净退出: 撤销哨兵, 表示这份快照已被证明能安全加载 */
+export const clearDateResumeAttempt = (): void => {
+    try {
+        sessionStorage.removeItem(RESUME_SENTINEL_KEY);
+    } catch {
+        // ignore
+    }
+};
+
+/**
+ * 进见面时调用: 若上一次恢复尝试的哨兵还残留 (说明进程在恢复途中被杀 = 崩溃了),
+ * 返回崩溃时正在恢复的 charId, 并顺手清掉哨兵 (只读一次)。没有残留则返回 null。
+ */
+export const takeCrashedDateResume = (): string | null => {
+    let raw: string | null = null;
+    try {
+        raw = sessionStorage.getItem(RESUME_SENTINEL_KEY);
+        if (raw) sessionStorage.removeItem(RESUME_SENTINEL_KEY);
+    } catch {
+        return null;
+    }
+    if (!raw) return null;
+    try {
+        const parsed = JSON.parse(raw);
+        return typeof parsed?.charId === 'string' && parsed.charId ? parsed.charId : null;
+    } catch {
+        return null;
+    }
+};


### PR DESCRIPTION
用户反馈：iOS Edge 上见面(DateApp)突然闪退后，刷新重进见面反复出现
灰屏→白屏「此网页反复出现问题」。这是 WebKit 内容进程被杀（OOM / 看门狗
超时）的表现，而非可被 AppErrorBoundary 捕获的 JS 异常。

根因链路：见面会话每 30s / 切后台 / 关页面会把当前 DateState 直接落库
(savedDateState)。这份快照本身很重（大图立绘/背景 + 阅读模式全量渲染历史）
时，在内存吃紧的 iOS 上「继续上次」会原样重放同一份重快照 → 每次都把进程
撑崩，用户被永久锁死在见面功能里（只能清站点数据自救）。

修复（两段式护栏，参考 chunkLoadRecovery 的 sessionStorage 思路）：
- 点「继续上次」武装崩溃哨兵；会话稳定挂载渲染 2.5s 没崩即撤销哨兵。
- 进程若在两者之间被杀（进程崩溃不跑 React 卸载逻辑），哨兵留存到下次进 见面被检出 → 丢弃这份有毒的 savedDateState（仅清恢复快照，消息历史不动）， 提示用户已清理存档、可重新开始。
- 干净退出 / SPA 内导航离开会话均撤销哨兵，避免误伤正常存档。
- 顺带：恢复会话时防御性回填 initialState（缺数组兜底 []），防老快照/落库 竞态导致的取值异常连累整个会话渲染。

新增 utils/dateSessionRecovery.ts + 单测（8 例，覆盖崩溃检出 / 只读一次 / 损坏哨兵 / storage 不可用降级）。


Claude-Session: https://claude.ai/code/session_01NAzUszDVqgVk85iwidRaQH