### PR TITLE
fix(chat): 流式预览气泡同构真实消息 DOM + 无缝交棒落库

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -3112,17 +3112,37 @@ const Chat: React.FC = () => {
                     </div>
                 )}
 
-                {/* 流式预览气泡：stream 开启时已完成的回复行先上屏（临时展示，落库后由真实消息替换） */}
+                {/* 流式预览气泡：stream 开启时已完成的回复行先上屏（临时展示，第一条真实消息
+                    落库时无缝交棒——见 useChatAI 的 setMessages 包装）。
+                    DOM 与真实消息同构（.group.justify-start > .absolute.z-0 头像 + .max-w-[72%].ml-12
+                    + .sully-bubble-ai > .select-text）——聊天细节微调（隐藏头像/贴边/字号行距）和
+                    气泡主题的颜色/圆角对预览一并生效，不再出现"预览不吃美化方案"的错位感。 */}
                 {streamingBubbles.length > 0 && !selectionMode && (
-                    <div className="flex items-end gap-3 px-3 mb-2 animate-fade-in">
-                        <img src={char.avatar} className={chatPendingAvatarClass} />
-                        <div className="flex flex-col items-start gap-1.5 max-w-[75%]">
-                            {streamingBubbles.map((bubble, i) => (
-                                <div key={i} className="px-4 py-2.5 rounded-2xl text-sm leading-relaxed whitespace-pre-wrap break-all bg-white text-slate-700 rounded-bl-sm shadow-sm border border-slate-100 animate-fade-in">
-                                    {bubble}
+                    <div className="space-y-1.5 mb-2">
+                        {streamingBubbles.map((bubble, i) => (
+                            <div key={i} className="group w-full flex justify-start relative px-3 animate-fade-in">
+                                {/* 头像只挂在最后一条上，贴合 grouped 折叠模式的观感；
+                                    absolute+z-0 结构让「隐藏头像」等微调 CSS 自动命中 */}
+                                {i === streamingBubbles.length - 1 && (
+                                    <div className="absolute left-3 bottom-0 z-0">
+                                        <img src={char.avatar} className={chatPendingAvatarClass} />
+                                    </div>
+                                )}
+                                <div className="relative max-w-[72%] min-w-0 ml-12">
+                                    <div
+                                        className="relative px-5 py-3 shadow-sm border border-black/5 overflow-visible sully-bubble-ai"
+                                        style={{
+                                            backgroundColor: activeTheme.ai.backgroundColor,
+                                            color: activeTheme.ai.textColor,
+                                            borderRadius: activeTheme.ai.borderRadius,
+                                            opacity: activeTheme.ai.opacity,
+                                        }}
+                                    >
+                                        <div className="select-text text-[15px] leading-relaxed whitespace-pre-wrap break-words">{bubble}</div>
+                                    </div>
                                 </div>
-                            ))}
-                        </div>
+                            </div>
+                        ))}
                     </div>
                 )}
                 {(isTyping || recallStatus || searchStatus || diaryStatus || isProactiveComposing) && !selectionMode && (

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -1376,9 +1376,17 @@ export const useChatAI = ({
             // 详见 utils/applyAssistantPostProcessing.ts。Phase 0 行为字节级不变;
             // Phase 1 会让 instant push 路径也调它 (skipSecondPassLLM=true);
             // Phase 2 会让 worker 端把识别的副作用打包成 directives 传过来重放。
-            // 预览气泡在真实消息开始落库前清掉，避免同一句话短暂双份显示。
-            // （后处理第一步就会 saveMessage+setMessages，空档只有几十毫秒。）
-            setStreamingBubbles([]);
+            // 预览气泡的无缝交棒：不提前清（提前清 = 气泡集体消失→再劈里啪啦重放，用户实报），
+            // 而是包装 setMessages——后处理第一条真实消息落库上屏的**同一帧**清预览。
+            // 交接前预览一直挂着，交接后 instantRender 秒速回填，视觉上是"预览定格成正式消息"。
+            let previewHandedOver = false;
+            const setMessagesWithPreviewHandover = (msgs: Message[]) => {
+                setMessages(msgs);
+                if (!previewHandedOver) {
+                    previewHandedOver = true;
+                    setStreamingBubbles([]);
+                }
+            };
             const rawAiContent = data.choices?.[0]?.message?.content || '';
             const xhsCaches: XhsCaches = {
                 xsecTokenCache: xsecTokenCacheRef.current,
@@ -1404,7 +1412,7 @@ export const useChatAI = ({
                     effectiveApi,
                 },
                 hooks: {
-                    setMessages,
+                    setMessages: setMessagesWithPreviewHandover,
                     addToast,
                     setRecallStatus,
                     setSearchStatus,


### PR DESCRIPTION
用户实报两个预览问题：①预览不吃美化方案（设置了隐藏头像却带头像、
气泡也不是自己的主题样式）②回复完成后预览集体消失、再从头劈里啪啦
重放一遍。

- 预览 DOM 改为与真实消息同构（.group.justify-start > .absolute.z-0 头像
  + .max-w-[72%].ml-12 + .sully-bubble-ai > .select-text）：聊天细节微调 的隐藏头像/贴边/字号行距 CSS、用户自定义白框 CSS 对预览自动生效； 气泡颜色/圆角/透明度取自当前气泡主题 (activeTheme.ai)；头像只挂最后 一条，贴合 grouped 折叠观感
- 落库交接改为包装 setMessages：第一条真实消息上屏的同一帧清预览， 之前挂着不动，之后 instantRender 秒速回填——视觉上是"预览定格成 正式消息"而非"收回重放"


Claude-Session: https://claude.ai/code/session_01CWyxHKDa3MktsDPSdriBVy