### PR TITLE
修复删角色后专属表情包残留（幽灵表情包）+ 设置页一键清理

### DIFF
--- a/apps/Character.tsx
+++ b/apps/Character.tsx
@@ -1884,7 +1884,8 @@ ${isInitialGeneration ? `
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-12 h-12 text-slate-300"><path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" /></svg>
                 <p className="text-sm text-slate-600 text-center leading-relaxed">
                     确定要删除与该角色的所有连接吗？<br/>
-                    <span className="text-xs text-red-400 font-bold">该操作不可恢复，记忆将被清空。</span>
+                    <span className="text-xs text-red-400 font-bold">该操作不可恢复，记忆将被清空。</span><br/>
+                    <span className="text-[10px] text-slate-400">仅对 ta 可见的专属表情分类也会一并删除。</span>
                 </p>
             </div>
         </Modal>

--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -24,6 +24,7 @@ import VersionInfo from '../components/settings/VersionInfo';
 import { isPushVapidReady } from '../utils/pushVapid';
 import ApiCallLogModal from '../components/settings/ApiCallLogModal';
 import type { CsyMigrationReport } from '../utils/csyMigration';
+import { DB } from '../utils/db';
 
 // hot_news（orz.ai）可选热榜平台。key 必须与 API 的 ?platform= 完全一致。
 const HOTNEWS_PLATFORM_OPTIONS: { key: string; label: string }[] = [
@@ -524,6 +525,36 @@ const Settings: React.FC = () => {
     } finally {
         setIsLoadingModels(false);
     }
+  };
+
+  // 一键清理「幽灵表情包」残留：先 dryRun 扫描，弹确认后才真正删。
+  // 残留的来历：旧版本删角色不会级联清理表情分类，只对已删角色可见的专属分类
+  // 会卡在数据库里——单聊面板看不到（也删不掉），群聊面板却能看到。
+  const [isCleaningResidue, setIsCleaningResidue] = useState(false);
+  const handleCleanupResidue = async () => {
+      if (isCleaningResidue) return;
+      setIsCleaningResidue(true);
+      try {
+          const validIds = (await DB.getAllCharacters()).map(c => c.id);
+          const scan = await DB.cleanupEmojiResidue(validIds, { dryRun: true });
+          if (scan.removedCategories.length === 0 && scan.fixedCategories.length === 0 && scan.removedEmojiCount === 0) {
+              addToast('很干净，没有发现表情包残留 ✨', 'success');
+              return;
+          }
+          const lines = [
+              scan.removedCategories.length > 0 ? `• 删除 ${scan.removedCategories.length} 个失效专属分类：${scan.removedCategories.map(c => `「${c.name}」`).join('、')}` : '',
+              scan.removedEmojiCount > 0 ? `• 删除 ${scan.removedEmojiCount} 个随分类失效/无主的表情` : '',
+              scan.fixedCategories.length > 0 ? `• 修复 ${scan.fixedCategories.length} 个分类里指向已删角色的绑定：${scan.fixedCategories.map(c => `「${c.name}」`).join('、')}` : '',
+          ].filter(Boolean).join('\n');
+          if (!window.confirm(`扫描到以下残留（角色已删除但表情包还在）：\n\n${lines}\n\n点「确定」清理，此操作不可撤销。`)) return;
+          const report = await DB.cleanupEmojiResidue(validIds);
+          addToast(`清理完成：删除 ${report.removedCategories.length} 个分类、${report.removedEmojiCount} 个表情${report.fixedCategories.length > 0 ? `，修复 ${report.fixedCategories.length} 处绑定` : ''}`, 'success');
+      } catch (err) {
+          console.error('[Settings] 表情包残留清理失败', err);
+          addToast('清理失败，请重试', 'error');
+      } finally {
+          setIsCleaningResidue(false);
+      }
   };
 
   const handleExport = async (mode: 'text_only' | 'media_only' | 'full') => {
@@ -1065,6 +1096,13 @@ const Settings: React.FC = () => {
                 • 兼容旧版 JSON 备份文件的导入。
             </p>
             
+            <button onClick={handleCleanupResidue} disabled={isCleaningResidue} className="w-full py-3 mb-2 bg-amber-50 border border-amber-100 text-amber-600 rounded-xl text-xs font-bold flex items-center justify-center gap-2 active:scale-95 transition-all disabled:opacity-50">
+                {isCleaningResidue ? '正在扫描…' : '一键清理表情包残留'}
+            </button>
+            <p className="text-[10px] text-slate-400 px-1 mb-4 leading-relaxed">
+                清理已删除角色遗留的「幽灵表情包」：专属分类的角色没了之后，单聊表情面板看不到它、群聊面板却还冒出来。先扫描列出结果，确认后才会删除。
+            </p>
+
             <button onClick={() => setShowResetConfirm(true)} className="w-full py-3 bg-red-50 border border-red-100 text-red-500 rounded-xl text-xs font-bold flex items-center justify-center gap-2">
                 格式化系统 (出厂设置)
             </button>

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -2332,7 +2332,21 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
     return newChar;
   };
   const updateCharacter = async (id: string, updates: Partial<CharacterProfile> | ((prev: CharacterProfile) => Partial<CharacterProfile>)) => { setCharacters(prev => { const updated = prev.map(c => c.id === id ? normalizeCharacterImpression({ ...c, ...(typeof updates === 'function' ? updates(c) : updates) }) : c); const target = updated.find(c => c.id === id); if (target) DB.saveCharacter(target); return updated; }); };
-  const deleteCharacter = async (id: string) => { setCharacters(prev => { const remaining = prev.filter(c => c.id !== id); if (remaining.length > 0 && activeCharacterId === id) { setActiveCharacterId(remaining[0].id); } return remaining; }); await DB.deleteCharacter(id); };
+  const deleteCharacter = async (id: string) => {
+    setCharacters(prev => { const remaining = prev.filter(c => c.id !== id); if (remaining.length > 0 && activeCharacterId === id) { setActiveCharacterId(remaining[0].id); } return remaining; });
+    await DB.deleteCharacter(id);
+    // 表情分类不随角色级联删除会留下「幽灵专属包」：单聊面板被可见性过滤掉（删不掉），
+    // 群聊面板/提示词却还能看到。删完角色顺手按剩余角色清一次残留（详见 DB.cleanupEmojiResidue）。
+    try {
+        const remainingIds = characters.filter(c => c.id !== id).map(c => c.id);
+        const report = await DB.cleanupEmojiResidue(remainingIds);
+        if (report.removedCategories.length > 0) {
+            addToast(`已连带清理 ta 的专属表情分类：${report.removedCategories.map(c => `「${c.name}」`).join('')}`, 'info');
+        }
+    } catch (err) {
+        console.warn('[deleteCharacter] 表情包残留清理失败（不影响角色删除）', err);
+    }
+  };
 
   // 角色分组方法（神经链接"文件夹"）
   const createCharacterGroup = async (name: string): Promise<CharacterGroup | null> => {

--- a/utils/db.emojiResidue.test.ts
+++ b/utils/db.emojiResidue.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { DB } from './db';
+
+// 「幽灵表情包」残留清理（cleanupEmojiResidue）：
+// 删角色不级联清理表情分类，只对已删角色可见的专属分类会卡在库里——
+// 单聊面板被可见性过滤（看不到也删不掉），群聊面板/提示词却还能看到。
+// 清理规则：绑定全失效的非系统分类连表情一起删；部分失效只剔除死 id；
+// categoryId 悬空的无主表情删除；系统分类只清绑定、绝不删。
+describe('cleanupEmojiResidue 幽灵表情包清理', () => {
+  it('dryRun 只统计不落库；真跑后残留分类/表情被删、混合绑定被修复、健康数据不动', async () => {
+    // char-a 还活着，char-b 已被删除
+    await DB.saveEmojiCategory({ id: 'cat-alive', name: '活人专属', allowedCharacterIds: ['char-a'] });
+    await DB.saveEmojiCategory({ id: 'cat-ghost', name: '幽灵专属', allowedCharacterIds: ['char-b'] });
+    await DB.saveEmojiCategory({ id: 'cat-mixed', name: '混合绑定', allowedCharacterIds: ['char-a', 'char-b'] });
+    await DB.saveEmojiCategory({ id: 'cat-public', name: '公开分类' });
+    await DB.saveEmojiCategory({ id: 'cat-system', name: '系统分类', isSystem: true, allowedCharacterIds: ['char-b'] });
+
+    await DB.saveEmoji('ghost-1', 'url-g1', 'cat-ghost');
+    await DB.saveEmoji('ghost-2', 'url-g2', 'cat-ghost');
+    await DB.saveEmoji('alive-1', 'url-a1', 'cat-alive');
+    await DB.saveEmoji('public-1', 'url-p1', undefined);
+    await DB.saveEmoji('dangling-1', 'url-d1', 'cat-gone'); // 分类早已不存在的无主表情
+
+    // 1) dryRun：报告正确，但数据一个都不能少
+    const scan = await DB.cleanupEmojiResidue(['char-a'], { dryRun: true });
+    expect(scan.removedCategories.map(c => c.id)).toEqual(['cat-ghost']);
+    expect(scan.fixedCategories.map(c => c.id).sort()).toEqual(['cat-mixed', 'cat-system']);
+    expect(scan.removedEmojiCount).toBe(3); // ghost-1 + ghost-2 + dangling-1
+    expect((await DB.getEmojis()).length).toBe(5);
+    expect((await DB.getEmojiCategories()).length).toBe(5);
+
+    // 2) 真跑
+    const report = await DB.cleanupEmojiResidue(['char-a']);
+    expect(report.removedCategories.map(c => c.id)).toEqual(['cat-ghost']);
+    expect(report.removedEmojiCount).toBe(3);
+
+    const cats = await DB.getEmojiCategories();
+    expect(cats.find(c => c.id === 'cat-ghost')).toBeUndefined();
+    // 混合绑定：只剔除已删角色，分类和表情保留
+    expect(cats.find(c => c.id === 'cat-mixed')?.allowedCharacterIds).toEqual(['char-a']);
+    // 系统分类：绑定全失效也不删，回落全员可见
+    expect(cats.find(c => c.id === 'cat-system')?.allowedCharacterIds).toEqual([]);
+    // 健康数据不动
+    expect(cats.find(c => c.id === 'cat-alive')?.allowedCharacterIds).toEqual(['char-a']);
+    expect(cats.find(c => c.id === 'cat-public')?.allowedCharacterIds).toBeUndefined();
+
+    const emojiNames = (await DB.getEmojis()).map(e => e.name).sort();
+    expect(emojiNames).toEqual(['alive-1', 'public-1']);
+
+    // 3) 幂等：再跑一次应该什么都扫不到
+    const again = await DB.cleanupEmojiResidue(['char-a']);
+    expect(again.removedCategories).toEqual([]);
+    expect(again.fixedCategories).toEqual([]);
+    expect(again.removedEmojiCount).toBe(0);
+  });
+});

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -995,6 +995,64 @@ export const DB = {
       });
   },
 
+  // 「幽灵表情包」清理：删角色不会级联清理表情分类，导致只对已删角色可见的
+  // 专属分类在单聊面板里被过滤掉（看不到也删不掉），却仍会出现在群聊表情面板
+  // 和 AI 提示词里。按「现存角色 id 白名单」做三件事：
+  //   1. 分类绑定里指向已删角色的 id → 剔除（部分失效只修绑定，不动表情）
+  //   2. 剔除后一个角色都不剩的非系统分类 → 整个删除，连同分类下所有表情
+  //   3. categoryId 指向已不存在分类的表情 → 删除（无主表情）
+  // dryRun=true 只扫描统计、不落库，供 UI 做「先扫描再确认」。
+  cleanupEmojiResidue: async (
+      validCharacterIds: string[],
+      options: { dryRun?: boolean } = {}
+  ): Promise<{
+      removedCategories: { id: string; name: string }[];
+      fixedCategories: { id: string; name: string }[];
+      removedEmojiCount: number;
+  }> => {
+      const validIds = new Set(validCharacterIds);
+      const [categories, emojis] = await Promise.all([DB.getEmojiCategories(), DB.getEmojis()]);
+
+      const removedCategories: { id: string; name: string }[] = [];
+      const fixedCategories: EmojiCategory[] = [];
+      for (const cat of categories) {
+          if (!cat.allowedCharacterIds || cat.allowedCharacterIds.length === 0) continue; // 全员可见，不动
+          const alive = cat.allowedCharacterIds.filter(cid => validIds.has(cid));
+          if (alive.length === cat.allowedCharacterIds.length) continue; // 绑定全部有效
+          if (alive.length === 0 && !cat.isSystem) {
+              removedCategories.push({ id: cat.id, name: cat.name });
+          } else {
+              // 系统分类绑定全失效时也走这里：清空绑定回落「全员可见」，绝不删系统分类
+              fixedCategories.push({ ...cat, allowedCharacterIds: alive });
+          }
+      }
+
+      const removedCatIds = new Set(removedCategories.map(c => c.id));
+      const remainingCatIds = new Set(categories.map(c => c.id).filter(id => !removedCatIds.has(id)));
+      const emojisToDelete = emojis.filter(e => e.categoryId && !remainingCatIds.has(e.categoryId));
+
+      if (!options.dryRun && (removedCategories.length || fixedCategories.length || emojisToDelete.length)) {
+          const db = await openDB();
+          const tx = db.transaction([STORE_EMOJI_CATEGORIES, STORE_EMOJIS], 'readwrite');
+          const catStore = tx.objectStore(STORE_EMOJI_CATEGORIES);
+          const emojiStore = tx.objectStore(STORE_EMOJIS);
+          removedCategories.forEach(c => catStore.delete(c.id));
+          fixedCategories.forEach(c => catStore.put(c));
+          emojisToDelete.forEach(e => emojiStore.delete(e.name));
+          await new Promise<void>((resolve, reject) => {
+              tx.oncomplete = () => resolve();
+              tx.onerror = () => reject(tx.error);
+              tx.onabort = () => reject(tx.error);
+          });
+      }
+
+      return {
+          removedCategories,
+          fixedCategories: fixedCategories.map(c => ({ id: c.id, name: c.name })),
+          removedEmojiCount: emojisToDelete.length,
+      };
+  },
+
   initializeEmojiData: async (): Promise<void> => {
       const cats = await DB.getEmojiCategories();
       // 巧妙利用 UI 强制保留 default 分类的特性：


### PR DESCRIPTION
问题：删除角色不会级联清理绑定给他的表情分类，残留分类在单聊面板
被可见性过滤（看不到也删不掉），群聊表情面板和 AI 提示词却仍能看到，
角色还会突然发出已删角色的专属表情。

改动：
- utils/db.ts 新增 DB.cleanupEmojiResidue(validCharacterIds, {dryRun})： 绑定全失效的非系统分类连表情级联删除；部分失效只剔除死角色 id； categoryId 悬空的无主表情删除；系统分类只清绑定绝不删。
- OSContext.deleteCharacter：删完角色按剩余角色同步清理， 连带删除专属分类时 toast 告知；清理失败不影响角色删除本身。
- Settings 备份区新增「一键清理表情包残留」：先 dryRun 扫描列出 明细，window.confirm 确认后才真正删除，用于清理历史残留。
- Character 删角色确认弹窗补充「专属表情分类会一并删除」提示。
- 新增 utils/db.emojiResidue.test.ts 回归测试（dryRun 不落库 / 级联删除 / 混合绑定修复 / 系统分类保护 / 幂等）。


Claude-Session: https://claude.ai/code/session_01F6qqty59LjDDpQGpH94vVe