### PR TITLE
fix(api): SSE 拼装保留思考通道——修「开思维链但角色不出思维链」

### DIFF
--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -762,11 +762,9 @@ export const useChatAI = ({
                     ? { ...char.emotionConfig!.api!, stream: (char.emotionConfig!.api as any).stream ?? evalStream }
                     : { baseUrl: apiConfig.baseUrl, apiKey: apiConfig.apiKey, model: apiConfig.model, stream: evalStream })
                 : null;
-            // 本地路径的情绪评估不在这里立刻发射，改为「主请求发出 ~1.5s 后」再发（见下方
-            // 主 fetch 前的 setTimeout）。原因（2026-07 实测日志）：便宜中转普遍按 key 串行/
-            // 低并发，评估这个同样几万 token 的大请求和主回复同时发射时谁先入队是随机的——
-            // 评估抢跑那几轮，主回复 headers 从 ~10s 恶化到 34s（被压后整整一个评估时长）。
-            // 错开 1.5s 保证主回复永远先到中转队列；评估结果只作用于下一轮，晚这一点零损失。
+            // 本地路径的情绪评估：主 fetch 发出后立即发射（见下方调用点）。
+            // 历史备注：曾为串行中转做过 1.5s 错峰（评估抢跑会把主回复压后一个评估时长），
+            // 用户侧已排查确认当前渠道无该并发问题，2026-07 应用户要求取消延迟。
             // instant 模式不受影响：worker 端本来就是主回复跑完才跑评估（天然串行）。
             const fireLocalEmotionEval = (emotionEvalEnabled && !instantOn && emotionApi) ? () => {
                 setEmotionStatus('evaluating');
@@ -966,9 +964,8 @@ export const useChatAI = ({
                 },
             } : undefined;
 
-            // 主请求即将发出 → 1.5s 后发射情绪评估（保证主回复先进中转队列，见上方定义处注释）。
-            // 不随主请求失败取消：旧行为里评估本来就无条件发射，保持一致。
-            if (fireLocalEmotionEval) setTimeout(fireLocalEmotionEval, 1500);
+            // 主请求即将发出 → 立即并行发射情绪评估（错峰延迟已按用户要求取消，见定义处注释）。
+            fireLocalEmotionEval?.();
 
             let data: any;
             try {

--- a/utils/safeApi.stream.test.ts
+++ b/utils/safeApi.stream.test.ts
@@ -85,3 +85,38 @@ describe('safeFetchJson streaming', () => {
         expect(data.choices[0].message.content).toBe('ab');
     });
 });
+
+describe('SSE 拼装保留思考通道 (reasoning_content)', () => {
+    it('delta.reasoning_content 累积进 message.reasoning_content（思维链显示依赖它）', async () => {
+        const events = [
+            'data: {"choices":[{"delta":{"reasoning_content":"她这句是在"}}]}\n\n',
+            'data: {"choices":[{"delta":{"reasoning_content":"逗我玩…"}}]}\n\n',
+            'data: {"choices":[{"delta":{"content":"哼，看穿你了"}}]}\n\n',
+            'data: [DONE]\n',
+        ];
+        vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: () => {} });
+        expect(data.choices[0].message.reasoning_content).toBe('她这句是在逗我玩…');
+        expect(data.choices[0].message.content).toBe('哼，看穿你了');
+    });
+
+    it('OpenRouter 形态 delta.reasoning 同样保留；onDelta 只吐正文不吐思考', async () => {
+        const events = [
+            'data: {"choices":[{"delta":{"reasoning":"thinking..."}}]}\n\n',
+            'data: {"choices":[{"delta":{"content":"回复正文"}}]}\n\n',
+            'data: [DONE]\n',
+        ];
+        vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
+        const deltas: string[] = [];
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: (d) => { deltas.push(d); } });
+        expect(data.choices[0].message.reasoning_content).toBe('thinking...');
+        expect(deltas.join('')).toBe('回复正文');
+    });
+
+    it('没有思考通道时不产生空的 reasoning_content 字段', async () => {
+        const events = ['data: {"choices":[{"delta":{"content":"普通回复"}}]}\n\n', 'data: [DONE]\n'];
+        vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: () => {} });
+        expect(data.choices[0].message).not.toHaveProperty('reasoning_content');
+    });
+});

--- a/utils/safeApi.ts
+++ b/utils/safeApi.ts
@@ -95,6 +95,11 @@ class SseAssembler {
     // tool_calls 流式分片: OpenAI 约定按 index 分组, id/name 在首片, arguments 逐片拼接。
     // 不拼的话开了 stream 的工具模式(瑞幸/MCP)会静默丢掉全部工具调用。
     private toolCalls: any[] = [];
+    // 思考通道: DeepSeek/Gemini 系走 delta.reasoning_content, OpenRouter 走 delta.reasoning。
+    // 丢掉它 = 开思考链的角色"不出思维链"(后处理从 message.reasoning_content 抽取),
+    // 且 extractContent / extractAssistantText 的 reasoning 兜底全部失效(思考模型把全部
+    // 输出塞进 reasoning 时表现为空回复→重试→巨慢)。2026-07 全局流式上线后被放大成必现。
+    private reasoning = '';
 
     /** 喂一行 SSE 文本，返回本行带来的正文增量（无正文则空串） */
     feedLine(line: string): string {
@@ -121,6 +126,8 @@ class SseAssembler {
                 delta = choice.delta.content;
                 this.content += delta;
             }
+            const dr = choice.delta.reasoning_content ?? choice.delta.reasoning;
+            if (typeof dr === 'string') this.reasoning += dr;
             if (choice.delta.role) this.role = choice.delta.role;
             if (Array.isArray(choice.delta.tool_calls)) {
                 for (const frag of choice.delta.tool_calls) {
@@ -139,6 +146,8 @@ class SseAssembler {
                 delta = choice.message.content;
                 this.content += delta;
             }
+            const mr = choice.message.reasoning_content ?? choice.message.reasoning;
+            if (typeof mr === 'string') this.reasoning += mr;
             if (choice.message.role) this.role = choice.message.role;
             if (Array.isArray(choice.message.tool_calls)) this.toolCalls.push(...choice.message.tool_calls);
         }
@@ -159,6 +168,7 @@ class SseAssembler {
                 message: {
                     role: this.role,
                     content: this.content,
+                    ...(this.reasoning ? { reasoning_content: this.reasoning } : {}),
                     ...(this.toolCalls.length ? {
                         tool_calls: this.toolCalls.filter(Boolean).map((tc, i) => ({ ...tc, id: tc.id || `call_sse_${i}` })),
                     } : {}),


### PR DESCRIPTION
SseAssembler 此前只累积 delta.content，把 delta.reasoning_content （DeepSeek/Gemini 系）与 delta.reasoning（OpenRouter 形态）全部丢弃。 全局流式上线后所有响应都经拼装器，后果：

- 思维链显示（后处理从 message.reasoning_content 抽取）拿不到思考 → 开着思维链的角色"不出思维链"，任何模型都中
- extractContent / extractAssistantText 的 reasoning 兜底失效 → 思考模型把全部输出塞进 reasoning 时表现为空回复→重试→变慢

修复：assembler 累积两种字段形态，finish() 输出 message.reasoning_content （无思考时不产生空字段）。整包路径 / 真流式路径 / 透明升级路径共用一份
实现，一处修三处好；补 3 条测试锁行为。

另：情绪评估 1.5s 错峰按用户要求取消（并发问题已排查确认不存在），
恢复主请求发出后立即并行发射。


Claude-Session: https://claude.ai/code/session_01CWyxHKDa3MktsDPSdriBVy