### PR TITLE
fix(chat): 消除 HTML 卡片周围若隐若现的裁切阴影框

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -2264,7 +2264,11 @@ const MessageItem = React.memo(({
         }
         // 沙盒 iframe：禁用脚本 / 同源 / 表单提交，避免任意 HTML 越权访问父页面。
         // srcDoc 用一个全宽中心化的 wrapper, 让 270px 的卡片在 iframe 里居中、背景透明。
-        const srcDoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>html,body{margin:0;padding:0;background:transparent;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#334155;}body{display:flex;justify-content:center;padding:0;}*{box-sizing:border-box;}img{max-width:100%;}</style></head><body>${html}</body></html>`;
+        // body>* 强制清掉最外层元素的 box-shadow/filter: 模型经常给卡片外层加柔和阴影,
+        // 但 iframe 只比卡片宽一点 + 外层 overflow-hidden, 阴影会被裁成一圈"若隐若现的
+        // 假边框"贴在卡片周围 —— 聊天里卡片约定是直接贴在聊天背景上、无背景无边框,
+        // 这里在渲染端兜底 (对已落库的旧卡片同样生效), 提示词端同步不再教模型加外层阴影。
+        const srcDoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>html,body{margin:0;padding:0;background:transparent;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#334155;}body{display:flex;justify-content:center;padding:0;}*{box-sizing:border-box;}img{max-width:100%;}body>*{box-shadow:none!important;filter:none!important;}</style></head><body>${html}</body></html>`;
         return commonLayout(
             <div className="rounded-[18px] overflow-hidden bg-transparent max-w-[280px]">
                 <iframe

--- a/utils/htmlPrompt.ts
+++ b/utils/htmlPrompt.ts
@@ -66,7 +66,7 @@ const BUILTIN_HTML_PROMPT = `
 * **留白即呼吸**：内容别贴边。最外层 \`padding\` 给到 \`16~20px\`，元素之间用 \`margin\` 拉开层次（标题与正文、正文与落款之间都要有间距）。宁可空，不要挤。
 * **建立信息层级**：用**字号 + 字重 + 透明度**三件套区分主次——主标题大而粗（\`18~22px / 700\`），正文中等（\`13~14px / 400\`），辅助信息小而淡（\`11~12px\` 配 \`opacity:0.6\`）。一眼能看出谁是重点。
 * **统一与对齐**：圆角、间距、字体在同一张卡里保持一致（圆角统一 \`12~16px\`，整体一套 \`font-family\`）。文字左对齐为主，居中只用于标题或仪式感强的卡（邀请函、票据）。
-* **柔和的光影**：阴影要轻、要散、要透明（如 \`box-shadow:0 4px 16px rgba(0,0,0,0.08)\`），模拟自然投影，别用又黑又硬的死阴影。需要分区时优先用浅色分隔线（\`border-top:1px solid rgba(0,0,0,0.06)\`）或背景色块，少用粗黑边框。
+* **柔和的光影（只用在卡片内部）**：卡片会**直接贴在聊天背景上渲染，没有气泡、没有边框**——所以**最外层 \`<div>\` 绝对不要加 \`box-shadow\` / 外发光 / \`filter: drop-shadow\`**，外层阴影会被容器裁切成一圈若隐若现的框，非常难看。层次感全部放在卡片**内部**做：内部元素（按钮、小卡块、头像）可以用轻、散、透明的阴影（如 \`box-shadow:0 4px 16px rgba(0,0,0,0.08)\`）；需要分区时优先用浅色分隔线（\`border-top:1px solid rgba(0,0,0,0.06)\`）或背景色块，少用粗黑边框。
 * **细节出质感**：英文小标签 / 标题加 \`letter-spacing:1~2px\` 更精致；行内文字 \`line-height:1.5~1.6\` 更舒展；适度用 emoji、CSS 形状、小圆点 / 标签胶囊点缀，但每张卡的点缀别超过 2~3 处。
 * **风格随情绪走**：温柔暧昧用粉调圆润，正式票据用素净留白，深夜 emo 用暗色低饱和。卡片的视觉气质要和你的人设、当下对话氛围对得上，而不是千篇一律。
 
@@ -76,7 +76,7 @@ const BUILTIN_HTML_PROMPT = `
 
 正常聊天里穿插一个邀请函卡片：
 
-[html]<div style="width:260px;padding:16px;border-radius:14px;background:linear-gradient(135deg,#ffe4ec,#fff0f5);font-family:system-ui;color:#5a3a4a;box-shadow:0 4px 12px rgba(0,0,0,0.08);"><div style="font-size:11px;letter-spacing:2px;opacity:0.6;">INVITATION</div><div style="font-size:20px;font-weight:700;margin-top:4px;">想和你一起去看电影</div><div style="font-size:13px;margin-top:8px;line-height:1.6;">本周六晚 19:30<br/>万象城 IMAX 3 号厅</div><div style="margin-top:12px;font-size:12px;opacity:0.7;">— 期待你的回复</div></div>[/html]
+[html]<div style="width:260px;padding:16px;border-radius:14px;background:linear-gradient(135deg,#ffe4ec,#fff0f5);font-family:system-ui;color:#5a3a4a;"><div style="font-size:11px;letter-spacing:2px;opacity:0.6;">INVITATION</div><div style="font-size:20px;font-weight:700;margin-top:4px;">想和你一起去看电影</div><div style="font-size:13px;margin-top:8px;line-height:1.6;">本周六晚 19:30<br/>万象城 IMAX 3 号厅</div><div style="margin-top:12px;font-size:12px;opacity:0.7;">— 期待你的回复</div></div>[/html]
 
 那要不？😳
 `;


### PR DESCRIPTION
聊天里 html_card 的约定是卡片直接贴在聊天背景上渲染 (无气泡/无边框),
但模型经常给卡片最外层 div 加 box-shadow —— iframe (280px) 只比卡片 (≤270px) 宽一点, 外层容器又是 overflow-hidden, 柔和阴影被边缘硬裁后
就变成一圈贴着卡片、时有时无的"假边框"。而且内置提示词的审美准则和
输出示例还在主动教模型加这个外层阴影。

- MessageItem srcDoc 注入 body>*{box-shadow:none;filter:none} 渲染端 兜底, 对已落库的旧卡片同样生效; 卡片内部元素的阴影不受影响
- htmlPrompt 光影准则改为"阴影只用在卡片内部, 最外层禁止", 输出示例 同步去掉外层 box-shadow


Claude-Session: https://claude.ai/code/session_012jewhAdx9LV8nBeanyGhw9