### PR TITLE
fix(StudyApp): 自习室出题/建课改用 extractJson 容错解析，修复 Claude JSON parse error

### DIFF
--- a/apps/StudyApp.tsx
+++ b/apps/StudyApp.tsx
@@ -5,7 +5,7 @@ import { DB } from '../utils/db';
 import { StudyCourse, StudyChapter, CharacterProfile, Message, UserProfile, APIConfig, StudyTutorPreset, QuizQuestion, QuizSession, QuizQuestionNote } from '../types';
 import { ContextBuilder } from '../utils/context';
 import Modal from '../components/os/Modal';
-import { safeResponseJson } from '../utils/safeApi';
+import { safeResponseJson, extractJson } from '../utils/safeApi';
 import { injectMemoryPalace } from '../utils/memoryPalace/pipeline';
 import { Notepad, Check, X, CheckCircle, XCircle, Hand } from '@phosphor-icons/react';
 
@@ -609,7 +609,11 @@ For each chapter, provide a title, a brief summary of what it covers, and a diff
         if (!response.ok) throw new Error('API Error');
         const data = await safeResponseJson(response);
         const content = data.choices[0].message.content.replace(/```json/g, '').replace(/```/g, '').trim();
-        const json = JSON.parse(content);
+        // 同 generateQuiz：走 extractJson 的多层容错，避免 Claude 未转义字符导致的 parse error。
+        const json = extractJson(content);
+        if (!json || !Array.isArray(json.chapters)) {
+            throw new Error('模型返回的章节格式无法解析，请重试');
+        }
 
         return {
             id: `course-${Date.now()}`,
@@ -978,6 +982,8 @@ ${chunkText.substring(0, 10000)}
 - Provide a brief explanation for each answer
 
 ### Output Format (Strict JSON, no markdown wrapping)
+- Output ONLY the JSON object, no prose before or after.
+- Inside any string value, escape special characters: use \\" for quotes, \\\\ for backslashes (e.g. LaTeX like \\\\frac), and \\n for line breaks. Do NOT put raw newlines or unescaped quotes inside a string.
 {
   "questions": [
     {
@@ -1017,7 +1023,12 @@ ${chunkText.substring(0, 10000)}
             if (!response.ok) throw new Error(`API Error: ${response.status}`);
             const data = await safeResponseJson(response);
             const content = (data.choices?.[0]?.message?.content || data.choices?.[0]?.message?.reasoning_content || '').replace(/```json/g, '').replace(/```/g, '').trim();
-            const json = JSON.parse(content);
+            // Claude 常返回未转义特殊字符（引号 / 反斜杠 / 换行）的 JSON，裸 JSON.parse 会在
+            // line 12 附近炸。走 extractJson 的多层容错（去围栏 / 补尾逗号 / 转义内层引号 / 修复截断）。
+            const json = extractJson(content);
+            if (!json || !Array.isArray(json.questions)) {
+                throw new Error('模型返回的题目格式无法解析，请重试');
+            }
 
             const questions: QuizQuestion[] = (json.questions || []).map((q: any, i: number) => ({
                 id: `q-${Date.now()}-${i}`,

--- a/utils/safeApi.extractJson.test.ts
+++ b/utils/safeApi.extractJson.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { extractJson } from './safeApi';
+
+/**
+ * 回归测试：自习室（StudyApp）生成题目时，Claude 高频返回未转义特殊字符的 JSON，
+ * 裸 JSON.parse 会在 line 12 附近抛 "Expected ',' or '}' after property value"。
+ * generateQuiz / createCourse 改用 extractJson 的多层容错来吃掉这类畸形输出。
+ */
+describe('extractJson – Claude quiz JSON recovery', () => {
+    it('recovers unescaped inner quotes inside a string value', () => {
+        const bad = `{
+  "questions": [
+    {
+      "type": "choice",
+      "stem": "First",
+      "options": ["A. x", "B. y", "C. z", "D. w"],
+      "answer": "A",
+      "explanation": "ok"
+    },
+    {
+      "type": "fill_blank",
+      "stem": "The term "React" refers to a ___",
+      "answer": "library",
+      "explanation": "because"
+    }
+  ]
+}`;
+        const j = extractJson(bad);
+        expect(j).not.toBeNull();
+        expect(Array.isArray(j.questions)).toBe(true);
+        expect(j.questions.length).toBe(2);
+    });
+
+    it('strips code fences and drops trailing commas', () => {
+        const bad = '```json\n{ "questions": [ { "type": "true_false", "answer": "true", }, ], }\n```';
+        const j = extractJson(bad);
+        expect(j).not.toBeNull();
+        expect(Array.isArray(j.questions)).toBe(true);
+    });
+
+    it('degrades safely on truncated output (hit max_tokens mid-array)', () => {
+        // extractJson cannot rebuild the { questions: [...] } wrapper from a mid-nested-array
+        // cutoff, so the StudyApp guard (!Array.isArray(json.questions)) rejects the result and
+        // shows a friendly "请重试" toast instead of the old uncaught JSON.parse crash.
+        const bad = '{ "questions": [ { "type": "choice", "stem": "Q1", "answer": "A", "explanation": "ok" }, { "type": "choice", "stem": "Q2", "answer';
+        const j = extractJson(bad);
+        const usable = j != null && Array.isArray(j.questions);
+        expect(usable).toBe(false);
+    });
+
+    it('returns null on hopeless garbage (caller then throws a friendly error)', () => {
+        expect(extractJson('this is not json at all')).toBeNull();
+    });
+});


### PR DESCRIPTION
自习室生成题目时，Claude 高频返回未转义特殊字符（内层引号 / 反斜杠 / 换行）的
JSON，裸 JSON.parse 在 line 12 附近抛 "Expected ',' or '}' after property value"， 换 API 站点/渠道都复现，Gemini 正常。

- generateQuiz / createCourse 从 JSON.parse(content) 改为走 utils/safeApi 里已有的 extractJson 多层容错（去 markdown 围栏 / 去尾逗号 / 单引号转双引号 / 转义内层未转义 引号 / 修复截断），解析失败时抛友好的「请重试」错误而非未捕获崩溃。
- 给出题 prompt 补一条 JSON 转义约束，从源头减少畸形输出。
- 新增 utils/safeApi.extractJson.test.ts 锁定这类畸形 JSON 的恢复行为。


Claude-Session: https://claude.ai/code/session_01QCeJM3jsJA6bDzsHc1rBYa