### PR TITLE
fix(群聊): 修复公共话题盒归档卡死 + 补齐时间流逝感知

### DIFF
--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -13,7 +13,7 @@ import { processImage } from '../utils/file';
 import { stickerNameFromUrl } from '../utils/messageFormat';
 import { PRESET_THEMES } from '../components/chat/ChatConstants';
 import { resolveChatTheme } from '../utils/groupChat/theme';
-import { parseDirectorActions, stripSkipMarker } from '../utils/groupChat/parse';
+import { parseDirectorActions, stripSkipMarker, parseGroupTopicBox } from '../utils/groupChat/parse';
 import { GroupPacketMeta, PacketReceiptMeta, ClaimResult, claimPacket, effectivePacketStatus, makePacketMeta } from '../utils/groupChat/redpacket';
 import { messageLogText } from '../utils/groupChat/format';
 import { buildMemberTimeline, DEFAULT_MEMBER_TIMELINE_CAP } from '../utils/groupChat/timeline';
@@ -511,14 +511,17 @@ const GroupChat: React.FC = () => {
         const now = Date.now();
         const diffHours = Math.floor((now - lastMsgTimestamp) / (1000 * 60 * 60));
         const diffMins = Math.floor((now - lastMsgTimestamp) / (1000 * 60));
-        
+        const diffDays = Math.floor(diffHours / 24);
+
         const currentHour = new Date().getHours();
         const isNight = currentHour >= 23 || currentHour <= 6;
 
         if (diffMins < 10) return '聊天正在火热进行中，大家都很活跃。';
         if (diffMins < 60) return `距离上次发言过了 ${diffMins} 分钟，话题可能有点冷场。`;
         if (diffHours < 12) return `距离上次发言过了 ${diffHours} 小时。${isNight ? '现在是深夜。' : ''}`;
-        return `大家已经 ${diffHours} 小时没说话了，群里很安静。`;
+        if (diffHours < 24) return `距离上次发言过了 ${diffHours} 小时，群里安静了大半天。`;
+        // 隔天以上：明确"日子已经过去了"，别把上一条当作刚刚发生、无缝续上旧话题。
+        return `距离群里上一条消息已经过了 ${diffDays} 天（${diffHours} 小时）。这段时间是真实流逝的——各自都过了好几天的生活，之前那个话题早就不是"刚才"的事了。除非有人明确重新提起，别当无事发生、直接续上几天前那句话；更自然的是有种"好久没聊了"的重启感，或者干脆聊点新的。`;
     };
 
     // New: Calculate private chat gap
@@ -961,7 +964,11 @@ const GroupChat: React.FC = () => {
     const buildGroupSystemHeader = (currentMsgs: Message[], groupMembers: CharacterProfile[]) => {
         const lastMsg = currentMsgs[currentMsgs.length - 1];
         const timeGapInfo = lastMsg ? getTimeGapHint(lastMsg.timestamp) : "这是群聊的第一条消息。";
-        const currentTimeStr = `${virtualTime.hours.toString().padStart(2, '0')}:${virtualTime.minutes.toString().padStart(2, '0')}`;
+        // 带上完整日期（年月日 + 星期），只给 HH:MM 时角色感知不到"过了几天"——
+        // 这正是"很久以后还无缝续上旧话题"的一个来源。virtualTime 只有时分，日期取真实当天。
+        const nowDate = new Date();
+        const weekNames = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
+        const currentTimeStr = `${nowDate.getFullYear()}年${nowDate.getMonth() + 1}月${nowDate.getDate()}日 ${weekNames[nowDate.getDay()]} ${virtualTime.hours.toString().padStart(2, '0')}:${virtualTime.minutes.toString().padStart(2, '0')}`;
         const liveMsgs = currentMsgs.filter(m => m.id > (activeGroup?.archivedThroughMessageId || 0));
         const sharedScene = ContextBuilder.buildGroupSharedScene(groupMembers, userProfile, liveMsgs);
 
@@ -1060,22 +1067,6 @@ ${memberTimeline || '(暂无互动记录)'}
               ]
             : prompt;
 
-    const parseTopicBoxResponse = (raw: string): { title: string; summary: string } | null => {
-        const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/i, '').trim();
-        try {
-            const parsed = JSON.parse(cleaned);
-            if (parsed?.summary) return { title: String(parsed.title || '一段群聊回忆'), summary: String(parsed.summary) };
-        } catch {}
-        const match = cleaned.match(/\{[\s\S]*\}/);
-        if (match) {
-            try {
-                const parsed = JSON.parse(match[0]);
-                if (parsed?.summary) return { title: String(parsed.title || '一段群聊回忆'), summary: String(parsed.summary) };
-            } catch {}
-        }
-        return null;
-    };
-
     /** 群公共话题盒：每群只调用一次总结 API，不再按开启记忆宫殿的成员分别复制。 */
     const createNextGroupTopicBox = async (force: boolean = false): Promise<boolean> => {
         if (!activeGroup || topicArchiveLockRef.current || !apiConfig.apiKey) return false;
@@ -1100,7 +1091,7 @@ ${memberTimeline || '(暂无互动记录)'}
             });
             if (!response.ok) throw new Error(`API 返回 ${response.status}`);
             const data = await safeResponseJson(response);
-            const parsed = parseTopicBoxResponse(data.choices?.[0]?.message?.content || '');
+            const parsed = parseGroupTopicBox(data.choices?.[0]?.message?.content || '');
             if (!parsed) throw new Error('总结格式无法解析');
 
             const box = makeGroupTopicBox(groupForArchive, batchPlan.messages, parsed.title, parsed.summary);

--- a/utils/groupChat/parse.test.ts
+++ b/utils/groupChat/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseDirectorActions, parseSummaryYaml } from './parse';
+import { parseDirectorActions, parseSummaryYaml, parseGroupTopicBox } from './parse';
 
 describe('parseDirectorActions', () => {
     it('标准 JSON 数组直接解析', () => {
@@ -68,5 +68,47 @@ describe('parseSummaryYaml', () => {
 
     it('空输入返回空串', () => {
         expect(parseSummaryYaml('')).toBe('');
+    });
+});
+
+describe('parseGroupTopicBox', () => {
+    it('第一层：标准 JSON', () => {
+        expect(parseGroupTopicBox('{"title":"猫猫围观","summary":"群里围观了一只猫。"}'))
+            .toEqual({ title: '猫猫围观', summary: '群里围观了一只猫。' });
+    });
+
+    it('第一层：带 ```json 围栏 + 前后废话', () => {
+        const raw = '好的：\n```json\n{"title":"旅行计划","summary":"大家聊了去哪玩。"}\n```\n以上。';
+        expect(parseGroupTopicBox(raw)).toEqual({ title: '旅行计划', summary: '大家聊了去哪玩。' });
+    });
+
+    it('第一层：剥推理模型 <think> 块', () => {
+        const raw = '<think>我先想想标题</think>{"title":"深夜emo","summary":"半夜大家都睡不着。"}';
+        expect(parseGroupTopicBox(raw)).toEqual({ title: '深夜emo', summary: '半夜大家都睡不着。' });
+    });
+
+    it('第二层：summary 里有裸换行（严格 JSON.parse 会挂）也能抠出字段', () => {
+        // 这正是线上"总结格式无法解析"的主因：字符串值里带真实换行
+        const raw = '{"title":"复盘","summary":"第一段发生了A。\n第二段发生了B。"}';
+        const parsed = parseGroupTopicBox(raw);
+        expect(parsed?.title).toBe('复盘');
+        expect(parsed?.summary).toContain('第一段发生了A。');
+        expect(parsed?.summary).toContain('第二段发生了B。');
+    });
+
+    it('第二层：缺 title 时给默认标题', () => {
+        const raw = '{"summary":"只有总结没标题。"}';
+        expect(parseGroupTopicBox(raw)).toEqual({ title: '一段群聊回忆', summary: '只有总结没标题。' });
+    });
+
+    it('第三层：完全没结构但有实质文本，整段兜底当总结', () => {
+        const raw = '群里今天聊了很多，气氛不错，大家分享了各自的近况。';
+        expect(parseGroupTopicBox(raw)).toEqual({ title: '一段群聊回忆', summary: raw });
+    });
+
+    it('空 / 无实质内容返回 null', () => {
+        expect(parseGroupTopicBox('')).toBeNull();
+        expect(parseGroupTopicBox('```json\n```')).toBeNull();
+        expect(parseGroupTopicBox('{}')).toBeNull();
     });
 });

--- a/utils/groupChat/parse.ts
+++ b/utils/groupChat/parse.ts
@@ -64,6 +64,73 @@ export function stripSkipMarker(raw: string): { skipped: boolean; content: strin
     return { skipped: content === '', content };
 }
 
+export interface GroupTopicBoxParsed {
+    title: string;
+    summary: string;
+}
+
+/**
+ * 解析「群公共话题盒」总结输出：提示词要求模型只吐 {"title","summary"} 的 JSON，
+ * 但实际返回常常掉格式（summary 里带裸换行 / 未转义引号、外面裹一层 ```json、
+ * 推理模型先来一段 <think>…</think>）。旧版 parseTopicBoxResponse 只做严格 JSON.parse，
+ * 一旦 parse 失败就整轮报「总结格式无法解析」并抛错——而这会让
+ * archivedThroughMessageId 永远推进不了，热区以前的消息越堆越多（用户实测卡到 649 条），
+ * 归档队列被一条坏输出永久堵死。这里按家规做三层容错，宁可给个粗糙总结也绝不卡住队列。
+ *
+ * 第一层（严格）：剥围栏 / <think> 后，整体 or 最外层 {…} 直接 JSON.parse。
+ * 第二层（宽松）：JSON 坏在字符串里的裸换行——直接正则抠 title / summary 字段值（允许含换行）。
+ * 第三层（兜底）：模型压根没给结构，只要有实质文本，整段当 summary 用（截断防超长）。
+ * 三层皆空返回 null，由调用方决定是否提示用户。
+ */
+export function parseGroupTopicBox(raw: string): GroupTopicBoxParsed | null {
+    const text = String(raw ?? '')
+        .replace(/<think>[\s\S]*?<\/think>/gi, '') // 推理模型的思考块，会把 JSON 冲垮
+        .replace(/```[a-zA-Z]*\r?\n?/g, '')
+        .replace(/```/g, '')
+        .trim();
+    if (!text) return null;
+
+    const fromObj = (p: any): GroupTopicBoxParsed | null => {
+        if (!p || typeof p !== 'object') return null;
+        const summary = p.summary == null ? '' : String(p.summary).trim();
+        if (!summary) return null;
+        const title = p.title == null ? '' : String(p.title).trim();
+        return { title: title || '一段群聊回忆', summary };
+    };
+
+    // 第一层：整体 JSON，或截取最外层 {…} 再 parse
+    try {
+        const hit = fromObj(JSON.parse(text));
+        if (hit) return hit;
+    } catch { /* 掉进下一层 */ }
+    const braceStart = text.indexOf('{');
+    const braceEnd = text.lastIndexOf('}');
+    if (braceStart !== -1 && braceEnd > braceStart) {
+        try {
+            const hit = fromObj(JSON.parse(text.slice(braceStart, braceEnd + 1)));
+            if (hit) return hit;
+        } catch { /* 掉进下一层 */ }
+    }
+
+    // 第二层：JSON 结构坏了，直接抠字段值（[\s\S] 容忍值里的裸换行）。
+    // summary 抠到闭合引号后紧跟的 , / } / 文末为止。
+    const summaryMatch = text.match(/["']?summary["']?\s*[:：]\s*["']([\s\S]*?)["']\s*(?:[,，}]|$)/i);
+    if (summaryMatch && summaryMatch[1].trim()) {
+        const titleMatch = text.match(/["']?title["']?\s*[:：]\s*["']([\s\S]*?)["']\s*(?:[,，}]|$)/i);
+        return {
+            title: (titleMatch?.[1] || '').trim() || '一段群聊回忆',
+            summary: summaryMatch[1].trim(),
+        };
+    }
+
+    // 第三层：完全没结构，但有实质文本——整段当总结用，好过永久卡死归档队列
+    const plain = text.replace(/^[{[]+/, '').replace(/[}\]]+$/, '').trim();
+    if (plain.length >= 10) {
+        return { title: '一段群聊回忆', summary: plain.length > 800 ? `${plain.slice(0, 800)}…` : plain };
+    }
+    return null;
+}
+
 /**
  * 解析群总结输出里的 summary 字段。
  * 第一层（严格）：剥围栏后匹配 `summary:` + 引号闭合配对（或裸值取到文末）。

--- a/utils/groupChat/prompts.test.ts
+++ b/utils/groupChat/prompts.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { buildGroupHistoryBlock, GROUP_HISTORY_GAP_THRESHOLD_MS } from './prompts';
+import type { Message, CharacterProfile } from '../../types';
+
+const char = (id: string, name: string): CharacterProfile => ({ id, name } as CharacterProfile);
+
+const msg = (id: number, role: Message['role'], content: string, timestamp: number, charId = ''): Message =>
+    ({ id, role, type: 'text', content, timestamp, charId } as Message);
+
+describe('buildGroupHistoryBlock 时间跳变分隔行', () => {
+    const chars = [char('c1', '小夏')];
+    const base = Date.UTC(2026, 6, 1, 12, 0, 0);
+
+    it('相邻消息隔得久时插一条"隔了约 N 天"的分隔行', () => {
+        const msgs: Message[] = [
+            msg(1, 'assistant', '在吗', base, 'c1'),
+            // 3 天后用户回来发一句
+            msg(2, 'user', '我回来了', base + 3 * 24 * 60 * 60 * 1000),
+        ];
+        const { text } = buildGroupHistoryBlock(msgs, chars, [], '用户');
+        expect(text).toContain('约 3 天');
+        expect(text).toContain('中间群里没人说话');
+        // 分隔行应夹在两条消息之间
+        expect(text.indexOf('小夏: 在吗')).toBeLessThan(text.indexOf('约 3 天'));
+        expect(text.indexOf('约 3 天')).toBeLessThan(text.indexOf('用户: 我回来了'));
+    });
+
+    it('间隔在阈值以内不插分隔行', () => {
+        const msgs: Message[] = [
+            msg(1, 'assistant', '早', base, 'c1'),
+            msg(2, 'user', '早呀', base + 60 * 1000),
+        ];
+        const { text } = buildGroupHistoryBlock(msgs, chars, [], '用户');
+        expect(text).not.toContain('中间群里没人说话');
+        expect(text).toBe('小夏: 早\n用户: 早呀');
+    });
+
+    it('阈值常量为 3 小时', () => {
+        expect(GROUP_HISTORY_GAP_THRESHOLD_MS).toBe(3 * 60 * 60 * 1000);
+    });
+});

--- a/utils/groupChat/prompts.ts
+++ b/utils/groupChat/prompts.ts
@@ -50,6 +50,19 @@ export interface GroupHistoryBlock {
     attachedImagesNote: string;
 }
 
+/** 相邻两条消息间隔超过这个阈值（毫秒）就在历史里插一条"隔了多久"的分隔行。默认 3 小时。 */
+export const GROUP_HISTORY_GAP_THRESHOLD_MS = 3 * 60 * 60 * 1000;
+
+/** 把毫秒时长说成人话："约 3 天" / "约 5 小时"，只在插分隔行时用。 */
+function formatGapDuration(ms: number): string {
+    const mins = Math.floor(ms / 60000);
+    const hours = Math.floor(mins / 60);
+    const days = Math.floor(hours / 24);
+    if (days >= 1) return `约 ${days} 天`;
+    if (hours >= 1) return `约 ${hours} 小时`;
+    return `约 ${mins} 分钟`;
+}
+
 /**
  * 群历史块（含最近图片结构化附带）。原 triggerDirector 内联逻辑，逐字搬出：
  * image 的 content 是 base64（processImage 压的 JPEG），emoji 是图床 URL——
@@ -74,7 +87,16 @@ export function buildGroupHistoryBlock(
     });
     const attachedSet = new Set(validImageWindowIdx.slice(-maxAttachedImages));
     const attachedImages: { tag: number; url: string }[] = [];
-    const text = msgs.map((m, i) => {
+    const lines: string[] = [];
+    let prevTs: number | null = null;
+    msgs.forEach((m, i) => {
+        // 相邻消息隔得久时插一条分隔行，让导演直接在记录里"看见"时间跳变——
+        // 否则用户隔几天回来发一句，模型会把几天前那条当"刚才"无缝续上旧话题。
+        if (prevTs != null && typeof m.timestamp === 'number' && m.timestamp - prevTs >= GROUP_HISTORY_GAP_THRESHOLD_MS) {
+            lines.push(`———（这里隔了 ${formatGapDuration(m.timestamp - prevTs)}，中间群里没人说话）———`);
+        }
+        if (typeof m.timestamp === 'number') prevTs = m.timestamp;
+
         let name = '用户';
         if (m.role === 'assistant') {
             name = characters.find(c => c.id === m.charId)?.name || '未知';
@@ -93,7 +115,7 @@ export function buildGroupHistoryBlock(
             content = `[表情包: ${stickerNameFromUrl(emojis, rawText.trim())}]`;
         } else if (m.type === 'transfer') {
             // 回执行自带完整句子（[系统: X 领取了 Y 的红包]），不加名字前缀
-            if (m.metadata?.packetReceipt) return packetHistoryLine(m, nameOf, now);
+            if (m.metadata?.packetReceipt) { lines.push(packetHistoryLine(m, nameOf, now)); return; }
             content = packetHistoryLine(m, nameOf, now);
         } else if (/^(data:|https?:\/\/)/i.test(rawText.trim())) {
             content = '[媒体]';
@@ -104,10 +126,12 @@ export function buildGroupHistoryBlock(
         if (m.replyTo) {
             const rawQuote = typeof m.replyTo.content === 'string' ? m.replyTo.content : '';
             const quoted = rawQuote.length > 60 ? rawQuote.slice(0, 60) + '…' : rawQuote;
-            return `[${name} 引用了 ${m.replyTo.name || '对方'} 说的「${quoted}」，并回复了 ↓]\n${name}: ${content}`;
+            lines.push(`[${name} 引用了 ${m.replyTo.name || '对方'} 说的「${quoted}」，并回复了 ↓]\n${name}: ${content}`);
+            return;
         }
-        return `${name}: ${content}`;
-    }).join('\n');
+        lines.push(`${name}: ${content}`);
+    });
+    const text = lines.join('\n');
     const attachedImagesNote = attachedImages.length > 0
         ? `\n（本轮附带 ${attachedImages.length} 张最近的图片，对应记录里的 [图片#1] ~ [图片#${attachedImages.length}]。请基于实际图片内容自然反应，不要无视，也不要瞎猜没附上的旧图。）\n`
         : '';


### PR DESCRIPTION
问题1（无法归档，消息卡在旧时间线）：
话题盒总结解析（原 parseTopicBoxResponse）只做严格 JSON.parse，
模型 summary 里带裸换行/未转义引号时必然失败并抛「总结格式无法解析」，
导致 archivedThroughMessageId 永远推进不了，热区以前的消息越堆越多
（用户实测卡到 649 条），整条归档队列被一条坏输出永久堵死。
改为在 utils/groupChat/parse.ts 新增可测的三层容错 parseGroupTopicBox： 严格 JSON → 正则抠字段（容忍换行）→ 有实质文本整段兜底当总结。

问题2（很久以后角色仍无缝续上旧话题）：
- getTimeGapHint 补充"隔天/隔多日"档，明确日子已经过去、别当刚才的事续话；
- 群聊系统头的当前时间补上完整日期与星期（原来只有 HH:MM，感知不到跨天）；
- buildGroupHistoryBlock 在相邻消息间隔 ≥3 小时时插入"隔了约 N 天"分隔行， 让导演直接在记录里看见时间跳变。

新增 parse / prompts 单测，全部通过。


Claude-Session: https://claude.ai/code/session_014T4AaCL2n3TbW6n6GhN6AP