### PR TITLE
fix(music): 设置页补上「恢复默认」，空地址保存时跟随中心 worker

### DIFF
--- a/apps/MusicApp.tsx
+++ b/apps/MusicApp.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useOS } from '../context/OSContext';
 import { useMusic, musicApi, normalizeCookie, toHttps, Song } from '../context/MusicContext';
+import { getProxyWorkerUrl } from '../utils/proxyWorker';
 import { DB } from '../utils/db';
 import { Gear, User as UserIcon, Crosshair, Play as PlayIcon, Pause as PauseIcon } from '@phosphor-icons/react';
 import {
@@ -445,7 +446,14 @@ const MusicApp: React.FC = () => {
   // ════════════════ 设置页 ════════════════
   const renderSettings = () => {
     const setDraft = (updates: Partial<typeof cfg>) => setCfg({ ...cfg, ...updates });
-    const commit = () => { addToast('已保存', 'success'); setView('search'); };
+    // 音乐的 worker 地址是独立持久化的，中心设置里的「恢复默认」管不到它——
+    // 这里必须自己兜底：地址清空就保存 = 跟随中心 worker，立即生效（不然存进空串，
+    // 请求会打相对路径直接挂，要等下次刷新 loadCfg 迁移才恢复）。
+    const commit = () => {
+      if (!cfg.workerUrl.trim()) setCfg({ ...cfg, workerUrl: getProxyWorkerUrl() });
+      addToast('已保存', 'success');
+      setView('search');
+    };
     return (
       <div className="flex flex-col h-full relative"
         style={{ background: `linear-gradient(180deg, #ffffff 0%, ${C.bg} 50%, ${C.bgDeep} 100%)` }}>
@@ -453,12 +461,19 @@ const MusicApp: React.FC = () => {
         <MizuHeader title="设置" onBack={() => setView('search')} />
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-5 text-sm relative z-10 shizuku-scrollbar">
           <div className="rounded-2xl p-3.5 shizuku-glass" style={{ boxShadow: `0 2px 16px ${C.glow}08` }}>
-            <div className="text-[10px] mb-2 tracking-wider flex items-center gap-1.5" style={{ color: C.muted }}>
-              <Sparkle size={6} color={C.glow} delay={0} /> 服务地址
+            <div className="text-[10px] mb-2 tracking-wider flex items-center justify-between" style={{ color: C.muted }}>
+              <span className="flex items-center gap-1.5"><Sparkle size={6} color={C.glow} delay={0} /> 服务地址</span>
+              {cfg.workerUrl.trim() !== getProxyWorkerUrl() && (
+                <button onClick={() => setDraft({ workerUrl: getProxyWorkerUrl() })}
+                  className="text-[9px] underline" style={{ color: C.muted }}>恢复默认</button>
+              )}
             </div>
             <input className="w-full rounded-xl px-3 py-2 outline-none text-xs shizuku-glass" value={cfg.workerUrl}
-              onChange={e => setDraft({ workerUrl: e.target.value })} placeholder="https://..."
+              onChange={e => setDraft({ workerUrl: e.target.value })} placeholder={getProxyWorkerUrl()}
               style={{ color: C.text }} />
+            <div className="text-[9px] mt-1.5 italic" style={{ color: C.faint }}>
+              留空保存 = 跟随「设置 → 自定义网络代理」的地址
+            </div>
           </div>
           <div className="rounded-2xl p-3.5 shizuku-glass" style={{ boxShadow: `0 2px 16px ${C.glow}08` }}>
             <div className="text-[10px] mb-2 tracking-wider flex items-center gap-1.5" style={{ color: C.muted }}>


### PR DESCRIPTION
音乐播放器的 worker 地址独立持久化，中心设置里的「恢复默认」管不到它，
而播放器设置页此前没有任何恢复默认的途径：清空输入框保存会存进空串，
网易云请求打到相对路径直接失败，要等下次刷新才被 loadCfg 迁移兜底——
表现就是「恢复默认保存后没真的恢复」。

- 服务地址栏新增「恢复默认」按钮（仅在偏离默认时显示），一键填回中心 worker
- 「保存」时地址为空 → 立即解析为中心 worker 并落盘，当场生效
- placeholder 直接显示当前默认地址，注明「留空保存 = 跟随自定义网络代理」


Claude-Session: https://claude.ai/code/session_01FQYA9NTjGEjVqxTaXGN2f4