### PR TITLE
fix(CallApp): keep 语音通话「说」按钮在换字体后不消失

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -1486,10 +1486,10 @@ const CallApp: React.FC = () => {
               ref={draftInputRef}
               value={draftInput}
               onChange={(e) => setDraftInput(e.target.value)}
-              className="flex-1 bg-transparent px-2 text-sm outline-none placeholder:text-white/35"
+              className="flex-1 min-w-0 bg-transparent px-2 text-sm outline-none placeholder:text-white/35"
               placeholder={isListening ? '在听你说……' : sendingBusy ? `${selectedChar?.name || '对方'}正在想……` : `想对${selectedChar?.name || '对方'}说什么？`}
             />
-            <button onClick={handleTurn} disabled={sendingBusy} className="px-4 py-2 rounded-xl text-sm font-medium text-white disabled:opacity-40 transition active:scale-95" style={{ backgroundColor: accentColor, boxShadow: `0 0 16px ${accentColor}66` }}>{sendingBusy ? '…' : '说'}</button>
+            <button onClick={handleTurn} disabled={sendingBusy} className="shrink-0 px-4 py-2 rounded-xl text-sm font-medium text-white disabled:opacity-40 transition active:scale-95" style={{ backgroundColor: accentColor, boxShadow: `0 0 16px ${accentColor}66` }}>{sendingBusy ? '…' : '说'}</button>
           </div>
           {isListening && <div className="text-[10px] text-white/40 mt-1 px-1 animate-pulse">正在聆听，点麦克风结束</div>}
         </div>


### PR DESCRIPTION
语音通话输入行是 flex 布局：麦克风(shrink-0) + 输入框(flex-1) + 「说」按钮(无 shrink-0)。 input 的默认 min-width:auto 会让 flex-1 无法收缩到其内在最小宽度以下；换成字形更宽的 自定义字体后 input 内在宽度变大，整行溢出容器，末尾的「说」按钮被挤出 overflow-hidden 的右边缘而不可见。

给 input 加 min-w-0 让其可正常收缩，给按钮加 shrink-0 使其永不被挤压。


Claude-Session: https://claude.ai/code/session_011NcHN9GTDHr2tUAzHk3cm3