### PR TITLE
[codex] self-handle safe area in home views

### DIFF
--- a/apps/RoomApp.tsx
+++ b/apps/RoomApp.tsx
@@ -1148,8 +1148,8 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
                 <div className="absolute inset-0 pointer-events-none opacity-70" style={{ backgroundImage: th.stars }} />
 
                 {/* 顶部：标题 + Tab（家园正式开始玩——进世界/编辑——时整块隐去，全屏沉浸） */}
-                <div className={`relative z-10 px-6 shrink-0 ${homeTab === 'worldHome' && worldHomeFull ? 'hidden' : ''}`} style={{ paddingTop: 'max(3rem, var(--safe-top))' }}>
-                    <button onClick={closeApp} className={`absolute left-4 p-2 rounded-full active:scale-90 transition-all ${th.back}`} style={{ top: 'max(3rem, var(--safe-top))' }}>
+                <div className={`relative z-10 px-6 shrink-0 ${homeTab === 'worldHome' && worldHomeFull ? 'hidden' : ''}`} style={{ paddingTop: 'max(3rem, var(--safe-top, 0px))' }}>
+                    <button onClick={closeApp} className={`absolute left-4 p-2 rounded-full active:scale-90 transition-all ${th.back}`} style={{ top: 'max(3rem, var(--safe-top, 0px))' }}>
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
                     </button>
                     <div className="text-center">
@@ -1362,7 +1362,7 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
             </button>
             {showSidebar && <div className="absolute inset-0 z-[290] bg-black/20" onClick={() => setShowSidebar(false)}></div>}
             <div className={`absolute right-0 top-0 bottom-0 w-3/4 max-w-sm bg-white shadow-2xl z-[300] transition-transform duration-300 ease-out flex flex-col ${showSidebar ? 'translate-x-0' : 'translate-x-full'}`}>
-                <div className="p-6 pb-2 border-b border-slate-100 flex justify-between items-center bg-slate-50" style={{ paddingTop: 'max(1.5rem, var(--safe-top))' }}>
+                <div className="p-6 pb-2 border-b border-slate-100 flex justify-between items-center bg-slate-50" style={{ paddingTop: 'max(1.5rem, var(--safe-top, 0px))' }}>
                     <h3 className="text-lg font-bold text-slate-700 tracking-tight">生活碎片</h3>
                     <button onClick={() => setShowSidebar(false)} className="p-2 -mr-2 text-slate-400 hover:text-slate-600"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-5 h-5"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" /></svg></button>
                 </div>
@@ -1428,7 +1428,7 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
             </div>
 
             {/* UI Overlay */}
-            <div className="absolute top-0 w-full px-4 pb-2 flex justify-between z-30 pointer-events-none" style={{ paddingTop: 'max(3rem, var(--safe-top))' }}>
+            <div className="absolute top-0 w-full px-4 pb-2 flex justify-between z-30 pointer-events-none" style={{ paddingTop: 'max(3rem, var(--safe-top, 0px))' }}>
                 <button onClick={() => setViewState('select')} className="bg-white/90 p-2 rounded-full shadow-md pointer-events-auto active:scale-90 transition-transform text-slate-600"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg></button>
                 <div className="flex gap-2 pointer-events-auto">
                     {/* REFRESH BUTTON — 仅在今天已生成时露出（未生成时走下方「更新这一天」横幅） */}
@@ -1462,8 +1462,24 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
 
             {/* Edit Mode Toolbar - Collapsible */}
             {mode === 'edit' && (
-                <div className={`absolute w-full bg-white border-t border-slate-200 z-[150] transition-transform duration-300 flex flex-col ${isToolbarCollapsed ? 'translate-y-[calc(100%-2.5rem)]' : ''}`} style={{ bottom: 'var(--safe-bottom, 0px)', maxHeight: isToolbarCollapsed ? 'auto' : '45vh' }}>
-                    <div className="h-10 w-full flex items-center justify-center cursor-pointer bg-white active:bg-slate-50 border-b border-slate-100" onClick={() => setIsToolbarCollapsed(!isToolbarCollapsed)}><div className="w-10 h-1 bg-slate-200 rounded-full"></div></div>
+                <div
+                    className="absolute bottom-0 w-full bg-white border-t border-slate-200 z-[150] transition-transform duration-300 flex flex-col"
+                    style={{
+                        paddingBottom: 'var(--safe-bottom, 0px)',
+                        maxHeight: isToolbarCollapsed ? 'auto' : '45vh',
+                        transform: isToolbarCollapsed ? 'translateY(calc(100% - 2.5rem - var(--safe-bottom, 0px)))' : undefined,
+                        boxSizing: 'border-box',
+                    }}
+                >
+                    <div
+                        className="w-full flex items-center justify-center cursor-pointer bg-white active:bg-slate-50 border-b border-slate-100"
+                        style={{
+                            height: isToolbarCollapsed ? 'calc(2.5rem + var(--safe-bottom, 0px))' : '2.5rem',
+                            paddingBottom: isToolbarCollapsed ? 'var(--safe-bottom, 0px)' : undefined,
+                            boxSizing: 'border-box',
+                        }}
+                        onClick={() => setIsToolbarCollapsed(!isToolbarCollapsed)}
+                    ><div className="w-10 h-1 bg-slate-200 rounded-full"></div></div>
                     <div className="p-4 overflow-y-auto flex-1">
                         {selectedItemId ? (
                             <div className="flex flex-col gap-3">

--- a/apps/RoomApp.tsx
+++ b/apps/RoomApp.tsx
@@ -1238,7 +1238,10 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
                         </div>
 
                         {/* 底部装饰 */}
-                        <div className={`relative z-10 shrink-0 pb-4 flex items-center justify-center gap-2.5 text-[8.5px] tracking-[0.35em] font-bold ${th.footer}`}>
+                        <div
+                            className={`relative z-10 shrink-0 flex items-center justify-center gap-2.5 text-[8.5px] tracking-[0.35em] font-bold ${th.footer}`}
+                            style={{ paddingBottom: 'calc(1rem + var(--safe-bottom, 0px))' }}
+                        >
                             <span>EXPLORE</span><span className={th.dot}>◆</span><span>CONNECT</span><span className={th.dot}>◆</span><span>DISCOVER</span>
                         </div>
                     </>
@@ -1370,7 +1373,7 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
                 </div>
                 
                 {/* Fixed: Add no-scrollbar class to hide scrollbar */}
-                <div className="flex-1 overflow-y-auto p-6 bg-[#fcfcfc] no-scrollbar">
+                <div className="flex-1 overflow-y-auto p-6 bg-[#fcfcfc] no-scrollbar" style={{ paddingBottom: 'calc(1.5rem + var(--safe-bottom, 0px))' }}>
                     {activePanel === 'todo' && (
                         <div className="space-y-6">
                             <div className="flex items-center justify-between"><span className="text-xs font-bold text-slate-400 uppercase tracking-widest">{todaysTodo?.date || 'Today'}</span><span className="text-[10px] bg-slate-100 px-2 py-1 rounded text-slate-500">完成度: {todaysTodo ? Math.round((todaysTodo.items.filter(i=>i.done).length / todaysTodo.items.length)*100) : 0}%</span></div>
@@ -1439,11 +1442,11 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
             </div>
 
             {/* Observation Card (Bottom) */}
-            {observationText && mode === 'view' && <div className="absolute bottom-6 left-4 right-4 bg-white p-5 rounded-2xl shadow-2xl border border-slate-100 z-[150] animate-slide-up"><div className="flex justify-between items-start mb-2"><span className="text-xs font-bold text-blue-500 uppercase tracking-widest">OBSERVATION</span><button onClick={() => setObservationText('')} className="text-slate-400 hover:text-slate-600">×</button></div><p className="text-sm text-slate-700 leading-relaxed font-medium text-justify">{observationText}</p></div>}
+            {observationText && mode === 'view' && <div className="absolute left-4 right-4 bg-white p-5 rounded-2xl shadow-2xl border border-slate-100 z-[150] animate-slide-up" style={{ bottom: 'calc(1.5rem + var(--safe-bottom, 0px))' }}><div className="flex justify-between items-start mb-2"><span className="text-xs font-bold text-blue-500 uppercase tracking-widest">OBSERVATION</span><button onClick={() => setObservationText('')} className="text-slate-400 hover:text-slate-600">×</button></div><p className="text-sm text-slate-700 leading-relaxed font-medium text-justify">{observationText}</p></div>}
 
             {/* 「更新这一天」横幅 —— 今天尚未生成时露出（进门不再阻塞，由用户主动触发） */}
             {mode === 'view' && !todayGenerated && !isInitializing && !observationText && (
-                <div className="absolute bottom-6 left-4 right-4 bg-white p-4 rounded-2xl shadow-2xl border border-slate-100 z-[150] animate-slide-up flex items-center gap-3">
+                <div className="absolute left-4 right-4 bg-white p-4 rounded-2xl shadow-2xl border border-slate-100 z-[150] animate-slide-up flex items-center gap-3" style={{ bottom: 'calc(1.5rem + var(--safe-bottom, 0px))' }}>
                     <div className="w-10 h-10 rounded-xl bg-primary-light flex items-center justify-center shrink-0">
                         <Door size={22} className="text-primary" />
                     </div>
@@ -1459,7 +1462,7 @@ ${!shouldGenerateTodo ? `(系统: 今日待办已存在，无需生成，请忽�
 
             {/* Edit Mode Toolbar - Collapsible */}
             {mode === 'edit' && (
-                <div className={`absolute bottom-0 w-full bg-white border-t border-slate-200 z-[150] transition-transform duration-300 flex flex-col ${isToolbarCollapsed ? 'translate-y-[calc(100%-2.5rem)]' : ''}`} style={{ maxHeight: isToolbarCollapsed ? 'auto' : '45vh' }}>
+                <div className={`absolute w-full bg-white border-t border-slate-200 z-[150] transition-transform duration-300 flex flex-col ${isToolbarCollapsed ? 'translate-y-[calc(100%-2.5rem)]' : ''}`} style={{ bottom: 'var(--safe-bottom, 0px)', maxHeight: isToolbarCollapsed ? 'auto' : '45vh' }}>
                     <div className="h-10 w-full flex items-center justify-center cursor-pointer bg-white active:bg-slate-50 border-b border-slate-100" onClick={() => setIsToolbarCollapsed(!isToolbarCollapsed)}><div className="w-10 h-1 bg-slate-200 rounded-full"></div></div>
                     <div className="p-4 overflow-y-auto flex-1">
                         {selectedItemId ? (

--- a/apps/WorldHomeApp.tsx
+++ b/apps/WorldHomeApp.tsx
@@ -1392,7 +1392,7 @@ const WorldView: React.FC<{
             className="flex-1 overflow-y-auto no-scrollbar"
             style={{
                 background: t.pageBg,
-                paddingTop: topSafe ? 'max(3rem, var(--safe-top))' : undefined,
+                paddingTop: topSafe ? 'max(3rem, var(--safe-top, 0px))' : undefined,
                 paddingBottom: 'calc(6rem + var(--safe-bottom, 0px))',
                 boxSizing: 'border-box',
             }}

--- a/apps/WorldHomeApp.tsx
+++ b/apps/WorldHomeApp.tsx
@@ -680,7 +680,10 @@ const WorldEditor: React.FC<{
     const labelCls = 'text-[10.5px] font-black text-stone-500 tracking-[0.12em] uppercase';
 
     return (
-        <div className="flex-1 overflow-y-auto no-scrollbar px-4 pb-28 pt-3 space-y-3">
+        <div
+            className="flex-1 overflow-y-auto no-scrollbar px-4 pt-3 space-y-3"
+            style={{ paddingBottom: 'calc(7rem + var(--safe-bottom, 0px))', boxSizing: 'border-box' }}
+        >
             <div className={sectionCls}>
                 <div className={labelCls}>世界名字</div>
                 <input className={inputCls} value={w.name} onChange={e => upd({ name: e.target.value })} placeholder="比如：栗子镇" />
@@ -920,7 +923,10 @@ const WorldEditor: React.FC<{
                 ⚠️ 每次「观测」大约会调用 <b>{Math.max(1, w.memberIds.length)}+1</b> 次 API（{w.memberIds.length} 个角色各 1 次 + NPC 世界引擎 1 次{w.timeMode === 'sim' ? '，每 20 天结卷再多 1 次' : ''}）。角色越多越费，请留意用量；建议在右上角 <b>齿轮</b> 给家园单独配一份<b>更轻量/便宜的 API</b>。
             </div>
 
-            <div className="fixed bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[#f3eee3] via-[#f3eee3]/95 to-transparent flex gap-2.5 max-w-md mx-auto">
+            <div
+                className="fixed bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[#f3eee3] via-[#f3eee3]/95 to-transparent flex gap-2.5 max-w-md mx-auto"
+                style={{ paddingBottom: 'calc(0.75rem + var(--safe-bottom, 0px))' }}
+            >
                 <button onClick={onCancel} className="flex-1 py-2.5 rounded-2xl bg-white border border-stone-200 text-stone-600 text-[13px] font-bold shadow-sm">取消</button>
                 <button
                     onClick={() => {
@@ -1142,7 +1148,8 @@ const WorldView: React.FC<{
     onEdit: () => void;
     onWorldUpdated: () => void;
     onBack?: () => void;
-}> = ({ world, characters, onEdit, onWorldUpdated, onBack }) => {
+    topSafe?: boolean;
+}> = ({ world, characters, onEdit, onWorldUpdated, onBack, topSafe }) => {
     const { addToast } = useOS();
     const [episodes, setEpisodes] = useState<WorldEpisode[]>([]);
     const [progress, setProgress] = useState<{ done: number; total: number; charName?: string } | null>(
@@ -1381,7 +1388,15 @@ const WorldView: React.FC<{
     };
 
     return (
-        <div className="flex-1 overflow-y-auto no-scrollbar pb-24" style={{ background: t.pageBg }}>
+        <div
+            className="flex-1 overflow-y-auto no-scrollbar"
+            style={{
+                background: t.pageBg,
+                paddingTop: topSafe ? 'max(3rem, var(--safe-top))' : undefined,
+                paddingBottom: 'calc(6rem + var(--safe-bottom, 0px))',
+                boxSizing: 'border-box',
+            }}
+        >
             {/* 伏笔删除确认（自定义弹窗，非原生） */}
             {pendingSeed && (
                 <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/45 backdrop-blur-sm p-6" onClick={() => setPendingSeed(null)}>
@@ -1906,7 +1921,7 @@ const WorldHomeApp: React.FC<{ embedded?: boolean; onFullscreen?: (full: boolean
             {/* 顶栏：内嵌进「小小窝」时，列表页只留齿轮/新建；进世界（正式开始玩）整条隐去做全屏，
                 返回靠世界视图里的浮动返回键。 */}
             {!(embedded && view === 'world') && (
-            <div className="shrink-0 sticky top-0 z-10" style={{ background: headerBg, paddingTop: embedded ? undefined : 'var(--safe-top)' }}>
+            <div className="shrink-0 sticky top-0 z-10" style={{ background: headerBg, paddingTop: embedded && view === 'list' ? undefined : 'var(--safe-top)' }}>
             <div className={embedded ? `${view === 'list' ? 'h-12' : 'h-20'} flex items-end pb-3 px-4` : 'flex items-center px-4 py-3'}>
                 <div className="flex items-center gap-2 w-full">
                     {!(embedded && view === 'list') && (
@@ -1945,7 +1960,10 @@ const WorldHomeApp: React.FC<{ embedded?: boolean; onFullscreen?: (full: boolean
             )}
 
             {view === 'list' && (
-                <div className="flex-1 overflow-y-auto no-scrollbar px-4 pb-24 pt-1 space-y-3">
+                <div
+                    className="flex-1 overflow-y-auto no-scrollbar px-4 pt-1 space-y-3"
+                    style={{ paddingBottom: 'calc(6rem + var(--safe-bottom, 0px))', boxSizing: 'border-box' }}
+                >
                     {/* 游戏封面横幅（淡紫梦幻：月亮 + 云霭 + 星点） */}
                     <div className="relative rounded-3xl overflow-hidden p-5 shadow-[0_10px_30px_rgba(120,100,180,.25)]" style={{ background: 'linear-gradient(150deg,#8e83c4 0%,#a99fd6 52%,#c3c9ea 100%)' }}>
                         <div className="absolute inset-0 pointer-events-none" style={{ backgroundImage: starsBg, animation: 'wh-twinkle 4s ease-in-out infinite' }} />
@@ -2021,6 +2039,7 @@ const WorldHomeApp: React.FC<{ embedded?: boolean; onFullscreen?: (full: boolean
                     onEdit={() => { setDraft(active); setView('edit'); }}
                     onWorldUpdated={reload}
                     onBack={goBack}
+                    topSafe={!!embedded}
                 />
             )}
         </div>

--- a/apps/pixelHome/AssetLibrary.tsx
+++ b/apps/pixelHome/AssetLibrary.tsx
@@ -308,7 +308,7 @@ const AssetLibrary: React.FC<Props> = ({ assets, onChanged, onSelectAsset, isSel
       </div>
 
       {/* 网格 */}
-      <div className="flex-1 overflow-y-auto px-3 pb-3 no-scrollbar">
+      <div className="flex-1 overflow-y-auto px-3 no-scrollbar" style={{ paddingBottom: 'calc(0.75rem + var(--safe-bottom, 0px))' }}>
         <div className="grid grid-cols-3 gap-2">
           {filtered.map(asset => {
             const isSelected = selectedIds.has(asset.id);

--- a/apps/pixelHome/MemoryDiveMode.tsx
+++ b/apps/pixelHome/MemoryDiveMode.tsx
@@ -739,7 +739,7 @@ const MemoryDiveMode: React.FC<Props> = ({
       {/* 顶栏（薄） */}
       <div
         className="shrink-0 flex items-center justify-between px-3 pb-1.5 bg-black/70 backdrop-blur-sm border-b border-slate-800 z-20"
-        style={{ paddingTop: 'max(2.75rem, var(--safe-top))' }}
+        style={{ paddingTop: 'max(2.75rem, var(--safe-top, 0px))' }}
       >
         <div className="flex items-center gap-1">
           <button onClick={handleUserExit}

--- a/apps/pixelHome/MemoryDiveMode.tsx
+++ b/apps/pixelHome/MemoryDiveMode.tsx
@@ -732,9 +732,15 @@ const MemoryDiveMode: React.FC<Props> = ({
     (!!currentDialogue || dialogueQueue.length > 0);
 
   return (
-    <div className="h-full w-full flex flex-col bg-slate-950 overflow-hidden select-none">
+    <div
+      className="h-full w-full flex flex-col bg-slate-950 overflow-hidden select-none"
+      style={{ paddingBottom: 'var(--safe-bottom, 0px)', boxSizing: 'border-box' }}
+    >
       {/* 顶栏（薄） */}
-      <div className="shrink-0 flex items-center justify-between px-3 pt-11 pb-1.5 bg-black/70 backdrop-blur-sm border-b border-slate-800 z-20">
+      <div
+        className="shrink-0 flex items-center justify-between px-3 pb-1.5 bg-black/70 backdrop-blur-sm border-b border-slate-800 z-20"
+        style={{ paddingTop: 'max(2.75rem, var(--safe-top))' }}
+      >
         <div className="flex items-center gap-1">
           <button onClick={handleUserExit}
             className="p-1.5 -ml-1 rounded-sm hover:bg-slate-700/60 active:scale-90 transition-all"

--- a/apps/pixelHome/PixelAssetGenerator.tsx
+++ b/apps/pixelHome/PixelAssetGenerator.tsx
@@ -294,7 +294,7 @@ const PixelAssetGenerator: React.FC<Props> = ({ onGenerated }) => {
   const readyCount = pending.filter(p => p.previewUri).length;
 
   return (
-    <div className="h-full overflow-y-auto px-4 py-4 space-y-4 no-scrollbar">
+    <div className="h-full overflow-y-auto px-4 pt-4 space-y-4 no-scrollbar" style={{ paddingBottom: 'calc(1rem + var(--safe-bottom, 0px))', boxSizing: 'border-box' }}>
       {/* 模式切换 */}
       <div className="flex gap-1 bg-slate-800/60 rounded-xl p-1">
         <button onClick={() => setMode('generate')}

--- a/apps/pixelHome/PixelCharEditor.tsx
+++ b/apps/pixelHome/PixelCharEditor.tsx
@@ -159,7 +159,7 @@ const PixelCharEditor: React.FC<Props> = ({ initial, target = 'char', targetLabe
   const canvasH = ASSET_SIZE.h * PAINT_SCALE;
 
   return (
-    <div className="h-full overflow-y-auto px-4 py-4 space-y-3 no-scrollbar">
+    <div className="h-full overflow-y-auto px-4 pt-4 space-y-3 no-scrollbar" style={{ paddingBottom: 'calc(1rem + var(--safe-bottom, 0px))', boxSizing: 'border-box' }}>
       {targetLabel && (
         <div className="text-center text-[11px] text-slate-400">
           正在捏 <span className={target === 'user' ? 'text-emerald-300 font-bold' : 'text-violet-300 font-bold'}>{targetLabel}</span>

--- a/apps/pixelHome/PixelHomeView.tsx
+++ b/apps/pixelHome/PixelHomeView.tsx
@@ -259,7 +259,7 @@ const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName
       {/* 顶部导航（潜行模式下隐藏，由 MemoryDiveMode 自带头部） */}
       {viewMode !== 'dive' && <div
         className="shrink-0 flex items-center justify-between px-4 pb-3 bg-slate-800/80 backdrop-blur-sm border-b border-slate-700/50"
-        style={{ paddingTop: 'max(3rem, var(--safe-top))' }}
+        style={{ paddingTop: 'max(3rem, var(--safe-top, 0px))' }}
       >
         <button
           onClick={() => {

--- a/apps/pixelHome/PixelHomeView.tsx
+++ b/apps/pixelHome/PixelHomeView.tsx
@@ -257,7 +257,10 @@ const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName
   return (
     <div className="h-full w-full flex flex-col bg-slate-900 overflow-hidden">
       {/* 顶部导航（潜行模式下隐藏，由 MemoryDiveMode 自带头部） */}
-      {viewMode !== 'dive' && <div className="shrink-0 flex items-center justify-between px-4 pt-12 pb-3 bg-slate-800/80 backdrop-blur-sm border-b border-slate-700/50">
+      {viewMode !== 'dive' && <div
+        className="shrink-0 flex items-center justify-between px-4 pb-3 bg-slate-800/80 backdrop-blur-sm border-b border-slate-700/50"
+        style={{ paddingTop: 'max(3rem, var(--safe-top))' }}
+      >
         <button
           onClick={() => {
             if (viewMode === 'map') { onBack(); return; }
@@ -336,7 +339,7 @@ const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName
 
       {/* 底部工具栏 */}
       {viewMode === 'map' && (
-        <div className="shrink-0 bg-slate-800/90 backdrop-blur-sm border-t border-slate-700/50">
+        <div className="shrink-0 bg-slate-800/90 backdrop-blur-sm border-t border-slate-700/50" style={{ paddingBottom: 'var(--safe-bottom, 0px)' }}>
           <div className="flex items-center justify-around px-4 py-2">
             <BottomTab label="家园" active onClick={() => setViewMode('map')} />
             <BottomTab label="🌀潜行" onClick={handleEnterDive} />

--- a/apps/pixelHome/PixelRoomEditor.tsx
+++ b/apps/pixelHome/PixelRoomEditor.tsx
@@ -836,7 +836,10 @@ const PixelRoomEditor: React.FC<Props> = ({ charId, charName, charSprite, userNa
       </div>
 
       {/* 底部工具栏 */}
-      <div className="shrink-0 bg-slate-800/95 backdrop-blur-sm border-t border-slate-700/50 px-3 py-2 max-h-[50%] overflow-y-auto no-scrollbar">
+      <div
+        className="shrink-0 bg-slate-800/95 backdrop-blur-sm border-t border-slate-700/50 px-3 pt-2 max-h-[50%] overflow-y-auto no-scrollbar"
+        style={{ paddingBottom: 'calc(0.5rem + var(--safe-bottom, 0px))' }}
+      >
         <div className="flex items-center justify-between mb-2">
           <div className="flex gap-1">
             <ModeBtn label="浏览" active={mode === 'view'} onClick={() => { setMode('view'); setSelectedSlot(null); }} />


### PR DESCRIPTION
## Summary

- complete safe-area self-handling for 小小窝, 像素家园, and embedded 家园 views
- add safe-bottom spacing to bottom sheets, fixed action bars, room banners, and pixel-home toolbars
- make embedded WorldHome resume safe-top handling once 小小窝 hides its outer header

## Root Cause

`AppID.Room` and `AppID.WorldHome` are already registered as self-safe-area apps, so `PhoneShell` stops applying shell padding. Several nested 小小窝/家园 views still had fixed `pt-*`, `bottom-*`, or plain `pb-*` spacing, leaving controls vulnerable to the iOS status area and home indicator.

## Validation

- `pnpm run build`
- `pnpm exec vitest run utils/safeAreaApps.test.ts`
- `git diff --check`

`pnpm exec tsc --noEmit` still reports existing repository type errors outside this change set.
