### PR TITLE
修复用户反馈的三连丢失：localStorage 被清后主题/盲盒/API 配置的兜底与反馈

### DIFF
--- a/apps/RoomApp.tsx
+++ b/apps/RoomApp.tsx
@@ -681,7 +681,12 @@ const RoomApp: React.FC = () => {
     };
 
     const initializeRoomState = async (c: CharacterProfile, currentItems: RoomItem[], force: boolean = false) => {
-        if (!apiConfig.apiKey) return;
+        // 不能静默 return：API 配置缺失时「更新这一天」会变成点了毫无反应的死按钮
+        // （用户现场：localStorage 被清 → os_api_config 丢失 → 此处静默退出）。
+        if (!apiConfig?.baseUrl || !apiConfig?.apiKey) {
+            addToast('请先在设置里配置 API（生成今日房间需要调用模型）', 'error');
+            return;
+        }
 
         setIsInitializing(true);
         const loadingTexts = [`正在打扫${c.name}的房间...`, "正在整理思绪...", "正在擦拭家具...", "正在生成全部物品记忆..."];

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -33,6 +33,7 @@ import { Capacitor } from '@capacitor/core';
 import { formatBytes } from '../utils/format';
 import { isEmotionEvalSkipped } from '../utils/devDebug';
 import { toMountedWorldbook } from '../utils/worldbook';
+import { initLocalStorageMirror } from '../utils/lsMirror';
 // 备份用：把存在 localStorage 的本机配置随导出一起带走（键名须与 importFullData 对齐）
 import { exportPostOfficeLocal } from '../utils/vrWorld/postOffice';
 import { exportSignalLocal } from '../utils/vrWorld/signal';
@@ -1096,6 +1097,15 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
         // 接口未授权会直接 reject —— 我们不在乎结果，吞掉异常。
         if (typeof navigator !== 'undefined' && navigator.storage && typeof navigator.storage.persist === 'function') {
             navigator.storage.persist().catch(() => {});
+        }
+
+        // localStorage 镜像回填：部分浏览器/清理工具会只清 localStorage 而留下 IndexedDB，
+        // 导致「主题回初始 / 盲盒收藏册清空 / API 配置丢失」三连。必须在 loadSettings
+        // 读 localStorage 之前完成回填。见 utils/lsMirror.ts。
+        const healedKeys = await initLocalStorageMirror().catch(() => [] as string[]);
+        if (healedKeys.length > 0) {
+            console.warn('[lsMirror] localStorage 疑似被清除，已从 IndexedDB 镜像回填:', healedKeys);
+            setTimeout(() => addToast(`检测到本地设置曾被浏览器清除，已自动恢复 ${healedKeys.length} 项（主题 / API 等）`, 'info'), 2500);
         }
 
         await loadSettings();
@@ -2178,7 +2188,13 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     // Clear data URI font from LS, keep URL font
     if (lsTheme.customFont && lsTheme.customFont.startsWith('data:')) lsTheme.customFont = '';
 
-    localStorage.setItem('os_theme', JSON.stringify(lsTheme));
+    try {
+        localStorage.setItem('os_theme', JSON.stringify(lsTheme));
+    } catch (e) {
+        // quota 满时静默失败 = 用户这次看着正常、下次启动主题回初始。必须让用户知道。
+        console.warn('[updateTheme] localStorage 写入失败', e);
+        addToast('主题没能保存到本地（存储空间可能已满），重启后可能会还原', 'error');
+    }
   };
   const updateApiConfig = (updates: Partial<APIConfig>) => { const newConfig = { ...apiConfig, ...updates }; setApiConfig(newConfig); localStorage.setItem('os_api_config', JSON.stringify(newConfig)); };
   const updateRealtimeConfig = (updates: Partial<RealtimeConfig>) => { const newConfig = { ...realtimeConfig, ...updates }; setRealtimeConfig(newConfig); localStorage.setItem('os_realtime_config', JSON.stringify(newConfig)); };
@@ -2555,7 +2571,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       try {
           localStorage.setItem('os_theme', JSON.stringify(lsTheme));
       } catch (e) {
+          // 静默跳过 = 预设这次看着已应用、下次启动却回初始主题。必须提示。
           console.warn('[applyAppearancePreset] localStorage 写入失败，已跳过', e);
+          addToast('主题没能保存到本地（存储空间可能已满），重启后可能会还原', 'error');
       }
       applyCustomFont(preset.theme.customFont);
       // Apply custom icons if present

--- a/utils/lsMirror.test.ts
+++ b/utils/lsMirror.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DB } from './db';
+import { MIRRORED_KEYS, healLocalStorageMirror, snapshotLocalStorageMirror } from './lsMirror';
+
+// localStorage 镜像：模拟"浏览器清了 localStorage 但 IndexedDB 幸存"的用户现场
+// （主题回初始 / 盲盒收藏册清空 / API 配置丢失导致「更新这一天」无反应）。
+describe('localStorage IndexedDB 镜像 (lsMirror)', () => {
+    beforeEach(async () => {
+        localStorage.clear();
+        await DB.saveAssetRaw('ls_mirror_v1', null as any).catch(() => {});
+    });
+
+    it('快照 → localStorage 被清 → 回填恢复', async () => {
+        localStorage.setItem('os_theme', '{"hue":300}');
+        localStorage.setItem('os_api_config', '{"baseUrl":"https://x","apiKey":"sk-1","model":"m"}');
+        localStorage.setItem('os_dream_collection', '{"sweet":{"firstAt":1,"count":2}}');
+        await snapshotLocalStorageMirror();
+
+        localStorage.clear(); // 模拟浏览器驱逐
+
+        const restored = await healLocalStorageMirror();
+        expect(restored.sort()).toEqual(['os_api_config', 'os_dream_collection', 'os_theme']);
+        expect(localStorage.getItem('os_theme')).toBe('{"hue":300}');
+        expect(localStorage.getItem('os_dream_collection')).toBe('{"sweet":{"firstAt":1,"count":2}}');
+    });
+
+    it('localStorage 已有值时回填不覆盖（真值永远是 localStorage）', async () => {
+        localStorage.setItem('os_theme', '{"hue":1}');
+        await snapshotLocalStorageMirror();
+
+        localStorage.setItem('os_theme', '{"hue":2}'); // 用户之后又改了主题
+        const restored = await healLocalStorageMirror();
+        expect(restored).toEqual([]);
+        expect(localStorage.getItem('os_theme')).toBe('{"hue":2}');
+    });
+
+    it('removeItem 语义：新快照不再含已删除的键，回填不会复活它', async () => {
+        localStorage.setItem('study_api_config', '{"baseUrl":"https://private"}');
+        localStorage.setItem('os_theme', '{"hue":9}');
+        await snapshotLocalStorageMirror();
+
+        localStorage.removeItem('study_api_config'); // 用户点了「恢复使用全局 API」
+        await snapshotLocalStorageMirror();          // 页面隐藏/定时快照跟进
+
+        localStorage.clear();
+        const restored = await healLocalStorageMirror();
+        expect(restored).toEqual(['os_theme']);
+        expect(localStorage.getItem('study_api_config')).toBeNull();
+    });
+
+    it('localStorage 全空时不写快照（不拿空覆盖有效镜像）', async () => {
+        localStorage.setItem('os_theme', '{"hue":7}');
+        await snapshotLocalStorageMirror();
+
+        localStorage.clear();
+        await snapshotLocalStorageMirror(); // 空的，应当被忽略
+
+        const restored = await healLocalStorageMirror();
+        expect(restored).toEqual(['os_theme']);
+    });
+
+    it('没有镜像时回填静默返回空数组', async () => {
+        const restored = await healLocalStorageMirror();
+        expect(restored).toEqual([]);
+    });
+
+    it('镜像键名单不含大体积键（data URI 类必须走 assets）', () => {
+        for (const k of MIRRORED_KEYS) {
+            expect(k).not.toMatch(/wallpaper|font|sprite|image|blob/i);
+        }
+    });
+});

--- a/utils/lsMirror.ts
+++ b/utils/lsMirror.ts
@@ -1,0 +1,119 @@
+/**
+ * 关键 localStorage 键的 IndexedDB 镜像（防浏览器"清 localStorage 但留 IndexedDB"式驱逐）。
+ *
+ * 背景：有用户遇到「主题回初始 + 梦境盲盒收藏册清空 + 小窝『更新这一天』点了没反应」
+ * 三连——三个症状对应的持久化恰好全在 localStorage（os_theme / os_dream_collection /
+ * os_api_config），而角色、聊天记录（IndexedDB）完好。部分移动端浏览器/系统清理工具
+ * 会只清 WebView 的 localStorage 而留下 IndexedDB，重新导入云备份后一切恢复也与此吻合。
+ *
+ * 方案：把「备份体系里也会带走的那批小体积配置键」定期快照进 IndexedDB assets 表；
+ * 启动时若发现某键在 localStorage 里缺失而镜像里有，就回填。真值仍是 localStorage，
+ * 镜像只在"丢了"的时候兜底——localStorage 里已有的值永远优先，不会被镜像覆盖。
+ *
+ * 注意 removeItem 语义：个别键（如 study_api_config）以"删除 = 恢复默认"为语义，
+ * 所以镜像必须靠频繁快照（启动后 / 页面隐藏 / pagehide / 定时）及时把删除同步进去，
+ * 避免启动回填把用户已删除的配置复活。实际的复活窗口 ≈ "删完立刻杀进程且没触发过
+ * 一次 pagehide"，可以接受。
+ */
+
+import { DB } from './db';
+
+/**
+ * 参与镜像的键。收录标准：用户手动配置或长期积累、丢了没法凭空再生、体积是小段
+ * JSON/字符串（严禁 data URI 等大体积——那些本来就该走 assets/blob 存储）。
+ * 这份名单与「设置 → 导出备份」带走的 localStorage 键保持同一批（见 OSContext
+ * exportFullData / importFullData），新增备份键时记得两边同步。
+ */
+export const MIRRORED_KEYS: readonly string[] = [
+    'os_theme',                          // 外观主题（丢了 = 回初始主题）
+    'os_api_config',                     // 全局 API（丢了 = 一切生成静默失效）
+    'os_api_presets',
+    'os_realtime_config',
+    'os_memory_palace_config',
+    'os_remote_vector_config',
+    'os_cloud_backup_config',            // 丢了连"从云端恢复"都要重新配
+    'os_dream_collection',               // 梦境盲盒收藏册（账号级图鉴，纯积累不可再生）
+    'world_home_api',                    // 家园全局 API 覆盖
+    'study_api_config',
+    'study_tutor_presets',
+    'instant_push_config_v1',
+    'push_vapid_v1',                     // VAPID 密钥对，须与浏览器既有推送订阅匹配
+    'chat_archive_prompts',
+    'chat_active_archive_prompt_id',
+    'character_refine_prompts',
+    'character_active_refine_prompt_id',
+    'os_last_active_char_id',
+];
+
+const MIRROR_ASSET_ID = 'ls_mirror_v1';
+const SNAPSHOT_INTERVAL_MS = 5 * 60_000;
+
+type MirrorPayload = { savedAt: number; data: Record<string, string> };
+
+/**
+ * 启动回填：镜像里有、localStorage 里没有的键写回 localStorage。
+ * 返回被回填的键名（空数组 = localStorage 完好或没有镜像）。
+ * 必须在任何读 localStorage 的初始化逻辑（OSContext.loadSettings 等）之前 await。
+ */
+export async function healLocalStorageMirror(): Promise<string[]> {
+    let payload: MirrorPayload | null = null;
+    try {
+        payload = await DB.getAssetRaw(MIRROR_ASSET_ID);
+    } catch {
+        return [];
+    }
+    const data = payload?.data;
+    if (!data || typeof data !== 'object') return [];
+
+    const restored: string[] = [];
+    for (const key of MIRRORED_KEYS) {
+        const v = data[key];
+        if (typeof v !== 'string') continue;
+        try {
+            if (localStorage.getItem(key) === null) {
+                localStorage.setItem(key, v);
+                restored.push(key);
+            }
+        } catch {
+            // quota 满 / 私有模式写不进：兜底失败就算了，不能让启动流程挂掉
+        }
+    }
+    return restored;
+}
+
+/** 把当前 localStorage 里的镜像键快照进 IndexedDB。全部缺失时不写（避免拿空快照覆盖有效镜像）。 */
+export async function snapshotLocalStorageMirror(): Promise<void> {
+    const data: Record<string, string> = {};
+    for (const key of MIRRORED_KEYS) {
+        try {
+            const v = localStorage.getItem(key);
+            if (v !== null) data[key] = v;
+        } catch { /* ignore */ }
+    }
+    if (Object.keys(data).length === 0) return;
+    try {
+        await DB.saveAssetRaw(MIRROR_ASSET_ID, { savedAt: Date.now(), data } satisfies MirrorPayload);
+    } catch { /* 镜像写失败不影响主流程 */ }
+}
+
+let listenersAttached = false;
+
+/**
+ * 应用启动时调一次：先回填、再拍一张新快照，并挂上"页面隐藏 / 关闭 / 定时"的快照钩子。
+ * 返回回填的键名，调用方可据此提示用户"本地设置曾丢失，已自动恢复"。
+ */
+export async function initLocalStorageMirror(): Promise<string[]> {
+    const restored = await healLocalStorageMirror();
+    await snapshotLocalStorageMirror();
+
+    if (!listenersAttached && typeof window !== 'undefined' && typeof document !== 'undefined') {
+        listenersAttached = true;
+        const snap = () => { void snapshotLocalStorageMirror(); };
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') snap();
+        });
+        window.addEventListener('pagehide', snap);
+        setInterval(snap, SNAPSHOT_INTERVAL_MS);
+    }
+    return restored;
+}


### PR DESCRIPTION
用户现场：主题回初始 + 梦境盲盒收藏册清空 + 小窝「更新这一天」点了毫无反应，
重新导入云备份后全部恢复。三个症状对应的持久化恰好全在 localStorage
（os_theme / os_dream_collection / os_api_config），而角色、聊天等 IndexedDB 数据完好——判定为浏览器/系统清理只清了 localStorage 而留下 IndexedDB。
与删除同名角色无关（deleteCharacter 只按 id 删角色本体，盲盒是账号级）。

- 新增 utils/lsMirror.ts：把备份体系同一批的小体积配置键定期快照进 IndexedDB assets，启动时发现 localStorage 缺失就回填并提示用户； localStorage 已有值永远优先，快照跟随页面隐藏/pagehide/定时刷新， removeItem 语义的键（study_api_config）不会被复活
- RoomApp「更新这一天」：API 配置缺失时从静默 return 改为明确报错提示 （这正是用户看到的"点了没反应没反馈"）
- 主题写 localStorage 失败（quota 满）从静默丢失/静默跳过改为 toast 提醒， 否则用户当天看着正常、重启就回初始主题


Claude-Session: https://claude.ai/code/session_01A11gi8Zbcyos96Wx4MseXG