### PR TITLE
笔友会: 历史章节多选/全选转发到聊天 (novel_card)

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -2312,6 +2312,50 @@ const MessageItem = React.memo(({
         return commonLayout(card);
     }
 
+    if (m.type === 'novel_card') {
+        const n: any = m.metadata?.novel || {};
+        const bookTitle: string = n.bookTitle || '无题';
+        const isCoauthor = Array.isArray(n.collaboratorNames) && n.collaboratorNames.includes(charName);
+        const coauthors: string[] = Array.isArray(n.collaboratorNames) ? n.collaboratorNames.filter((name: string) => name && name !== charName) : [];
+        const chapters: Array<{ index?: number; summary?: string }> = Array.isArray(n.chapters) ? n.chapters : [];
+        const card = (
+            <div className="w-72">
+                <div
+                    className="rounded-2xl overflow-hidden border border-amber-300/40 shadow-[0_6px_20px_rgba(120,80,20,0.22)]"
+                    style={{ background: 'linear-gradient(155deg,#fdf6e3 0%,#f5e9cf 100%)' }}
+                >
+                    {/* 头部 */}
+                    <div className="px-3.5 pt-3 pb-2.5 flex items-center gap-2.5 border-b border-amber-900/10">
+                        <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0" style={{ background: 'linear-gradient(135deg,#d97706,#b45309)' }}>
+                            <svg viewBox="0 0 24 24" fill="none" className="w-4 h-4 text-white"><path d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                        </div>
+                        <div className="flex-1 min-w-0">
+                            <div className="text-[9px] tracking-[0.25em] text-amber-700/70 font-bold uppercase">笔友会 · {isCoauthor ? '一起写的书' : '分享的书'}</div>
+                            <div className="text-[13px] text-amber-950 font-semibold truncate font-serif">《{bookTitle}》{n.subtitle ? <span className="text-amber-800/60 text-[11px] ml-1">{n.subtitle}</span> : null}</div>
+                        </div>
+                    </div>
+                    {/* 章节归档节选 */}
+                    <div className="px-3.5 py-3 space-y-2.5 max-h-60 overflow-hidden">
+                        {chapters.length === 0 && <p className="text-[12px] text-amber-800/60 italic font-serif">一段手稿</p>}
+                        {chapters.slice(0, 3).map((c, i) => (
+                            <div key={i} className="text-[12px] leading-relaxed text-amber-950/85">
+                                <span className="text-amber-700 font-semibold font-serif mr-1">第{c.index ?? '?'}章</span>
+                                <span className="border-l-2 border-amber-600/25 pl-2 block mt-0.5 line-clamp-3 font-serif">{(c.summary || '').trim()}</span>
+                            </div>
+                        ))}
+                        {chapters.length > 3 && <div className="text-[10px] text-amber-700/50 text-center pt-0.5">…共 {chapters.length} 章归档</div>}
+                    </div>
+                    {/* 页脚 */}
+                    <div className="px-3.5 py-2 border-t border-amber-900/10 flex items-center justify-between">
+                        <span className="text-[9px] text-amber-700/60 italic truncate">{isCoauthor ? (coauthors.length ? `与 ${coauthors.join('、')} 合著` : '我们合写的手稿') : '递到你手里的手稿'}</span>
+                        <span className="text-[9px] text-amber-700/90 font-bold tracking-wide shrink-0 ml-2">＋共同回忆</span>
+                    </div>
+                </div>
+            </div>
+        );
+        return commonLayout(card);
+    }
+
     if (m.type === 'news_card') {
         const md: any = m.metadata || {};
         const title: string = md.title || '热点';

--- a/components/novel/NovelWriter.tsx
+++ b/components/novel/NovelWriter.tsx
@@ -10,6 +10,8 @@ import Modal from '../os/Modal';
 import ConfirmDialog from '../os/ConfirmDialog';
 import { useOS } from '../../context/OSContext';
 import { safeResponseJson } from '../../utils/safeApi';
+import { DB } from '../../utils/db';
+import { CharacterGroupFilterBar, filterCharactersByGroup, GROUP_FILTER_ALL } from '../character/CharacterGroupFilter';
 
 interface NovelWriterProps {
     activeBook: NovelBook;
@@ -93,7 +95,7 @@ const NovelWriter: React.FC<NovelWriterProps> = ({
     apiConfig, onBack, updateCharacter, collaborators,
     targetCharId, setTargetCharId, onOpenSettings
 }) => {
-    const { addToast } = useOS();
+    const { addToast, characterGroups } = useOS();
     const activeTheme = useMemo(() => NOVEL_THEMES.find(t => t.id === activeBook.coverStyle) || NOVEL_THEMES[0], [activeBook.coverStyle]);
     
     // State
@@ -116,6 +118,13 @@ const NovelWriter: React.FC<NovelWriterProps> = ({
     const [isGeneratingSummary, setIsGeneratingSummary] = useState(false);
     const [showHistoryModal, setShowHistoryModal] = useState(false);
     const [readingChapterIndex, setReadingChapterIndex] = useState<number | null>(null);
+
+    // 历史章节多选转发（选中的是章节总结段落的 id）
+    const [selectedChapterIds, setSelectedChapterIds] = useState<Set<string>>(new Set());
+    const [showForwardModal, setShowForwardModal] = useState(false);
+    const [forwardTargets, setForwardTargets] = useState<Set<string>>(new Set());
+    const [forwardGroupId, setForwardGroupId] = useState(GROUP_FILTER_ALL);
+    const [isForwarding, setIsForwarding] = useState(false);
 
     const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -386,6 +395,67 @@ ${chapterText.substring(0, 200000)}
         addToast('章节已归档，记忆已同步', 'success');
     };
 
+    // --- 历史章节多选 → 转发到聊天 ---
+    const toggleSelectChapter = (id: string) => {
+        setSelectedChapterIds(prev => {
+            const n = new Set(prev);
+            n.has(id) ? n.delete(id) : n.add(id);
+            return n;
+        });
+    };
+
+    const allChaptersSelected = historicalSummaries.length > 0 && selectedChapterIds.size === historicalSummaries.length;
+    const toggleSelectAllChapters = () => {
+        setSelectedChapterIds(allChaptersSelected ? new Set() : new Set(historicalSummaries.map(s => s.id)));
+    };
+
+    const openForwardModal = () => {
+        if (selectedChapterIds.size === 0) { addToast('请先选择要转发的章节', 'error'); return; }
+        // 默认勾上共创者——他们是最需要"记得这本书"的人
+        setForwardTargets(new Set(activeBook.collaboratorIds.filter(id => characters.some(c => c.id === id))));
+        setForwardGroupId(GROUP_FILTER_ALL);
+        setShowForwardModal(true);
+    };
+
+    // 把选中的章节归档打包成 novel_card，写进每个目标角色的聊天上下文，
+    // 让角色在聊天里"读过"这本一起写的书（与 TRPG trpg_card 同一套机制）
+    const handleForwardChapters = async () => {
+        if (selectedChapterIds.size === 0 || forwardTargets.size === 0) return;
+        setIsForwarding(true);
+        try {
+            const chapters = historicalSummaries
+                .map((s, i) => ({ seg: s, index: i + 1 }))
+                .filter(c => selectedChapterIds.has(c.seg.id))
+                .map(c => ({ index: c.index, summary: c.seg.content }));
+            const novel = {
+                bookTitle: activeBook.title,
+                subtitle: activeBook.subtitle || '',
+                bookSummary: activeBook.summary || '',
+                userName: userProfile.name,
+                collaboratorNames: collaborators.map(c => c.name),
+                chapters,
+                count: chapters.length,
+            };
+            const targets = characters.filter(c => forwardTargets.has(c.id));
+            for (const t of targets) {
+                await DB.saveMessage({
+                    charId: t.id,
+                    role: 'user',
+                    type: 'novel_card',
+                    content: `[笔友会小说]《${activeBook.title}》${chapters.length > 1 ? `${chapters.length} 章归档` : `第 ${chapters[0].index} 章归档`}`,
+                    metadata: { novel },
+                });
+            }
+            addToast(`已转发到 ${targets.length} 位角色的聊天`, 'success');
+            setShowForwardModal(false);
+            setSelectedChapterIds(new Set());
+        } catch (e: any) {
+            addToast(`转发失败: ${e.message}`, 'error');
+        } finally {
+            setIsForwarding(false);
+        }
+    };
+
     return (
         <div className={`h-full w-full flex flex-col font-serif ${activeTheme.bg} transition-colors duration-500 relative`}>
             <ConfirmDialog isOpen={!!confirmDialog} title={confirmDialog?.title || ''} message={confirmDialog?.message || ''} variant={confirmDialog?.variant} confirmText={confirmDialog?.confirmText || (confirmDialog?.onConfirm ? '确认' : 'OK')} onConfirm={confirmDialog?.onConfirm || (() => setConfirmDialog(null))} onCancel={() => setConfirmDialog(null)} />
@@ -517,18 +587,61 @@ ${chapterText.substring(0, 200000)}
             <Modal isOpen={showSummaryModal} title="章节总结" onClose={() => setShowSummaryModal(false)} footer={isGeneratingSummary ? <div className="w-full py-3 bg-slate-100 text-slate-500 font-bold rounded-2xl text-center">AI生成中...</div> : <button onClick={confirmChapterSummary} className="w-full py-3 bg-indigo-500 text-white font-bold rounded-2xl shadow-lg">确认归档并开启新章</button>}>
                 <textarea value={summaryContent} onChange={e => setSummaryContent(e.target.value)} className="w-full h-64 bg-slate-50 border border-slate-200 rounded-xl p-3 text-sm resize-none focus:outline-none leading-relaxed" placeholder="总结生成中..." />
             </Modal>
-            <Modal isOpen={showHistoryModal} title="历史章节" onClose={() => setShowHistoryModal(false)}>
-                <div className="max-h-[60vh] overflow-y-auto space-y-4 p-1">
+            <Modal isOpen={showHistoryModal} title="历史章节" onClose={() => { setShowHistoryModal(false); setSelectedChapterIds(new Set()); }}>
+                {historicalSummaries.length > 0 && (
+                    <div className="flex items-center justify-between mb-3 px-1">
+                        <button onClick={toggleSelectAllChapters} className="text-xs font-bold text-slate-500 hover:text-slate-800 flex items-center gap-1.5 transition-colors">
+                            <span className={`w-4 h-4 rounded border flex items-center justify-center transition-colors ${allChaptersSelected ? 'bg-indigo-500 border-indigo-500 text-white' : 'border-slate-300 bg-white'}`}>{allChaptersSelected && <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3"><path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" /></svg>}</span>
+                            {allChaptersSelected ? '取消全选' : '全选'}
+                        </button>
+                        <button onClick={openForwardModal} disabled={selectedChapterIds.size === 0} className="text-[10px] bg-indigo-500 text-white px-3 py-1.5 rounded-lg font-bold shadow-sm hover:bg-indigo-600 disabled:opacity-40 disabled:cursor-not-allowed transition-all flex items-center gap-1">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3"><path d="M3.105 2.288a.75.75 0 0 0-.826.95l1.414 4.926A1.5 1.5 0 0 0 5.135 9.25h6.115a.75.75 0 0 1 0 1.5H5.135a1.5 1.5 0 0 0-1.442 1.086l-1.414 4.926a.75.75 0 0 0 .826.95 28.897 28.897 0 0 0 15.293-7.155.75.75 0 0 0 0-1.114A28.897 28.897 0 0 0 3.105 2.288Z" /></svg>
+                            转发到聊天 ({selectedChapterIds.size})
+                        </button>
+                    </div>
+                )}
+                <div className="max-h-[55vh] overflow-y-auto space-y-4 p-1">
                     {historicalSummaries.length === 0 && <div className="text-center text-slate-400 py-4 text-xs">暂无历史章节</div>}
-                    {historicalSummaries.map((s, i) => (
-                        <div key={s.id} className="bg-slate-50 p-4 rounded-xl border border-slate-100">
-                            <div className="flex items-center justify-between mb-2">
-                                <div className="font-bold text-sm text-slate-700">第 {i + 1} 章</div>
-                                <button onClick={() => { setReadingChapterIndex(i); setShowHistoryModal(false); }} className="text-[10px] bg-indigo-50 text-indigo-600 px-2.5 py-1 rounded-lg font-bold hover:bg-indigo-100 border border-indigo-100 transition-colors">阅读原文</button>
+                    {historicalSummaries.map((s, i) => {
+                        const selected = selectedChapterIds.has(s.id);
+                        return (
+                            <div key={s.id} onClick={() => toggleSelectChapter(s.id)} className={`p-4 rounded-xl border cursor-pointer transition-colors ${selected ? 'bg-indigo-50/70 border-indigo-200' : 'bg-slate-50 border-slate-100 hover:border-slate-200'}`}>
+                                <div className="flex items-center justify-between mb-2">
+                                    <div className="flex items-center gap-2">
+                                        <span className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${selected ? 'bg-indigo-500 border-indigo-500 text-white' : 'border-slate-300 bg-white'}`}>{selected && <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3"><path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" /></svg>}</span>
+                                        <div className="font-bold text-sm text-slate-700">第 {i + 1} 章</div>
+                                    </div>
+                                    <button onClick={(e) => { e.stopPropagation(); setReadingChapterIndex(i); setShowHistoryModal(false); }} className="text-[10px] bg-indigo-50 text-indigo-600 px-2.5 py-1 rounded-lg font-bold hover:bg-indigo-100 border border-indigo-100 transition-colors">阅读原文</button>
+                                </div>
+                                <div className="text-xs text-slate-600 leading-relaxed whitespace-pre-wrap line-clamp-4">{s.content}</div>
                             </div>
-                            <div className="text-xs text-slate-600 leading-relaxed whitespace-pre-wrap line-clamp-4">{s.content}</div>
-                        </div>
-                    ))}
+                        );
+                    })}
+                </div>
+            </Modal>
+
+            {/* 转发章节：选择目标角色（默认勾上共创者，也可以分享给圈外角色） */}
+            <Modal isOpen={showForwardModal} title="转发章节到聊天" onClose={() => setShowForwardModal(false)} footer={
+                <button onClick={handleForwardChapters} disabled={isForwarding || forwardTargets.size === 0} className="w-full py-3 bg-indigo-500 text-white font-bold rounded-2xl shadow-lg disabled:opacity-40 flex items-center justify-center gap-2">
+                    {isForwarding ? <><div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div> 转发中...</> : `转发 ${selectedChapterIds.size} 章给 ${forwardTargets.size} 位角色`}
+                </button>
+            }>
+                <p className="text-xs text-slate-400 mb-3">章节归档会进入所选角色的聊天记录，之后聊天时 Ta 就"读过"这本书了。共创者已默认勾选。</p>
+                <CharacterGroupFilterBar characters={characters} groups={characterGroups} value={forwardGroupId} onChange={setForwardGroupId} className="mb-3" />
+                <div className="max-h-[45vh] overflow-y-auto space-y-2 p-1">
+                    {filterCharactersByGroup(characters, characterGroups, forwardGroupId).map(c => {
+                        const checked = forwardTargets.has(c.id);
+                        const isCollab = activeBook.collaboratorIds.includes(c.id);
+                        return (
+                            <button key={c.id} onClick={() => setForwardTargets(prev => { const n = new Set(prev); n.has(c.id) ? n.delete(c.id) : n.add(c.id); return n; })} className={`w-full flex items-center gap-3 p-3 rounded-xl border shadow-sm active:scale-[0.98] transition-all text-left ${checked ? 'bg-indigo-50/70 border-indigo-200' : 'bg-white border-slate-100 hover:border-slate-200'}`}>
+                                <img src={c.avatar} className="w-9 h-9 rounded-full object-cover" />
+                                <div className="flex-1 min-w-0">
+                                    <div className="font-bold text-sm text-slate-700 flex items-center gap-2">{c.name}{isCollab && <span className="text-[9px] bg-amber-50 text-amber-600 border border-amber-100 px-1.5 py-0.5 rounded-full font-bold">共创者</span>}</div>
+                                </div>
+                                <span className={`w-5 h-5 rounded-full border flex items-center justify-center shrink-0 transition-colors ${checked ? 'bg-indigo-500 border-indigo-500 text-white' : 'border-slate-300 bg-white'}`}>{checked && <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-3 h-3"><path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" /></svg>}</span>
+                            </button>
+                        );
+                    })}
                 </div>
             </Modal>
 

--- a/types.ts
+++ b/types.ts
@@ -2919,7 +2919,7 @@ export interface GameSession {
     lastPlayedAt: number;
 }
 
-export type MessageType = 'text' | 'image' | 'emoji' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'luckin_card' | 'html_card' | 'news_card' | 'vr_card' | 'trpg_card' | 'world_card' | 'sim_card' | 'phone_card' | 'webpage_card' | 'theater_card' | 'room_card' | 'life_card';
+export type MessageType = 'text' | 'image' | 'emoji' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'luckin_card' | 'html_card' | 'news_card' | 'vr_card' | 'trpg_card' | 'novel_card' | 'world_card' | 'sim_card' | 'phone_card' | 'webpage_card' | 'theater_card' | 'room_card' | 'life_card';
 
 export interface Message {
     id: number;

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -50,6 +50,7 @@ function summarizeGroupMsgContent(m: Message): string {
         case 'html_card': return '[HTML卡片]';
         case 'news_card': return '[新闻卡片]';
         case 'trpg_card': return `[TRPG游戏片段${meta.trpg?.gameTitle ? '：《' + meta.trpg.gameTitle + '》' : ''}]`;
+        case 'novel_card': return `[笔友会小说章节${meta.novel?.bookTitle ? '：《' + meta.novel.bookTitle + '》' : ''}]`;
         case 'world_card': return `[家园生活记录${meta.worldName ? '：' + meta.worldName : ''}]`;
         case 'sim_card': return `[一段回忆${meta.simCard?.theme ? '：' + meta.simCard.theme : ''}]`;
         case 'phone_card': return `[手机内容${meta.phoneCard?.title ? '：' + meta.phoneCard.title : ''}]`;
@@ -1124,9 +1125,9 @@ ${userProfile.name} 给你反馈时，别当成约束，当成信任——ta 在
                         content = `${timeStr} [系统卡片]`;
                     }
                 }
-                else if ((m.type as string) === 'trpg_card') {
-                    // TRPG 跑团片段：从游戏多选转发进来的剧情。复用 normalizeMessageContent
-                    // 把完整节选翻成文本，让角色"记得"和用户一起玩游戏时发生了什么。
+                else if ((m.type as string) === 'trpg_card' || (m.type as string) === 'novel_card') {
+                    // TRPG 跑团片段 / 笔友会小说章节：从对应 app 多选转发进来的内容。
+                    // 复用 normalizeMessageContent 翻成完整文本，让角色"记得"一起玩过/写过什么。
                     content = `${timeStr} ${normalizeMessageContent(m, char?.name || '你', userProfile?.name || '用户')}`;
                 }
                 else content = `${timeStr} ${sourceTag} ${content}`;

--- a/utils/messageFormat.novelCard.test.ts
+++ b/utils/messageFormat.novelCard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMessageContent } from './messageFormat';
+import { ChatPrompts } from './chatPrompts';
+
+// 锁住「笔友会历史章节转发到聊天后，角色在上下文里读得到书」这条链路。
+//
+// novel_card 的 content 只是占位（[笔友会小说]《书名》…），真正的章节归档在
+// metadata.novel 里。上下文 / 归档 / palace 都靠 normalizeMessageContent 把它
+// 翻成完整文本——漏翻的话角色只看到占位符，等于没转发。
+// 另外钉住共创者 / 非共创者两种视角的措辞：共创者要知道"这书有你一份"，
+// 旁观者不能被诱导成"我也写过"。
+
+const novelMeta = {
+    novel: {
+        bookTitle: '雾中灯塔',
+        subtitle: '第一卷',
+        bookSummary: '一座只在雾天出现的灯塔。',
+        userName: '我',
+        collaboratorNames: ['小笔友', '路人乙'],
+        chapters: [
+            { index: 1, summary: '守塔人捡到了一封没有署名的信。' },
+            { index: 3, summary: '信的笔迹和守塔人自己的一模一样。' },
+        ],
+        count: 2,
+    },
+};
+
+const baseMsg = {
+    id: 1,
+    charId: 'c1',
+    role: 'user',
+    type: 'novel_card',
+    content: '[笔友会小说]《雾中灯塔》2 章归档',
+    timestamp: Date.now(),
+    metadata: novelMeta,
+} as any;
+
+describe('normalizeMessageContent novel_card 脱水', () => {
+    it('共创者视角: 带书名 + 全部章节总结 + "你是执笔人之一"', () => {
+        const text = normalizeMessageContent(baseMsg, '小笔友', '我');
+        expect(text).toContain('《雾中灯塔》');
+        expect(text).toContain('执笔人之一');
+        expect(text).toContain('守塔人捡到了一封没有署名的信');
+        expect(text).toContain('第3章总结');
+        expect(text).toContain('一座只在雾天出现的灯塔');
+        // 其他共创者也要出现（"还有路人乙"），别把合著者写丢
+        expect(text).toContain('路人乙');
+    });
+
+    it('非共创者视角: 明确"没有参与创作", 不冒认执笔', () => {
+        const text = normalizeMessageContent(baseMsg, '圈外角色', '我');
+        expect(text).toContain('《雾中灯塔》');
+        expect(text).toContain('没有参与创作');
+        expect(text).not.toContain('执笔人之一');
+        // 章节内容照样可读——分享的意义就是让 ta 读到
+        expect(text).toContain('信的笔迹和守塔人自己的一模一样');
+    });
+
+    it('metadata 缺失时兜底为占位, 不抛错', () => {
+        const broken = { ...baseMsg, metadata: {} };
+        expect(normalizeMessageContent(broken, '小笔友', '我')).toBe('[笔友会小说章节]');
+    });
+});
+
+describe('buildMessageHistory 私聊上下文里 novel_card 完整可读', () => {
+    it('角色上下文里带出章节归档全文, 不是光秃秃的占位 (退化即挂)', () => {
+        const char = { id: 'c1', name: '小笔友' } as any;
+        const userProfile = { name: '我' } as any;
+        const history = [{ ...baseMsg, timestamp: Date.now() - 60_000 }];
+        const { apiMessages } = ChatPrompts.buildMessageHistory(history, 10, char, userProfile, []);
+        const userMsg = apiMessages.find((m: any) => m.role === 'user');
+        const content = userMsg!.content as string;
+        expect(content).toContain('笔友会');
+        expect(content).toContain('守塔人捡到了一封没有署名的信');
+        expect(content).toContain('执笔人之一');
+    });
+});

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -183,6 +183,36 @@ export function normalizeMessageContent(
         return '[TRPG游戏片段]';
     }
 
+    // 笔友会小说章节：从笔友会历史章节多选转发到聊天的归档总结。必须翻成完整可读文本，
+    // 让上下文 / 归档 / palace 都能读到"这本书写了什么"。共创者视角是"我们一起写的书"，
+    // 非共创者视角是"用户分享给我看的书"，措辞要区分开。
+    if (type === 'novel_card') {
+        const n = msg.metadata?.novel as {
+            bookTitle?: string;
+            subtitle?: string;
+            bookSummary?: string;
+            userName?: string;
+            collaboratorNames?: string[];
+            chapters?: Array<{ index?: number; summary?: string }>;
+        } | undefined;
+        if (n) {
+            const collabs = n.collaboratorNames || [];
+            const isCoauthor = collabs.includes(charName);
+            const others = collabs.filter(name => name && name !== charName);
+            const uName = n.userName || userName;
+            const withPart = others.length ? `（还有${others.join('、')}）` : '';
+            const head = isCoauthor
+                ? `这是${charName}和${uName}${withPart}一起在笔友会共同创作的小说《${n.bookTitle || '无题'}》的章节归档（用户转发到聊天，这本书是你们共同的创作回忆，你是执笔人之一）`
+                : `这是${uName}${collabs.length ? `和${collabs.join('、')}` : ''}在笔友会创作的小说《${n.bookTitle || '无题'}》的章节归档（用户分享给${charName}看的，${charName}没有参与创作）`;
+            const intro = (n.bookSummary || '').trim() ? `\n简介：${(n.bookSummary || '').trim()}` : '';
+            const body = (n.chapters || [])
+                .map(c => `第${c.index ?? '?'}章总结：\n${(c.summary || '').trim().slice(0, 2000)}`)
+                .join('\n\n');
+            return `[笔友会小说章节] ${head}：${intro}\n${body}`;
+        }
+        return '[笔友会小说章节]';
+    }
+
     // 小红书卡片：把笔记标题 + 正文 desc + 作者翻成可读文本喂给角色。标题来自分享文案
     // （无需后端），desc/作者来自 MCP 抓取（可能没有）。没专门分支时会走默认只给 content(=标题)，
     // 抓空时甚至空字符串，角色读不到任何东西。


### PR DESCRIPTION
历史章节弹窗支持勾选/全选章节归档，打包成 novel_card 转发进目标角色
的聊天上下文（默认勾选共创者，也可分享给其他角色），让角色在聊天里
"读过"这本一起写的书——机制与 TRPG 的 trpg_card 转发一致。

- NovelWriter: 历史章节多选 + 全选 + 角色选择弹窗（带分组筛选）
- messageFormat: novel_card 脱水成完整可读文本，区分共创者/旁观者视角
- chatPrompts: 1v1 上下文完整注入，群聊占位符带书名
- MessageItem: 书页质感的 novel_card 聊天卡片
- 新增 messageFormat.novelCard.test.ts 钉住脱水链路


Claude-Session: https://claude.ai/code/session_0178jzRhiUTvkZAY2ma9ckcV