### PR TITLE
Make `clearMessages` return a Promise and handle IndexedDB errors

### DIFF
--- a/utils/db.ts
+++ b/utils/db.ts
@@ -714,20 +714,27 @@ export const DB = {
 
   clearMessages: async (charId: string): Promise<void> => {
     const db = await openDB();
-    const transaction = db.transaction(STORE_MESSAGES, 'readwrite');
-    const store = transaction.objectStore(STORE_MESSAGES);
-    const index = store.index('charId');
-    const request = index.openCursor(IDBKeyRange.only(charId));
-    request.onsuccess = () => {
-      const cursor = request.result;
-      if (cursor) { 
-          const m = cursor.value as Message;
-          if (!m.groupId) { 
-              store.delete(cursor.primaryKey); 
-          }
-          cursor.continue(); 
-      }
-    };
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_MESSAGES, 'readwrite');
+      const store = transaction.objectStore(STORE_MESSAGES);
+      const index = store.index('charId');
+      const request = index.openCursor(IDBKeyRange.only(charId));
+
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (cursor) {
+            const m = cursor.value as Message;
+            if (!m.groupId) {
+                store.delete(cursor.primaryKey);
+            }
+            cursor.continue();
+        }
+      };
+      request.onerror = () => reject(request.error);
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error || new Error('clearMessages aborted'));
+    });
   },
 
   getGroups: async (): Promise<GroupProfile[]> => {


### PR DESCRIPTION
### Motivation
- Ensure `clearMessages` reliably waits for the IndexedDB transaction to finish and surface errors instead of returning immediately, preventing race conditions and unhandled failures when removing messages by `charId`.

### Description
- Wrap the `clearMessages` implementation in a `Promise`, add `request.onerror`, and wire `transaction.oncomplete`, `transaction.onerror`, and `transaction.onabort` to resolve or reject appropriately so callers can await completion and receive errors.

### Testing
- Ran the automated test suite (`yarn test`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f078c0bcc8330a70d0fc7c479c05e)