### PR TITLE
修复编辑消息后「转换语音」仍播放旧语音的问题

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -325,7 +325,13 @@ const Chat: React.FC = () => {
     };
 
     const handleManualTts = async (msg: Message, autoTriggered = false) => {
-        if (voiceDataMap[msg.id] || voiceLoading.has(msg.id)) return;
+        if (voiceLoading.has(msg.id)) return;
+        if (voiceDataMap[msg.id]) {
+            if (autoTriggered) return;
+            // 手动点「转换语音」= 用户要求重新生成（典型场景：编辑了消息内容后）。
+            // 丢掉这条旧语音再走正常合成；文本没变时会命中共享 TTS 缓存，不会重复请求 API。
+            discardVoiceForMessages([msg.id]);
+        }
 
         // Parse the structured voice output: spoken text (sanitized) + per-message emotion.
         const parsedVoice = parseVoiceOutput(msg.content);
@@ -2050,7 +2056,10 @@ const Chat: React.FC = () => {
 
     const confirmEditMessage = async () => {
         if (!selectedMessage) return;
+        const contentChanged = editContent !== selectedMessage.content;
         await DB.updateMessage(selectedMessage.id, editContent);
+        // 内容变了旧语音就作废，否则语音条仍会播放编辑前的音频。
+        if (contentChanged) discardVoiceForMessages([selectedMessage.id]);
         setMessages(prev => prev.map(m => m.id === selectedMessage.id ? { ...m, content: editContent } : m));
         setModalType('none');
         setSelectedMessage(null);


### PR DESCRIPTION
两处根因都在 Chat.tsx 的每条消息语音持久化层（非共享 TTS 缓存，
后者按文本+音色参数哈希做键，文本变了键就变，不受影响）：

1. confirmEditMessage 只更新文字，不作废该消息已持久化的旧语音， 语音条继续播放编辑前的音频。现在内容变更时调用 discardVoiceForMessages 丢弃旧语音。
2. handleManualTts 遇到已有语音直接 return，用户点「转换语音」 实际是空操作。现在手动触发时先丢弃旧语音再重新合成； 自动触发（auto-TTS）保持原跳过逻辑。文本未变时重新合成会 命中共享 TTS 缓存，不产生额外 API 请求。


Claude-Session: https://claude.ai/code/session_01PJW7wb6sBwy6Vrr9nAYUcr