### PR TITLE
fix(chat): 一键存入记忆宫殿补齐进度反馈与真实待处理数

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -122,6 +122,9 @@ const Chat: React.FC = () => {
     const [settingsHtmlModeCustomPrompt, setSettingsHtmlModeCustomPrompt] = useState('');
     const [preserveContext, setPreserveContext] = useState(true);
     const [isVectorizing, setIsVectorizing] = useState(false);
+    // 记忆宫殿「一键存入」：打开设置弹窗时算出待处理条数（排除热区的真实口径），处理中显示逐轮进度
+    const [vectorizePendingCount, setVectorizePendingCount] = useState<number | null>(null);
+    const [vectorizeProgress, setVectorizeProgress] = useState('');
     const [selectedMessage, setSelectedMessage] = useState<Message | null>(null);
     const [selectedEmoji, setSelectedEmoji] = useState<Emoji | null>(null);
     const [selectedCategory, setSelectedCategory] = useState<EmojiCategory | null>(null); // For deletion modal
@@ -1828,6 +1831,26 @@ const Chat: React.FC = () => {
         setModalType('none');
     };
 
+    // 打开「聊天设置」弹窗且开了记忆宫殿时，算一次待处理条数显示在「一键存入」按钮上。
+    // 口径与 pipeline 一致（getMemoryPalaceUnprocessedBufferCount 已排除热区 200 条）。
+    useEffect(() => {
+        if (modalType !== 'chat-settings' || !char?.memoryPalaceEnabled) {
+            setVectorizePendingCount(null);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            try {
+                const { getMemoryPalaceUnprocessedBufferCount } = await import('../utils/memoryPalace/pipeline');
+                const n = await getMemoryPalaceUnprocessedBufferCount(char.id);
+                if (!cancelled) setVectorizePendingCount(n);
+            } catch {
+                // 算不出就不显示条数，不影响按钮可用
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [modalType, char?.id, char?.memoryPalaceEnabled]);
+
     const handleForceVectorize = async () => {
         if (!char || !char.memoryPalaceEnabled || isVectorizing) return;
         const mpEmb = memoryPalaceConfig?.embedding;
@@ -1838,13 +1861,12 @@ const Chat: React.FC = () => {
         }
 
         setIsVectorizing(true);
-        setModalType('none');
+        // 留在「聊天设置」弹窗里，按钮原地转成逐轮进度，跑完才收
+        setVectorizeProgress('准备中...');
         addToast('🏰 开始向量化所有聊天记录...', 'info');
 
         try {
-            const { processNewMessages, getMemoryPalaceHighWaterMark, mergePalaceFragmentsIntoMemories } = await import('../utils/memoryPalace/pipeline');
-            const BATCH_PROCESS_RATIO = 0.85;
-            const BATCH_SIZE = 170; // 200 * 0.85
+            const { processNewMessages, getMemoryPalaceHighWaterMark, getMemoryPalaceUnprocessedBufferCount, mergePalaceFragmentsIntoMemories } = await import('../utils/memoryPalace/pipeline');
             let totalProcessed = 0;
             let round = 0;
             const MAX_ROUNDS = 50; // 安全上限
@@ -1855,20 +1877,15 @@ const Chat: React.FC = () => {
             while (round < MAX_ROUNDS) {
                 round++;
                 const hwm = getMemoryPalaceHighWaterMark(char.id);
-                const allMessages = await DB.getMessagesByCharId(char.id, true);
-                const textMessages = allMessages
-                    .filter(m => m.type === 'text' && m.content?.trim())
-                    .sort((a, b) => a.id - b.id);
+                // 用 pipeline 的真实缓冲区口径（排除热区），与 processNewMessages(force) 实际会处理的量一致，
+                // 循环才能正确收敛，进度条数也不会骗人。
+                const remaining = await getMemoryPalaceUnprocessedBufferCount(char.id);
+                if (remaining < 10) break; // 剩余太少，停止
+                setVectorizeProgress(`第 ${round} 轮 · 剩余 ${remaining} 条`);
+                setVectorizePendingCount(remaining);
 
-                // 计算未处理的消息
-                const unprocessed = textMessages.filter(m => m.id > hwm);
-                if (unprocessed.length < 10) break; // 剩余太少，停止
-
-                // 取一批处理
-                const batch = unprocessed.slice(0, BATCH_SIZE);
-                console.log(`🏰 [ForceVectorize] 第 ${round} 轮：处理 ${batch.length} 条消息（hwm=${hwm}，剩余 ${unprocessed.length}）`);
-
-                const pipelineResult = await processNewMessages(batch, char.id, char.name, mpEmb, mpLLM, userProfile?.name || '', true);
+                // processNewMessages 内部直接从 DB 加载并按缓冲区口径取批，忽略首个参数，传 [] 即可
+                const pipelineResult = await processNewMessages([], char.id, char.name, mpEmb, mpLLM, userProfile?.name || '', true);
 
                 // 软跳过：缓冲区还没到阈值 / 热区还没被挤出 / 已有任务在跑 —— 不是 LLM 失败
                 if (pipelineResult?.skipReason) {
@@ -1878,7 +1895,7 @@ const Chat: React.FC = () => {
                     break;
                 }
 
-                totalProcessed += batch.length;
+                totalProcessed += pipelineResult?.processedMessages || 0;
 
                 // 累积自动归档，统一在循环结束后 updateCharacter
                 // 避免每轮 setState 触发 char 对象重建进而 dep 失效
@@ -1914,6 +1931,11 @@ const Chat: React.FC = () => {
                 } as any);
             }
 
+            // 跑完刷新按钮上的待处理条数
+            try {
+                setVectorizePendingCount(await getMemoryPalaceUnprocessedBufferCount(char.id));
+            } catch { /* 忽略：刷新失败不影响结果提示 */ }
+
             if (totalProcessed > 0) {
                 addToast(`✅ 向量化完成：${round} 轮处理了约 ${totalProcessed} 条消息`, 'success');
             } else {
@@ -1923,6 +1945,7 @@ const Chat: React.FC = () => {
             addToast(`❌ 向量化失败：${e.message}`, 'error');
         } finally {
             setIsVectorizing(false);
+            setVectorizeProgress('');
         }
     };
 
@@ -2754,6 +2777,8 @@ const Chat: React.FC = () => {
                 onToggleScheduleFeature={handleToggleScheduleFeature}
                 isMemoryPalaceEnabled={!!char.memoryPalaceEnabled}
                 isVectorizing={isVectorizing}
+                vectorizePendingCount={vectorizePendingCount}
+                vectorizeProgress={vectorizeProgress}
                 onForceVectorize={handleForceVectorize}
                 apiPresets={apiPresets}
                 onAddApiPreset={addApiPreset}

--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -1876,16 +1876,21 @@ const Chat: React.FC = () => {
 
             while (round < MAX_ROUNDS) {
                 round++;
+                // 角色已切走就中断：Chat 是单实例复用、这些是共享 state，继续跑会把旧角色的进度串到新角色 UI 上。
+                // 向量化基于高水位、可续跑，下次进这个角色再点会接着来。
+                if (char.id !== activeCharIdRef.current) break;
                 const hwm = getMemoryPalaceHighWaterMark(char.id);
                 // 用 pipeline 的真实缓冲区口径（排除热区），与 processNewMessages(force) 实际会处理的量一致，
                 // 循环才能正确收敛，进度条数也不会骗人。
                 const remaining = await getMemoryPalaceUnprocessedBufferCount(char.id);
+                if (char.id !== activeCharIdRef.current) break;
                 if (remaining < 10) break; // 剩余太少，停止
                 setVectorizeProgress(`第 ${round} 轮 · 剩余 ${remaining} 条`);
                 setVectorizePendingCount(remaining);
 
                 // processNewMessages 内部直接从 DB 加载并按缓冲区口径取批，忽略首个参数，传 [] 即可
                 const pipelineResult = await processNewMessages([], char.id, char.name, mpEmb, mpLLM, userProfile?.name || '', true);
+                if (char.id !== activeCharIdRef.current) break;
 
                 // 软跳过：缓冲区还没到阈值 / 热区还没被挤出 / 已有任务在跑 —— 不是 LLM 失败
                 if (pipelineResult?.skipReason) {
@@ -1931,15 +1936,18 @@ const Chat: React.FC = () => {
                 } as any);
             }
 
-            // 跑完刷新按钮上的待处理条数
-            try {
-                setVectorizePendingCount(await getMemoryPalaceUnprocessedBufferCount(char.id));
-            } catch { /* 忽略：刷新失败不影响结果提示 */ }
+            // 仅当仍停在这个角色时刷新按钮 + 弹结果提示，避免串台到刚切过去的新角色
+            if (char.id === activeCharIdRef.current) {
+                // 跑完刷新按钮上的待处理条数
+                try {
+                    setVectorizePendingCount(await getMemoryPalaceUnprocessedBufferCount(char.id));
+                } catch { /* 忽略：刷新失败不影响结果提示 */ }
 
-            if (totalProcessed > 0) {
-                addToast(`✅ 向量化完成：${round} 轮处理了约 ${totalProcessed} 条消息`, 'success');
-            } else {
-                addToast('所有聊天记录都已处理完毕，无需操作', 'info');
+                if (totalProcessed > 0) {
+                    addToast(`✅ 向量化完成：${round} 轮处理了约 ${totalProcessed} 条消息`, 'success');
+                } else {
+                    addToast('所有聊天记录都已处理完毕，无需操作', 'info');
+                }
             }
         } catch (e: any) {
             addToast(`❌ 向量化失败：${e.message}`, 'error');

--- a/components/chat/ChatModals.tsx
+++ b/components/chat/ChatModals.tsx
@@ -117,6 +117,10 @@ interface ChatModalsProps {
     // Memory Palace force vectorize
     isMemoryPalaceEnabled?: boolean;
     isVectorizing?: boolean;
+    /** 待处理条数（排除热区的真实缓冲区口径）：null=未算出/未开弹窗，0=已全同步 */
+    vectorizePendingCount?: number | null;
+    /** 处理中的逐轮进度文案，如「第 2 轮 · 剩余 340 条」 */
+    vectorizeProgress?: string;
     onForceVectorize?: () => void;
     // Emotion (embedded under schedule modal, synced on/off with scheduleStyle)
     apiPresets?: ApiPreset[];
@@ -231,7 +235,7 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     scheduleData, isScheduleGenerating, onScheduleEdit, onScheduleDelete, onScheduleReroll, onScheduleCoverChange,
     onScheduleStyleChange, onPlayTheater,
     isScheduleFeatureEnabled, onToggleScheduleFeature,
-    isMemoryPalaceEnabled, isVectorizing, onForceVectorize,
+    isMemoryPalaceEnabled, isVectorizing, vectorizePendingCount, vectorizeProgress, onForceVectorize,
     apiPresets, onAddApiPreset, onSaveEmotion, onClearBuffs,
 }) => {
     const bgInputRef = useRef<HTMLInputElement>(null);
@@ -510,13 +514,20 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                              <button
                                  onClick={onForceVectorize}
                                  disabled={isVectorizing}
-                                 className="w-full py-3 bg-emerald-50 text-emerald-600 font-bold rounded-2xl border border-emerald-200 active:scale-95 transition-transform flex items-center justify-center gap-2"
+                                 className="w-full py-3 bg-emerald-50 text-emerald-600 font-bold rounded-2xl border border-emerald-200 active:scale-95 transition-transform flex items-center justify-center gap-2 disabled:opacity-70"
                              >
-                                 {isVectorizing ? '🏰 存进记忆宫殿中...' : '🏰 一键把所有聊天存进记忆宫殿'}
+                                 {isVectorizing
+                                     ? `🏰 ${vectorizeProgress || '存进记忆宫殿中...'}`
+                                     : (vectorizePendingCount != null && vectorizePendingCount > 0)
+                                         ? `🏰 一键存进记忆宫殿 · 待处理 ${vectorizePendingCount} 条`
+                                         : (vectorizePendingCount === 0)
+                                             ? '🏰 记忆宫殿已同步 · 无待处理'
+                                             : '🏰 一键把所有聊天存进记忆宫殿'}
                              </button>
                              <p className="text-[10px] text-slate-400 mt-2 text-center leading-relaxed">
-                                 将所有未处理的聊天记录交给记忆宫殿处理，完成后可安全清空聊天。<br/>
-                                 <span className="text-slate-300">看不懂这是什么的话不需要操作此按钮。</span>
+                                 {isVectorizing
+                                     ? '正在分批交给副 API 处理，保持应用打开、先别切走～完成前请勿清空聊天。'
+                                     : <>将所有未处理的聊天记录交给记忆宫殿处理，完成后可安全清空聊天。<br/><span className="text-slate-300">看不懂这是什么的话不需要操作此按钮。</span></>}
                              </p>
                          </div>
                      )}

--- a/utils/memoryPalace/bufferCount.test.ts
+++ b/utils/memoryPalace/bufferCount.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { countUnprocessedBufferMessages } from './bufferCount';
+
+/** 造一批 id 连续、内容非空的文本消息 */
+const makeMsgs = (n: number, startId = 1) =>
+    Array.from({ length: n }, (_, i) => ({ id: startId + i, type: 'text', content: 'x' })) as any;
+
+describe('countUnprocessedBufferMessages（记忆宫殿未同步口径）', () => {
+    it('消息数 <= 热区时恒为 0（全在热区，永远不会被处理）', () => {
+        expect(countUnprocessedBufferMessages(makeMsgs(200), 0, 200)).toBe(0);
+        // 小热区同理
+        expect(countUnprocessedBufferMessages(makeMsgs(3), 0, 3)).toBe(0);
+    });
+
+    it('排除最后 N 条热区：250 条、hwm=0、热区200 → 只数前 50 条', () => {
+        expect(countUnprocessedBufferMessages(makeMsgs(250), 0, 200)).toBe(50);
+    });
+
+    it('再排除已处理(id <= hwm)：250 条、hwm=30、热区200 → 50 里去掉前 30 = 20', () => {
+        expect(countUnprocessedBufferMessages(makeMsgs(250), 30, 200)).toBe(20);
+    });
+
+    it('小热区精确边界：5 条、热区3、hwm=0 → 只有 id 1、2 落在缓冲区 = 2', () => {
+        // 排序后 [1,2,3,4,5]，热区起点 = 倒数第 3 条 = id 3；缓冲区 = id>0 且 id<3 = {1,2}
+        expect(countUnprocessedBufferMessages(makeMsgs(5), 0, 3)).toBe(2);
+    });
+
+    it('乱序输入也按 id 排序后计算，结果一致', () => {
+        const shuffled = [{ id: 5 }, { id: 1 }, { id: 3 }, { id: 2 }, { id: 4 }] as any;
+        expect(countUnprocessedBufferMessages(shuffled, 0, 3)).toBe(2);
+    });
+
+    it('回归守卫：绝不能退回 "id > hwm" 裸口径', () => {
+        const msgs = makeMsgs(250); // id 1..250
+        const naive = msgs.filter((m: any) => m.id > 0).length; // 裸口径 = 250
+        const correct = countUnprocessedBufferMessages(msgs, 0, 200); // 正确 = 50
+        expect(correct).toBe(50);
+        expect(correct).not.toBe(naive); // 若有人改回裸过滤，这一行会挂
+    });
+});

--- a/utils/memoryPalace/bufferCount.ts
+++ b/utils/memoryPalace/bufferCount.ts
@@ -1,0 +1,31 @@
+import type { Message } from '../../types';
+
+/**
+ * 纯计算：记忆宫殿"未同步"缓冲区条数——即真正能被 pipeline 处理的历史消息数。
+ *
+ * 口径必须和 pipeline 的缓冲区定义一致：
+ *   - 排除热区（最后 hotZoneSize 条永远留在上下文，不参与处理）
+ *   - 排除已处理（id <= hwm）
+ *
+ * 切勿退回 "id > hwm" 裸过滤——那会把永远不处理的热区也算进未同步，
+ * UI 会显示几百条待处理、用户点了却跑不出新水位，等于骗人。
+ * 这个坑已经踩过一次，bufferCount.test.ts 把正确口径钉住了。
+ *
+ * @param semanticMessages 已过滤成"语义相关"的消息（可不排序，本函数内部按 id 排序）
+ * @param hwm 当前高水位标记（id <= hwm 视为已处理）
+ * @param hotZoneSize 热区大小，默认 200，与 pipeline 的 HOT_ZONE_SIZE 对齐
+ */
+export function countUnprocessedBufferMessages(
+    semanticMessages: Message[],
+    hwm: number,
+    hotZoneSize = 200,
+): number {
+    const sorted = [...semanticMessages].sort((a, b) => a.id - b.id);
+    if (sorted.length <= hotZoneSize) return 0;
+    const hotZoneStartId = sorted[sorted.length - hotZoneSize].id;
+    let count = 0;
+    for (const m of sorted) {
+        if (m.id > hwm && m.id < hotZoneStartId) count++;
+    }
+    return count;
+}

--- a/utils/memoryPalace/pipeline.ts
+++ b/utils/memoryPalace/pipeline.ts
@@ -19,6 +19,7 @@
 
 import type { Message } from '../../types';
 import type { EmbeddingConfig, PersonalityStyle, RemoteVectorConfig, ScoredMemory } from './types';
+import { countUnprocessedBufferMessages } from './bufferCount';
 
 /** 从 localStorage 读取远程向量配置（避免在每个调用点都传参） */
 function getRemoteVectorConfig(): RemoteVectorConfig | undefined {
@@ -1149,17 +1150,8 @@ const PROCESS_RATIO = 0.85;
  */
 export async function getMemoryPalaceUnprocessedBufferCount(charId: string): Promise<number> {
     const allMessages = await DB.getMessagesByCharId(charId, true);
-    const semantic = allMessages
-        .filter(m => isMessageSemanticallyRelevant(m))
-        .sort((a, b) => a.id - b.id);
-    if (semantic.length <= HOT_ZONE_SIZE) return 0;
-    const hotZoneStartId = semantic[semantic.length - HOT_ZONE_SIZE].id;
-    const hwm = getLastProcessedId(charId);
-    let count = 0;
-    for (const m of semantic) {
-        if (m.id > hwm && m.id < hotZoneStartId) count++;
-    }
-    return count;
+    const semantic = allMessages.filter(m => isMessageSemanticallyRelevant(m));
+    return countUnprocessedBufferMessages(semantic, getLastProcessedId(charId), HOT_ZONE_SIZE);
 }
 
 /** 并发锁：防止多次 AI 回复同时触发 processNewMessages 产生竞态 */


### PR DESCRIPTION
## 背景

用户反馈：点「一键把所有聊天存进记忆宫殿」后没有任何反应，反复点击也没声，最后是去 API 记录里才发现其实一直在总结。

排查发现该按钮点击后会**立刻关闭弹窗**、只弹一个几秒即逝的 toast，之后整个分批处理（最多 50 轮）期间界面零提示；处理中再点又被 `isVectorizing` 静默 `return`，所以怎么点都"没反应"。

## 改动

| | 改前 | 改后 |
|---|---|---|
| 点击瞬间 | 弹窗立刻关闭，仅闪一个 toast | 弹窗保持打开，按钮原地转进度 |
| 处理中 | 界面无提示 | 按钮显示 `第 N 轮 · 剩余 X 条`，附"保持应用打开"提示 |
| 待处理量 | 看不到 | 未运行时按钮显示 `待处理 X 条`，全同步后显示 `已同步 · 无待处理` |
| 重复点击 | 静默 return | 处理中按钮置灰，点不动 |

## 顺带修正的口径

原本待处理数用 `id > hwm` 裸算，会把永远不参与处理的热区（最近 200 条）也算进去——显示几百条、点了却跑不出新记忆。现改用与 `pipeline` 一致、排除热区的缓冲区口径（`getMemoryPalaceUnprocessedBufferCount`），与记忆宫殿 App 的「立即追平」共用同一算法，界面数字与实际能处理的量对齐。同时该按钮不再向 `processNewMessages` 传无用的 batch（该函数内部直接从 DB 读、忽略首参）。

## 测试

- 新增 `utils/memoryPalace/bufferCount.ts` 纯函数 + `bufferCount.test.ts`（6 用例），把"排除热区"的口径钉成回归守卫，防止退回裸口径。
- 全量 `pnpm vitest run`：80 文件 / 917 用例通过。
- 改动的 4 个文件 `tsc --noEmit` 零类型错误。

https://claude.ai/code/session_01MTUT6rz7r28BTSa82w46XY
