### PR TITLE
feat(ui): 外观新增「聊天细节微调」——社区白框美化 CSS 收编为可视化设置

### DIFF
--- a/apps/Appearance.tsx
+++ b/apps/Appearance.tsx
@@ -139,6 +139,8 @@ const CHAT_LAYOUT_COMBOS: { name: string; desc: string; config: Partial<OSTheme>
     { name: '微信风格', desc: '方形头像+扁平气泡', config: { chatAvatarShape: 'square', chatAvatarSize: 'medium', chatBubbleStyle: 'flat', chatMessageSpacing: 'default', chatHeaderStyle: 'default', chatInputStyle: 'flat', chatShowTimestamp: 'always' } },
     { name: 'iMessage', desc: '大圆头像+宽松气泡', config: { chatAvatarShape: 'circle', chatAvatarSize: 'large', chatBubbleStyle: 'modern', chatMessageSpacing: 'spacious', chatHeaderStyle: 'minimal', chatInputStyle: 'rounded', chatShowTimestamp: 'always' } },
     { name: '简约模式', desc: '小头像+最简界面', config: { chatAvatarShape: 'circle', chatAvatarSize: 'small', chatBubbleStyle: 'flat', chatMessageSpacing: 'compact', chatHeaderStyle: 'minimal', chatInputStyle: 'flat', chatShowTimestamp: 'never' } },
+    { name: '沉浸剧场', desc: '无头像+贴边+松行距', config: { chatAvatarShape: 'circle', chatAvatarSize: 'medium', chatBubbleStyle: 'flat', chatMessageSpacing: 'spacious', chatHeaderStyle: 'minimal', chatInputStyle: 'flat', chatShowTimestamp: 'never', chatAvatarVisibility: 'hide_both', chatSnapToEdge: true, chatBubbleLineHeight: 1.5 } },
+    { name: '紧凑密聊', desc: '小字紧排+顶对齐头像', config: { chatAvatarShape: 'rounded', chatAvatarSize: 'small', chatBubbleStyle: 'flat', chatMessageSpacing: 'compact', chatHeaderStyle: 'default', chatInputStyle: 'flat', chatShowTimestamp: 'never', chatAvatarVisibility: 'both', chatAvatarAlign: 'top', chatBubbleFontSize: 13, chatBubbleLineHeight: 1.35 } },
 ];
 
 // --- 桌面整机风格（皮肤）---
@@ -253,6 +255,13 @@ const ChatAppearanceEditor: React.FC<{ theme: OSTheme; updateTheme: (u: Partial<
     const headerStyle = theme.chatHeaderStyle || 'default';
     const inputStyle = theme.chatInputStyle || 'default';
     const showTimestamp = theme.chatShowTimestamp || 'always';
+    // 聊天细节微调 → 预览联动（近似演示：字号按比例缩小 3px 以配合迷你预览）
+    const fineVis = theme.chatAvatarVisibility || 'both';
+    const previewAlignClass = (theme.chatAvatarAlign || 'bottom') === 'top' ? 'items-start' : theme.chatAvatarAlign === 'center' ? 'items-center' : 'items-end';
+    const previewTextStyle: React.CSSProperties = {
+        ...(theme.chatBubbleFontSize ? { fontSize: `${Math.max(9, theme.chatBubbleFontSize - 3)}px` } : {}),
+        ...(theme.chatBubbleLineHeight ? { lineHeight: theme.chatBubbleLineHeight } : {}),
+    };
 
     const OptionButton: React.FC<{ active: boolean; label: string; desc?: string; onClick: () => void }> = ({ active, label, desc, onClick }) => (
         <button onClick={onClick}
@@ -270,7 +279,9 @@ const ChatAppearanceEditor: React.FC<{ theme: OSTheme; updateTheme: (u: Partial<
                 <p className="text-[10px] text-slate-400 mb-3">一键切换聊天界面风格组合，包含头像、气泡、间距等全套配置。</p>
                 <div className="flex gap-2 overflow-x-auto no-scrollbar pb-1">
                     {CHAT_LAYOUT_COMBOS.map(combo => (
-                        <button key={combo.name} onClick={() => updateTheme(combo.config)}
+                        // 先铺一层细节微调的默认值再叠预设：否则从「沉浸剧场」切回其他预设时
+                        // 隐藏头像/贴边等残留字段不会被清掉（旧预设没写这些键）
+                        <button key={combo.name} onClick={() => updateTheme({ chatAvatarVisibility: 'both', chatSnapToEdge: false, chatAvatarAlign: 'bottom', chatAvatarOffsetY: 0, chatBubbleFontSize: 0, chatBubbleLineHeight: 0, chatBubbleIndent: 0, ...combo.config })}
                             className="shrink-0 px-4 py-2.5 bg-slate-50 rounded-xl border border-slate-200 hover:border-primary/40 active:scale-95 transition-all text-left">
                             <div className="text-xs font-bold text-slate-700">{combo.name}</div>
                             <div className="text-[9px] text-slate-400 mt-0.5">{combo.desc}</div>
@@ -294,21 +305,26 @@ const ChatAppearanceEditor: React.FC<{ theme: OSTheme; updateTheme: (u: Partial<
                     {/* Fake messages */}
                     <div className={`p-3 space-y-${msgSpacing === 'compact' ? '1' : msgSpacing === 'spacious' ? '4' : '2'}`}>
                         {/* AI message */}
-                        <div className="flex gap-2 items-end">
-                            <div className={`${AVATAR_SIZES.find(s => s.value === avatarSize)?.size || 'w-9 h-9'} ${AVATAR_SHAPES.find(s => s.value === avatarShape)?.preview || 'rounded-full'} bg-pink-200 shrink-0`} />
-                            <div className={`px-3 py-2 text-[11px] max-w-[65%] ${bubbleStyle === 'outline' ? 'bg-transparent border-2 border-slate-300 rounded-2xl rounded-bl-sm' : bubbleStyle === 'shadow' ? 'bg-white shadow-md rounded-2xl rounded-bl-sm' : bubbleStyle === 'flat' ? 'bg-slate-100 rounded-2xl rounded-bl-sm' : 'bg-white/90 backdrop-blur-sm rounded-2xl rounded-bl-sm shadow-sm'}`}>
+                        <div className={`flex gap-2 ${previewAlignClass}`}>
+                            {fineVis !== 'hide_ai' && fineVis !== 'hide_both' && (
+                                <div className={`${AVATAR_SIZES.find(s => s.value === avatarSize)?.size || 'w-9 h-9'} ${AVATAR_SHAPES.find(s => s.value === avatarShape)?.preview || 'rounded-full'} bg-pink-200 shrink-0`} />
+                            )}
+                            <div className={`px-3 py-2 text-[11px] max-w-[65%] ${bubbleStyle === 'outline' ? 'bg-transparent border-2 border-slate-300 rounded-2xl rounded-bl-sm' : bubbleStyle === 'shadow' ? 'bg-white shadow-md rounded-2xl rounded-bl-sm' : bubbleStyle === 'flat' ? 'bg-slate-100 rounded-2xl rounded-bl-sm' : 'bg-white/90 backdrop-blur-sm rounded-2xl rounded-bl-sm shadow-sm'}`}
+                                style={previewTextStyle}>
                                 你好呀，今天过得怎么样？
                                 {showTimestamp === 'always' && <div className="text-[8px] text-slate-300 mt-1 text-right">14:32</div>}
                             </div>
                         </div>
                         {/* User message */}
-                        <div className="flex gap-2 items-end justify-end">
+                        <div className={`flex gap-2 ${previewAlignClass} justify-end`}>
                             <div className={`px-3 py-2 text-[11px] text-white max-w-[65%] ${bubbleStyle === 'outline' ? 'bg-transparent border-2 border-primary text-primary rounded-2xl rounded-br-sm' : bubbleStyle === 'shadow' ? 'bg-primary shadow-md rounded-2xl rounded-br-sm' : bubbleStyle === 'flat' ? 'bg-primary rounded-2xl rounded-br-sm' : 'bg-primary/90 backdrop-blur-sm rounded-2xl rounded-br-sm shadow-sm'}`}
-                                style={bubbleStyle === 'outline' ? { color: `hsl(${theme.hue}, ${theme.saturation}%, ${theme.lightness}%)` } : undefined}>
+                                style={{ ...(bubbleStyle === 'outline' ? { color: `hsl(${theme.hue}, ${theme.saturation}%, ${theme.lightness}%)` } : {}), ...previewTextStyle }}>
                                 挺好的，今天天气不错！
                                 {showTimestamp === 'always' && <div className={`text-[8px] mt-1 text-right ${bubbleStyle === 'outline' ? 'opacity-50' : 'text-white/60'}`}>14:33</div>}
                             </div>
-                            <div className={`${AVATAR_SIZES.find(s => s.value === avatarSize)?.size || 'w-9 h-9'} ${AVATAR_SHAPES.find(s => s.value === avatarShape)?.preview || 'rounded-full'} bg-primary/30 shrink-0`} />
+                            {fineVis !== 'hide_user' && fineVis !== 'hide_both' && (
+                                <div className={`${AVATAR_SIZES.find(s => s.value === avatarSize)?.size || 'w-9 h-9'} ${AVATAR_SHAPES.find(s => s.value === avatarShape)?.preview || 'rounded-full'} bg-primary/30 shrink-0`} />
+                            )}
                         </div>
                     </div>
                     {/* Fake input */}
@@ -347,6 +363,76 @@ const ChatAppearanceEditor: React.FC<{ theme: OSTheme; updateTheme: (u: Partial<
                     ))}
                 </div>
                 <p className="text-[11px] text-slate-400 mt-2">聊天和群聊里发出的表情包图片尺寸。用自定义 CSS 调过尺寸的美化会继续覆盖这里的设置。</p>
+            </section>
+
+            {/* Chat Fine-tune —— 收编社区白框美化的可视化版 */}
+            <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100 space-y-4">
+                <div>
+                    <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest">聊天细节微调</h2>
+                    <p className="text-[11px] text-slate-400 mt-1">头像显隐/对齐、贴边、字号行距——不用再手写 CSS。手写过美化代码的用户不受影响（自定义 CSS 优先级更高）。</p>
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">头像分组</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        <OptionButton active={(theme.chatAvatarMode || 'grouped') === 'grouped'} label="连续消息折叠" desc="组内只显一条" onClick={() => updateTheme({ chatAvatarMode: 'grouped' })} />
+                        <OptionButton active={theme.chatAvatarMode === 'every_message'} label="每条都显示" onClick={() => updateTheme({ chatAvatarMode: 'every_message' })} />
+                    </div>
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">头像显示</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        {([['both', '全部显示'], ['hide_ai', '隐藏角色侧'], ['hide_user', '隐藏我的'], ['hide_both', '全部隐藏']] as const).map(([v, label]) => (
+                            <OptionButton key={v} active={(theme.chatAvatarVisibility || 'both') === v} label={label} onClick={() => updateTheme({ chatAvatarVisibility: v })} />
+                        ))}
+                    </div>
+                    {(theme.chatAvatarVisibility || 'both') !== 'both' && (
+                        <label className="flex items-center gap-2 mt-2 text-[11px] text-slate-500">
+                            <input type="checkbox" checked={!!theme.chatSnapToEdge} onChange={(e) => updateTheme({ chatSnapToEdge: e.target.checked })} className="accent-current" />
+                            隐藏的一侧气泡贴边（收回头像空位）
+                        </label>
+                    )}
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">头像对齐气泡</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        {([['bottom', '底部（默认）'], ['top', '顶部'], ['center', '垂直居中']] as const).map(([v, label]) => (
+                            <OptionButton key={v} active={(theme.chatAvatarAlign || 'bottom') === v} label={label} onClick={() => updateTheme({ chatAvatarAlign: v })} />
+                        ))}
+                    </div>
+                    <div className="flex items-center gap-3 mt-2">
+                        <span className="text-[11px] text-slate-500 shrink-0">垂直微调</span>
+                        <input type="range" min={-16} max={16} step={2} value={theme.chatAvatarOffsetY || 0}
+                            onChange={(e) => updateTheme({ chatAvatarOffsetY: Number(e.target.value) })} className="flex-1 accent-current" />
+                        <span className="text-[11px] font-mono text-slate-500 w-10 text-right">{theme.chatAvatarOffsetY || 0}px</span>
+                    </div>
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">气泡正文字号</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        <OptionButton active={!theme.chatBubbleFontSize} label="默认" onClick={() => updateTheme({ chatBubbleFontSize: 0 })} />
+                        {[12, 13, 14, 15, 16].map(v => (
+                            <OptionButton key={v} active={theme.chatBubbleFontSize === v} label={`${v}px`} onClick={() => updateTheme({ chatBubbleFontSize: v })} />
+                        ))}
+                    </div>
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">气泡正文行距</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        <OptionButton active={!theme.chatBubbleLineHeight} label="默认" onClick={() => updateTheme({ chatBubbleLineHeight: 0 })} />
+                        {[1.2, 1.35, 1.5, 1.7].map(v => (
+                            <OptionButton key={v} active={theme.chatBubbleLineHeight === v} label={String(v)} onClick={() => updateTheme({ chatBubbleLineHeight: v })} />
+                        ))}
+                    </div>
+                </div>
+                <div>
+                    <h3 className="text-[11px] font-bold text-slate-500 mb-2">气泡与头像间距</h3>
+                    <div className="flex gap-2 flex-wrap">
+                        <OptionButton active={!theme.chatBubbleIndent} label="默认 (48px)" onClick={() => updateTheme({ chatBubbleIndent: 0 })} />
+                        {[28, 60, 72].map(v => (
+                            <OptionButton key={v} active={theme.chatBubbleIndent === v} label={`${v}px`} onClick={() => updateTheme({ chatBubbleIndent: v })} />
+                        ))}
+                    </div>
+                </div>
             </section>
 
             {/* Bubble Style */}

--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -5,6 +5,7 @@ import { DB } from '../utils/db';
 import { Message, MessageType, MemoryFragment, Emoji, EmojiCategory, DailySchedule, ScheduleSlot } from '../types';
 import { processImage } from '../utils/file';
 import { safeResponseJson, extractContent } from '../utils/safeApi';
+import { buildChatFineTuneCss } from '../utils/chatFineTuneCss';
 import { generateDailyScheduleForChar, isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { generateSlotTheater } from '../utils/theaterGenerator';
 import TheaterPlayer from '../components/schedule/TheaterPlayer';
@@ -2515,6 +2516,8 @@ const Chat: React.FC = () => {
     // 动森下强制覆盖角色自定义聊天背景，保证整机一致的彩蛋观感
     // 进入/切换的过场由 CharacterEntryTransition 覆盖层负责，根容器不再自己做淡入。
     const finalRootStyle = acnh ? acnhRootStyle : chatRootStyle;
+    // 聊天细节微调 CSS（外观 → 聊天细节）：全默认时为空串，不注入任何 <style>
+    const chatFineTuneCss = useMemo(() => buildChatFineTuneCss(osTheme), [osTheme]);
     const chatAvatarSizeClass = osTheme.chatAvatarSize === 'small' ? 'w-7 h-7' : osTheme.chatAvatarSize === 'large' ? 'w-12 h-12' : 'w-9 h-9';
     const chatAvatarRadiusClass = osTheme.chatAvatarShape === 'square' ? 'rounded-sm' : osTheme.chatAvatarShape === 'rounded' ? 'rounded-xl' : 'rounded-full';
     const chatPendingAvatarClass = `${chatAvatarSizeClass} ${chatAvatarRadiusClass} object-cover`;
@@ -2524,6 +2527,9 @@ const Chat: React.FC = () => {
             className={`sully-chat-root ${finalRootClass}`}
             style={finalRootStyle}
         >
+             {/* 聊天细节微调（外观 App 可视化设置生成）：排在用户自定义 CSS 之前——
+                 同为 !important 时后写的胜，手写美化代码永远可覆盖可视化设置。 */}
+             {chatFineTuneCss && <style>{chatFineTuneCss}</style>}
              {/* 白框自定义 CSS：全局默认在前、角色专属在后（后者叠加覆盖）。作用于 .sully-chat-* 各零件。
                  守护样式统一放在气泡主题 customCss 之后（见下），保证对所有用户 CSS 都能兜底。 */}
              {osTheme.chatChromeCustomCss && <style>{osTheme.chatChromeCustomCss}</style>}

--- a/types.ts
+++ b/types.ts
@@ -95,6 +95,22 @@ export interface OSTheme {
   /** 聊天表情包大小三挡：小 96px（默认）/ 中 128px / 大 160px（旧版尺寸）。经 --sully-emoji-size CSS 变量生效 */
   chatEmojiSize?: 'small' | 'medium' | 'large';
   chatAvatarMode?: 'grouped' | 'every_message';
+  // ── 聊天细节微调（外观 → 聊天细节）。收编自社区白框美化 CSS，全部可选，缺省 = 现状。
+  //    经 utils/chatFineTuneCss.ts 生成 CSS 注入 .sully-chat-root；用户自定义白框 CSS 排在其后可覆盖。
+  /** 头像显示：双侧 / 隐藏角色侧 / 隐藏用户侧 / 全部隐藏 */
+  chatAvatarVisibility?: 'both' | 'hide_ai' | 'hide_user' | 'hide_both';
+  /** 头像与气泡的对齐：底部（默认）/ 顶部 / 垂直居中 */
+  chatAvatarAlign?: 'bottom' | 'top' | 'center';
+  /** 头像垂直微调 px（负上正下），0/undefined = 不调 */
+  chatAvatarOffsetY?: number;
+  /** 气泡正文字号 px，0/undefined = 默认 */
+  chatBubbleFontSize?: number;
+  /** 气泡正文行距（如 1.35），0/undefined = 默认 */
+  chatBubbleLineHeight?: number;
+  /** 气泡与头像侧的间距 px，0/undefined = 默认（48px） */
+  chatBubbleIndent?: number;
+  /** 隐藏头像的一侧是否贴边（收回头像空位） */
+  chatSnapToEdge?: boolean;
   chatBubbleStyle?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios';
   chatMessageSpacing?: 'compact' | 'default' | 'spacious';
   chatShowTimestamp?: 'always' | 'hover' | 'never';

--- a/utils/chatFineTuneCss.test.ts
+++ b/utils/chatFineTuneCss.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildChatFineTuneCss } from './chatFineTuneCss';
+
+// 聊天细节微调 CSS 生成器：全默认零输出；各旋钮生成的选择器与社区已验证版本一致。
+
+describe('buildChatFineTuneCss', () => {
+    it('全默认 → 空串（不注入任何 style）', () => {
+        expect(buildChatFineTuneCss({})).toBe('');
+        expect(buildChatFineTuneCss({ chatAvatarVisibility: 'both', chatAvatarAlign: 'bottom', chatAvatarOffsetY: 0, chatBubbleFontSize: 0, chatBubbleLineHeight: 0, chatBubbleIndent: 0 })).toBe('');
+    });
+
+    it('隐藏角色侧头像只影响 justify-start；贴边只收隐藏侧空位', () => {
+        const css = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_ai', chatSnapToEdge: true });
+        expect(css).toContain('.group.justify-start > [class~="absolute"][class~="z-0"] { display: none');
+        expect(css).not.toContain('.group.justify-end > [class~="absolute"][class~="z-0"] { display: none');
+        expect(css).toContain('.ml-12 { margin-left: 0 !important; }');
+        expect(css).not.toContain('margin-right: 0');
+    });
+
+    it('顶部对齐 + 垂直微调', () => {
+        const css = buildChatFineTuneCss({ chatAvatarAlign: 'top', chatAvatarOffsetY: -8 });
+        expect(css).toContain('bottom: auto !important; top: -0.5rem !important;');
+        expect(css).toContain('translateY(-8px)');
+    });
+
+    it('垂直居中把偏移并进 calc（transform 不互相覆盖）', () => {
+        const css = buildChatFineTuneCss({ chatAvatarAlign: 'center', chatAvatarOffsetY: 4 });
+        expect(css).toContain('translateY(calc(-50% + 4px))');
+    });
+
+    it('字号/行距走社区版四层选择器，内联元素 inherit', () => {
+        const css = buildChatFineTuneCss({ chatBubbleFontSize: 14, chatBubbleLineHeight: 1.5 });
+        expect(css).toContain('.sully-bubble-ai > div[class~="select-text"]');
+        expect(css).toContain('font-size: 14px !important;');
+        expect(css).toContain('line-height: 1.5 !important;');
+        expect(css).toContain('font-size: inherit !important;');
+        expect(css).toContain('[class*="text-[13px]"]');
+    });
+
+    it('气泡缩进对两侧生效；贴边侧让位', () => {
+        const css = buildChatFineTuneCss({ chatBubbleIndent: 60 });
+        expect(css).toContain('margin-left: 60px !important;');
+        expect(css).toContain('margin-right: 60px !important;');
+        const snapCss = buildChatFineTuneCss({ chatBubbleIndent: 60, chatAvatarVisibility: 'hide_ai', chatSnapToEdge: true });
+        expect(snapCss).toContain('margin-left: 0 !important;');
+        expect(snapCss).not.toContain('margin-left: 60px');
+        expect(snapCss).toContain('margin-right: 60px !important;');
+    });
+});

--- a/utils/chatFineTuneCss.ts
+++ b/utils/chatFineTuneCss.ts
@@ -1,0 +1,81 @@
+/**
+ * 聊天细节微调 CSS 生成器（外观 → 聊天细节）。
+ *
+ * 收编自社区「白框作者」的美化 CSS：隐藏头像、头像对齐/微调、消息贴边、
+ * 气泡缩进、正文字号/行距。选择器沿用社区版本已在真实 DOM 上验证过的形态
+ * （锚 .group.justify-* 与 .sully-bubble-* 结构），生成规则带 !important
+ * 以压过 Tailwind 工具类。
+ *
+ * 注入位置：Chat.tsx 在用户自定义白框 CSS（chatChromeCustomCss / 角色
+ * chromeCustomCss）**之前**插入本样式——同为 !important 时后者胜，老用户
+ * 手写的美化代码永远能覆盖这里的可视化设置，互不打架。
+ *
+ * 全部字段缺省时返回空串（一个 <style> 都不注入，现状零变化）。
+ */
+
+import type { OSTheme } from '../types';
+
+const AI_AVATAR = '.sully-chat-root .group.justify-start > [class~="absolute"][class~="z-0"]';
+const USER_AVATAR = '.sully-chat-root .group.justify-end > [class~="absolute"][class~="z-0"]';
+const AI_BODY = '.sully-chat-root .sully-bubble-ai > div[class~="select-text"]';
+const USER_BODY = '.sully-chat-root .sully-bubble-user > div[class~="select-text"]';
+const AI_WRAP = '.sully-chat-root .group.justify-start [class~="max-w-[72%]"].ml-12';
+const USER_WRAP = '.sully-chat-root .group.justify-end [class~="max-w-[72%]"].mr-12';
+
+const hideRule = (sel: string) =>
+    `${sel} { display: none !important; visibility: hidden !important; opacity: 0 !important; pointer-events: none !important; }`;
+
+export function buildChatFineTuneCss(theme: Pick<OSTheme,
+    'chatAvatarVisibility' | 'chatAvatarAlign' | 'chatAvatarOffsetY' |
+    'chatBubbleFontSize' | 'chatBubbleLineHeight' | 'chatBubbleIndent' | 'chatSnapToEdge'
+>): string {
+    const rules: string[] = [];
+    const vis = theme.chatAvatarVisibility || 'both';
+    const hideAi = vis === 'hide_ai' || vis === 'hide_both';
+    const hideUser = vis === 'hide_user' || vis === 'hide_both';
+
+    // ── 隐藏头像 ──
+    if (hideAi) rules.push(hideRule(AI_AVATAR));
+    if (hideUser) rules.push(hideRule(USER_AVATAR));
+
+    // ── 贴边（只对隐藏了头像的一侧收回空位）──
+    if (theme.chatSnapToEdge) {
+        if (hideAi) rules.push(`${AI_WRAP} { margin-left: 0 !important; }`);
+        if (hideUser) rules.push(`${USER_WRAP} { margin-right: 0 !important; }`);
+    }
+
+    // ── 头像对齐 + 垂直微调 ──
+    const align = theme.chatAvatarAlign || 'bottom';
+    const offY = theme.chatAvatarOffsetY || 0;
+    if (align !== 'bottom' || offY !== 0) {
+        const both = `${AI_AVATAR}, ${USER_AVATAR}`;
+        if (align === 'top') {
+            rules.push(`${both} { bottom: auto !important; top: -0.5rem !important;${offY ? ` transform: translateY(${offY}px) !important;` : ''} }`);
+        } else if (align === 'center') {
+            rules.push(`${both} { bottom: auto !important; top: 50% !important; transform: translateY(calc(-50% + ${offY}px)) !important; }`);
+        } else {
+            rules.push(`${both} { transform: translateY(${offY}px) !important; }`);
+        }
+    }
+
+    // ── 气泡与头像侧的间距（贴边侧不重复设置，贴边优先）──
+    const indent = theme.chatBubbleIndent || 0;
+    if (indent > 0) {
+        if (!(theme.chatSnapToEdge && hideAi)) rules.push(`${AI_WRAP} { margin-left: ${indent}px !important; }`);
+        if (!(theme.chatSnapToEdge && hideUser)) rules.push(`${USER_WRAP} { margin-right: ${indent}px !important; }`);
+    }
+
+    // ── 正文字号 / 行距（沿用社区版的四层选择器：容器/内层行/内联继承/引用行）──
+    const fs = theme.chatBubbleFontSize || 0;
+    const lh = theme.chatBubbleLineHeight || 0;
+    if (fs > 0 || lh > 0) {
+        const decl = `${fs > 0 ? ` font-size: ${fs}px !important;` : ''}${lh > 0 ? ` line-height: ${lh} !important;` : ''}`;
+        const inheritDecl = `${fs > 0 ? ' font-size: inherit !important;' : ''}${lh > 0 ? ' line-height: inherit !important;' : ''}`;
+        rules.push(`${AI_BODY}, ${USER_BODY} {${decl} }`);
+        rules.push(`${AI_BODY} div, ${USER_BODY} div {${decl} }`);
+        rules.push(`${AI_BODY} strong, ${AI_BODY} em, ${AI_BODY} span, ${USER_BODY} strong, ${USER_BODY} em, ${USER_BODY} span {${inheritDecl} }`);
+        rules.push(`${AI_BODY} [class*="text-[13px]"], ${USER_BODY} [class*="text-[13px]"] {${decl} }`);
+    }
+
+    return rules.length ? `/* 聊天细节微调（外观 App 生成，用户自定义 CSS 可覆盖） */\n${rules.join('\n')}` : '';
+}


### PR DESCRIPTION
把社区流传的白框美化小代码（隐藏头像/头像对齐与微调/消息贴边/气泡缩进/
字号行距）做成外观 App 的可视化控件：

- OSTheme 新增 7 个可选字段，全部缺省 = 现状零变化
- utils/chatFineTuneCss.ts 纯函数生成 CSS（选择器沿用社区已在真实 DOM 验证过的形态），Chat.tsx 注入在用户自定义白框 CSS **之前**——手写美化 代码永远可覆盖可视化设置，两代方案不打架
- 外观 App「聊天细节微调」区块：头像分组（把原生 chatAvatarMode 首次 暴露成 UI）/头像显隐+贴边/对齐三挡+垂直微调滑杆/字号/行距/气泡缩进， 预览 mock 实时联动
- 快速风格新增「沉浸剧场」（无头像贴边松行距）「紧凑密聊」（小字紧排顶 对齐）两个预设；切换预设先铺微调默认值再叠配置，不留残留
- 设置随外观预设体系一起保存/导出（preset.theme 整包快照，白吃白拿）


Claude-Session: https://claude.ai/code/session_01CWyxHKDa3MktsDPSdriBVy