### PR TITLE
修复 iOS+火狐 opus-4.8 一直 400：新模型废弃 temperature，统一出口摘掉采样参数

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useEffect, useState, useRef, useCallback } from 'react';
 import { APIConfig, AppID, OSTheme, VirtualTime, CharacterProfile, ChatTheme, Toast, FullBackupData, UserProfile, ApiPreset, GroupProfile, SystemLog, Worldbook, NovelBook, SongSheet, Message, RealtimeConfig, AppearancePreset, CloudBackupConfig, CloudBackupFile } from '../types';
 import { DB } from '../utils/db';
+import { modelRejectsSamplingParams, stripSamplingParams, isSamplingParamError } from '../utils/samplingParamCompat';
 import { extractImagesInPlace, deepCloneForExport } from '../utils/backupExport';
 import { writeV2Backup, assembleV2Backup, type BackupManifest, type ZipFileWriter, type ZipFileReader } from '../utils/backupFormat';
 import { encodeVectorsForBackup } from '../utils/memoryPalace/db';
@@ -753,8 +754,43 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           const urlStr = String(resource);
           const fetchStartedAt = Date.now();
 
+          // 采样参数兼容层（详见 utils/samplingParamCompat.ts）：
+          // 某些模型废弃了 temperature/top_p/top_k，带上直接 400。这里在所有 /chat/completions
+          // 的统一出口做发送前主动摘除，覆盖 Schedule / 记忆 / 见面等全部旁路调用点。
+          let sendArgs: [RequestInfo | URL, RequestInit?] = args;
+          if (urlStr.includes('/chat/completions')) {
+              const rawBody = (config as RequestInit | undefined)?.body;
+              if (typeof rawBody === 'string') {
+                  try {
+                      const parsed = JSON.parse(rawBody);
+                      if (modelRejectsSamplingParams(parsed?.model) && stripSamplingParams(parsed)) {
+                          sendArgs = [resource, { ...(config as RequestInit), body: JSON.stringify(parsed) }];
+                      }
+                  } catch { /* 非 JSON body：原样放行 */ }
+              }
+          }
+
           try {
-              const response = await originalFetch(...args);
+              let response = await originalFetch(...sendArgs);
+
+              // 兜底：模型没被上面清单覆盖但仍拒收采样参数时，读 400 报文自愈——摘掉后重试一次。
+              if (!response.ok && response.status === 400 && urlStr.includes('/chat/completions')) {
+                  const sentBody = (sendArgs[1] as RequestInit | undefined)?.body;
+                  if (typeof sentBody === 'string') {
+                      let errText = '';
+                      try { errText = await response.clone().text(); } catch { /* 读不出就算了 */ }
+                      if (isSamplingParamError(errText)) {
+                          try {
+                              const parsed = JSON.parse(sentBody);
+                              if (stripSamplingParams(parsed)) {
+                                  sendArgs = [resource, { ...(sendArgs[1] as RequestInit), body: JSON.stringify(parsed) }];
+                                  response = await originalFetch(...sendArgs);
+                              }
+                          } catch { /* 解析失败：保留原始 400 响应 */ }
+                      }
+                  }
+              }
+
               const durationMs = Date.now() - fetchStartedAt;
 
               // 「API 调用记录」统一记录入口：所有 /chat/completions（裸 fetch + safeFetchJson
@@ -762,7 +798,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               // （safeFetchJson 传的精确信息），裸 fetch 没有就由 recordApiCall 用环境兜底。
               if (urlStr.includes('/chat/completions')) {
                   const meta = (config as any)?.__sullyMeta;
-                  const body = (config as any)?.body;
+                  const body = (sendArgs[1] as any)?.body;
                   const status = response.status;
                   const ok = response.ok;
                   // clone 出来异步读 usage，不阻塞调用方拿 response
@@ -788,7 +824,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                           // 把发出去的请求体摘要也记上 —— 排查"只有点单(带工具)报错"必须看到 model/参数/tools/消息结构
                           let reqSummary = '';
                           try {
-                              const b = (config as any)?.body;
+                              const b = (sendArgs[1] as any)?.body;
                               if (typeof b === 'string') {
                                   const j = JSON.parse(b);
                                   const toolNames = Array.isArray(j.tools) ? j.tools.map((t: any) => t?.function?.name).filter(Boolean) : [];
@@ -820,7 +856,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           } catch (err: any) {
               // Network Failure
               if (urlStr.includes('/chat/completions')) {
-                  recordApiCall({ url: urlStr, body: (config as any)?.body, ok: false, meta: (config as any)?.__sullyMeta, durationMs: Date.now() - fetchStartedAt });
+                  recordApiCall({ url: urlStr, body: (sendArgs[1] as any)?.body, ok: false, meta: (config as any)?.__sullyMeta, durationMs: Date.now() - fetchStartedAt });
               }
               setSystemLogs(prev => [{
                   id: `log-${Date.now()}`,

--- a/utils/samplingParamCompat.test.ts
+++ b/utils/samplingParamCompat.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { modelRejectsSamplingParams, stripSamplingParams, isSamplingParamError } from './samplingParamCompat';
+
+describe('modelRejectsSamplingParams', () => {
+    it('识别会废弃采样参数的模型（带上 temperature 会 400）', () => {
+        const reject = [
+            'anthropic/claude-opus-4.8',
+            'claude-opus-4-8',
+            'claude-opus-4.7',
+            'anthropic/claude-opus-4-7',
+            'claude-sonnet-5',
+            'anthropic/claude-sonnet-5',
+            'claude-fable-5',
+            'claude-mythos-5',
+            'openai/gpt-5',
+            'gpt-5-mini',
+            'claude-opus-4-8-fast',
+        ];
+        for (const m of reject) {
+            expect(modelRejectsSamplingParams(m), m).toBe(true);
+        }
+    });
+
+    it('对仍接受 temperature 的模型返回 false（不误伤）', () => {
+        const keep = [
+            'claude-opus-4-6',
+            'anthropic/claude-opus-4.6',
+            'claude-opus-4-5',
+            'claude-sonnet-4-6',
+            'claude-sonnet-4-5',
+            'claude-haiku-4-5',
+            'gpt-4o',
+            'gpt-4-turbo',
+            'deepseek-chat',
+            'gemini-2.0-flash',
+            '',
+            undefined,
+            null,
+        ];
+        for (const m of keep) {
+            expect(modelRejectsSamplingParams(m as any), String(m)).toBe(false);
+        }
+    });
+});
+
+describe('stripSamplingParams', () => {
+    it('摘掉 temperature/top_p/top_k 并报告有改动', () => {
+        const body: any = { model: 'x', messages: [], temperature: 0.85, top_p: 0.9, top_k: 40, max_tokens: 100 };
+        expect(stripSamplingParams(body)).toBe(true);
+        expect('temperature' in body).toBe(false);
+        expect('top_p' in body).toBe(false);
+        expect('top_k' in body).toBe(false);
+        expect(body.max_tokens).toBe(100); // 其它字段保留
+    });
+
+    it('没有采样参数时返回 false', () => {
+        expect(stripSamplingParams({ model: 'x', messages: [] })).toBe(false);
+    });
+});
+
+describe('isSamplingParamError', () => {
+    it('命中 provider 的 temperature 废弃报文', () => {
+        expect(isSamplingParamError('temperature is deprecated for this model.')).toBe(true);
+        expect(isSamplingParamError('{"error":{"message":"temperature is not supported"}}')).toBe(true);
+        expect(isSamplingParamError('top_p is no longer supported on this model')).toBe(true);
+    });
+
+    it('对无关 400 报文不误判', () => {
+        expect(isSamplingParamError('prompt is too long: 10494')).toBe(false);
+        expect(isSamplingParamError('invalid api key')).toBe(false);
+        expect(isSamplingParamError('')).toBe(false);
+    });
+});

--- a/utils/samplingParamCompat.ts
+++ b/utils/samplingParamCompat.ts
@@ -1,0 +1,70 @@
+/**
+ * 采样参数兼容层
+ *
+ * 背景：部分较新的模型已经废弃了 temperature / top_p / top_k 采样参数，请求里带上
+ * 就直接 400。典型报错（OpenRouter 透传 Azure/Anthropic）：
+ *   {"type":"invalid_request_error","message":"temperature is deprecated for this model."}
+ *
+ * 已知会因此 400 的模型：
+ *   - Claude：Opus 4.7 / 4.8（及以上）、Sonnet 5（及以上）、Fable 5 / Mythos 5
+ *   - OpenAI：gpt-5 系
+ *   （o1/o3/o4 等推理模型也只接受默认 temperature，靠下面第 2 层兜底覆盖）
+ *
+ * 关键点：OpenRouter 会把 `anthropic/claude-opus-4.8` 路由到 Azure / Anthropic，
+ * 这些 provider 同样拒收 temperature，所以「换 API / 换 OR」都没用——根因是**模型本身
+ * 不收这个参数**，跟 key、上文长度、格式都无关。
+ *
+ * 兼容策略（在 fetch 统一出口做，覆盖全部 /chat/completions 调用点）：
+ *   1) 发送前：识别到会废弃采样参数的模型，主动摘掉 temperature/top_p/top_k；
+ *   2) 收到 400 且报文点名采样参数「deprecated / not supported」时，摘掉后重试一次。
+ * 第 2 层是兜底：即便模型名没被第 1 层清单覆盖，也能自愈。
+ */
+
+const SAMPLING_KEYS = ['temperature', 'top_p', 'top_k'] as const;
+
+/**
+ * 该模型是否已废弃采样参数（带上会 400）。
+ * model 为空 / 非字符串 / 未知时返回 false —— 默认保持原样，不误伤仍需要 temperature 的模型。
+ */
+export function modelRejectsSamplingParams(model: unknown): boolean {
+    if (typeof model !== 'string' || !model) return false;
+    const m = model.toLowerCase();
+
+    // Claude 系：版本号里的分隔符可能是 . 或 -（claude-opus-4.8 / claude-opus-4-8 都有）
+    if (/opus[-.\s]?4[-.\s]?(7|8|9)\b/.test(m)) return true;   // Opus 4.7 / 4.8 / 4.9
+    if (/opus[-.\s]?(?:[5-9]|\d\d)\b/.test(m)) return true;    // Opus 5 及以上
+    if (/sonnet[-.\s]?(?:[5-9]|\d\d)\b/.test(m)) return true;  // Sonnet 5 及以上
+    if (/\b(?:fable|mythos)[-.\s]?\d/.test(m)) return true;    // Fable / Mythos
+
+    // OpenAI gpt-5 系（gpt-5 / gpt-5-mini / gpt5 等）
+    if (/\bgpt-?5/.test(m)) return true;
+
+    return false;
+}
+
+/**
+ * 从请求体里摘掉采样参数（就地修改）；返回是否真的删掉了东西。
+ */
+export function stripSamplingParams(body: Record<string, any>): boolean {
+    if (!body || typeof body !== 'object') return false;
+    let changed = false;
+    for (const k of SAMPLING_KEYS) {
+        if (k in body && body[k] !== undefined) {
+            delete body[k];
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+/**
+ * 400 报文是否在抱怨采样参数（temperature / top_p / top_k 被废弃 / 不支持）。
+ * 用来决定要不要摘掉采样参数重试一次。
+ */
+export function isSamplingParamError(responseText: string): boolean {
+    if (!responseText) return false;
+    const t = responseText.toLowerCase();
+    const mentionsParam = /temperature|top_p|top_k/.test(t);
+    const mentionsReject = /deprecat|not supported|unsupported|no longer supported|not allowed|isn'?t supported|not permitted|unexpected/.test(t);
+    return mentionsParam && mentionsReject;
+}


### PR DESCRIPTION
根因不是设备/上文/key，而是 Claude Opus 4.7/4.8、Sonnet 5、Fable/Mythos 等新模型 已废弃 temperature/top_p/top_k，带上直接 400（provider 报 "temperature is deprecated for this model."）。OpenRouter 会把 anthropic/claude-opus-4.8 路由到 Azure/Anthropic，同样拒收，所以换 API/换 OR 都没用。

在所有 /chat/completions 的统一出口（OSContext 全局 fetch 拦截器）加采样参数兼容层， 一处修好覆盖 Schedule/记忆/见面等全部旁路调用点（原先散在 58 个文件里无条件带
temperature: 0.85）：
- 发送前：识别会废弃采样参数的模型，主动摘掉 temperature/top_p/top_k
- 兜底：收到 400 且报文点名采样参数被废弃/不支持时，摘掉后自愈重试一次
- 仍接受 temperature 的模型（Opus 4.6/4.5、Sonnet 4.6、Haiku、GPT-4 等）不受影响

新增 utils/samplingParamCompat.ts + 单测（模型识别不误伤 + 报文匹配）。


Claude-Session: https://claude.ai/code/session_01ESjteccVix8ynW7dkitcYB