### PR TITLE
优化世界书分组选择与表情包面板的大数据量性能

### DIFF
--- a/apps/Character.tsx
+++ b/apps/Character.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { useOS } from '../context/OSContext';
 import { AppID, CharacterProfile, CharacterExportData, UserImpression, MemoryFragment } from '../types';
 import { SlidersHorizontal, SpeakerHigh, Books, BookOpen } from '@phosphor-icons/react';
@@ -135,6 +135,9 @@ const Character: React.FC = () => {
   const [showBatchModal, setShowBatchModal] = useState(false); 
   const [deleteConfirmTarget, setDeleteConfirmTarget] = useState<string | null>(null);
   const [showWorldbookModal, setShowWorldbookModal] = useState(false); // New Modal
+  // 挂载世界书弹窗：搜索词 + 当前展开的分组（分组默认折叠，避免全量条目一次性渲染卡爆）
+  const [wbModalSearch, setWbModalSearch] = useState('');
+  const [wbModalExpandedCategory, setWbModalExpandedCategory] = useState<string | null>(null);
   const [showGroupModal, setShowGroupModal] = useState(false); // 角色分组管理
   const [newGroupName, setNewGroupName] = useState('');
   // 编辑页「新建分组并指派」的内联输入
@@ -360,6 +363,36 @@ const Character: React.FC = () => {
       if (!formData) return;
       const currentBooks = formData.mountedWorldbooks || [];
       handleChange('mountedWorldbooks', currentBooks.filter(b => b.id !== bookId));
+  };
+
+  // 挂载弹窗的分组数据。必须 useMemo：之前这段 reduce 内联在 JSX 里，
+  // 弹窗没打开时整个编辑表单每敲一个字都会重新分组一遍全部世界书。
+  const wbModalGroups = useMemo(() => {
+      const groups: Record<string, typeof worldbooks> = {};
+      worldbooks.forEach(wb => {
+          const cat = wb.category || '未分类设定 (General)';
+          if (!groups[cat]) groups[cat] = [];
+          groups[cat].push(wb);
+      });
+      return Object.entries(groups);
+  }, [worldbooks]);
+
+  // 搜索态：按标题/分组名过滤，最多展示前 60 条避免长列表卡顿。
+  const WB_SEARCH_LIMIT = 60;
+  const wbModalSearchResults = useMemo(() => {
+      const query = wbModalSearch.trim().toLowerCase();
+      if (!query) return null;
+      const matched = worldbooks.filter(wb =>
+          wb.title.toLowerCase().includes(query) ||
+          (wb.category || '未分类设定 (General)').toLowerCase().includes(query)
+      );
+      return { books: matched.slice(0, WB_SEARCH_LIMIT), total: matched.length };
+  }, [worldbooks, wbModalSearch]);
+
+  const openWorldbookModal = () => {
+      setWbModalSearch('');
+      setWbModalExpandedCategory(null);
+      setShowWorldbookModal(true);
   };
 
   // ... (Other handlers unchanged)
@@ -1523,7 +1556,7 @@ ${isInitialGeneration ? `
                            <div>
                                <div className="flex justify-between items-center mb-2 px-1">
                                    <label className="text-[10px] font-bold text-indigo-500 uppercase tracking-widest block flex items-center gap-1"><Books size={12} /> 扩展设定 (Worldbooks)</label>
-                                   <button onClick={() => setShowWorldbookModal(true)} className="text-[10px] bg-indigo-50 text-indigo-600 px-2 py-1 rounded font-bold hover:bg-indigo-100">+ 挂载</button>
+                                   <button onClick={openWorldbookModal} className="text-[10px] bg-indigo-50 text-indigo-600 px-2 py-1 rounded font-bold hover:bg-indigo-100">+ 挂载</button>
                                 </div>
                                 <div className="space-y-2">
                                    {formData.mountedWorldbooks && formData.mountedWorldbooks.length > 0 ? (
@@ -1707,47 +1740,96 @@ ${isInitialGeneration ? `
             title="挂载世界书" 
             onClose={() => setShowWorldbookModal(false)} 
         >
-            <div className="max-h-[50vh] overflow-y-auto no-scrollbar space-y-4 p-1">
+            <div className="max-h-[50vh] overflow-y-auto no-scrollbar space-y-3 p-1">
                 {worldbooks.length === 0 ? (
                     <div className="text-center text-slate-400 text-xs py-8">
                         还没有世界书，请去桌面【世界书】App 创建。
                     </div>
                 ) : (
-                    // Group books for UI
-                    Object.entries(worldbooks.reduce((acc, wb) => {
-                        const cat = wb.category || '未分类设定 (General)';
-                        if (!acc[cat]) acc[cat] = [];
-                        acc[cat].push(wb);
-                        return acc;
-                    }, {} as Record<string, typeof worldbooks>)).map(([category, books]) => (
-                        <div key={category} className="space-y-2">
-                            <div className="flex justify-between items-center px-1">
-                                <h4 className="text-xs font-bold text-slate-400 uppercase tracking-wider">{category}</h4>
-                                <button 
-                                    onClick={() => mountCategory(category)}
-                                    className="text-[10px] bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded font-bold hover:bg-indigo-100"
-                                >
-                                    挂载整组
-                                </button>
+                    <>
+                        <input
+                            value={wbModalSearch}
+                            onChange={e => setWbModalSearch(e.target.value)}
+                            placeholder="搜索世界书标题或分组..."
+                            className="w-full px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm text-slate-700 outline-none focus:bg-white focus:border-indigo-300 transition-all"
+                        />
+                        {wbModalSearchResults ? (
+                            // 搜索态：扁平结果列表
+                            <div className="space-y-2">
+                                {wbModalSearchResults.books.length === 0 ? (
+                                    <div className="text-center text-slate-400 text-xs py-6">没有匹配的世界书。</div>
+                                ) : (
+                                    wbModalSearchResults.books.map(wb => {
+                                        const isMounted = formData?.mountedWorldbooks?.some(m => m.id === wb.id);
+                                        return (
+                                            <button
+                                                key={wb.id}
+                                                onClick={() => !isMounted && mountWorldbook(wb.id)}
+                                                disabled={isMounted}
+                                                className={`w-full p-3 rounded-xl border text-left transition-all ${isMounted ? 'bg-slate-50 border-slate-200 opacity-50 cursor-not-allowed' : 'bg-white border-indigo-100 hover:border-indigo-300 shadow-sm active:scale-95'}`}
+                                            >
+                                                <div className="flex justify-between items-center gap-2">
+                                                    <span className="font-bold text-slate-700 text-sm truncate">{wb.title}</span>
+                                                    {isMounted && <span className="text-[10px] text-slate-400 shrink-0">已挂载</span>}
+                                                </div>
+                                                <div className="text-[10px] text-slate-400 truncate mt-0.5">{wb.category || '未分类设定 (General)'}</div>
+                                            </button>
+                                        );
+                                    })
+                                )}
+                                {wbModalSearchResults.total > wbModalSearchResults.books.length && (
+                                    <div className="text-center text-[10px] text-slate-400 py-1">
+                                        共 {wbModalSearchResults.total} 条匹配，仅显示前 {wbModalSearchResults.books.length} 条，请继续输入缩小范围。
+                                    </div>
+                                )}
                             </div>
-                            {books.map(wb => {
-                                const isMounted = formData?.mountedWorldbooks?.some(m => m.id === wb.id);
+                        ) : (
+                            // 默认态：分组手风琴，只渲染展开分组的条目
+                            wbModalGroups.map(([category, books]) => {
+                                const isExpanded = wbModalExpandedCategory === category;
                                 return (
-                                    <button 
-                                        key={wb.id} 
-                                        onClick={() => !isMounted && mountWorldbook(wb.id)}
-                                        disabled={isMounted}
-                                        className={`w-full p-4 rounded-xl border text-left transition-all ${isMounted ? 'bg-slate-50 border-slate-200 opacity-50 cursor-not-allowed' : 'bg-white border-indigo-100 hover:border-indigo-300 shadow-sm active:scale-95'}`}
-                                    >
-                                        <div className="flex justify-between items-center mb-1">
-                                            <span className="font-bold text-slate-700 text-sm truncate">{wb.title}</span>
-                                            {isMounted && <span className="text-[10px] text-slate-400">已挂载</span>}
+                                    <div key={category} className="rounded-xl border border-slate-100 bg-slate-50/50 overflow-hidden">
+                                        <div
+                                            onClick={() => setWbModalExpandedCategory(isExpanded ? null : category)}
+                                            className="flex items-center gap-2 px-3 py-2.5 cursor-pointer select-none"
+                                        >
+                                            <span className={`transition-transform duration-200 text-slate-400 ${isExpanded ? 'rotate-90' : ''}`}>
+                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3.5 h-3.5"><path fillRule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clipRule="evenodd" /></svg>
+                                            </span>
+                                            <h4 className="flex-1 min-w-0 text-xs font-bold text-slate-500 truncate">{category}</h4>
+                                            <span className="text-[10px] text-slate-400 shrink-0">{books.length}</span>
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); mountCategory(category); }}
+                                                className="text-[10px] bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded font-bold hover:bg-indigo-100 shrink-0"
+                                            >
+                                                挂载整组
+                                            </button>
                                         </div>
-                                    </button>
+                                        {isExpanded && (
+                                            <div className="px-2 pb-2 space-y-2">
+                                                {books.map(wb => {
+                                                    const isMounted = formData?.mountedWorldbooks?.some(m => m.id === wb.id);
+                                                    return (
+                                                        <button
+                                                            key={wb.id}
+                                                            onClick={() => !isMounted && mountWorldbook(wb.id)}
+                                                            disabled={isMounted}
+                                                            className={`w-full p-3 rounded-xl border text-left transition-all ${isMounted ? 'bg-slate-50 border-slate-200 opacity-50 cursor-not-allowed' : 'bg-white border-indigo-100 hover:border-indigo-300 shadow-sm active:scale-95'}`}
+                                                        >
+                                                            <div className="flex justify-between items-center gap-2">
+                                                                <span className="font-bold text-slate-700 text-sm truncate">{wb.title}</span>
+                                                                {isMounted && <span className="text-[10px] text-slate-400 shrink-0">已挂载</span>}
+                                                            </div>
+                                                        </button>
+                                                    );
+                                                })}
+                                            </div>
+                                        )}
+                                    </div>
                                 );
-                            })}
-                        </div>
-                    ))
+                            })
+                        )}
+                    </>
                 )}
             </div>
         </Modal>

--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -12,6 +12,7 @@ import { processImage } from '../utils/file';
 import { stickerNameFromUrl } from '../utils/messageFormat';
 import { DEFAULT_ARCHIVE_PROMPTS } from '../components/chat/ChatConstants';
 import { CharacterGroupFilterBar, filterCharactersByGroup, GROUP_FILTER_ALL } from '../components/character/CharacterGroupFilter';
+import { useIncrementalReveal } from '../hooks/useIncrementalReveal';
 import { UsersThree } from '@phosphor-icons/react';
 
 const TWEMOJI_BASE = 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72';
@@ -223,6 +224,8 @@ const GroupChat: React.FC = () => {
 
     // Data State
     const [emojis, setEmojis] = useState<{name: string, url: string, categoryId?: string}[]>([]);
+    // 表情抽屉增量渲染：表情多时一次性挂载几百张 base64 图会卡爆
+    const { count: visibleEmojiCount, hasMore: hasMoreEmojis, sentinelRef: emojiSentinelRef } = useIncrementalReveal(emojis.length, 60, showEmojiPicker);
     const [categories, setCategories] = useState<EmojiCategory[]>([]); // New
     
     // Create/Edit Group State
@@ -1401,12 +1404,17 @@ ${attachedImagesNote}
                 {showEmojiPicker && (
                     <div className="h-64 bg-[#f0f2f5] border-t border-slate-200 p-4 animate-slide-up overflow-y-auto no-scrollbar">
                         <div className="grid grid-cols-5 gap-3">
-                            {emojis.map((e, i) => (
+                            {emojis.slice(0, visibleEmojiCount).map((e, i) => (
                                 <button key={i} onClick={() => handleSendMessage(e.url, 'emoji')} className="aspect-square bg-white rounded-xl p-2 border border-slate-200 shadow-sm active:scale-95 flex items-center justify-center">
-                                    <img src={e.url} className="w-full h-full object-contain pointer-events-none" />
+                                    <img src={e.url} loading="lazy" decoding="async" className="w-full h-full object-contain pointer-events-none" />
                                 </button>
                             ))}
                         </div>
+                        {hasMoreEmojis && (
+                            <div ref={emojiSentinelRef} className="py-3 text-center text-[10px] text-slate-400">
+                                加载中... ({visibleEmojiCount}/{emojis.length})
+                            </div>
+                        )}
                     </div>
                 )}
             </div>

--- a/apps/WorldbookApp.tsx
+++ b/apps/WorldbookApp.tsx
@@ -30,6 +30,7 @@ const WorldbookApp: React.FC = () => {
     const [tempTitle, setTempTitle] = useState('');
     const [tempContent, setTempContent] = useState('');
     const [tempCategory, setTempCategory] = useState('');
+    const [showCategoryPicker, setShowCategoryPicker] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showImportConfirm, setShowImportConfirm] = useState(false);
     const importRef = useRef<HTMLInputElement>(null);
@@ -52,20 +53,30 @@ const WorldbookApp: React.FC = () => {
     const groupedBooks = useMemo(() => {
         const groups: Record<string, Worldbook[]> = {};
         const defaultCat = '未分类设定 (General)';
-        
+
         worldbooks.forEach(wb => {
             const cat = wb.category || defaultCat;
             if (!groups[cat]) groups[cat] = [];
             groups[cat].push(wb);
         });
-        
+
         // Auto-expand the first category if none selected and groups exist
         if (!expandedCategory && Object.keys(groups).length > 0) {
             // setExpandedCategory(Object.keys(groups)[0]); // Optional: Auto open first
         }
-        
+
         return groups;
     }, [worldbooks]);
+
+    const categoryNames = useMemo(() => Object.keys(groupedBooks), [groupedBooks]);
+
+    // 编辑页「已有分组」建议列表：随输入实时过滤。
+    // 不能用原生 datalist —— 分组一多，移动端 WebView 会把候选渲染成撑爆屏幕、无法滚动的巨型下拉。
+    const filteredCategorySuggestions = useMemo(() => {
+        const query = tempCategory.trim().toLowerCase();
+        if (!query) return categoryNames;
+        return categoryNames.filter(cat => cat.toLowerCase().includes(query));
+    }, [categoryNames, tempCategory]);
 
     const handleCreate = () => {
         setEditingBook(null); 
@@ -86,6 +97,7 @@ const WorldbookApp: React.FC = () => {
         setTempProbability(100);
         setTempCaseSensitive(false);
         setTempWholeWords(false);
+        setShowCategoryPicker(false);
         setIsEditing(true);
     };
 
@@ -108,6 +120,7 @@ const WorldbookApp: React.FC = () => {
         setTempProbability(book.probability ?? 100);
         setTempCaseSensitive(book.caseSensitive === true);
         setTempWholeWords(book.matchWholeWords === true);
+        setShowCategoryPicker(false);
         setIsEditing(true);
     };
 
@@ -273,14 +286,40 @@ const WorldbookApp: React.FC = () => {
                                     onChange={e => setTempCategory(e.target.value)}
                                     placeholder="例如: 世界观、人物、地理..."
                                     className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all"
-                                    list="category-suggestions"
                                 />
-                                <datalist id="category-suggestions">
-                                    {Object.keys(groupedBooks).map(cat => (
-                                        <option key={cat} value={cat} />
-                                    ))}
-                                </datalist>
-                                <p className="text-[10px] text-slate-400 mt-1.5 px-1">同名条目会自动归入已有分组。</p>
+                                {categoryNames.length > 0 && (
+                                    <div className="mt-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowCategoryPicker(v => !v)}
+                                            className="flex items-center gap-1.5 text-[11px] font-bold text-indigo-500 px-1 py-1 active:scale-95 transition-transform"
+                                        >
+                                            <span className={`transition-transform duration-200 inline-block ${showCategoryPicker ? 'rotate-90' : ''}`}>
+                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3"><path fillRule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clipRule="evenodd" /></svg>
+                                            </span>
+                                            选择已有分组 ({categoryNames.length})
+                                        </button>
+                                        {showCategoryPicker && (
+                                            <div className="mt-1.5 max-h-36 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50/60 p-2 flex flex-wrap gap-1.5 overscroll-contain">
+                                                {filteredCategorySuggestions.length === 0 ? (
+                                                    <span className="text-[10px] text-slate-400 px-1 py-0.5">没有匹配「{tempCategory.trim()}」的分组，保存后将新建。</span>
+                                                ) : (
+                                                    filteredCategorySuggestions.map(cat => (
+                                                        <button
+                                                            key={cat}
+                                                            type="button"
+                                                            onClick={() => { setTempCategory(cat); setShowCategoryPicker(false); }}
+                                                            className={`max-w-full truncate text-[11px] px-2.5 py-1 rounded-full border transition-colors active:scale-95 ${tempCategory.trim() === cat ? 'bg-indigo-500 text-white border-indigo-500' : 'bg-white text-slate-600 border-slate-200 hover:border-indigo-300'}`}
+                                                        >
+                                                            {cat}
+                                                        </button>
+                                                    ))
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                                <p className="text-[10px] text-slate-400 mt-1.5 px-1">同名条目会自动归入已有分组；输入文字可过滤上方候选。</p>
                             </div>
                         </div>
 

--- a/components/chat/ChatInputArea.tsx
+++ b/components/chat/ChatInputArea.tsx
@@ -1,9 +1,10 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { ShareNetwork, Trash, Plus, Smiley, PaperPlaneTilt, Money, BookOpenText, GearSix, Image, Lock, ArrowsClockwise, ChatCircleDots, CalendarBlank, ForkKnife, Coffee, Code, Brain, PencilSimple, BellSimpleRinging, Sparkle } from '@phosphor-icons/react';
+import { ShareNetwork, Trash, Plus, Smiley, PaperPlaneTilt, Money, BookOpenText, GearSix, Image, Lock, ArrowsClockwise, ChatCircleDots, CalendarBlank, ForkKnife, Coffee, Code, Brain, PencilSimple, BellSimpleRinging, Sparkle, CaretDown } from '@phosphor-icons/react';
 import { CharacterProfile, ChatTheme, EmojiCategory, Emoji } from '../../types';
 import { PRESET_THEMES } from './ChatConstants';
 import { AcnhActionTile } from '../os/acnhIcons';
 import { isIOSStandaloneWebApp } from '../../utils/iosStandalone';
+import { useIncrementalReveal } from '../../hooks/useIncrementalReveal';
 
 interface ChatInputAreaProps {
     input: string;
@@ -81,6 +82,10 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
     const [actionsPage, setActionsPage] = useState<0 | 1>(0);
     const [emojiSelectionMode, setEmojiSelectionMode] = useState(false);
     const [selectedEmojis, setSelectedEmojis] = useState<any[]>([]);
+    // 分组太多时横向拖不动：提供「展开全部分组」网格总览
+    const [showCategoryOverview, setShowCategoryOverview] = useState(false);
+    // 表情网格增量渲染：几百张 base64 图一次性挂载会卡爆，滚动到底再补
+    const { count: visibleEmojiCount, hasMore: hasMoreEmojis, sentinelRef: emojiSentinelRef } = useIncrementalReveal(emojis.length, 48, activeCategory);
     const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const startPos = useRef({ x: 0, y: 0 });
     const isLongPressTriggered = useRef(false); // Track if long press action fired
@@ -255,6 +260,7 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
         if (showPanel !== 'emojis') {
             setEmojiSelectionMode(false);
             setSelectedEmojis([]);
+            setShowCategoryOverview(false);
         }
     }, [showPanel]);
 
@@ -475,7 +481,7 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                         </button>
                                     ))}
                                     <button onClick={() => onPanelAction('add-category')} className={categoryAddButtonClass}>+</button>
-                                    <div className="w-6 shrink-0 pointer-events-none" />
+                                    <div className="w-14 shrink-0 pointer-events-none" />
                                 </div>
                                 {emojiSelectionMode ? (
                                     <div 
@@ -499,9 +505,22 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                         </button>
                                     </div>
                                 ) : (
-                                    <div className="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-end px-3 pointer-events-none">
-                                        <button 
-                                            onClick={(e) => { e.stopPropagation(); setEmojiSelectionMode(true); }} 
+                                    <div className="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-end gap-1.5 px-3 pointer-events-none">
+                                        {categories.length > 1 && (
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); setShowCategoryOverview(v => !v); }}
+                                                title="展开全部分组"
+                                                className={`w-6 h-6 rounded-full flex items-center justify-center transition-colors shadow-sm pointer-events-auto ${
+                                                    isPixelStyle ? 'bg-[#c99872] text-[#fff7ed] hover:bg-[#b07d57]' :
+                                                    isDiscordStyle ? 'bg-slate-700 text-slate-300 hover:bg-slate-600' :
+                                                    'bg-white/90 text-slate-600 hover:bg-slate-100 backdrop-blur-sm border border-slate-200/50'
+                                                }`}
+                                            >
+                                                <CaretDown className={`w-3.5 h-3.5 transition-transform ${showCategoryOverview ? 'rotate-180' : ''}`} weight="bold" />
+                                            </button>
+                                        )}
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setEmojiSelectionMode(true); }}
                                             className={`w-6 h-6 rounded-full flex items-center justify-center transition-colors shadow-sm pointer-events-auto ${
                                                 isPixelStyle ? 'bg-[#c99872] text-[#fff7ed] hover:bg-[#b07d57]' :
                                                 isDiscordStyle ? 'bg-slate-700 text-slate-300 hover:bg-slate-600' :
@@ -513,6 +532,28 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                     </div>
                                 )}
                             </div>
+
+                            {/* 分组总览：换行网格 + 限高滚动，分组再多也不用横向拖 */}
+                            {showCategoryOverview && !emojiSelectionMode && (
+                                <div className={`shrink-0 max-h-24 overflow-y-auto overscroll-contain px-3 py-2 flex flex-wrap gap-1.5 border-b ${
+                                    isPixelStyle ? 'bg-[#eadfce] border-[#8f674a]/40' :
+                                    isDiscordStyle ? 'bg-slate-950 border-white/10' :
+                                    'bg-white border-slate-100'
+                                }`}>
+                                    {categories.map(cat => (
+                                        <button
+                                            key={cat.id}
+                                            onClick={() => { onPanelAction('select-category', cat.id); setShowCategoryOverview(false); }}
+                                            className={`px-3 py-1 text-xs rounded-full whitespace-nowrap max-w-full truncate transition-all select-none flex items-center gap-1 ${activeCategory === cat.id ? activeCategoryClass : inactiveCategoryClass}`}
+                                        >
+                                            {cat.name}
+                                            {cat.allowedCharacterIds && cat.allowedCharacterIds.length > 0 && (
+                                                <Lock className="w-3 h-3 opacity-60" weight="bold" />
+                                            )}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
 
                             <div className="flex-1 overflow-y-auto no-scrollbar p-4">
                                 <div className="grid grid-cols-4 gap-3">
@@ -531,11 +572,11 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                     ) : (
                                         <button onClick={() => onPanelAction('emoji-import')} className={emojiImportTileClass}>+</button>
                                     )}
-                                    {emojis.map((e, i) => {
+                                    {emojis.slice(0, visibleEmojiCount).map((e, i) => {
                                         const isSelected = selectedEmojiUrls.has(e.url);
                                         return (
-                                        <button 
-                                            key={i} 
+                                        <button
+                                            key={i}
                                             onClick={(ev) => handleItemClick(ev, e, 'emoji')}
                                             // Long press handlers for Emojis
                                             onTouchStart={(ev) => handleTouchStart(e, 'emoji', ev)}
@@ -549,7 +590,7 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                             className={`${emojiTileClass} ${isSelected ? '!border-blue-500' : ''}`}
                                         >
                                             <div className="aspect-square w-full">
-                                                <img src={e.url} className="w-full h-full object-contain pointer-events-none" />
+                                                <img src={e.url} loading="lazy" decoding="async" className="w-full h-full object-contain pointer-events-none" />
                                             </div>
                                             <span className={`text-[9px] truncate w-full text-center mt-0.5 leading-tight pointer-events-none ${emojiLabelClass}`}>{e.name}</span>
                                             {isSelected && <div className="absolute inset-0 bg-blue-500/20 rounded-2xl pointer-events-none border-2 border-blue-500" />}
@@ -557,6 +598,11 @@ const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                                         );
                                     })}
                                 </div>
+                                {hasMoreEmojis && (
+                                    <div ref={emojiSentinelRef} className={`py-3 text-center text-[10px] ${emojiLabelClass}`}>
+                                        加载中... ({visibleEmojiCount}/{emojis.length})
+                                    </div>
+                                )}
                             </div>
                         </>
                     )}

--- a/hooks/useIncrementalReveal.ts
+++ b/hooks/useIncrementalReveal.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * 大列表增量渲染：先渲染前 step 个，滚动到 sentinel 附近时自动追加。
+ * 用于表情包网格这类「几百张 base64 图一次性挂载会卡爆」的场景。
+ * resetKey 变化（如切换分组）时回到初始数量。
+ */
+export function useIncrementalReveal(total: number, step = 48, resetKey?: unknown) {
+    const [count, setCount] = useState(step);
+    const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        setCount(step);
+    }, [resetKey, step]);
+
+    useEffect(() => {
+        const el = sentinelRef.current;
+        if (!el || count >= total) return;
+        const observer = new IntersectionObserver(
+            entries => {
+                if (entries.some(entry => entry.isIntersecting)) {
+                    setCount(current => Math.min(current + step, total));
+                }
+            },
+            { rootMargin: '200px' }
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [count, total, step]);
+
+    return {
+        count: Math.min(count, total),
+        hasMore: count < total,
+        sentinelRef,
+    };
+}


### PR DESCRIPTION
世界书分组：
- 世界书编辑页弃用原生 datalist（移动端 WebView 分组多时会渲染成撑爆 屏幕、无法滚动的巨型下拉），改为应用内限高可滚动的分组候选面板， 随输入实时过滤，点选即填
- 角色页「挂载世界书」弹窗：分组改为默认折叠的手风琴，只渲染展开分组 的条目；新增标题/分组搜索（结果上限 60 条）；分组计算移入 useMemo， 不再在编辑表单每次渲染时全量重算

表情包：
- 新增 useIncrementalReveal hook：大列表先渲染一屏，滚动到底自动追加
- 聊天表情面板与群聊表情抽屉改为增量渲染 + 图片 loading=lazy， 几百张 base64 表情不再一次性挂载
- 表情分组栏新增「展开全部分组」按钮，弹出换行网格总览（限高可滚动）， 分组多时无需横向长距离拖动


Claude-Session: https://claude.ai/code/session_01T2rvCcYuYimk2Mh25mXCLA