### PR TITLE
feat(ui): 外观新增「表情包大小」三挡设置（小96/中128/大160·旧版）

### DIFF
--- a/apps/Appearance.tsx
+++ b/apps/Appearance.tsx
@@ -100,6 +100,11 @@ const AVATAR_SIZES: { value: 'small' | 'medium' | 'large'; label: string; size: 
     { value: 'medium', label: '中', size: 'w-9 h-9' },
     { value: 'large', label: '大', size: 'w-12 h-12' },
 ];
+const EMOJI_SIZES: { value: 'small' | 'medium' | 'large'; label: string; desc: string }[] = [
+    { value: 'small', label: '小', desc: '96px' },
+    { value: 'medium', label: '中', desc: '128px' },
+    { value: 'large', label: '大', desc: '160px · 旧版' },
+];
 const BUBBLE_STYLES: { value: 'modern' | 'flat' | 'outline' | 'shadow'; label: string; desc: string }[] = [
     { value: 'modern', label: '现代', desc: '圆角气泡+微透明' },
     { value: 'flat', label: '扁平', desc: '无阴影纯色气泡' },
@@ -331,6 +336,17 @@ const ChatAppearanceEditor: React.FC<{ theme: OSTheme; updateTheme: (u: Partial<
                         <OptionButton key={s.value} active={avatarSize === s.value} label={s.label} onClick={() => updateTheme({ chatAvatarSize: s.value })} />
                     ))}
                 </div>
+            </section>
+
+            {/* Emoji Sticker Size */}
+            <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100">
+                <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-3">表情包大小</h2>
+                <div className="flex gap-2">
+                    {EMOJI_SIZES.map(s => (
+                        <OptionButton key={s.value} active={(theme.chatEmojiSize || 'small') === s.value} label={s.label} desc={s.desc} onClick={() => updateTheme({ chatEmojiSize: s.value })} />
+                    ))}
+                </div>
+                <p className="text-[11px] text-slate-400 mt-2">聊天和群聊里发出的表情包图片尺寸。用自定义 CSS 调过尺寸的美化会继续覆盖这里的设置。</p>
             </section>
 
             {/* Bubble Style */}

--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -253,7 +253,8 @@ const GroupMessageItem = React.memo(({
                     </div>
                 );
             case 'emoji':
-                return <img src={msg.content} className="w-24 h-24 object-contain drop-shadow-sm hover:scale-110 transition-transform" />;
+                // 尺寸跟随外观 → 表情包大小（--sully-emoji-size 三挡，默认 96px = 原 w-24）
+                return <img src={msg.content} className="sully-emoji-msg max-w-[var(--sully-emoji-size,96px)] max-h-[var(--sully-emoji-size,96px)] object-contain drop-shadow-sm hover:scale-110 transition-transform" />;
             case 'transfer':
                 return (
                     <div onClick={(e) => { if (selectionMode) handleClick(e); }}>

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -3032,7 +3032,7 @@ const MessageItem = React.memo(({
     if (m.type === 'emoji') {
         return commonLayout(
             m.content ? (
-                <img src={m.content} className="sully-emoji-msg max-w-[96px] max-h-[96px] w-auto h-auto object-contain hover:scale-105 transition-transform drop-shadow-md active:scale-95" loading="lazy" decoding="async" />
+                <img src={m.content} className="sully-emoji-msg max-w-[var(--sully-emoji-size,96px)] max-h-[var(--sully-emoji-size,96px)] w-auto h-auto object-contain hover:scale-105 transition-transform drop-shadow-md active:scale-95" loading="lazy" decoding="async" />
             ) : (
                 <div className="px-3 py-2 rounded-2xl bg-slate-100 text-slate-400 text-xs italic">[表情已丢失]</div>
             )

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1312,6 +1312,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       root.style.setProperty('--primary-sat', `${s}%`);
       root.style.setProperty('--primary-lightness', `${l}%`);
 
+      // 聊天表情包尺寸（外观 → 表情包大小，三挡）：小 96 / 中 128 / 大 160（旧版尺寸）。
+      // 私聊 MessageItem 与群聊的表情 img 都用 var(--sully-emoji-size, 96px) 消费。
+      const emojiSize = theme.chatEmojiSize === 'large' ? '160px' : theme.chatEmojiSize === 'medium' ? '128px' : '96px';
+      root.style.setProperty('--sully-emoji-size', emojiSize);
+
       // 桌面皮肤：写到 <html data-skin>，供全局 CSS（index.html）与组件读取。
       root.dataset.skin = theme.skin || 'default';
   }, [theme]);

--- a/types.ts
+++ b/types.ts
@@ -92,6 +92,8 @@ export interface OSTheme {
   // Chat UI customization (global)
   chatAvatarShape?: 'circle' | 'rounded' | 'square';
   chatAvatarSize?: 'small' | 'medium' | 'large';
+  /** 聊天表情包大小三挡：小 96px（默认）/ 中 128px / 大 160px（旧版尺寸）。经 --sully-emoji-size CSS 变量生效 */
+  chatEmojiSize?: 'small' | 'medium' | 'large';
   chatAvatarMode?: 'grouped' | 'every_message';
   chatBubbleStyle?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios';
   chatMessageSpacing?: 'compact' | 'default' | 'spacious';


### PR DESCRIPTION
- Theme 新增 chatEmojiSize，经全局 CSS 变量 --sully-emoji-size 生效 （OSContext 主题应用处统一写入，默认 96px）
- 私聊 MessageItem 与群聊表情 img 改用 var(--sully-emoji-size,96px)， 群聊原本固定 w-24(=96px)，默认档行为不变
- 外观 App 头像大小下方加三挡选择器，沿用 OptionButton 范式
- 自定义 CSS（.sully-emoji-msg / !important 美化）仍可覆盖此设置


Claude-Session: https://claude.ai/code/session_01CWyxHKDa3MktsDPSdriBVy