### PR TITLE
fix(memory-palace): 早退分支归零消化计数器——修"每轮都弹门牌整理"

### DIFF
--- a/utils/memoryPalace/digestion.test.ts
+++ b/utils/memoryPalace/digestion.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { runCognitiveDigestion, incrementDigestRound, getDigestRoundCount } from './digestion';
+
+// fake-indexeddb + localStorage stub 由 test-setup.ts 注入。
+// 回归守卫：消化的"无材料早退"分支必须归零轮数计数器。
+// 此前它漏掉 resetDigestRounds → 计数器卡在 ≥50 → 之后每一轮聊天都重触发
+// 自动消化（挂上门牌整理后 = 每轮弹浮窗 + 每轮烧一次 LLM）。
+// 空库上早退发生在任何 LLM 调用之前（回填也因 totalLines=0 直接返回），测试不碰网络。
+
+describe('认知消化 — 轮数计数器', () => {
+    it('无材料早退分支也必须归零计数器（防每轮重触发自动消化）', async () => {
+        const charId = 'char_digest_counter_test';
+        // 模拟聊到第 50 轮：计数器达到自动消化阈值
+        let shouldDigest = false;
+        for (let i = 0; i < 50; i++) shouldDigest = incrementDigestRound(charId);
+        expect(shouldDigest).toBe(true);
+        expect(getDigestRoundCount(charId)).toBe(50);
+
+        // 空库 → 走早退分支（在任何 LLM 调用之前返回）
+        const result = await runCognitiveDigestion(
+            charId, '测试角色', '人设', { baseUrl: 'http://invalid.test', apiKey: 'k', model: 'm' },
+        );
+        expect(result).not.toBeNull();
+
+        // 关键断言：计数器归零，下一轮 increment 后是 1 而不是 51
+        expect(getDigestRoundCount(charId)).toBe(0);
+        expect(incrementDigestRound(charId)).toBe(false);
+    });
+});

--- a/utils/memoryPalace/digestion.ts
+++ b/utils/memoryPalace/digestion.ts
@@ -886,18 +886,16 @@ export async function runCognitiveDigestion(
         material.recentEpisodes.length === 0) {
         if (embeddingConfig) await vectorizeOrphanedNodes(charId, embeddingConfig);
         const emptyResult: DigestResult = { resolved: [], deepened: [], faded: [], fulfilled: [], disappointed: [], internalized: [], synthesizedUser: [], selfInsights: [], selfConfused: [], worries: [], aspirations: [], distilled: [] };
-        // 门牌整理不受消化门槛限制：卧室节点从不进消化材料池，但「我们之间」需要它们
-        let plateUpdated: PlateRoom[] = await maybeBootstrapPlates(charId, charName, userName, llmConfig, onProgress);
-        try {
-            onProgress?.('正在整理门牌…');
-            const { consolidateAllPlates } = await import('./roomPlates');
-            const consolidated = (await consolidateAllPlates(charId, charName, userName, llmConfig, undefined, getLastDigestTs(charId))).updated;
-            for (const r of consolidated) if (!plateUpdated.includes(r)) plateUpdated.push(r);
-        } catch (e: any) {
-            console.warn(`🚪 [Digest] 门牌整理失败（不影响消化结果）: ${e?.message || e}`);
-        }
+        // 早退分支不跑门牌整理：回看窗口（客厅+卧室）都空 = 上次消化以来门牌房间
+        // 没有任何新节点，整理只会让 LLM 对着旧材料重排——纯烧钱。只做回填续传
+        // （它有自己的完成标记/进度护栏，欠账没还清时才会真正跑）。
+        const plateUpdated: PlateRoom[] = await maybeBootstrapPlates(charId, charName, userName, llmConfig, onProgress);
         emptyResult.plateUpdated = plateUpdated;
         await saveDigestReport(charId, trigger, userName, null, emptyResult, {}, plateUpdated);
+        // ⚠️ 计数器必须归零：此前早退分支漏掉 resetDigestRounds，轮数卡在 ≥50，
+        // 之后**每一轮聊天**都re触发自动消化——用户看到"每聊一句就弹门牌整理浮窗"
+        // 的根因就是它（早退分支挂上门牌整理后，这个老 bug 从隐性变成每轮可见+烧钱）。
+        resetDigestRounds(charId);
         markDigested(charId);
         return emptyResult;
     }


### PR DESCRIPTION
用户反馈每聊一句都出现门牌更新浮窗。根因是上游隐性 bug 被放大：
消化的"无材料早退"分支只调 markDigested、漏掉 resetDigestRounds,
轮数卡在 ≥50 后**每一轮聊天**都重触发自动消化。早退分支挂上门牌
整理后, 这个老 bug 从隐性（空跑无感）变成每轮可见 + 每轮烧一次
整理 LLM。

- 早退分支补 resetDigestRounds（根因）
- 早退分支移除门牌整理: 回看窗口都空 = 门牌房间自上次消化零新增, 整理只是让 LLM 对旧材料重排, 纯烧钱。回填续传保留（自带护栏）
- 回归测试钉死: 空库早退后计数器必须为 0（不碰网络）

预期节奏恢复: 门牌更新只发生在 ~50 轮消化与事件盒压缩时;
每轮对话只有一次纯 IndexedDB 读（注入门牌, 零 LLM 零弹窗）。


Claude-Session: https://claude.ai/code/session_01UNPTphuTspZ7ydyAqRtpUo