### PR TITLE
天气源加 Open-Meteo：免 key 开箱即用，OWM 不稳时自动回落

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -7,7 +7,7 @@ import { Share } from '@capacitor/share';
 import { safeResponseJson } from '../utils/safeApi';
 import { EXPORT_CHUNK_SIZE, sliceRanges } from '../utils/backupExport';
 import Modal from '../components/os/Modal';
-import { NotionManager, FeishuManager } from '../utils/realtimeContext';
+import { NotionManager, FeishuManager, RealtimeContextManager, fetchOwmWeather, fetchOpenMeteoWeather } from '../utils/realtimeContext';
 import { XhsMcpClient } from '../utils/xhsMcpClient';
 import { getMcdToken, setMcdToken as saveMcdToken, isMcdEnabled, setMcdEnabled as saveMcdEnabled, testMcdConnection, resetMcdSession } from '../utils/mcdMcpClient';
 import { getLuckinToken, setLuckinToken as saveLuckinToken, isLuckinEnabled, setLuckinEnabled as saveLuckinEnabled, testLuckinConnection, resetLuckinSession } from '../utils/luckinMcpClient';
@@ -815,28 +815,26 @@ const Settings: React.FC = () => {
               userXsecToken: realtimeConfig.xhsMcpConfig?.userXsecToken, // 保留自动获取的 token
           }
       });
+      RealtimeContextManager.clearCache(); // 城市/来源改了就别再吐旧缓存
       addToast('实时感知配置已保存', 'success');
       setShowRealtimeModal(false);
   };
 
-  // 测试天气API连接
+  // 测试天气API连接：填了 key 测 OpenWeatherMap，没填测免费的 Open-Meteo
   const testWeatherApi = async () => {
-      if (!rtWeatherKey) {
-          setRtTestStatus('请先填写 API Key');
+      if (!rtWeatherCity) {
+          setRtTestStatus('请先填写城市');
           return;
       }
       setRtTestStatus('正在测试...');
       try {
-          const url = `https://api.openweathermap.org/data/2.5/weather?q=${rtWeatherCity}&appid=${rtWeatherKey}&units=metric&lang=zh_cn`;
-          const res = await fetch(url);
-          if (res.ok) {
-              const data = await safeResponseJson(res);
-              setRtTestStatus(`连接成功！${data.name}: ${data.weather[0]?.description}, ${Math.round(data.main.temp)}°C`);
-          } else {
-              setRtTestStatus(`连接失败: HTTP ${res.status}`);
-          }
+          const weather = rtWeatherKey
+              ? await fetchOwmWeather(rtWeatherCity, rtWeatherKey)
+              : await fetchOpenMeteoWeather(rtWeatherCity);
+          const source = rtWeatherKey ? 'OpenWeatherMap' : 'Open-Meteo';
+          setRtTestStatus(`连接成功！(${source}) ${weather.city}: ${weather.description}, ${weather.temp}°C`);
       } catch (e: any) {
-          setRtTestStatus(`网络错误: ${e.message}`);
+          setRtTestStatus(`连接失败: ${e.message}`);
       }
   };
 
@@ -2472,12 +2470,12 @@ const Settings: React.FC = () => {
                   {rtWeatherEnabled && (
                       <div className="space-y-2">
                           <div>
-                              <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">OpenWeatherMap API Key</label>
-                              <input type="password" value={rtWeatherKey} onChange={e => setRtWeatherKey(e.target.value)} className="w-full bg-white/80 border border-emerald-200 rounded-xl px-3 py-2 text-sm font-mono" placeholder="获取: openweathermap.org" />
+                              <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">OpenWeatherMap API Key（可选）</label>
+                              <input type="password" value={rtWeatherKey} onChange={e => setRtWeatherKey(e.target.value)} className="w-full bg-white/80 border border-emerald-200 rounded-xl px-3 py-2 text-sm font-mono" placeholder="留空则用免费的 Open-Meteo，无需注册" />
                           </div>
                           <div>
-                              <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">城市 (英文)</label>
-                              <input type="text" value={rtWeatherCity} onChange={e => setRtWeatherCity(e.target.value)} className="w-full bg-white/80 border border-emerald-200 rounded-xl px-3 py-2 text-sm" placeholder="Beijing, Shanghai, etc." />
+                              <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">城市</label>
+                              <input type="text" value={rtWeatherCity} onChange={e => setRtWeatherCity(e.target.value)} className="w-full bg-white/80 border border-emerald-200 rounded-xl px-3 py-2 text-sm" placeholder="北京 / Beijing / Shanghai" />
                           </div>
                           <button onClick={testWeatherApi} className="w-full py-2 bg-emerald-100 text-emerald-600 text-xs font-bold rounded-xl active:scale-95 transition-transform">测试天气API</button>
                       </div>

--- a/types.ts
+++ b/types.ts
@@ -346,8 +346,8 @@ export interface CharacterBuff {
 export interface RealtimeConfig {
   // 天气配置
   weatherEnabled: boolean;
-  weatherApiKey: string;  // OpenWeatherMap API Key
-  weatherCity: string;    // 城市名
+  weatherApiKey: string;  // OpenWeatherMap API Key（可选；留空走免 key 的 Open-Meteo）
+  weatherCity: string;    // 城市名（如 "北京"、"Beijing"）
 
   // 新闻配置
   newsEnabled: boolean;

--- a/utils/realtimeContext.ts
+++ b/utils/realtimeContext.ts
@@ -33,8 +33,8 @@ export interface SearchResult {
 export interface RealtimeConfig {
     // 天气配置
     weatherEnabled: boolean;
-    weatherApiKey: string;  // OpenWeatherMap API Key
-    weatherCity: string;    // 城市名 (如 "Beijing" 或 "Shanghai")
+    weatherApiKey: string;  // OpenWeatherMap API Key（可选；留空走免 key 的 Open-Meteo）
+    weatherCity: string;    // 城市名 (如 "北京"、"Beijing"，Open-Meteo 支持中文)
 
     // 新闻配置
     newsEnabled: boolean;
@@ -89,6 +89,100 @@ export const defaultRealtimeConfig: RealtimeConfig = {
 let weatherCache: { data: WeatherData | null; timestamp: number } = { data: null, timestamp: 0 };
 let newsCache: { data: NewsItem[]; timestamp: number } = { data: [], timestamp: 0 };
 
+// Open-Meteo 地名解析缓存：城市名 → 坐标，避免每次取天气都多打一次 geocoding
+const geocodeCache = new Map<string, { latitude: number; longitude: number; name: string }>();
+
+// WMO weather code（Open-Meteo 返回的 weather_code）→ 中文描述 + 近似 OWM icon 码
+// 完整码表见 https://open-meteo.com/en/docs（WMO Weather interpretation codes）
+const WMO_WEATHER_CODES: Record<number, { description: string; icon: string }> = {
+    0: { description: '晴', icon: '01d' },
+    1: { description: '大致晴朗', icon: '02d' },
+    2: { description: '局部多云', icon: '03d' },
+    3: { description: '阴', icon: '04d' },
+    45: { description: '雾', icon: '50d' },
+    48: { description: '雾凇', icon: '50d' },
+    51: { description: '轻微毛毛雨', icon: '09d' },
+    53: { description: '毛毛雨', icon: '09d' },
+    55: { description: '浓密毛毛雨', icon: '09d' },
+    56: { description: '冻毛毛雨', icon: '09d' },
+    57: { description: '强冻毛毛雨', icon: '09d' },
+    61: { description: '小雨', icon: '10d' },
+    63: { description: '中雨', icon: '10d' },
+    65: { description: '大雨', icon: '10d' },
+    66: { description: '冻雨', icon: '13d' },
+    67: { description: '强冻雨', icon: '13d' },
+    71: { description: '小雪', icon: '13d' },
+    73: { description: '中雪', icon: '13d' },
+    75: { description: '大雪', icon: '13d' },
+    77: { description: '雪粒', icon: '13d' },
+    80: { description: '小阵雨', icon: '09d' },
+    81: { description: '阵雨', icon: '09d' },
+    82: { description: '强阵雨', icon: '09d' },
+    85: { description: '小阵雪', icon: '13d' },
+    86: { description: '强阵雪', icon: '13d' },
+    95: { description: '雷阵雨', icon: '11d' },
+    96: { description: '雷阵雨伴小冰雹', icon: '11d' },
+    99: { description: '雷阵雨伴大冰雹', icon: '11d' },
+};
+
+/**
+ * OpenWeatherMap 源（需要 API Key）。失败时抛错，由调用方决定是否回落。
+ */
+export const fetchOwmWeather = async (city: string, apiKey: string): Promise<WeatherData> => {
+    const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric&lang=zh_cn`;
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`OpenWeatherMap HTTP ${response.status}`);
+    }
+    const data = await safeResponseJson(response);
+    return {
+        temp: Math.round(data.main.temp),
+        feelsLike: Math.round(data.main.feels_like),
+        humidity: data.main.humidity,
+        description: data.weather[0]?.description || '未知',
+        icon: data.weather[0]?.icon || '01d',
+        city: data.name
+    };
+};
+
+/**
+ * Open-Meteo 源（免费、免 key、CORS 友好）。城市名先过官方 geocoding（支持中文），失败时抛错。
+ */
+export const fetchOpenMeteoWeather = async (city: string): Promise<WeatherData> => {
+    let geo = geocodeCache.get(city);
+    if (!geo) {
+        const geoUrl = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1&language=zh&format=json`;
+        const geoRes = await fetch(geoUrl);
+        if (!geoRes.ok) {
+            throw new Error(`Open-Meteo geocoding HTTP ${geoRes.status}`);
+        }
+        const geoData = await safeResponseJson(geoRes);
+        const hit = geoData.results?.[0];
+        if (!hit) {
+            throw new Error(`Open-Meteo 找不到城市: ${city}`);
+        }
+        geo = { latitude: hit.latitude, longitude: hit.longitude, name: hit.name };
+        geocodeCache.set(city, geo);
+    }
+
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${geo.latitude}&longitude=${geo.longitude}&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code&timezone=auto`;
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Open-Meteo HTTP ${response.status}`);
+    }
+    const data = await safeResponseJson(response);
+    const current = data.current;
+    const wmo = WMO_WEATHER_CODES[current.weather_code] || { description: '未知', icon: '01d' };
+    return {
+        temp: Math.round(current.temperature_2m),
+        feelsLike: Math.round(current.apparent_temperature),
+        humidity: Math.round(current.relative_humidity_2m),
+        description: wmo.description,
+        icon: wmo.icon,
+        city: geo.name
+    };
+};
+
 // 特殊日期表
 const SPECIAL_DATES: Record<string, string> = {
     '01-01': '元旦',
@@ -111,10 +205,10 @@ const SPECIAL_DATES: Record<string, string> = {
 export const RealtimeContextManager = {
 
     /**
-     * 获取天气信息
+     * 获取天气信息。填了 OpenWeatherMap key 优先走 OWM，失败或没填 key 时回落免费的 Open-Meteo。
      */
     fetchWeather: async (config: RealtimeConfig): Promise<WeatherData | null> => {
-        if (!config.weatherEnabled || !config.weatherApiKey) {
+        if (!config.weatherEnabled || !config.weatherCity) {
             return null;
         }
 
@@ -126,34 +220,29 @@ export const RealtimeContextManager = {
             return weatherCache.data;
         }
 
-        try {
-            const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(config.weatherCity)}&appid=${config.weatherApiKey}&units=metric&lang=zh_cn`;
+        let weather: WeatherData | null = null;
 
-            const response = await fetch(url);
-            if (!response.ok) {
-                console.error('Weather API error:', response.status);
+        if (config.weatherApiKey) {
+            try {
+                weather = await fetchOwmWeather(config.weatherCity, config.weatherApiKey);
+            } catch (e) {
+                console.warn('OpenWeatherMap 失败，回落 Open-Meteo:', e);
+            }
+        }
+
+        if (!weather) {
+            try {
+                weather = await fetchOpenMeteoWeather(config.weatherCity);
+            } catch (e) {
+                console.error('Failed to fetch weather:', e);
                 return null;
             }
-
-            const data = await safeResponseJson(response);
-
-            const weather: WeatherData = {
-                temp: Math.round(data.main.temp),
-                feelsLike: Math.round(data.main.feels_like),
-                humidity: data.main.humidity,
-                description: data.weather[0]?.description || '未知',
-                icon: data.weather[0]?.icon || '01d',
-                city: data.name
-            };
-
-            // 更新缓存
-            weatherCache = { data: weather, timestamp: now };
-
-            return weather;
-        } catch (e) {
-            console.error('Failed to fetch weather:', e);
-            return null;
         }
+
+        // 更新缓存
+        weatherCache = { data: weather, timestamp: now };
+
+        return weather;
     },
 
     // hot_news（orz.ai）平台 key → 中文展示名。用于 source 标注，让提示词读起来自然。
@@ -533,8 +622,8 @@ export const RealtimeContextManager = {
             parts.push(`🎉 今日特殊: ${specialDates.join('、')}`);
         }
 
-        // 3. 天气信息
-        if (config.weatherEnabled && config.weatherApiKey) {
+        // 3. 天气信息（有没有 OWM key 都能取：无 key 走 Open-Meteo）
+        if (config.weatherEnabled) {
             const weather = await RealtimeContextManager.fetchWeather(config);
             if (weather) {
                 parts.push('');
@@ -612,6 +701,7 @@ export const RealtimeContextManager = {
     clearCache: () => {
         weatherCache = { data: null, timestamp: 0 };
         newsCache = { data: [], timestamp: 0 };
+        geocodeCache.clear();
     },
 
     /**

--- a/utils/realtimeContext.weather.test.ts
+++ b/utils/realtimeContext.weather.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    RealtimeContextManager,
+    fetchOpenMeteoWeather,
+    defaultRealtimeConfig,
+    type RealtimeConfig,
+} from './realtimeContext';
+
+// 天气双源策略：有 OWM key 走 OWM，失败 / 没 key 回落免费的 Open-Meteo。
+// Open-Meteo 路径 = geocoding（中文城市名 → 坐标）+ forecast（WMO code → 中文描述）。
+
+function jsonResponse(body: any, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        text: async () => JSON.stringify(body),
+    } as any;
+}
+
+const GEO_BEIJING = {
+    results: [{ latitude: 39.9042, longitude: 116.4074, name: '北京市' }],
+};
+
+const METEO_CURRENT = {
+    current: {
+        temperature_2m: 21.3,
+        apparent_temperature: 19.8,
+        relative_humidity_2m: 55,
+        weather_code: 61,
+    },
+};
+
+const OWM_RESPONSE = {
+    main: { temp: 20.6, feels_like: 19.2, humidity: 60 },
+    weather: [{ description: '多云', icon: '03d' }],
+    name: 'Beijing',
+};
+
+function makeConfig(overrides: Partial<RealtimeConfig>): RealtimeConfig {
+    return { ...defaultRealtimeConfig, weatherEnabled: true, ...overrides };
+}
+
+beforeEach(() => {
+    RealtimeContextManager.clearCache();
+    vi.restoreAllMocks();
+});
+
+describe('fetchOpenMeteoWeather', () => {
+    it('中文城市名 → geocoding → forecast，WMO code 映射成中文描述', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(GEO_BEIJING))
+            .mockResolvedValueOnce(jsonResponse(METEO_CURRENT));
+
+        const weather = await fetchOpenMeteoWeather('北京');
+
+        expect(weather).toEqual({
+            temp: 21, feelsLike: 20, humidity: 55,
+            description: '小雨', icon: '10d', city: '北京市',
+        });
+        const geoUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+        expect(geoUrl).toContain('geocoding-api.open-meteo.com');
+        expect(geoUrl).toContain(encodeURIComponent('北京'));
+        const forecastUrl = vi.mocked(fetch).mock.calls[1][0] as string;
+        expect(forecastUrl).toContain('latitude=39.9042');
+    });
+
+    it('同城市第二次调用命中 geocoding 缓存，只打 forecast', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(GEO_BEIJING))
+            .mockResolvedValue(jsonResponse(METEO_CURRENT));
+
+        await fetchOpenMeteoWeather('缓存城');
+        await fetchOpenMeteoWeather('缓存城');
+
+        const geoCalls = vi.mocked(fetch).mock.calls
+            .filter(c => (c[0] as string).includes('geocoding-api'));
+        expect(geoCalls.length).toBe(1);
+    });
+
+    it('城市找不到时抛错', async () => {
+        global.fetch = vi.fn().mockResolvedValue(jsonResponse({ results: [] }));
+        await expect(fetchOpenMeteoWeather('不存在的地方')).rejects.toThrow('找不到城市');
+    });
+
+    it('未知 WMO code 描述兜底为「未知」', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(GEO_BEIJING))
+            .mockResolvedValueOnce(jsonResponse({
+                current: { ...METEO_CURRENT.current, weather_code: 42 },
+            }));
+        const weather = await fetchOpenMeteoWeather('未知码城');
+        expect(weather.description).toBe('未知');
+    });
+});
+
+describe('RealtimeContextManager.fetchWeather 双源策略', () => {
+    it('没填 key 时直接走 Open-Meteo', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(jsonResponse(GEO_BEIJING))
+            .mockResolvedValueOnce(jsonResponse(METEO_CURRENT));
+
+        const weather = await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherApiKey: '', weatherCity: '北京' }));
+
+        expect(weather?.description).toBe('小雨');
+        const urls = vi.mocked(fetch).mock.calls.map(c => c[0] as string);
+        expect(urls.some(u => u.includes('openweathermap'))).toBe(false);
+    });
+
+    it('填了 key 优先走 OWM', async () => {
+        global.fetch = vi.fn().mockResolvedValueOnce(jsonResponse(OWM_RESPONSE));
+
+        const weather = await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherApiKey: 'k123', weatherCity: 'Beijing' }));
+
+        expect(weather).toEqual({
+            temp: 21, feelsLike: 19, humidity: 60,
+            description: '多云', icon: '03d', city: 'Beijing',
+        });
+        expect(vi.mocked(fetch).mock.calls[0][0]).toContain('openweathermap');
+    });
+
+    it('OWM 挂了自动回落 Open-Meteo（不再直接返回 null）', async () => {
+        global.fetch = vi.fn()
+            .mockResolvedValueOnce(jsonResponse({}, false, 503)) // OWM 不稳定
+            .mockResolvedValueOnce(jsonResponse(GEO_BEIJING))
+            .mockResolvedValueOnce(jsonResponse(METEO_CURRENT));
+
+        const weather = await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherApiKey: 'k123', weatherCity: '北京' }));
+
+        expect(weather?.description).toBe('小雨');
+        expect(weather?.city).toBe('北京市');
+    });
+
+    it('weatherEnabled=false 或城市为空时返回 null 且不发请求', async () => {
+        global.fetch = vi.fn();
+        expect(await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherEnabled: false }))).toBeNull();
+        expect(await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherCity: '' }))).toBeNull();
+        expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('两个源都挂时返回 null 不抛错', async () => {
+        global.fetch = vi.fn().mockResolvedValue(jsonResponse({}, false, 500));
+        const weather = await RealtimeContextManager.fetchWeather(
+            makeConfig({ weatherApiKey: '', weatherCity: '北京' }));
+        expect(weather).toBeNull();
+    });
+});


### PR DESCRIPTION
OpenWeatherMap 国内直连经常不稳定，且强制用户注册填 key。现改为双源：

- 没填 key：直接走 Open-Meteo（免费免注册，geocoding 支持中文城市名， WMO weather code 映射成中文描述）
- 填了 key：优先 OWM，请求失败自动回落 Open-Meteo，不再直接静默失联
- 设置页：key 标为可选，测试按钮按当前配置测对应源并标注来源； 保存配置时清天气/地理缓存，改城市立即生效


Claude-Session: https://claude.ai/code/session_01Mb51pf5gDbyqgP8NEAmFHi