### PR TITLE
fix(archive): 分角色头像界面打磨——角色圆头像、末页占位防弹跳、备份文案更准

### DIFF
--- a/components/user/PerCharAvatarPicker.tsx
+++ b/components/user/PerCharAvatarPicker.tsx
@@ -144,7 +144,7 @@ const PerCharAvatarPicker: React.FC = () => {
                             return (
                                 <button key={c.id} onClick={() => openEditor(c.id)} className="flex flex-col items-center gap-1.5 group active:scale-95 transition-transform">
                                     <div className="relative">
-                                        <img src={c.avatar} alt="" className="w-14 h-14 rounded-2xl object-cover bg-slate-100 border border-slate-100 group-hover:border-primary/30 transition-colors" />
+                                        <img src={c.avatar} alt="" className="w-14 h-14 rounded-full object-cover bg-slate-100 border border-slate-100 group-hover:border-primary/30 transition-colors" />
                                         {/* 右下小圆 = 这个聊天里「你」的头像；设置过 → 主题色描边，否则灰显整体头像 */}
                                         <img
                                             src={override || userProfile.avatar}
@@ -156,6 +156,13 @@ const PerCharAvatarPicker: React.FC = () => {
                                 </button>
                             );
                         })}
+                        {/* 末页不满 8 人时用隐形占位补齐两行高度，翻页时容器不弹跳 */}
+                        {pageCount > 1 && pageChars.length < PAGE_SIZE && Array.from({ length: PAGE_SIZE - pageChars.length }, (_, i) => (
+                            <div key={`pad-${i}`} className="flex flex-col items-center gap-1.5 invisible" aria-hidden="true">
+                                <div className="w-14 h-14 rounded-full" />
+                                <span className="text-[10px]">&nbsp;</span>
+                            </div>
+                        ))}
                     </div>
 
                     {pageCount > 1 && (
@@ -191,7 +198,7 @@ const PerCharAvatarPicker: React.FC = () => {
 
                         <div className="flex items-center justify-center gap-5 mb-4">
                             <div className="flex flex-col items-center gap-1">
-                                <img src={editingChar.avatar} className="w-16 h-16 rounded-2xl object-cover bg-slate-100" alt="" />
+                                <img src={editingChar.avatar} className="w-16 h-16 rounded-full object-cover bg-slate-100" alt="" />
                                 <span className="text-[10px] text-slate-400">{editingChar.name}</span>
                             </div>
                             <span className="text-slate-300 text-lg">×</span>
@@ -213,7 +220,7 @@ const PerCharAvatarPicker: React.FC = () => {
                                 <button onClick={applyUrl} className="shrink-0 rounded-xl bg-primary px-3 py-2 text-[11px] font-bold text-white active:scale-95 transition-transform">使用</button>
                             </div>
                             <p className="mt-1.5 text-[10px] leading-relaxed text-slate-400">
-                                推荐链接：不占本地空间，备份导出更小更快，换设备也不丢。
+                                推荐链接：不占本地空间，备份更小更快；「纯文字备份」也只有链接能把图带走（本地上传的图会被剥掉）。
                             </p>
                         </div>
 

--- a/utils/backupRoundtrip.test.ts
+++ b/utils/backupRoundtrip.test.ts
@@ -127,9 +127,12 @@ describe('v2 真实链路：分片 → 组装 → importFullData', () => {
             chatFineTune: { enabled: true, chatBubbleFontSize: 15, chatAvatarVisibility: 'hide_ai' },
         };
         const theme = { chatAvatarVisibility: 'hide_both', chatSnapToEdge: true, chatBubbleLineHeight: 1.5, chatEmojiSize: 'large' };
+        // 分角色聊天头像（URL 形态）随 user_profile 单例走；data: 形态在 full/media 模式
+        // 走 assets 抽取回填（restoreAssetsInPlace），text_only 剥掉——与整体头像同规则。
+        const userProfile = { name: 'me', avatar: 'https://img.example/me.png', bio: '', perCharAvatars: { ft1: 'https://img.example/me-ft1.png' } };
 
         const zip = new FakeZip();
-        const manifest = await writeV2Backup(zip, { characters: [char], theme } as any, {});
+        const manifest = await writeV2Backup(zip, { characters: [char], theme, userProfile } as any, {});
         const data: any = await assembleV2Backup(zip, manifest);
 
         // theme 是非数组字段 → 原样拼回（导入端 OSContext 直接拿它 updateTheme）
@@ -138,6 +141,8 @@ describe('v2 真实链路：分片 → 组装 → importFullData', () => {
         await DB.importFullData(data);
         const restored = (await DB.getRawStoreData('characters')).find((c: any) => c.id === 'ft1');
         expect(restored.chatFineTune).toEqual(char.chatFineTune);
+        const profile = (await DB.getRawStoreData('user_profile'))[0];
+        expect(profile.perCharAvatars).toEqual(userProfile.perCharAvatars);
     });
 
     it('formatVersion 3 在组装阶段 abort，DB 未发生任何写（test 12）', async () => {


### PR DESCRIPTION
- 选择器与编辑弹层里的角色头像改圆形，和用户头像小圆视觉统一
- 末页不满 8 人时用隐形占位补齐两行高度，翻页时容器不再突然弹动
- 核查备份链路后修正推荐文案：URL 头像任何备份模式都能带走；本地上传 （data:image）在 full/media 模式走 assets 抽取回填，「纯文字备份」会被 stripBase64 剥掉（与整体头像同规则）——文案照实说
- 备份往返测试补 userProfile.perCharAvatars 断言，钉死随 user_profile 单例导出导入不丢


Claude-Session: https://claude.ai/code/session_01B18LgGKuZScVyPMJp5NeN2