### PR TITLE
fix(date): 见面立绘兜底不再捞到 chibi blobref 令牌——修"没传立绘的角色见面裂图"

### DIFF
--- a/components/date/DateSession.tsx
+++ b/components/date/DateSession.tsx
@@ -6,6 +6,8 @@ import { DB } from '../../utils/db';
 import DateSettings from './DateSettings';
 import ObserveHUD from './ObserveHUD';
 import { extractObservation, hasObservation } from '../../utils/datePrompts';
+import { pickDateFallbackSprite } from '../../utils/dateSprites';
+import { isBlobRef } from '../../utils/blobRef';
 import { clearDateResumeAttempt } from '../../utils/dateSessionRecovery';
 import { cleanTextForTts, VALID_EMOTIONS } from '../../utils/minimaxTts';
 import { synthesizeSpeech, characterHasVoice } from '../../utils/ttsRouter';
@@ -353,7 +355,9 @@ const DateSession: React.FC<DateSessionProps> = ({
             // Resume — 防御性回填：老快照 / 落库竞态可能缺字段，缺数组兜底成 []，
             // 否则后续 dialogueQueue.length 等取值会抛异常连累整个会话渲染。
             setBgImage(initialState.bgImage || '');
-            setCurrentSprite(initialState.currentSprite || '');
+            // 老快照可能存了 blobref 令牌当立绘（chibi 误兜底期间落库的），不能直接喂 <img>，洗成头像
+            const resumedSprite = initialState.currentSprite || '';
+            setCurrentSprite(isBlobRef(resumedSprite) ? (char.avatar || '') : resumedSprite);
             setCurrentText(initialState.currentText || '');
             setDisplayedText(initialState.currentText || '');
             setDialogueQueue(Array.isArray(initialState.dialogueQueue) ? initialState.dialogueQueue : []);
@@ -368,13 +372,7 @@ const DateSession: React.FC<DateSessionProps> = ({
                 }
                 return char.sprites;
             })();
-            let initSprite = s?.['normal'] || s?.['default'];
-            if (!initSprite && s) {
-                const fallbackKey = dateEmotionKeys.find(k => s[k]);
-                initSprite = fallbackKey ? s[fallbackKey] : Object.values(s).find(v => v) || char.avatar;
-            }
-            if (!initSprite) initSprite = char.avatar;
-            setCurrentSprite(initSprite);
+            setCurrentSprite(pickDateFallbackSprite(s, dateEmotionKeys, char.avatar) || '');
             
             // Parse Peek Status as opening — 先剥出观测块（开了 OBSERVE 才有）
             const startText = peekStatus || "Waiting for connection...";

--- a/components/date/DateSettings.tsx
+++ b/components/date/DateSettings.tsx
@@ -3,6 +3,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { useOS } from '../../context/OSContext';
 import { CharacterProfile, SpriteConfig, SkinSet, DateStyleConfig } from '../../types';
 import { processImage } from '../../utils/file';
+import { pickDateFallbackSprite } from '../../utils/dateSprites';
 import { DATE_STYLE_PRESETS } from '../../utils/datePrompts';
 import ObserveSettings from './ObserveSettings';
 
@@ -82,7 +83,11 @@ const DateSettings: React.FC<DateSettingsProps> = ({ char, onBack }) => {
         }
         return sprites;
     }, [activeSkinId, skinSets, sprites]);
-    const currentSpriteImg = previewSprites['normal'] || previewSprites['default'] || Object.values(previewSprites)[0] || char.avatar;
+    const currentSpriteImg = pickDateFallbackSprite(
+        previewSprites,
+        [...REQUIRED_EMOTIONS, ...(char.customDateSprites || [])],
+        char.avatar,
+    );
 
     const triggerUpload = (target: 'bg' | 'sprite', emotionKey?: string) => {
         setUploadTarget(target);

--- a/docs/chibi-studio.md
+++ b/docs/chibi-studio.md
@@ -10,6 +10,8 @@
 | `vr` | 彼方 VRWorldApp | `char.vrState.chibi.img`（scale/offsetY/flip 保留不动） | dataURL |
 | `like520` | 特别时光 520 活动 | 已通关：`char.specialMomentRecords['like520_2026'].customData.charChibi`；未通关：`char.chibiStudio.like520.img` 兜底 | dataURL |
 
+> ⚠️ `char.sprites` 是混装袋：`chibi`（blobref 令牌）与见面情绪立绘同居一个对象。任何「从 sprites 里随便挑一张当立绘」的兜底都必须跳过 `chibi` 键和 blobref 值（不能直接当 `<img src>`），统一走 `utils/dateSprites.ts` 的 `pickDateFallbackSprite`——否则会复现「没传见面立绘的角色，捏完 Q 版后见面模式裂图」。
+
 捏人器完整导出 state（选件 + 换色 + 翻转 + 眼型…）按槽位存 `char.chibiStudio.{room,vr,like520}.state`（`types.ts` 的 `ChibiStudioData`），再编辑时整套还原。`chibiStudio` 属运行时本地状态，已加入 `CARD_STRIPPED_FIELDS`（角色卡导出/导入双向剥离）。
 
 ## 关键文件

--- a/utils/dateSprites.test.ts
+++ b/utils/dateSprites.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { pickDateFallbackSprite } from './dateSprites';
+
+const KEYS = ['normal', 'happy', 'angry', 'sad', 'shy'];
+const AVATAR = 'data:image/png;base64,AVATAR';
+
+describe('pickDateFallbackSprite', () => {
+    it('优先 normal / default', () => {
+        expect(pickDateFallbackSprite({ normal: 'data:n', happy: 'data:h' }, KEYS, AVATAR)).toBe('data:n');
+        expect(pickDateFallbackSprite({ default: 'data:d' }, KEYS, AVATAR)).toBe('data:d');
+    });
+
+    it('无 normal 时按见面情绪键兜底', () => {
+        expect(pickDateFallbackSprite({ shy: 'data:s' }, KEYS, AVATAR)).toBe('data:s');
+        expect(pickDateFallbackSprite({ excited: 'data:e' }, [...KEYS, 'excited'], AVATAR)).toBe('data:e');
+    });
+
+    it('只有 chibi（blobref 令牌）时回落到头像，绝不把令牌当 img src', () => {
+        expect(pickDateFallbackSprite({ chibi: 'blobref:img_abc' }, KEYS, AVATAR)).toBe(AVATAR);
+    });
+
+    it('chibi 即使是 dataURL 也不当见面立绘用', () => {
+        expect(pickDateFallbackSprite({ chibi: 'data:image/png;base64,CHIBI' }, KEYS, AVATAR)).toBe(AVATAR);
+    });
+
+    it('非 chibi 的杂项键、可直接渲染的值仍可兜底（保留旧行为）', () => {
+        expect(pickDateFallbackSprite({ legacy_pose: 'https://img.example/a.png' }, KEYS, AVATAR)).toBe('https://img.example/a.png');
+    });
+
+    it('杂项键但值是 blobref 令牌 → 跳过，回落头像', () => {
+        expect(pickDateFallbackSprite({ legacy_pose: 'blobref:img_xyz' }, KEYS, AVATAR)).toBe(AVATAR);
+    });
+
+    it('空 sprites / undefined → 头像；连头像都没有 → undefined', () => {
+        expect(pickDateFallbackSprite({}, KEYS, AVATAR)).toBe(AVATAR);
+        expect(pickDateFallbackSprite(undefined, KEYS, AVATAR)).toBe(AVATAR);
+        expect(pickDateFallbackSprite(undefined, KEYS, undefined)).toBeUndefined();
+    });
+});

--- a/utils/dateSprites.ts
+++ b/utils/dateSprites.ts
@@ -1,0 +1,26 @@
+// 见面模式（DateApp）立绘兜底选择。
+//
+// 背景：char.sprites 是个混装袋——除了见面情绪立绘（normal/happy/…/自定义），还装着
+// 小小窝的房间立绘 sprites['chibi']。7.10 更新后，小小窝上传 / QQ捏人工坊写入的 chibi
+// 是 `blobref:<id>` 令牌（见 utils/blobRef.ts），不能直接当 <img src> 用。
+// 老的兜底写法 `Object.values(sprites)[0]` 会在头像之前捞到它 → 没传见面立绘、
+// 一直靠头像显示的角色，见面模式直接裂图。
+//
+// 这里统一兜底顺序：normal/default → 见面情绪键 → 其它可直接渲染的 sprite
+// （跳过 chibi 键与一切 blobref 令牌）→ 头像。
+import { isBlobRef } from './blobRef';
+
+export function pickDateFallbackSprite(
+    sprites: Record<string, string> | undefined | null,
+    dateEmotionKeys: string[],
+    avatar?: string,
+): string | undefined {
+    const s = sprites || {};
+    const direct = s['normal'] || s['default'];
+    if (direct && !isBlobRef(direct)) return direct;
+    const emoKey = dateEmotionKeys.find(k => s[k] && !isBlobRef(s[k]));
+    if (emoKey) return s[emoKey];
+    const stray = Object.entries(s).find(([k, v]) => v && k !== 'chibi' && !isBlobRef(v));
+    if (stray) return stray[1];
+    return avatar;
+}


### PR DESCRIPTION
7.10 更新后，小小窝房间立绘上传 / QQ捏人工坊写入的 char.sprites['chibi'] 是 blobref:<id> 令牌（不能直接当 <img src>）。而见面模式两处兜底用
Object.values(sprites) 随手挑第一张，会在头像之前捞到它：
没传见面情绪立绘、一直靠头像显示的角色，捏完 Q 版后进见面/场景布置直接裂图，
且只有被捏过的那只角色出问题（用户反馈特征完全吻合）。

- 新增 utils/dateSprites.ts pickDateFallbackSprite：normal/default → 见面情绪键 → 其它可渲染 sprite（跳过 chibi 键与一切 blobref 值）→ 头像，DateSession 开局与 DateSettings 预览统一走它
- 恢复会话（继续上次）时把老快照里存下的 blobref currentSprite 洗成头像
- docs/chibi-studio.md 补坑位说明；utils/dateSprites.test.ts 7 条回归


Claude-Session: https://claude.ai/code/session_013TTYihuYXgUox8FY1gmNmz