### PR TITLE
feat(备份): 新增「该备份啦」定期提醒弹窗 + 可调频率

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -25,6 +25,7 @@ import VersionInfo from '../components/settings/VersionInfo';
 import { isPushVapidReady } from '../utils/pushVapid';
 import ApiCallLogModal from '../components/settings/ApiCallLogModal';
 import { DB } from '../utils/db';
+import { getBackupReminderState, setBackupReminderIntervalDays, daysSinceLastBackup, BACKUP_REMINDER_MIN_DAYS, BACKUP_REMINDER_MAX_DAYS } from '../utils/backupReminder';
 
 // hot_news（orz.ai）可选热榜平台。key 必须与 API 的 ?platform= 完全一致。
 const HOTNEWS_PLATFORM_OPTIONS: { key: string; label: string }[] = [
@@ -338,6 +339,10 @@ const Settings: React.FC = () => {
   const [cloudBackupFiles, setCloudBackupFiles] = useState<import('../types').CloudBackupFile[]>([]);
   const [cloudTestResult, setCloudTestResult] = useState<string>('');
   const [cloudTesting, setCloudTesting] = useState(false);
+
+  // 「该备份啦」提醒频率（1~30 天）。改动即落 localStorage（backupReminder 模块自管持久化）。
+  const [backupReminderDays, setBackupReminderDays] = useState<number>(() => getBackupReminderState().intervalDays);
+  const backupDaysAgo = daysSinceLastBackup();
 
   // Cloud backup local config state (WebDAV)
   const [cbUrl, setCbUrl] = useState(cloudBackupConfig.webdavUrl);
@@ -1264,7 +1269,38 @@ const Settings: React.FC = () => {
                 • <b>媒体与美化素材</b>: 导出相册、表情包、聊天图片、头像、主题气泡、壁纸、图标等图片资源和外观配置。<br/>
                 • 兼容旧版 JSON 备份文件的导入。
             </p>
-            
+
+            {/* 备份提醒频率：糯米机数据只在本机，隔 N 天没导出会弹一次提醒 */}
+            <div className="mb-4 p-3.5 bg-gradient-to-br from-rose-50 to-orange-50 border border-rose-100 rounded-xl">
+                <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs font-bold text-slate-600">备份提醒频率</span>
+                    <span className="text-xs font-bold text-rose-500">每 {backupReminderDays} 天</span>
+                </div>
+                <input
+                    type="range"
+                    min={BACKUP_REMINDER_MIN_DAYS}
+                    max={BACKUP_REMINDER_MAX_DAYS}
+                    step={1}
+                    value={backupReminderDays}
+                    onChange={e => {
+                        const v = parseInt(e.target.value, 10);
+                        setBackupReminderDays(v);
+                        setBackupReminderIntervalDays(v);
+                    }}
+                    className="w-full h-2 bg-rose-100 rounded-full appearance-none accent-rose-500"
+                />
+                <div className="flex justify-between text-[9px] text-slate-400 mt-1 px-0.5">
+                    <span>{BACKUP_REMINDER_MIN_DAYS} 天</span>
+                    <span>{BACKUP_REMINDER_MAX_DAYS} 天</span>
+                </div>
+                <p className="text-[10px] text-slate-400 mt-2 leading-relaxed">
+                    超过这个天数没有导出，就会弹窗提醒一次。
+                    {backupDaysAgo == null
+                        ? ' 你还没有导出过备份，记得留一份哦。'
+                        : ` 上次备份是在 ${backupDaysAgo} 天前。`}
+                </p>
+            </div>
+
             <button onClick={handleCleanupResidue} disabled={isCleaningResidue} className="w-full py-3 mb-2 bg-amber-50 border border-amber-100 text-amber-600 rounded-xl text-xs font-bold flex items-center justify-center gap-2 active:scale-95 transition-all disabled:opacity-50">
                 {isCleaningResidue ? '正在扫描…' : '一键清理表情包残留'}
             </button>

--- a/components/BackupReminderEvent.tsx
+++ b/components/BackupReminderEvent.tsx
@@ -1,0 +1,99 @@
+/**
+ * BackupReminderEvent.tsx
+ * 「该备份啦」提醒弹窗。
+ *
+ * 糯米机是 local-first：所有数据只躺在你这台设备的浏览器里，没有云端副本。
+ * 隔一段时间（默认 7 天，可在设置里改 1~30 天）没导出，就温柔弹一次提醒。
+ *
+ * 显隐判定在 utils/backupReminder.ts；这里只管长得好看 + 两个出口：
+ *  - 去备份：跳到「设置 → 备份与恢复」
+ *  - 知道了：记一次提醒时间，进入冷却，下个间隔到了才会再弹
+ */
+
+import React from 'react';
+import { daysSinceLastBackup, getBackupReminderState } from '../utils/backupReminder';
+
+interface BackupReminderPopupProps {
+    /** 「知道了 / 稍后」——外层会 markBackupReminderShown 并关闭 */
+    onDismiss: () => void;
+    /** 「去备份」——外层跳设置备份区并关闭 */
+    onGoBackup: () => void;
+}
+
+export const BackupReminderPopup: React.FC<BackupReminderPopupProps> = ({ onDismiss, onGoBackup }) => {
+    const days = daysSinceLastBackup();
+    const interval = getBackupReminderState().intervalDays;
+    // 顶部那句"多久没备份了"——从未备份 vs 已过 N 天，说人话。
+    const gapLine = days == null
+        ? '你还没有导出过备份'
+        : `距离上次备份已经过去 ${days} 天`;
+
+    return (
+        <div className="fixed inset-0 z-[9998] flex items-center justify-center p-5 animate-fade-in">
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-md" onClick={onDismiss} />
+            <div className="relative w-full max-w-sm bg-white/95 backdrop-blur-xl rounded-[2.5rem] shadow-2xl border border-white/30 overflow-hidden animate-slide-up">
+                {/* 顶部渐变头图 + 盾牌图标 */}
+                <div className="relative pt-8 pb-5 px-6 text-center bg-gradient-to-br from-rose-400 via-orange-300 to-amber-300">
+                    <div className="w-16 h-16 mx-auto mb-3 rounded-3xl bg-white/25 backdrop-blur-sm flex items-center justify-center ring-1 ring-white/40 shadow-lg">
+                        <svg viewBox="0 0 24 24" fill="none" className="w-9 h-9 text-white" aria-hidden="true">
+                            <path d="M12 2.5 5 5.2v5.3c0 4.2 2.9 8.1 7 9.2 4.1-1.1 7-5 7-9.2V5.2L12 2.5Z"
+                                stroke="currentColor" strokeWidth="1.7" strokeLinejoin="round" />
+                            <path d="m9.2 12 2 2 3.6-3.8" stroke="currentColor" strokeWidth="1.7"
+                                strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                    </div>
+                    <h2 className="text-xl font-extrabold text-white drop-shadow-sm">该备份啦</h2>
+                    <p className="text-[12px] text-white/90 mt-1 font-medium">{gapLine}</p>
+                </div>
+
+                {/* 正文 */}
+                <div className="px-6 pt-5 pb-2 space-y-3">
+                    <div className="bg-gradient-to-br from-rose-50 to-orange-50 border border-rose-100 rounded-2xl p-4 space-y-2.5">
+                        <p className="text-[13px] text-slate-700 leading-relaxed">
+                            <strong>您本周没有进行备份，请注意。</strong>
+                        </p>
+                        <p className="text-[12.5px] text-slate-600 leading-relaxed">
+                            糯米机的数据完全掌握在<strong className="text-rose-500">您自己手中</strong>——
+                            角色、聊天记录、记忆、设置全都只存在这台设备的浏览器里，我们看不到、也帮不了你找回。
+                        </p>
+                        <p className="text-[12.5px] text-slate-600 leading-relaxed">
+                            一旦清理浏览器缓存、卸载重装、换手机，或者遇到系统抽风，
+                            <strong className="text-rose-500">没有备份就意味着这些全部丢失，无法恢复</strong>。
+                        </p>
+                        <p className="text-[12px] text-slate-500 leading-relaxed">
+                            请养成定期导出的习惯，把 ZIP 存到网盘 / 电脑 / 云备份，给自己留条后路 💛
+                        </p>
+                    </div>
+                    <p className="text-[10.5px] text-slate-400 text-center leading-relaxed">
+                        当前每 {interval} 天提醒一次，可在「设置 → 备份与恢复」里调整频率
+                    </p>
+                </div>
+
+                {/* 按钮 */}
+                <div className="px-6 pb-7 pt-3 space-y-2">
+                    <button
+                        onClick={onGoBackup}
+                        className="w-full py-3.5 font-bold rounded-2xl text-sm text-white bg-gradient-to-r from-rose-500 to-orange-500 shadow-lg shadow-rose-200 active:scale-95 transition-transform"
+                    >
+                        立即备份
+                    </button>
+                    <button
+                        onClick={onDismiss}
+                        className="w-full py-2.5 text-slate-400 font-medium text-[12px] active:scale-95 transition-transform"
+                    >
+                        知道了，稍后再说
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+interface BackupReminderControllerProps {
+    onDismiss: () => void;
+    onGoBackup: () => void;
+}
+
+export const BackupReminderController: React.FC<BackupReminderControllerProps> = (props) => {
+    return <BackupReminderPopup {...props} />;
+};

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -130,6 +130,8 @@ setAppPayloadWarmer((id: AppID) => { const c = APP_BY_ID[id]; if (c) warmLazy(c)
 import { Like520Controller, shouldShowLike520Popup } from './Like520Event';
 import { UpdateNotificationController, shouldShowUpdateNotification } from './UpdateNotificationEvent';
 import { WorkerUpdateReminderController, shouldShowWorkerUpdateReminder } from './WorkerUpdateReminderEvent';
+import { BackupReminderController } from './BackupReminderEvent';
+import { shouldShowBackupReminder, markBackupReminderShown } from '../utils/backupReminder';
 import { formatBytes } from '../utils/format';
 import { AppID } from '../types';
 import { shellHandlesSafeArea } from '../utils/safeAreaApps';
@@ -589,6 +591,24 @@ const PhoneShell: React.FC = () => {
     if (shouldShowWorkerUpdateReminder()) setShowWorkerUpdateReminder(true);
   }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, isDataLoaded]);
 
+  // 「该备份啦」提醒 — local-first 数据只在本机，隔 N 天（默认 7，可在设置里改）没导出就弹一次
+  const [showBackupReminder, setShowBackupReminder] = useState(false);
+  useEffect(() => {
+    if (showDisclaimer || showImportRecoveryPrompt || showAuthorLetter || showUpdateNotification || showLike520Popup || showWorkerUpdateReminder) return;
+    if (!isDataLoaded || isLocked) return;
+    if (shouldShowBackupReminder()) setShowBackupReminder(true);
+  }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, showWorkerUpdateReminder, isDataLoaded, isLocked]);
+
+  const dismissBackupReminder = () => {
+    markBackupReminderShown();
+    setShowBackupReminder(false);
+  };
+  const goBackupFromReminder = () => {
+    markBackupReminderShown();
+    setShowBackupReminder(false);
+    openApp(AppID.Settings);
+  };
+
   // Capacitor Native Handling
   useEffect(() => {
     const initNative = async () => {
@@ -924,6 +944,14 @@ const PhoneShell: React.FC = () => {
        {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && showWorkerUpdateReminder && (
          <WorkerUpdateReminderController
            onClose={() => setShowWorkerUpdateReminder(false)}
+         />
+       )}
+
+       {/* 「该备份啦」提醒（local-first 数据只在本机，隔 N 天没导出弹一次） */}
+       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && !showWorkerUpdateReminder && showBackupReminder && (
+         <BackupReminderController
+           onDismiss={dismissBackupReminder}
+           onGoBackup={goBackupFromReminder}
          />
        )}
     </div>

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -20,6 +20,7 @@ import { safeFetchJson } from '../utils/safeApi';
 import { recordApiCall, setApiCallAmbientContext } from '../utils/apiCallLog';
 import { rewriteStaleWorkerUrl } from '../utils/proxyWorker';
 import { INSTALLED_APPS } from '../constants';
+import { markBackupDone } from '../utils/backupReminder';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
@@ -3311,6 +3312,8 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           );
 
           setSysOperation({ status: 'idle', message: '', progress: 100 });
+          // 备份成功 → 推进「该备份啦」提醒的计时（本地导出 / 云备份都走这里，一处覆盖两条路径）
+          markBackupDone();
           return content;
 
       } catch (e: any) {

--- a/utils/backupReminder.test.ts
+++ b/utils/backupReminder.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    getBackupReminderState,
+    setBackupReminderIntervalDays,
+    markBackupDone,
+    markBackupReminderShown,
+    shouldShowBackupReminder,
+    daysSinceLastBackup,
+    clampReminderDays,
+    BACKUP_REMINDER_DEFAULT_DAYS,
+} from './backupReminder';
+
+const DAY = 24 * 60 * 60 * 1000;
+const T0 = 1_700_000_000_000; // 固定基准时间，避开 Date.now()
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('clampReminderDays', () => {
+    it('夹在 1~30，取整，非法值回默认', () => {
+        expect(clampReminderDays(0)).toBe(1);
+        expect(clampReminderDays(999)).toBe(30);
+        expect(clampReminderDays(7.6)).toBe(8);
+        expect(clampReminderDays(NaN)).toBe(BACKUP_REMINDER_DEFAULT_DAYS);
+    });
+});
+
+describe('getBackupReminderState', () => {
+    it('首次读取锚定 firstSeenAt 并回写，默认间隔 7 天', () => {
+        const st = getBackupReminderState(T0);
+        expect(st.intervalDays).toBe(BACKUP_REMINDER_DEFAULT_DAYS);
+        expect(st.firstSeenAt).toBe(T0);
+        expect(st.lastBackupAt).toBe(0);
+        // 回写后再读，firstSeenAt 不再随 now 变
+        expect(getBackupReminderState(T0 + 5 * DAY).firstSeenAt).toBe(T0);
+    });
+});
+
+describe('shouldShowBackupReminder', () => {
+    it('新用户刚进来（未到间隔）不弹', () => {
+        getBackupReminderState(T0); // 锚 firstSeenAt = T0
+        expect(shouldShowBackupReminder(T0 + 3 * DAY)).toBe(false);
+    });
+
+    it('从未备份且超过间隔 → 弹', () => {
+        getBackupReminderState(T0);
+        expect(shouldShowBackupReminder(T0 + 8 * DAY)).toBe(true);
+    });
+
+    it('弹过之后进入一个间隔的冷却，不再连弹', () => {
+        getBackupReminderState(T0);
+        expect(shouldShowBackupReminder(T0 + 8 * DAY)).toBe(true);
+        markBackupReminderShown(T0 + 8 * DAY);
+        expect(shouldShowBackupReminder(T0 + 9 * DAY)).toBe(false); // 冷却中
+        expect(shouldShowBackupReminder(T0 + 16 * DAY)).toBe(true);  // 又过了一个间隔
+    });
+
+    it('备份成功后不再弹，且清掉提醒冷却', () => {
+        getBackupReminderState(T0);
+        markBackupReminderShown(T0 + 8 * DAY);
+        markBackupDone(T0 + 9 * DAY);
+        expect(getBackupReminderState().lastRemindedAt).toBe(0);
+        expect(shouldShowBackupReminder(T0 + 10 * DAY)).toBe(false);
+        // 距上次备份再次超过间隔才会重新弹
+        expect(shouldShowBackupReminder(T0 + 17 * DAY)).toBe(true);
+    });
+
+    it('间隔可调：设成 1 天后隔天就弹', () => {
+        getBackupReminderState(T0);
+        setBackupReminderIntervalDays(1, T0);
+        expect(shouldShowBackupReminder(T0 + 12 * 60 * 60 * 1000)).toBe(false); // 半天
+        expect(shouldShowBackupReminder(T0 + 1.5 * DAY)).toBe(true);
+    });
+});
+
+describe('daysSinceLastBackup', () => {
+    it('从未备份返回 null', () => {
+        getBackupReminderState(T0);
+        expect(daysSinceLastBackup(T0 + 3 * DAY)).toBeNull();
+    });
+    it('备份后按天数向下取整', () => {
+        markBackupDone(T0);
+        expect(daysSinceLastBackup(T0 + 3.9 * DAY)).toBe(3);
+    });
+});

--- a/utils/backupReminder.ts
+++ b/utils/backupReminder.ts
@@ -1,0 +1,103 @@
+/**
+ * backupReminder.ts
+ * 「该备份啦」提醒的纯逻辑 + localStorage 持久化。
+ *
+ * 背景：糯米机（SullyOS）是 local-first，全部数据只在用户自己的浏览器 IndexedDB 里，
+ * 清缓存 / 换设备 / 崩溃就全没了。所以隔一段时间没导出就温柔提醒一次。
+ *
+ * 设计：自包含模块（不进 OSContext 那坨大 interface），对齐 WorkerUpdateReminderEvent 的写法。
+ *  - 频率用户可在「设置 → 备份」里改，1~30 天，默认 7 天。
+ *  - markBackupDone(): 任何一次成功导出/云备份后调用，推进 lastBackupAt 并清掉提醒态。
+ *  - shouldShowBackupReminder(): PhoneShell 用它决定弹不弹。
+ *  - 纯函数都接受可注入的 now，方便 vitest 直测。
+ */
+
+const KEY = 'sullyos_backup_reminder';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const BACKUP_REMINDER_MIN_DAYS = 1;
+export const BACKUP_REMINDER_MAX_DAYS = 30;
+export const BACKUP_REMINDER_DEFAULT_DAYS = 7;
+
+export interface BackupReminderState {
+    /** 提醒间隔（天），1~30 */
+    intervalDays: number;
+    /** 上次成功备份的时间戳（ms）；0 = 从未备份 */
+    lastBackupAt: number;
+    /** 上次弹过提醒的时间戳（ms）；0 = 从未提醒（提醒后进入一个间隔的冷却，避免天天弹） */
+    lastRemindedAt: number;
+    /** 首次见到此设备的时间戳（ms）；从未备份时用它当"多久没备份"的起算点，避免新用户一装就被念叨 */
+    firstSeenAt: number;
+}
+
+export const clampReminderDays = (n: number): number => {
+    const v = Math.round(Number(n));
+    if (!Number.isFinite(v)) return BACKUP_REMINDER_DEFAULT_DAYS;
+    return Math.min(BACKUP_REMINDER_MAX_DAYS, Math.max(BACKUP_REMINDER_MIN_DAYS, v));
+};
+
+const persist = (s: BackupReminderState): void => {
+    try { localStorage.setItem(KEY, JSON.stringify(s)); } catch { /* 隐私模式等：存不了就算了 */ }
+};
+
+/**
+ * 读当前状态；缺字段用默认补齐。首次读取（firstSeenAt 为 0）时把它锚到 now 并回写，
+ * 这样"从未备份"的用户也有个合理的起算点，不会一进 App 就被提醒。
+ */
+export function getBackupReminderState(now: number = Date.now()): BackupReminderState {
+    let raw: Partial<BackupReminderState> = {};
+    try {
+        const s = localStorage.getItem(KEY);
+        if (s) raw = JSON.parse(s) as Partial<BackupReminderState>;
+    } catch { /* 坏 JSON 当空处理 */ }
+
+    const state: BackupReminderState = {
+        intervalDays: clampReminderDays(raw.intervalDays ?? BACKUP_REMINDER_DEFAULT_DAYS),
+        lastBackupAt: Number(raw.lastBackupAt) || 0,
+        lastRemindedAt: Number(raw.lastRemindedAt) || 0,
+        firstSeenAt: Number(raw.firstSeenAt) || 0,
+    };
+    if (state.firstSeenAt === 0) {
+        state.firstSeenAt = now;
+        persist(state);
+    }
+    return state;
+}
+
+/** 设置提醒频率（天），返回落库后的新状态。 */
+export function setBackupReminderIntervalDays(days: number, now: number = Date.now()): BackupReminderState {
+    const next = { ...getBackupReminderState(now), intervalDays: clampReminderDays(days) };
+    persist(next);
+    return next;
+}
+
+/** 一次成功备份后调用：推进 lastBackupAt，并清掉提醒冷却（下次到点重新算）。 */
+export function markBackupDone(now: number = Date.now()): void {
+    persist({ ...getBackupReminderState(now), lastBackupAt: now, lastRemindedAt: 0 });
+}
+
+/** 弹过提醒后调用：记下时间，进入一个间隔的冷却，避免反复弹。 */
+export function markBackupReminderShown(now: number = Date.now()): void {
+    persist({ ...getBackupReminderState(now), lastRemindedAt: now });
+}
+
+/**
+ * 是否该弹提醒：
+ *  - 距上次备份（从未备份则距首见）已超过 intervalDays，且
+ *  - 距上次提醒也已超过 intervalDays（提醒冷却；备份成功会把它清 0，于是自然不再弹）。
+ */
+export function shouldShowBackupReminder(now: number = Date.now()): boolean {
+    const st = getBackupReminderState(now);
+    const intervalMs = st.intervalDays * DAY_MS;
+    const backupAnchor = st.lastBackupAt > 0 ? st.lastBackupAt : st.firstSeenAt;
+    if (now - backupAnchor < intervalMs) return false;
+    if (now - st.lastRemindedAt < intervalMs) return false;
+    return true;
+}
+
+/** 距上次备份过了几天（向下取整）；从未备份返回 null。给弹窗文案用。 */
+export function daysSinceLastBackup(now: number = Date.now()): number | null {
+    const st = getBackupReminderState(now);
+    if (st.lastBackupAt <= 0) return null;
+    return Math.max(0, Math.floor((now - st.lastBackupAt) / DAY_MS));
+}


### PR DESCRIPTION
糯米机是 local-first，数据只在本机浏览器里，长期不导出风险很高。
新增一个温柔的定期提醒：隔 N 天没备份就弹一次，默认 7 天，
可在「设置 → 备份与恢复」里 1~30 天调节。

- utils/backupReminder.ts：自包含的纯逻辑 + localStorage 持久化 （对齐 WorkerUpdateReminderEvent 的写法）。首见锚点避免新用户一装就被念叨； 弹过进入一个间隔的冷却；备份成功清冷却并推进计时。附单测。
- components/BackupReminderEvent.tsx：渐变盾牌弹窗，文案强调数据在用户自己手中、 丢了无法恢复，主按钮「立即备份」跳设置备份区。
- PhoneShell：接进现有弹窗链末位（在免责/导入恢复/版本/520/worker 之后）， 仅在数据加载完且已解锁时判定。
- OSContext.exportSystem：成功后 markBackupDone()，本地导出与云备份都走这里，一处覆盖两条路径。
- Settings：备份区新增频率滑块（1~30 天）+ 上次备份距今提示。


Claude-Session: https://claude.ai/code/session_014T4AaCL2n3TbW6n6GhN6AP