### PR TITLE
fix(ui): 实际后端琥珀判定支持圆括号渠道标签 + 模型两行不再截断

### DIFF
--- a/components/settings/ApiCallLogModal.tsx
+++ b/components/settings/ApiCallLogModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import Modal from '../os/Modal';
 import { DB } from '../../utils/db';
+import { coreModelName } from '../../utils/apiCallLog';
 import type { ApiCallLogEntry } from '../../utils/apiCallLog';
 
 interface ApiCallLogModalProps {
@@ -104,7 +105,7 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                         <span className="font-semibold">有可能</span>被换了便宜模型，但也可能只是站子标签没写整齐——别只凭这一行去定罪。
                     </p>
                     <p>
-                        <span className="font-semibold">⚪ 灰色</span>：名字基本一致，只是格式不同（比如少了 [渠道] 前缀）。正常。
+                        <span className="font-semibold">⚪ 灰色</span>：名字基本一致，只是格式不同（比如少了 [渠道]、(按次) 这类标签）。正常。
                     </p>
                     <p>
                         <span className="font-semibold">🫥 没有这一行</span>：最常见的情况。要么对面把你请求的名字<span className="font-semibold">原样抄了回来</span>（等于什么都没说），要么干脆没报。
@@ -178,21 +179,20 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                                     <Field label="角色" value={e.charName} />
                                     <Field label="用途" value={e.purpose} />
                                     <div className="col-span-2">
-                                        <Field label="模型" value={e.model} mono />
+                                        {/* 模型/实际后端两行不截断（break-all 换行）：截断会把「为什么黄了」的
+                                            关键差异（后缀 -c、渠道标签）藏进省略号里，用户看着两行一样却标黄一头雾水 */}
+                                        <Field label="模型" value={e.model} mono wrap />
                                     </div>
-                                    {/* 后端自报身份（response.model）：字符串不同就展示；但只有剥掉「[渠道]」
-                                        前缀后核心模型名也对不上时才琥珀高亮——请求「[千岛-自营]X」自报「X」是
-                                        中转正常剥前缀（灰色），自报「[逆-V]X-c」才是真被换了后端（琥珀）。 */}
+                                    {/* 后端自报身份（response.model）：字符串不同就展示；但只有剥掉渠道标签
+                                        （[方括号]/（圆括号），见 coreModelName）后核心名也对不上时才琥珀高亮——
+                                        请求「(按次)X」自报「X」是中转正常剥标签（灰色），自报「[逆-V]X-c」
+                                        才是真被换了后端（琥珀）。 */}
                                     {e.backendModel && e.backendModel !== e.model && (() => {
-                                        const core = (m: string) => m.replace(/\[[^\]]*\]/g, '').trim();
-                                        const swapped = core(e.backendModel) !== core(e.model);
+                                        const swapped = coreModelName(e.backendModel) !== coreModelName(e.model);
                                         return (
                                             <div className="col-span-2 flex items-baseline gap-1.5 min-w-0">
                                                 <span className={`text-[10px] shrink-0 ${swapped ? 'text-amber-500' : 'text-slate-400'}`}>实际后端</span>
-                                                <span
-                                                    className={`truncate font-mono ${swapped ? 'font-semibold text-amber-600' : 'text-slate-500'}`}
-                                                    title={e.backendModel}
-                                                >
+                                                <span className={`break-all font-mono ${swapped ? 'font-semibold text-amber-600' : 'text-slate-500'}`}>
                                                     {e.backendModel}{swapped ? ' ⚠️' : ''}
                                                 </span>
                                             </div>
@@ -222,16 +222,17 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
     );
 };
 
-const Field: React.FC<{ label: string; value?: string; accent?: boolean; mono?: boolean }> = ({
+const Field: React.FC<{ label: string; value?: string; accent?: boolean; mono?: boolean; wrap?: boolean }> = ({
     label,
     value,
     accent,
     mono,
+    wrap,
 }) => (
     <div className="flex items-baseline gap-1.5 min-w-0">
         <span className="text-[10px] text-slate-400 shrink-0">{label}</span>
         <span
-            className={`truncate ${mono ? 'font-mono' : ''} ${
+            className={`${wrap ? 'break-all' : 'truncate'} ${mono ? 'font-mono' : ''} ${
                 accent ? 'font-semibold text-primary' : 'text-slate-600'
             }`}
             title={value || ''}

--- a/utils/apiCallLog.test.ts
+++ b/utils/apiCallLog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scanSseForLog } from './apiCallLog';
+import { scanSseForLog, coreModelName } from './apiCallLog';
 
 // 锁住 API 调用记录的 SSE 兜底解析：流式响应 JSON.parse 必然失败，
 // 后端自报 model（首个非空）与 usage（末个非空）从 data: 行里扫出来。
@@ -27,5 +27,22 @@ describe('scanSseForLog', () => {
 
     it('非 SSE 文本返回空结果', () => {
         expect(scanSseForLog('{"model":"x"}')).toEqual({ model: undefined, usage: undefined });
+    });
+});
+
+describe('coreModelName 核心名归一化（实际后端琥珀判定用）', () => {
+    it('剥方括号/半角圆括号/全角圆括号渠道标签', () => {
+        expect(coreModelName('[千岛-自营]gemini-3.1-pro-preview')).toBe('gemini-3.1-pro-preview');
+        expect(coreModelName('(按次)gemini-3.1-pro-preview')).toBe('gemini-3.1-pro-preview');
+        expect(coreModelName('（官转）gemini-3.1-pro-preview')).toBe('gemini-3.1-pro-preview');
+    });
+
+    it('渠道标签不同但核心名相同 → 判定一致（不误报琥珀）', () => {
+        expect(coreModelName('(按次)gemini-3.1-pro-preview')).toBe(coreModelName('gemini-3.1-pro-preview'));
+        expect(coreModelName('[co假流]Gemini-3.1-Pro-Preview')).toBe(coreModelName('gemini-3.1-pro-preview'));
+    });
+
+    it('核心名真的不同（如 -c 后缀）→ 判定不一致（该报琥珀）', () => {
+        expect(coreModelName('[逆-V]gemini-3.1-pro-preview-c')).not.toBe(coreModelName('[千岛-自营]gemini-3.1-pro-preview'));
     });
 });

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -97,6 +97,19 @@ function hostOf(url: string): string {
     }
 }
 
+/**
+ * 模型名的"核心名"：剥掉渠道标签（[方括号]、(半角圆括号)、（全角圆括号））、
+ * 去空白、统一小写。用于判断「请求名 vs 后端自报名」是不是同一个模型——
+ * `(按次)gemini-3.1-pro-preview` 和 `gemini-3.1-pro-preview` 是同一个（只是渠道标签），
+ * `gemini-3.1-pro-preview` 和 `gemini-3.1-pro-preview-c` 才是真的换了后端。
+ */
+export function coreModelName(m: string): string {
+    return (m || '')
+        .replace(/\[[^\]]*\]|\([^)]*\)|（[^）]*）/g, '')
+        .replace(/\s+/g, '')
+        .toLowerCase();
+}
+
 /** 从请求体里抠出 model 字段（body 可能是 JSON 字符串或对象）。 */
 function extractModel(body: unknown): string {
     if (!body) return '';


### PR DESCRIPTION
- 核心名对比抽成 coreModelName：剥 [方括号]/(半角圆括号)/（全角圆括号） 渠道标签 + 去空白 + 小写归一。修「(按次)X vs X」被误报琥珀的假阳性 （旧版只剥方括号）
- 模型 / 实际后端两行 truncate → break-all 换行显示：截断会把「为什么黄」 的关键差异（-c 后缀、渠道标签）藏进省略号，用户看着两行一样却标黄
- 帮助文案同步提及圆括号标签


Claude-Session: https://claude.ai/code/session_01CWyxHKDa3MktsDPSdriBVy