### PR TITLE
fix: 切歌后重新判断一起听并补充世界书引导

### DIFF
--- a/apps/WorldbookApp.tsx
+++ b/apps/WorldbookApp.tsx
@@ -480,7 +480,7 @@ const WorldbookApp: React.FC = () => {
                                 <div>
                                     <label className="flex items-center gap-2 text-xs font-bold text-slate-400 mb-2">
                                         <input type="checkbox" checked={tempUseProbability} onChange={e => setTempUseProbability(e.target.checked)} className="accent-indigo-500" />
-                                        使用概率
+                                        启用随机概率
                                     </label>
                                     <input
                                         type="number"
@@ -492,6 +492,10 @@ const WorldbookApp: React.FC = () => {
                                         className="w-full text-sm text-slate-700 bg-slate-50/80 border border-slate-200 rounded-xl px-4 py-3 outline-none focus:bg-white focus:border-indigo-400 focus:ring-4 focus:ring-indigo-50 transition-all disabled:opacity-40"
                                     />
                                 </div>
+                            </div>
+                            <div className="rounded-xl border border-indigo-100 bg-indigo-50/70 px-4 py-3 text-[10px] leading-relaxed text-indigo-700">
+                                <span className="font-bold">未勾选“启用随机概率”不代表条目没有激活。</span>
+                                未勾选时会跳过随机判定：只要条目已启用且满足常驻／关键词条件，就会按 100% 通过；勾选后，才会在条件满足时按上方百分比再次随机判断。
                             </div>
                         </div>
 
@@ -548,6 +552,21 @@ const WorldbookApp: React.FC = () => {
 
             {/* Content List */}
             <div className="flex-1 overflow-y-auto p-5 pb-24 space-y-4 no-scrollbar relative z-0">
+                <div className="rounded-2xl border border-indigo-100/80 bg-white/75 backdrop-blur-md p-4 shadow-sm text-slate-600">
+                    <div className="flex items-center gap-2 text-xs font-bold text-indigo-600">
+                        <BookOpen size={16} weight="bold" /> 世界书是做什么的？
+                    </div>
+                    <p className="mt-2 text-[11px] leading-relaxed">
+                        世界书是一组按条件提供给 AI 的补充设定，可用于世界观、人物关系、地点和规则等内容。它不会自己发消息，也不等同于角色记忆。
+                    </p>
+                    <p className="mt-1.5 text-[11px] leading-relaxed text-slate-500">
+                        创建或导入后，还要在角色编辑页的“扩展设定”中挂载；聊天生成回复时，已启用并满足常驻或关键词条件（以及可选的概率判定）的条目才会注入提示词。
+                    </p>
+                    <p className="mt-2 rounded-xl bg-indigo-50 px-3 py-2 text-[10px] leading-relaxed text-indigo-700">
+                        注意：“启用随机概率”未点亮 = 不使用随机抽取，条件满足时按 100% 通过；并不是“未激活”。
+                    </p>
+                </div>
+
                 {Object.keys(groupedBooks).length === 0 && (
                     <div className="flex flex-col items-center justify-center h-64 text-slate-400 gap-4 opacity-60">
                         <BookOpen size={48} className="text-slate-400" />

--- a/context/MusicContext.tsx
+++ b/context/MusicContext.tsx
@@ -15,6 +15,7 @@ import { cachedCall as _cachedCall, invalidate as _invalidateCache, clearAll as 
 import { DB } from '../utils/db';
 import { getProxyWorkerUrl, DEFAULT_PROXY_WORKER, PROXY_WORKER_CHANGED_EVENT } from '../utils/proxyWorker';
 import type { PostProcessMusicHooks } from '../utils/applyAssistantPostProcessing';
+import { createMusicTrackChangeDetail, MUSIC_TRACK_CHANGED_EVENT, type MusicTrackChangeDetail } from '../utils/musicTrackChange';
 
 /* ───────────── 类型 ───────────── */
 export type MusicQuality = 'standard' | 'higher' | 'exhigh' | 'lossless' | 'hires';
@@ -537,16 +538,19 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setListeningTogetherWith(prev => prev.length ? [] : prev);
   }, []);
 
-  // 当 current 歌曲变化（切歌 / 初次播放新歌）→ 清空"一起听"
-  // 这样 char 选择 "join" 仅对当前这一首有效，切到下一首后回到 off
-  const currentSongIdRef = useRef<number | null>(null);
+  // 切歌后清空上一首的"一起听"；新歌真正开始播放后，再通知刚才的 char 重新判断
+  const previousSongRef = useRef<Song | null>(null);
+  const pendingTrackChangeRef = useRef<MusicTrackChangeDetail | null>(null);
   useEffect(() => {
-    const newId = current?.id ?? null;
-    if (currentSongIdRef.current !== null && currentSongIdRef.current !== newId) {
+    const previousSong = previousSongRef.current;
+    const detail = createMusicTrackChangeDetail(previousSong, current, listeningTogetherWith);
+
+    if (previousSong && previousSong.id !== current?.id) {
       setListeningTogetherWith([]);
+      pendingTrackChangeRef.current = detail;
     }
-    currentSongIdRef.current = newId;
-  }, [current]);
+    previousSongRef.current = current;
+  }, [current, listeningTogetherWith]);
 
   // 前进/后退 refs (避免循环依赖 & audio 事件闭包陷阱)
   const queueRef = useRef(queue); queueRef.current = queue;
@@ -562,7 +566,14 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     // 注意: 不要设置 crossOrigin — NetEase CDN 没有 CORS 头，会变成静默加载失败
     audioRef.current = a;
 
-    const onPlay = () => setPlaying(true);
+    const onPlay = () => {
+      setPlaying(true);
+      const detail = pendingTrackChangeRef.current;
+      if (detail) {
+        pendingTrackChangeRef.current = null;
+        window.dispatchEvent(new CustomEvent(MUSIC_TRACK_CHANGED_EVENT, { detail }));
+      }
+    };
     const onPause = () => setPlaying(false);
     const onTime = () => setProgress(a.currentTime);
     const onMeta = () => setDuration(a.duration || 0);

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -26,7 +26,8 @@ import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
 import { buildChatRequestPayload } from '../utils/chatRequestPayload';
 import { extractHtmlBlocks } from '../utils/htmlPrompt';
-import { loadMusicPlaybackSnapshot } from './MusicContext';
+import { loadMusicHooks, loadMusicPlaybackSnapshot } from './MusicContext';
+import { buildMusicTrackChangeHint, MUSIC_TRACK_CHANGED_EVENT, type MusicTrackChangeDetail } from '../utils/musicTrackChange';
 import { setMinimaxRegion } from '../utils/minimaxEndpoint';
 import { setTtsProvider, setVoicePromptOverrides } from '../utils/ttsProvider';
 import { LocalNotifications } from '@capacitor/local-notifications';
@@ -43,6 +44,13 @@ import { exportLuckinLocal } from '../utils/luckinMcpClient';
 import { exportMcdLocal } from '../utils/mcdMcpClient';
 import { exportDesktopSkinLocal } from '../utils/desktopSkinBackup';
 import { inspectCsyBackup, prepareCsyMigration, type CsyMigrationReport } from '../utils/csyMigration';
+
+type ProactiveRunReason = { kind: 'music-track-change'; detail: MusicTrackChangeDetail };
+
+interface ProactiveQueueEntry {
+  charId: string;
+  reason?: ProactiveRunReason;
+}
 
 const normalizeProactiveAiContent = (raw: string): string => {
   let cleaned = raw;
@@ -1516,7 +1524,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   }, [sendProactiveNativeNotification]);
 
   const proactiveRunningRef = useRef(false);
-  const proactiveQueueRef = useRef<string[]>([]);
+  const proactiveQueueRef = useRef<ProactiveQueueEntry[]>([]);
   // Per-character innerState cache for proactive turns — mirrors useChatAI's
   // evolvedNarrative state so consecutive proactive triggers carry continuity.
   const proactiveInnerStateRef = useRef<Map<string, string>>(new Map());
@@ -1553,16 +1561,20 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       if (!isDataLoaded) return;
 
       const drainQueuedProactive = () => {
-          const nextQueuedCharId = proactiveQueueRef.current.shift();
-          if (nextQueuedCharId) {
-              void runProactive(nextQueuedCharId);
+          const next = proactiveQueueRef.current.shift();
+          if (next) {
+              void runProactive(next.charId, next.reason);
           }
       };
 
-      const runProactive = async (charId: string) => {
+      const runProactive = async (charId: string, reason?: ProactiveRunReason) => {
           if (proactiveRunningRef.current) {
-              if (!proactiveQueueRef.current.includes(charId)) {
-                  proactiveQueueRef.current.push(charId);
+              const queuedIndex = proactiveQueueRef.current.findIndex(item => item.charId === charId);
+              if (queuedIndex < 0) {
+                  proactiveQueueRef.current.push({ charId, reason });
+              } else if (reason?.kind === 'music-track-change') {
+                  // 同一角色排队期间再次收到更具体的换歌事件时，以最新歌曲为准。
+                  proactiveQueueRef.current[queuedIndex] = { charId, reason };
               }
               return;
           }
@@ -1580,8 +1592,8 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               return;
           }
 
-          // Respect per-character proactive config
-          if (char.proactiveConfig && !char.proactiveConfig.enabled) {
+          // 换歌判断属于用户刚刚发起的“一起听”交互，不受定时主动消息开关限制。
+          if (reason?.kind !== 'music-track-change' && char.proactiveConfig && !char.proactiveConfig.enabled) {
               drainQueuedProactive();
               console.log(`🔕 [Proactive/Global] Skipped for ${char.name}: disabled`);
               return;
@@ -1650,9 +1662,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               const justMetOffline = lastRealMsgRaw?.metadata?.source === 'date'
                   && (now.getTime() - lastRealMsgRaw.timestamp) < DATE_AFTERGLOW_MS;
 
-              const hintContent = justMetOffline
-                  ? `[系统提示（非${userName}发言）: 现在是 ${timeStr}。你和${userName}刚刚在线下见过面（如果上下文里有标着 [约会] 的内容，那就是你们见面时发生的事），现在你们暂时分开了，你拿起手机想给${userName}发条消息。请基于刚才的见面来发——可以回味见面里的某个细节、补一句当时没说出口的话、关心${userName}到家了没，或者就是刚分开就有点想念。绝对不要表现得好像很久没联系，更不要对刚才的见面毫不知情。一两句话就好。]`
-                  : `[系统提示（非${userName}发言）: 现在是 ${timeStr}。${timeSinceUser ? `${userName}已经 ${timeSinceUser} 没有找你说话了。` : ''}这是系统给你的一次主动发消息机会——${userName}并没有在跟你说话，是你想主动找${userName}。像真人一样随意地发条消息吧，比如：随手拍了张照片想分享、刚看到个有趣的事想说、突然想到个冷知识、吐槽今天的天气/食物/见闻、或者就是单纯想找${userName}聊几句。不要刻意，不要像在"汇报近况"，就像你真的拿起手机随手发了条消息。一两句话就好。${timeSinceUser && parseInt(timeSinceUser) > 2 ? `（${userName}挺久没找你了，你也可以表达想念、好奇${userName}在干嘛、或者小小地抱怨一下。）` : ''}]`;
+              const hintContent = reason?.kind === 'music-track-change'
+                  ? buildMusicTrackChangeHint(reason.detail, userName)
+                  : justMetOffline
+                      ? `[系统提示（非${userName}发言）: 现在是 ${timeStr}。你和${userName}刚刚在线下见过面（如果上下文里有标着 [约会] 的内容，那就是你们见面时发生的事），现在你们暂时分开了，你拿起手机想给${userName}发条消息。请基于刚才的见面来发——可以回味见面里的某个细节、补一句当时没说出口的话、关心${userName}到家了没，或者就是刚分开就有点想念。绝对不要表现得好像很久没联系，更不要对刚才的见面毫不知情。一两句话就好。]`
+                      : `[系统提示（非${userName}发言）: 现在是 ${timeStr}。${timeSinceUser ? `${userName}已经 ${timeSinceUser} 没有找你说话了。` : ''}这是系统给你的一次主动发消息机会——${userName}并没有在跟你说话，是你想主动找${userName}。像真人一样随意地发条消息吧，比如：随手拍了张照片想分享、刚看到个有趣的事想说、突然想到个冷知识、吐槽今天的天气/食物/见闻、或者就是单纯想找${userName}聊几句。不要刻意，不要像在"汇报近况"，就像你真的拿起手机随手发了条消息。一两句话就好。${timeSinceUser && parseInt(timeSinceUser) > 2 ? `（${userName}挺久没找你了，你也可以表达想念、好奇${userName}在干嘛、或者小小地抱怨一下。）` : ''}]`;
 
               await DB.saveMessage({
                   charId,
@@ -1730,6 +1744,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               }, 2, 0, { appName: '消息', charId, charName: char.name, purpose: '主动消息' });
 
               // 5. Process & save response
+              if (reason?.kind === 'music-track-change'
+                  && loadMusicPlaybackSnapshot()?.current?.id !== reason.detail.currentSong.id) {
+                  console.log(`🎵 [Proactive/Global] Skipped stale track-change response for ${char.name}`);
+                  return;
+              }
               let aiContent = data.choices?.[0]?.message?.content || '';
               // 思考链抽取 — 与 useChatAI 保持一致:reasoning_content 字段 + 主 content 里的 <think>/<thinking>/<thought> 块,
               // 拼接后挂到本回合首条 assistant 消息的 metadata.thinkingChain
@@ -1756,6 +1775,26 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               aiContent = aiContent.replace(/\s*\[(?:聊天|通话|约会)\]\s*/g, '\n').trim();
 
               aiContent = normalizeProactiveAiContent(aiContent);
+
+              // 换歌触发只执行 MUSIC_ACTION，不顺带放开主动消息路径里的其他动作。
+              // 卡片由 ChatParser 落库；正文继续走下方原有的主动消息保存流程。
+              let musicActionExecuted = false;
+              const musicActionTagPattern = /\[\[MUSIC_ACTION:(?:join|add|add_new|join_and_add|join_and_add_new)(?:\|[^\]]*)?\]\]/g;
+              const musicActionTags = aiContent.match(musicActionTagPattern);
+              if (reason?.kind === 'music-track-change' && musicActionTags?.length) {
+                  const musicHooks = loadMusicHooks();
+                  if (musicHooks) {
+                      await ChatParser.parseAndExecuteActions(
+                          musicActionTags.join(' '),
+                          charId,
+                          char.name,
+                          () => {},
+                          musicHooks,
+                      );
+                      musicActionExecuted = true;
+                  }
+                  aiContent = aiContent.replace(musicActionTagPattern, '').trim();
+              }
 
               const savedPreviewChunks: string[] = [];
               const baseTimestamp = Date.now();
@@ -1951,9 +1990,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   }
               }
 
-              if (offset > 0) {
+              if (offset > 0 || musicActionExecuted) {
                   const previewSource = savedPreviewChunks.join(' ').trim();
-                  const preview = previewSource.replace(/\s+/g, ' ').trim().slice(0, 120) || `${char.name} sent a proactive message`;
+                  const preview = previewSource.replace(/\s+/g, ' ').trim().slice(0, 120)
+                      || (musicActionExecuted ? `${char.name} 回应了新歌` : `${char.name} sent a proactive message`);
 
                   // 6. Notify OS for unread badge + toast
                   window.dispatchEvent(new CustomEvent('proactive-message-sent', {
@@ -1977,6 +2017,15 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       ProactiveChat.onTrigger((charId: string) => {
           void runProactive(charId);
       });
+
+      const onMusicTrackChanged = (event: Event) => {
+          const detail = (event as CustomEvent<MusicTrackChangeDetail>).detail;
+          if (!detail?.currentSong || !Array.isArray(detail.charIds)) return;
+          for (const charId of new Set(detail.charIds)) {
+              void runProactive(charId, { kind: 'music-track-change', detail });
+          }
+      };
+      window.addEventListener(MUSIC_TRACK_CHANGED_EVENT, onMusicTrackChanged);
 
       // 「彼方」自主登入 —— 独立调度，复用同一批 refs 拿最新状态
       const runVR = async (charId: string, room?: string, letterId?: string) => {
@@ -2078,6 +2127,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           ProactiveChat.onTrigger(() => {});
           VRScheduler.onTrigger(() => {});
           WorldScheduler.onTrigger(() => {});
+          window.removeEventListener(MUSIC_TRACK_CHANGED_EVENT, onMusicTrackChanged);
           window.removeEventListener('world-reroll-request', onRerollRequest as EventListener);
       };
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/utils/musicTrackChange.test.ts
+++ b/utils/musicTrackChange.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildMusicTrackChangeHint, createMusicTrackChangeDetail } from './musicTrackChange';
+
+const first = { id: 1, name: '第一首', artists: '歌手甲' };
+const second = { id: 2, name: '第二首', artists: '歌手乙' };
+
+describe('music track change together-listening handoff', () => {
+    it('只在一起听期间真正切到另一首歌时创建重新判断事件', () => {
+        expect(createMusicTrackChangeDetail(null, first, ['char-1'])).toBeNull();
+        expect(createMusicTrackChangeDetail(first, first, ['char-1'])).toBeNull();
+        expect(createMusicTrackChangeDetail(first, second, [])).toBeNull();
+
+        expect(createMusicTrackChangeDetail(first, second, ['char-1'])).toEqual({
+            charIds: ['char-1'],
+            previousSong: first,
+            currentSong: second,
+        });
+    });
+
+    it('明确让角色针对新歌重新决定，而不是自动延续一起听', () => {
+        const detail = createMusicTrackChangeDetail(first, second, ['char-1'])!;
+        const hint = buildMusicTrackChangeHint(detail, '条条');
+
+        expect(hint).toContain('上一首歌的“一起听”状态已经结束');
+        expect(hint).toContain('重新判断');
+        expect(hint).toContain('《第二首》 - 歌手乙');
+        expect(hint).toContain('[[MUSIC_ACTION:join]]');
+        expect(hint).toContain('不想继续时不要使用该指令');
+    });
+});

--- a/utils/musicTrackChange.ts
+++ b/utils/musicTrackChange.ts
@@ -1,0 +1,43 @@
+export const MUSIC_TRACK_CHANGED_EVENT = 'music-track-changed';
+
+export interface MusicTrackInfo {
+    id: number;
+    name: string;
+    artists: string;
+}
+
+export interface MusicTrackChangeDetail {
+    charIds: string[];
+    previousSong: MusicTrackInfo;
+    currentSong: MusicTrackInfo;
+}
+
+export function createMusicTrackChangeDetail(
+    previousSong: MusicTrackInfo | null,
+    currentSong: MusicTrackInfo | null,
+    listeningCharIds: string[],
+): MusicTrackChangeDetail | null {
+    if (!previousSong || !currentSong || previousSong.id === currentSong.id || listeningCharIds.length === 0) {
+        return null;
+    }
+
+    return {
+        charIds: [...listeningCharIds],
+        previousSong: {
+            id: previousSong.id,
+            name: previousSong.name,
+            artists: previousSong.artists,
+        },
+        currentSong: {
+            id: currentSong.id,
+            name: currentSong.name,
+            artists: currentSong.artists,
+        },
+    };
+}
+
+export function buildMusicTrackChangeHint(detail: MusicTrackChangeDetail, userName: string): string {
+    const previous = `《${detail.previousSong.name}》 - ${detail.previousSong.artists}`;
+    const current = `《${detail.currentSong.name}》 - ${detail.currentSong.artists}`;
+    return `[系统提示（非${userName}发言）：你刚才正在和${userName}一起听 ${previous}，现在播放器已经切换到 ${current}。上一首歌的“一起听”状态已经结束；请根据新歌和此刻的气氛，重新判断你是否想继续陪${userName}一起听。想继续时可以自然回应并使用 [[MUSIC_ACTION:join]]；不想继续时不要使用该指令，也不要为了触发卡片而勉强加入。不要提及你收到了系统提示。]`;
+}


### PR DESCRIPTION
## 修改内容

- 保持“一起听”按单曲生效：切歌后清空上一首的共同收听状态。
- 新歌真正开始播放后，通知上一首正在一起听的角色重新判断是否继续；只有角色再次选择加入时才生成一起听卡片。
- 丢弃切歌判断期间产生的过时回复，避免角色加入到已经再次切换的歌曲。
- 为世界书首页补充用途、挂载方式与生效条件说明。
- 将“使用概率”改为“启用随机概率”，明确未勾选表示跳过随机判定、条件满足时按 100% 通过，并不表示条目未激活。

## 原因

原实现切歌会正确清空一起听状态，但角色不会感知换歌并重新作出选择。与此同时，世界书的概率复选框缺少明确说明，容易被误解为未勾选即未启用条目。

## 影响

- 不改变原有按单曲约束，也不改网易云播放、队列和歌词逻辑。
- 不改变世界书实际激活算法，仅补充界面引导文案。

## 验证

- `npm run test:run -- utils/musicTrackChange.test.ts utils/messageFormat.cards.test.ts utils/applyAssistantPostProcessing.test.ts`（15 项通过）
- `npm run test:run -- utils/worldbook.test.ts`（7 项通过）
- Vite 生产构建通过