### PR TITLE
fix(chat): 外语语音消息不再在气泡顶部重复渲染译文

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -2760,6 +2760,12 @@ const MessageItem = React.memo(({
     // Voice-only messages (no display text, only voice bar): skip bubble styling
     const isVoiceOnlyMsg = !displayContent && hasVoiceContent && !isUser && m.type === 'text';
 
+    // 外语语音消息：语音条展开区（转文字）本身就完整呈现「口播原文 + 中文翻译」两行，
+    // 顶部气泡再渲染一遍 displayContent 就成了重复——翻译模式下顶部是中文、语音条翻译行
+    // 也是中文，用户看到两份一样的翻译。这类消息把双语文字统一收进语音条，
+    // 顶部不再重复渲染正文，也不再显示（此时已无意义的）译/原文切换按钮。
+    const isForeignVoiceMsg = !isUser && m.type === 'text' && !!voiceData?.url && !!voiceData?.lang && !!cleanVoiceText(voiceData?.spokenText);
+
     return commonLayout(
         <div className={isVoiceOnlyMsg
             ? 'relative animate-fade-in'
@@ -2801,14 +2807,15 @@ const MessageItem = React.memo(({
             )}
 
             {/* Layer 4: Text Content — shown when there's visible text after stripping voice tags */}
-            {displayContent && (
+            {/* 外语语音消息把双语文字交给下方语音条渲染，顶部不再重复正文 */}
+            {displayContent && !isForeignVoiceMsg && (
             <div className="relative z-10 text-[15px] leading-relaxed whitespace-pre-wrap break-all select-text" style={{ color: styleConfig.textColor }}>
                 {renderContent(displayContent)}
             </div>
             )}
 
             {/* Layer 5: Per-bubble Translate Toggle (AI bilingual messages only) */}
-            {showTranslateButton && displayContent && (
+            {showTranslateButton && displayContent && !isForeignVoiceMsg && (
                 <div className="relative z-10 mt-2 flex justify-end">
                     <button
                         onClick={(e) => { e.stopPropagation(); e.preventDefault(); onTranslateToggle?.(m.id); }}
@@ -2841,8 +2848,9 @@ const MessageItem = React.memo(({
                 const vbBtn = styleConfig.voiceBarBtnColor;
                 const vbWave = styleConfig.voiceBarWaveColor;
                 const vbText = styleConfig.voiceBarTextColor;
-                // Voice-only mode: no visible text, voice bar is primary content
-                const isVoiceOnly = !!voiceData?.url && !displayContent;
+                // Voice-only mode: no visible text, voice bar is primary content.
+                // 外语语音消息顶部正文已隐藏（交给语音条渲染），同样按纯语音处理，去掉多余上间距。
+                const isVoiceOnly = !!voiceData?.url && (!displayContent || isForeignVoiceMsg);
                 return (
                 <div className={`relative z-10 ${isVoiceOnly ? '' : 'mt-2.5'}`}>
                     {voiceData?.url ? (


### PR DESCRIPTION
翻译模式下的外语语音消息，气泡顶部 displayContent 显示中文译文，而下方语音条
展开区（转文字）本身已经完整呈现「口播原文 + 中文翻译」两行——两处都是中文，
用户看到两份一样的翻译。

对外语语音消息（有 voiceData.url + lang + spokenText）把双语文字统一收进语音条： 顶部气泡不再重复渲染正文，也不再显示此时已无意义的译/原文切换按钮，并按纯语音
处理去掉语音条多余上间距。译文只保留在语音条翻译行这一处。


Claude-Session: https://claude.ai/code/session_01Hf9FJpfwvnQM7jAT5gQdht