### PR TITLE
feat(ui): 装扮调试体验重做——预览常驻+翻页调试，聊天装扮改悬浮气泡小面板

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -7,6 +7,7 @@ import { processImage } from '../utils/file';
 import { safeResponseJson, extractContent } from '../utils/safeApi';
 import { buildChatFineTuneCss, mergeChatFineTune } from '../utils/chatFineTuneCss';
 import ChatFineTunePanel from '../components/chat/ChatFineTunePanel';
+import { FadersHorizontal } from '@phosphor-icons/react';
 import { generateDailyScheduleForChar, isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { generateSlotTheater } from '../utils/theaterGenerator';
 import TheaterPlayer from '../components/schedule/TheaterPlayer';
@@ -109,7 +110,12 @@ const Chat: React.FC = () => {
     // Reply Logic
     const [replyTarget, setReplyTarget] = useState<Message | null>(null);
 
-    const [modalType, setModalType] = useState<'none' | 'transfer' | 'emoji-import' | 'chat-settings' | 'message-options' | 'edit-message' | 'delete-emoji' | 'delete-category' | 'add-category' | 'history-manager' | 'archive-settings' | 'prompt-editor' | 'category-options' | 'category-visibility' | 'emoji-options' | 'rename-emoji' | 'schedule' | 'chrome-css' | 'chrome-sound' | 'fine-tune'>('none');
+    const [modalType, setModalType] = useState<'none' | 'transfer' | 'emoji-import' | 'chat-settings' | 'message-options' | 'edit-message' | 'delete-emoji' | 'delete-category' | 'add-category' | 'history-manager' | 'archive-settings' | 'prompt-editor' | 'category-options' | 'category-visibility' | 'emoji-options' | 'rename-emoji' | 'schedule' | 'chrome-css' | 'chrome-sound'>('none');
+    // 「聊天装扮」悬浮态：不走全屏 modal——圆气泡挂在聊天上，点开小面板边看真聊天边调。
+    const [fineTuneOpen, setFineTuneOpen] = useState(false);          // 圆气泡在场
+    const [fineTunePanelOpen, setFineTunePanelOpen] = useState(false); // 小面板展开/收起
+    // 切换角色时收掉装扮气泡：定制是 per-character 的，避免误改到下一个角色
+    useEffect(() => { setFineTuneOpen(false); setFineTunePanelOpen(false); }, [activeCharacterId]);
     const [scheduleData, setScheduleData] = useState<DailySchedule | null>(null);
     // 小剧场（窥视演出）：正在播放的时段索引（null = 未打开），以及生成中标志
     const [theaterSlotIdx, setTheaterSlotIdx] = useState<number | null>(null);
@@ -1181,7 +1187,7 @@ const Chat: React.FC = () => {
             case 'settings': setModalType('chat-settings'); break;
             case 'chrome-css': setModalType('chrome-css'); break;
             case 'chrome-sound': setModalType('chrome-sound'); break;
-            case 'fine-tune': setModalType('fine-tune'); break;
+            case 'fine-tune': setShowPanel('none'); setFineTuneOpen(true); setFineTunePanelOpen(true); break;
             case 'emoji-import': setModalType('emoji-import'); break;
             case 'send-emoji': if (payload) handleSendText(payload.url, 'emoji'); break;
             case 'delete-emoji-req': setSelectedEmoji(payload); setModalType('delete-emoji'); break;
@@ -3292,62 +3298,79 @@ const Chat: React.FC = () => {
                 />
             )}
 
-            {/* 角色专属「聊天装扮」Modal —— 从加号面板「聊天装扮」进入。全局打底，开了「为 TA 单独定制」
-                后已改动的字段逐个覆盖全局（写到 char.chatFineTune），上方聊天界面即实时预览。 */}
-            {char && modalType === 'fine-tune' && (() => {
+            {/* 角色专属「聊天装扮」悬浮气泡 + 小面板 —— 从加号面板「聊天装扮」进入。
+                不是全屏 modal：没有遮罩，聊天内容一直可见、就是实时预览。点圆气泡收起/展开面板
+                （收起后能看清整个聊天再继续调），点「完成」气泡消失、调试结束。
+                全局打底，开了「为 TA 单独定制」后已改动的字段逐个覆盖全局（写到 char.chatFineTune）。 */}
+            {char && fineTuneOpen && (() => {
                 const override = char.chatFineTune;
                 const customized = override?.enabled === true;
                 // 控件展示合并后的生效值：未覆盖的字段显示全局当前值，改哪个才覆盖哪个
                 const effective = mergeChatFineTune(osTheme, override);
                 return (
-                    <div className="fixed inset-0 z-[110] flex items-end justify-center bg-black/5" onClick={() => setModalType('none')}>
-                        <div
-                            className="w-full max-h-[68vh] overflow-y-auto rounded-t-3xl border-t border-white/60 bg-white/95 p-5 shadow-[0_-12px_40px_rgba(15,23,42,0.18)] backdrop-blur-xl [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                            style={{ paddingBottom: 'calc(1.25rem + var(--safe-bottom))' }}
-                            onClick={(e) => e.stopPropagation()}
+                    <>
+                        {/* 悬浮圆气泡：挂在右侧中部，点击 = 收起/展开小面板 */}
+                        <button
+                            onClick={() => setFineTunePanelOpen(v => !v)}
+                            className={`fixed right-3 z-[106] flex h-12 w-12 items-center justify-center rounded-full shadow-lg transition-all active:scale-90 ${fineTunePanelOpen ? 'bg-primary text-white ring-4 ring-primary/20' : 'bg-white/95 text-primary ring-1 ring-primary/30 backdrop-blur'}`}
+                            style={{ top: 'calc(var(--safe-top) + 35vh)' }}
+                            aria-label={fineTunePanelOpen ? '收起聊天装扮面板' : '展开聊天装扮面板'}
                         >
-                            <div className="mb-3 flex items-start justify-between">
-                                <div>
-                                    <div className="text-sm font-bold text-slate-800">聊天装扮 · {char.name}</div>
-                                    <div className="mt-0.5 text-[10px] text-slate-400">↑ 上方聊天界面即实时预览。头像显隐、对齐、字号行距这些细节，可以只给 TA 单独一套。</div>
-                                </div>
-                                <button onClick={() => setModalType('none')} className="px-2 text-xl leading-none text-slate-400 hover:text-slate-600">{'×'}</button>
-                            </div>
-                            <div className="mb-4 flex items-center justify-between rounded-2xl bg-slate-50 px-3 py-2.5">
-                                <div className="min-w-0 pr-3">
-                                    <div className="text-[11px] font-bold text-slate-700">{customized ? '为 TA 单独定制中' : '跟随全局设置（默认）'}</div>
-                                    <div className="mt-0.5 text-[10px] text-slate-400">
-                                        {customized
-                                            ? '只有你改过的项目覆盖全局，其余仍跟随「外观 → 聊天界面」。关掉开关会回到跟随全局，定制内容保留。'
-                                            : '当前用的是「外观 → 聊天界面 → 聊天细节微调」的全局设置。打开开关即可为这个角色单独定制。'}
+                            <FadersHorizontal className="h-6 w-6" weight="bold" />
+                        </button>
+                        {/* 小面板：贴在下方但不遮全屏，上半屏聊天照常可见可滚动 */}
+                        {fineTunePanelOpen && (
+                            <div
+                                className="fixed left-1/2 z-[105] w-[94%] max-w-md -translate-x-1/2 overflow-y-auto rounded-3xl border border-white/60 bg-white/95 p-4 shadow-[0_12px_40px_rgba(15,23,42,0.22)] backdrop-blur-xl [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                                style={{ bottom: 'calc(84px + var(--safe-bottom))', maxHeight: '46vh' }}
+                            >
+                                <div className="mb-3 flex items-start justify-between gap-2">
+                                    <div>
+                                        <div className="text-[13px] font-bold text-slate-800">聊天装扮 · {char.name}</div>
+                                        <div className="mt-0.5 text-[10px] text-slate-400">改动立刻生效在上方聊天里；点右侧圆气泡可收起面板看效果。</div>
                                     </div>
-                                </div>
-                                <button
-                                    onClick={() => updateCharacter(char.id, { chatFineTune: { ...override, enabled: !customized } } as any)}
-                                    className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${customized ? 'bg-primary' : 'bg-slate-300'}`}
-                                    aria-pressed={customized}
-                                >
-                                    <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${customized ? 'left-[22px]' : 'left-0.5'}`} />
-                                </button>
-                            </div>
-                            {customized && (
-                                <>
-                                    <ChatFineTunePanel
-                                        value={effective}
-                                        onChange={(patch) => updateCharacter(char.id, { chatFineTune: { ...override, enabled: true, ...patch } } as any)}
-                                    />
                                     <button
-                                        onClick={() => { updateCharacter(char.id, { chatFineTune: undefined } as any); addToast('已清除该角色的聊天装扮，回到跟随全局', 'success'); }}
-                                        className="mt-4 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-[11px] font-bold text-slate-500 transition-all hover:bg-slate-100 active:scale-[0.99]">
-                                        清除定制，回到跟随全局
+                                        onClick={() => { setFineTuneOpen(false); setFineTunePanelOpen(false); }}
+                                        className="shrink-0 rounded-full bg-primary px-4 py-1.5 text-[11px] font-bold text-white shadow-sm transition-all active:scale-95">
+                                        完成
                                     </button>
-                                </>
-                            )}
-                            <p className="mt-3 text-[10px] leading-relaxed text-slate-400">
-                                只影响私聊界面，群聊不受影响。手写过「白框」自定义 CSS 的话不用担心：<b>自定义 CSS 优先级更高</b>，永远盖得过这里的设置。
-                            </p>
-                        </div>
-                    </div>
+                                </div>
+                                <div className="mb-3 flex items-center justify-between rounded-2xl bg-slate-50 px-3 py-2.5">
+                                    <div className="min-w-0 pr-3">
+                                        <div className="text-[11px] font-bold text-slate-700">{customized ? '为 TA 单独定制中' : '跟随全局设置（默认）'}</div>
+                                        <div className="mt-0.5 text-[10px] text-slate-400">
+                                            {customized
+                                                ? '只有你改过的项目覆盖全局，其余仍跟随「外观 → 聊天界面」。关掉开关回到跟随全局，定制内容保留。'
+                                                : '当前用的是「外观 → 聊天界面」的全局设置。打开开关即可为这个角色单独定制。'}
+                                        </div>
+                                    </div>
+                                    <button
+                                        onClick={() => updateCharacter(char.id, { chatFineTune: { ...override, enabled: !customized } } as any)}
+                                        className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${customized ? 'bg-primary' : 'bg-slate-300'}`}
+                                        aria-pressed={customized}
+                                    >
+                                        <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${customized ? 'left-[22px]' : 'left-0.5'}`} />
+                                    </button>
+                                </div>
+                                {customized && (
+                                    <>
+                                        <ChatFineTunePanel
+                                            value={effective}
+                                            onChange={(patch) => updateCharacter(char.id, { chatFineTune: { ...override, enabled: true, ...patch } } as any)}
+                                        />
+                                        <button
+                                            onClick={() => { updateCharacter(char.id, { chatFineTune: undefined } as any); addToast('已清除该角色的聊天装扮，回到跟随全局', 'success'); }}
+                                            className="mt-3 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-[11px] font-bold text-slate-500 transition-all hover:bg-slate-100 active:scale-[0.99]">
+                                            清除定制，回到跟随全局
+                                        </button>
+                                    </>
+                                )}
+                                <p className="mt-3 text-[10px] leading-relaxed text-slate-400">
+                                    只影响私聊界面，群聊不受影响。手写过「白框」自定义 CSS 的话不用担心：<b>自定义 CSS 优先级更高</b>，永远盖得过这里的设置。
+                                </p>
+                            </div>
+                        )}
+                    </>
                 );
             })()}
 

--- a/components/appearance/ChatAppearanceEditor.tsx
+++ b/components/appearance/ChatAppearanceEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { AppID, OSTheme, ChatFineTuneFields } from '../../types';
 import WhiteboxSoundEditor from '../chat/WhiteboxSoundEditor';
 import { WhiteboxSound } from '../../utils/whiteboxSound';
@@ -408,6 +408,12 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
     const showHeaderBuffs = theme.chatHideHeaderBuffs !== true;
     const [showStyleHelp, setShowStyleHelp] = useState(false);
 
+    // 调试区左右翻页：预览常驻在上，下面一页一个主题，改哪项都能立刻在预览里看到。
+    const PAGE_TITLES = ['快速预设', '聊天壳', '头部', '气泡与头像', '细节微调', '表情包与输入栏'];
+    const [page, setPage] = useState(0);
+    const swipeStartX = useRef<number | null>(null);
+    const goPage = (next: number) => setPage(Math.max(0, Math.min(PAGE_TITLES.length - 1, next)));
+
     // 聊天细节微调 → 预览联动（近似演示：字号按比例缩小 3px 以配合迷你预览）
     const fineVis = theme.chatAvatarVisibility || 'both';
     const hidePreviewAiAvatar = fineVis === 'hide_ai' || fineVis === 'hide_both';
@@ -445,29 +451,13 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
 
     return (
         <div className="space-y-5">
-            <section className={groupClass}>
-                <div className="mb-3">
-                    <h2 className="text-sm font-bold uppercase tracking-widest text-slate-400">聊天壳预设</h2>
-                    <p className="mt-1 text-[10px] text-slate-400">自由更换聊天界面的外观。</p>
-                </div>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {presets.map((preset) => (
-                        <button
-                            key={preset.name}
-                            onClick={() => updateTheme({ ...FINE_TUNE_DEFAULTS, ...preset.config })}
-                            className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-left transition-all hover:border-primary/30 hover:bg-white active:scale-[0.98]"
-                        >
-                            <div className="text-xs font-bold text-slate-700">{preset.name}</div>
-                            <div className="mt-1 text-[10px] text-slate-400">{preset.desc}</div>
-                        </button>
-                    ))}
-                </div>
-            </section>
-
-            <section className={groupClass}>
-                <div className="mb-3">
-                    <h2 className="text-sm font-bold uppercase tracking-widest text-slate-400">实时预览</h2>
-                    <p className="mt-1 text-[10px] text-slate-400">头部、消息区和输入栏都会跟着你的选择同步变化。</p>
+            {/* 实时预览：sticky 常驻顶部——往下翻到哪一页、改哪个选项，效果都始终看得见。
+                -top-5 抵消外层滚动容器的 p-5 内边距，贴住 tab 栏下沿。 */}
+            <div className="sticky -top-5 z-20 -mx-1 bg-slate-50 px-1 pb-1 pt-1">
+            <section className="rounded-3xl border border-slate-100 bg-white p-3 shadow-sm">
+                <div className="mb-2 flex items-baseline justify-between px-1">
+                    <h2 className="text-[11px] font-bold uppercase tracking-widest text-slate-400">实时预览</h2>
+                    <span className="text-[9px] text-slate-300">全局设置 · 改动立即反映</span>
                 </div>
                 <div className={`sully-chat-root overflow-hidden rounded-[28px] ${shellClass(chromeStyle)}`} style={backgroundStyleForPreview(backgroundStyle, chromeStyle)}>
                     {/* 实时套用「白框自定义」CSS：预览各零件挂了同样的 .sully-chat-* 钩子，故能即时反映。
@@ -493,7 +483,7 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
                             {headerAlign !== 'center' && <div className={`sully-chat-token text-[9px] font-mono ${headerStyle === 'discord' ? 'text-slate-400' : headerStyle === 'pixel' ? 'text-[#f3ddc7]' : 'text-slate-400'}`}>42 tok</div>}
                         </div>
                     </div>
-                    <div className={`flex min-h-[190px] flex-col p-4 ${previewGap}`}>
+                    <div className={`flex min-h-[150px] flex-col p-3 ${previewGap}`}>
                         {previewMessages.map((message, index) => {
                             const isUser = message.role === 'user';
                             const nextRole = index < previewMessages.length - 1 ? previewMessages[index + 1].role : null;
@@ -526,15 +516,71 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
                     </div>
                 </div>
             </section>
+            </div>
 
+            {/* 调试区：一页一个主题，左右滑动或点页签切换；预览常驻上方，改哪项都立刻看得到 */}
             <section className={groupClass}>
-                <ChoiceGroup title="聊天壳" items={choices.chrome} value={chromeStyle} onPick={(value) => updateTheme({ chatChromeStyle: value as OSTheme['chatChromeStyle'] })} />
-                <div className="mt-4">
-                    <ChoiceGroup title="消息区背景" items={choices.background} value={backgroundStyle} onPick={(value) => updateTheme({ chatBackgroundStyle: value as OSTheme['chatBackgroundStyle'] })} />
+                <div className="mb-4 flex items-center gap-1.5">
+                    <button
+                        onClick={() => goPage(page - 1)}
+                        disabled={page === 0}
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-100 text-base text-slate-500 transition-all active:scale-90 disabled:opacity-30"
+                        aria-label="上一页"
+                    >‹</button>
+                    <div className="flex flex-1 gap-1.5 overflow-x-auto no-scrollbar">
+                        {PAGE_TITLES.map((title, i) => (
+                            <button
+                                key={title}
+                                onClick={() => setPage(i)}
+                                className={`shrink-0 rounded-full px-3 py-1.5 text-[11px] font-bold transition-all active:scale-95 ${i === page ? 'bg-primary text-white shadow-sm' : 'bg-slate-100 text-slate-500'}`}
+                            >{title}</button>
+                        ))}
+                    </div>
+                    <button
+                        onClick={() => goPage(page + 1)}
+                        disabled={page === PAGE_TITLES.length - 1}
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-100 text-base text-slate-500 transition-all active:scale-90 disabled:opacity-30"
+                        aria-label="下一页"
+                    >›</button>
                 </div>
-            </section>
+                <div
+                    onTouchStart={(e) => {
+                        // 滑杆等横向控件里起手的触摸不算翻页手势（否则拖「垂直微调」滑杆会误翻页）
+                        swipeStartX.current = (e.target as HTMLElement).closest('input') ? null : (e.touches[0]?.clientX ?? null);
+                    }}
+                    onTouchEnd={(e) => {
+                        const startX = swipeStartX.current;
+                        swipeStartX.current = null;
+                        const endX = e.changedTouches[0]?.clientX;
+                        if (startX == null || endX == null) return;
+                        const dx = endX - startX;
+                        if (Math.abs(dx) > 48) goPage(page + (dx < 0 ? 1 : -1));
+                    }}
+                >
+                {page === 0 && (<>
+                    <p className="mb-3 text-[10px] text-slate-400">一键换整套聊天壳（含头像、气泡、间距与细节微调），切预设会先清掉微调残留。</p>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                        {presets.map((preset) => (
+                            <button
+                                key={preset.name}
+                                onClick={() => updateTheme({ ...FINE_TUNE_DEFAULTS, ...preset.config })}
+                                className="rounded-2xl border border-slate-200 bg-slate-50 p-3 text-left transition-all hover:border-primary/30 hover:bg-white active:scale-[0.98]"
+                            >
+                                <div className="text-xs font-bold text-slate-700">{preset.name}</div>
+                                <div className="mt-1 text-[10px] text-slate-400">{preset.desc}</div>
+                            </button>
+                        ))}
+                    </div>
+                </>)}
 
-            <section className={groupClass}>
+                {page === 1 && (<>
+                    <ChoiceGroup title="聊天壳" items={choices.chrome} value={chromeStyle} onPick={(value) => updateTheme({ chatChromeStyle: value as OSTheme['chatChromeStyle'] })} />
+                    <div className="mt-4">
+                        <ChoiceGroup title="消息区背景" items={choices.background} value={backgroundStyle} onPick={(value) => updateTheme({ chatBackgroundStyle: value as OSTheme['chatBackgroundStyle'] })} />
+                    </div>
+                </>)}
+
+                {page === 2 && (<>
                 <ChoiceGroup title="头部风格" items={choices.header} value={headerStyle} onPick={(value) => updateTheme({ chatHeaderStyle: value as OSTheme['chatHeaderStyle'] })} />
                 <div className="mt-4">
                     <ChoiceGroup title="头部对齐" items={choices.align} value={headerAlign} onPick={(value) => updateTheme({ chatHeaderAlign: value as OSTheme['chatHeaderAlign'] })} />
@@ -558,9 +604,9 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
                         <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${showHeaderBuffs ? 'left-[22px]' : 'left-0.5'}`} />
                     </button>
                 </div>
-            </section>
+                </>)}
 
-            <section className={groupClass}>
+                {page === 3 && (<>
                 <ChoiceGroup title="消息气泡" items={choices.bubble} value={bubbleStyle} onPick={(value) => updateTheme({ chatBubbleStyle: value as OSTheme['chatBubbleStyle'] })} />
                 <div className="mt-4">
                     <ChoiceGroup title="头像形状" items={choices.avatarShape} value={avatarShape} onPick={(value) => updateTheme({ chatAvatarShape: value as OSTheme['chatAvatarShape'] })} />
@@ -590,37 +636,35 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
                         <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-all ${pendingIndicator ? 'left-[22px]' : 'left-0.5'}`} />
                     </button>
                 </div>
-            </section>
+                </>)}
 
-            <section className={groupClass}>
-                <ChoiceGroup title="表情包大小" items={choices.emojiSize} value={theme.chatEmojiSize || 'small'} onPick={(value) => updateTheme({ chatEmojiSize: value as OSTheme['chatEmojiSize'] })} />
-                <p className="mt-2 text-[10px] text-slate-400">聊天和群聊里发出的表情包图片尺寸。用自定义 CSS 调过尺寸的美化会继续覆盖这里的设置。</p>
-            </section>
-
-            {/* 聊天细节微调 —— 收编社区白框美化的可视化版（控件组件与聊天内「聊天装扮」弹窗共用） */}
-            <section className={groupClass}>
-                <div className="mb-3">
-                    <h2 className="text-sm font-bold uppercase tracking-widest text-slate-400">聊天细节微调</h2>
-                    <p className="mt-1 text-[10px] leading-relaxed text-slate-400">
+                {/* 聊天细节微调 —— 收编社区白框美化的可视化版（控件组件与聊天内「聊天装扮」弹窗共用） */}
+                {page === 4 && (<>
+                    <p className="mb-3 text-[10px] leading-relaxed text-slate-400">
                         头像显隐/对齐、贴边、字号行距——不用再手写 CSS，改动实时反映在上方预览里。
                         手写过美化代码的老用户不受影响：<b>你的自定义 CSS 优先级更高</b>，永远盖得过这里。
                     </p>
-                </div>
-                <ChatFineTunePanel value={theme} onChange={(patch) => updateTheme(patch)} />
-                <button
-                    onClick={() => updateTheme({ ...FINE_TUNE_DEFAULTS })}
-                    className="mt-4 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-[11px] font-bold text-slate-500 transition-all hover:bg-slate-100 active:scale-[0.99]">
-                    微调全部回默认（一键清残留）
-                </button>
-                <p className="mt-2 text-[10px] text-slate-400">
-                    这里设置的是全局打底。想给某个角色单独一套？进 ta 的聊天 → 「＋」菜单 → 「聊天装扮」。
-                </p>
-            </section>
+                    <ChatFineTunePanel value={theme} onChange={(patch) => updateTheme(patch)} />
+                    <button
+                        onClick={() => updateTheme({ ...FINE_TUNE_DEFAULTS })}
+                        className="mt-4 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-[11px] font-bold text-slate-500 transition-all hover:bg-slate-100 active:scale-[0.99]">
+                        微调全部回默认（一键清残留）
+                    </button>
+                    <p className="mt-2 text-[10px] text-slate-400">
+                        这里设置的是全局打底。想给某个角色单独一套？进 ta 的聊天 → 「＋」菜单 → 「聊天装扮」。
+                    </p>
+                </>)}
 
-            <section className={groupClass}>
-                <ChoiceGroup title="输入栏风格" items={choices.input} value={inputStyle} onPick={(value) => updateTheme({ chatInputStyle: value as OSTheme['chatInputStyle'] })} />
-                <div className="mt-4">
-                    <ChoiceGroup title="发送按钮" items={choices.send} value={sendButtonStyle} onPick={(value) => updateTheme({ chatSendButtonStyle: value as OSTheme['chatSendButtonStyle'] })} />
+                {page === 5 && (<>
+                    <ChoiceGroup title="表情包大小" items={choices.emojiSize} value={theme.chatEmojiSize || 'small'} onPick={(value) => updateTheme({ chatEmojiSize: value as OSTheme['chatEmojiSize'] })} />
+                    <p className="mt-2 text-[10px] text-slate-400">聊天和群聊里发出的表情包图片尺寸。用自定义 CSS 调过尺寸的美化会继续覆盖这里的设置。（表情包尺寸预览里看不到，进聊天发一张试试。）</p>
+                    <div className="mt-4">
+                        <ChoiceGroup title="输入栏风格" items={choices.input} value={inputStyle} onPick={(value) => updateTheme({ chatInputStyle: value as OSTheme['chatInputStyle'] })} />
+                    </div>
+                    <div className="mt-4">
+                        <ChoiceGroup title="发送按钮" items={choices.send} value={sendButtonStyle} onPick={(value) => updateTheme({ chatSendButtonStyle: value as OSTheme['chatSendButtonStyle'] })} />
+                    </div>
+                </>)}
                 </div>
             </section>
 


### PR DESCRIPTION
痛点：两边的预览都和控件抢屏幕——外观 App 往下滚就看不见预览、改了不知道
变没变；聊天里的装扮弹窗盖住大半个聊天，真正的"预览"（聊天本身）反而被
挡住。职责也顺势理清：外观 App 管整体聊天外观（全局），聊天「＋」管局部
微调（按角色）。

外观 App「聊天界面」tab：
- 实时预览 sticky 常驻顶部（抵消滚动容器内边距贴住 tab 栏），翻到哪一页、 改哪个选项都始终看得见；预览压缩了内边距给下方控件让位
- 下方调试区改成左右翻页：快速预设 / 聊天壳 / 头部 / 气泡与头像 / 细节 微调 / 表情包与输入栏，页签直达 + 箭头 + 横滑翻页（滑杆里起手的触摸 不算翻页手势，防误翻）；提示音/进阶装扮/白框救援等不影响预览的区块 保持在翻页区下方平铺

聊天「聊天装扮」：
- 弃用全屏底部弹窗，改为悬浮圆气泡 + 小面板：点「＋」→「聊天装扮」直接 出现右侧圆气泡并展开小面板（半高、无遮罩），聊天内容一直可见、就是 实时预览；点圆气泡收起/展开面板，点「完成」气泡消失调试结束
- 切换角色自动收掉气泡（定制是 per-character 的，防误改下一个角色）


Claude-Session: https://claude.ai/code/session_01B18LgGKuZScVyPMJp5NeN2