### PR TITLE
Fix ChatApp streaming previews and live reasoning

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -22,7 +22,7 @@ import { isMcdConfigured } from '../utils/mcdMcpClient';
 import { isMcdActivatedInMessages, MCD_ACTIVATE_TRIGGER, MCD_DEACTIVATE_TRIGGER } from '../utils/mcdToolBridge';
 import { isLuckinConfigured } from '../utils/luckinMcpClient';
 import { isLuckinActivatedInMessages, LUCKIN_ACTIVATE_TRIGGER, LUCKIN_DEACTIVATE_TRIGGER } from '../utils/luckinToolBridge';
-import MessageItem from '../components/chat/MessageItem';
+import MessageItem, { ThinkingChainBlock } from '../components/chat/MessageItem';
 import McdMiniApp from '../components/mcd/McdMiniApp';
 import LuckinMiniApp from '../components/luckin/LuckinMiniApp';
 import LuckinLocationModal from '../components/luckin/LuckinLocationModal';
@@ -99,6 +99,12 @@ const Chat: React.FC = () => {
     const scrollThrottleRef = useRef(0);
     const visibleCountRef = useRef(30);
     const activeCharIdRef = useRef(activeCharacterId);
+    // 流式预览接棒过的正式消息在当前会话内始终跳过入场动画，避免后续 DB 刷新时动画类又被加回来。
+    const streamPreviewHandoverIdsRef = useRef<Set<number>>(new Set());
+    const registerStreamPreviewHandover = useCallback((charId: string, messageIds: number[]) => {
+        if (activeCharIdRef.current !== charId) return;
+        messageIds.forEach(id => streamPreviewHandoverIdsRef.current.add(id));
+    }, []);
     const charRef = useRef<typeof char>(null as any);
     // 白框提示音：记录当前角色"见过的最大消息 ID" + "上一条气泡到达时刻"，一轮回复只在首条气泡响一次。
     // 用 max-id 基线天然免疫：切角色/进入(先记基线不播)、翻旧历史(末尾 ID 变小不响)、自己发消息(role≠assistant 不响)。
@@ -204,7 +210,7 @@ const Chat: React.FC = () => {
     const luckinChatRef = useRef<import('../utils/luckinToolBridge').LuckinChatState | undefined>(undefined);
 
     // --- Initialize Hook ---
-    const { isTyping, streamingBubbles, recallStatus, searchStatus, diaryStatus, emotionStatus, memoryPalaceStatus, memoryPalaceResult, setMemoryPalaceResult, lastDigestResult, setLastDigestResult, lastTokenUsage, tokenBreakdown, setLastTokenUsage, triggerAI, startProactiveChat, stopProactiveChat, isProactiveActive } = useChatAI({
+    const { isTyping, streamingBubbles, streamingThinking, recallStatus, searchStatus, diaryStatus, emotionStatus, memoryPalaceStatus, memoryPalaceResult, setMemoryPalaceResult, lastDigestResult, setLastDigestResult, lastTokenUsage, tokenBreakdown, setLastTokenUsage, triggerAI, startProactiveChat, stopProactiveChat, isProactiveActive } = useChatAI({
         char,
         userProfile,
         apiConfig,
@@ -214,6 +220,7 @@ const Chat: React.FC = () => {
         addToast,
         showError,
         setMessages,
+        onStreamPreviewHandover: registerStreamPreviewHandover,
         realtimeConfig,
         translationConfig: translationEnabled
             ? { enabled: true, sourceLang: translateSourceLang, targetLang: translateTargetLang }
@@ -822,7 +829,7 @@ const Chat: React.FC = () => {
                 scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
             }
         }
-    }, [messages, isTyping, streamingBubbles, recallStatus, searchStatus, diaryStatus, selectionMode, windowedFocusMsgId]);
+    }, [messages, isTyping, streamingBubbles, streamingThinking, recallStatus, searchStatus, diaryStatus, selectionMode, windowedFocusMsgId]);
 
     // 白框提示音：当 char 新发的消息成为会话最后一条时播放一次（用户自己/历史/翻旧消息都不响）。
     // 声音配置编码在白框 CSS 注释里（角色 chromeCustomCss 覆盖全局 chatChromeCustomCss），随白框分享一起走。
@@ -2412,6 +2419,7 @@ const Chat: React.FC = () => {
     // 切角色 / 首次进入：清基线，下一轮 detect 只记录不播
     useEffect(() => {
         animSeenMaxIdRef.current = null;
+        streamPreviewHandoverIdsRef.current.clear();
         setAnimatingIds(new Set());
     }, [activeCharacterId]);
     // 检测新增：id 超过基线的才淡入；首帧只记基线不播
@@ -2421,7 +2429,9 @@ const Chat: React.FC = () => {
         for (const m of displayMessages) if (typeof m.id === 'number' && m.id > maxId) maxId = m.id;
         if (animSeenMaxIdRef.current === null) { animSeenMaxIdRef.current = maxId; return; }
         const baseline = animSeenMaxIdRef.current;
-        const fresh = displayMessages.filter(m => typeof m.id === 'number' && m.id > baseline).map(m => m.id);
+        const fresh = displayMessages
+            .filter(m => typeof m.id === 'number' && m.id > baseline && !streamPreviewHandoverIdsRef.current.has(m.id))
+            .map(m => m.id);
         if (fresh.length > 0) {
             setAnimatingIds(prev => { const next = new Set(prev); fresh.forEach(id => next.add(id)); return next; });
             animSeenMaxIdRef.current = maxId;
@@ -3020,13 +3030,14 @@ const Chat: React.FC = () => {
                         !nextMessage ||
                         nextMessage.role !== m.role ||
                         Math.abs(nextMessage.timestamp - m.timestamp) > messageGroupGapMs;
+                    const suppressEntranceAnimation = streamPreviewHandoverIdsRef.current.has(m.id);
                     return (
                         <div
                             key={m.id || i}
                             id={`chat-msg-${m.id}`}
                             className={[
                                 flashMsgId === m.id ? 'ring-2 ring-yellow-300 bg-yellow-50/40 rounded-2xl mx-2' : '',
-                                animatingIds.has(m.id) ? 'animate-fade-in' : '',
+                                animatingIds.has(m.id) && !suppressEntranceAnimation ? 'animate-fade-in' : '',
                                 'transition-all duration-300',
                             ].filter(Boolean).join(' ')}
                             onAnimationEnd={(e) => {
@@ -3062,6 +3073,7 @@ const Chat: React.FC = () => {
                             bubbleVariant={osTheme.chatBubbleStyle}
                             messageSpacing={osTheme.chatMessageSpacing}
                             showTimestamp={osTheme.chatShowTimestamp}
+                            suppressEntranceAnimation={suppressEntranceAnimation}
                             isPending={false}
                             pendingIndicator={osTheme.chatPendingIndicator !== false}
                             onMcdSendCart={handleMcdSendCart}
@@ -3112,38 +3124,58 @@ const Chat: React.FC = () => {
                     </div>
                 )}
 
-                {/* 流式预览气泡：stream 开启时已完成的回复行先上屏（临时展示，第一条真实消息
-                    落库时无缝交棒——见 useChatAI 的 setMessages 包装）。
-                    DOM 与真实消息同构（.group.justify-start > .absolute.z-0 头像 + .max-w-[72%].ml-12
-                    + .sully-bubble-ai > .select-text）——聊天细节微调（隐藏头像/贴边/字号行距）和
-                    气泡主题的颜色/圆角对预览一并生效，不再出现"预览不吃美化方案"的错位感。 */}
+                {/* 渠道确实发送 reasoning 增量时，先用正式心象卡实时展示；落库后同帧交给正式消息。 */}
+                {streamingThinking && !selectionMode && (
+                    <div className="group flex items-end justify-start relative px-3 mb-1.5 animate-fade-in">
+                        <div className="relative max-w-[72%] min-w-0 ml-12">
+                            <ThinkingChainBlock
+                                chain={streamingThinking}
+                                styleId={thinkingChainOptions.styleId}
+                                customColors={thinkingChainOptions.customColors}
+                                onOpenSettings={thinkingChainOptions.onOpenSettings}
+                            />
+                        </div>
+                    </div>
+                )}
+
+                {/* 流式预览直接复用正式 MessageItem：气泡变体、主题背景图/装饰、头像框、
+                    grouped/every_message、消息间距、时间戳、Markdown 与所有自定义 CSS 天然一致。
+                    落库时 useChatAI 会登记接棒 id，正式消息首帧不再重播 fade-in。 */}
                 {streamingBubbles.length > 0 && !selectionMode && (
-                    <div className="space-y-1.5 mb-2">
+                    <>
                         {streamingBubbles.map((bubble, i) => (
-                            <div key={i} className="group w-full flex justify-start relative px-3 animate-fade-in">
-                                {/* 头像只挂在最后一条上，贴合 grouped 折叠模式的观感；
-                                    absolute+z-0 结构让「隐藏头像」等微调 CSS 自动命中 */}
-                                {i === streamingBubbles.length - 1 && (
-                                    <div className="absolute left-3 bottom-0 z-0">
-                                        <img src={char.avatar} className={chatPendingAvatarClass} />
-                                    </div>
-                                )}
-                                <div className="relative max-w-[72%] min-w-0 ml-12">
-                                    <div
-                                        className="relative px-5 py-3 shadow-sm border border-black/5 overflow-visible sully-bubble-ai"
-                                        style={{
-                                            backgroundColor: activeTheme.ai.backgroundColor,
-                                            color: activeTheme.ai.textColor,
-                                            borderRadius: activeTheme.ai.borderRadius,
-                                            opacity: activeTheme.ai.opacity,
-                                        }}
-                                    >
-                                        <div className="select-text text-[15px] leading-relaxed whitespace-pre-wrap break-words">{bubble}</div>
-                                    </div>
-                                </div>
+                            <div key={`stream-preview-${i}`} className="transition-all duration-300">
+                                <MessageItem
+                                    msg={{
+                                        id: -(i + 1),
+                                        charId: char.id,
+                                        role: 'assistant',
+                                        type: 'text',
+                                        content: bubble,
+                                        timestamp: Date.now(),
+                                    }}
+                                    isFirstInGroup={i === 0}
+                                    isLastInGroup={i === streamingBubbles.length - 1}
+                                    activeTheme={activeTheme}
+                                    charAvatar={char.avatar}
+                                    charName={char.name}
+                                    userAvatar={userProfile.perCharAvatars?.[char.id] || userProfile.avatar}
+                                    onLongPress={() => {}}
+                                    onReply={() => {}}
+                                    selectionMode={false}
+                                    isSelected={false}
+                                    onToggleSelect={() => {}}
+                                    avatarShape={osTheme.chatAvatarShape}
+                                    avatarSize={osTheme.chatAvatarSize}
+                                    avatarMode={osTheme.chatAvatarMode}
+                                    bubbleVariant={osTheme.chatBubbleStyle}
+                                    messageSpacing={osTheme.chatMessageSpacing}
+                                    showTimestamp={osTheme.chatShowTimestamp}
+                                    thinkingChainOptions={thinkingChainOptions}
+                                />
                             </div>
                         ))}
-                    </div>
+                    </>
                 )}
                 {(isTyping || recallStatus || searchStatus || diaryStatus || isProactiveComposing) && !selectionMode && (
                     <div className="flex items-end gap-3 px-3 mb-6 animate-fade-in">

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -412,7 +412,7 @@ export const PsycheDecor: React.FC<{ spec: ThinkingChainStyleSpec; compact?: boo
 // 思考链卡片：可视化 metadata.thinkingChain。
 // 内容来源：useChatAI 抽取的 LLM reasoning_content + <think>/<thinking>/<thought>。
 // 多风格通过 resolveThinkingChainStyle() 统一渲染；齿轮触发 onOpenSettings 进入设置弹窗。
-const ThinkingChainBlock: React.FC<{
+export const ThinkingChainBlock: React.FC<{
     chain: string;
     styleId?: ThinkingChainStyleId;
     customColors?: { bg?: string; accent?: string; text?: string };
@@ -1228,6 +1228,8 @@ interface MessageItemProps {
     bubbleVariant?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios';
     messageSpacing?: 'compact' | 'default' | 'spacious';
     showTimestamp?: 'always' | 'hover' | 'never';
+    /** 流式预览无缝接棒时，正式消息首帧已经可见，不应再次从透明态淡入。 */
+    suppressEntranceAnimation?: boolean;
     /** Instant Push 准备中：在用户气泡左侧渲染 dot pulse */
     isPending?: boolean;
     /** 是否开启 dot pulse 指示。关掉则 pending 期间不显示任何视觉 */
@@ -1278,6 +1280,7 @@ const MessageItem = React.memo(({
     bubbleVariant = 'modern',
     messageSpacing = 'default',
     showTimestamp = 'always',
+    suppressEntranceAnimation = false,
     isPending = false,
     pendingIndicator = true,
     onMcdSendCart,
@@ -3233,8 +3236,8 @@ const MessageItem = React.memo(({
 
     return commonLayout(
         <div className={isVoiceOnlyMsg
-            ? 'relative animate-fade-in'
-            : `relative ${bubbleVariant === 'flat' || bubbleVariant === 'outline' || bubbleVariant === 'wechat' ? '' : 'shadow-sm '}px-5 py-3 animate-fade-in ${bubbleVariant === 'outline' ? '' : 'border border-black/5 '}active:scale-[0.98] transition-transform overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'}`}
+            ? `relative ${suppressEntranceAnimation ? '' : 'animate-fade-in'}`
+            : `relative ${bubbleVariant === 'flat' || bubbleVariant === 'outline' || bubbleVariant === 'wechat' ? '' : 'shadow-sm '}px-5 py-3 ${suppressEntranceAnimation ? '' : 'animate-fade-in'} ${bubbleVariant === 'outline' ? '' : 'border border-black/5 '}active:scale-[0.98] transition-transform overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'}`}
             style={isVoiceOnlyMsg ? undefined : containerStyle}>
 
             {/* Layer 1: Background Image with Independent Opacity */}
@@ -3512,6 +3515,7 @@ const MessageItem = React.memo(({
            prev.bubbleVariant === next.bubbleVariant &&
            prev.messageSpacing === next.messageSpacing &&
            prev.showTimestamp === next.showTimestamp &&
+           prev.suppressEntranceAnimation === next.suppressEntranceAnimation &&
            prev.voiceData?.url === next.voiceData?.url &&
            prev.voiceLoading === next.voiceLoading &&
            prev.isVoicePlaying === next.isVoicePlaying;

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -33,7 +33,11 @@ import {
     type InstantPushPayload,
 } from '../utils/instantPushClient';
 import { applyAssistantPostProcessing, type XhsCaches } from '../utils/applyAssistantPostProcessing';
-import { computeStreamPreviewBubbles } from '../utils/streamPreview';
+import {
+    computeStreamPreviewBubbles,
+    extractStreamingEmbeddedThinking,
+    findNewStreamPreviewHandoverIds,
+} from '../utils/streamPreview';
 import { ActiveMsgStore } from '../utils/activeMsgStore';
 import { applyEmotionEvalRaw, extractAssistantText } from '../utils/emotionApply';
 import { shouldRequestAmbient, buildAmbientEvalSection } from '../utils/roomAmbient';
@@ -364,6 +368,8 @@ interface UseChatAIProps {
     /** 长报错走弹窗 (toast 一行装不下), 手机用户能看清并复制反馈 */
     showError?: (title: string, details: string) => void;
     setMessages: (msgs: Message[]) => void; // Callback to update UI messages
+    /** 正式消息接替流式预览前同步登记 id，避免真实气泡重新播放入场动画。 */
+    onStreamPreviewHandover?: (charId: string, messageIds: number[]) => void;
     realtimeConfig?: RealtimeConfig; // 新增：实时配置
     translationConfig?: { enabled: boolean; sourceLang: string; targetLang: string };
     memoryPalaceConfig?: { embedding: { baseUrl: string; apiKey: string; model: string; dimensions: number }; lightLLM: { baseUrl: string; apiKey: string; model: string } };
@@ -387,6 +393,7 @@ export const useChatAI = ({
     addToast,
     showError,
     setMessages,
+    onStreamPreviewHandover,
     realtimeConfig,  // 新增
     translationConfig,
     memoryPalaceConfig,
@@ -400,9 +407,10 @@ export const useChatAI = ({
     const music = useMusic();
 
     const [isTyping, setIsTyping] = useState(false);
-    // 流式预览气泡：stream 开启时，已完成的回复行先以临时气泡上屏（体感秒回）。
+    // 流式预览气泡：stream 开启时，已完成行与安全尾句随增量以临时气泡上屏。
     // 流结束后由 applyAssistantPostProcessing 正常落库渲染，预览随即清空 —— 只影响体感，不改持久化。
     const [streamingBubbles, setStreamingBubbles] = useState<string[]>([]);
+    const [streamingThinking, setStreamingThinking] = useState('');
     const [recallStatus, setRecallStatus] = useState<string>('');
     const [searchStatus, setSearchStatus] = useState<string>('');
     const [diaryStatus, setDiaryStatus] = useState<string>('');
@@ -641,6 +649,8 @@ export const useChatAI = ({
             : char;
 
         setIsTyping(true);
+        setStreamingBubbles([]);
+        setStreamingThinking('');
         setRecallStatus('');
 
         // Keep the Service Worker alive while we make potentially long AI calls
@@ -947,20 +957,48 @@ export const useChatAI = ({
 
             // 流式预览：仅在用户开了 stream、且非工具/双语模式时启用。
             // 工具模式的首轮响应可能是 tool_calls（无正文可预览）；双语模式正文包在
-            // 跨行 <翻译> 标签里，预览过滤后什么都不剩 —— 这两类直接不挂钩子，行为同旧版。
+            // 跨行 <翻译> 标签里。这两类连正文/思考钩子都不挂，完整走原有整包路径。
+            // 语音、日记、HTML 等由内容标签动态识别，computeStreamPreviewBubbles 会扣住控制块，
+            // 只允许标签外确实属于普通文字的部分预览。
             // 每次 onDelta 基于累计全文全量重算（safeFetchJson 重试会重开流，天然重置）；
-            // 只有气泡数组真变了才 setState，部分行内增量不会触发重渲染。
-            const streamPreviewEligible = !!userStream && !toolModeActive && !bilingualActive;
+            // 正文尾句和思考内容只在累计文本确实变化时触发重渲染。
+            const streamUiEligible = !!userStream && !toolModeActive && !bilingualActive;
+            const streamPreviewEligible = streamUiEligible;
+            const streamThinkingEligible = streamUiEligible && payload.flags.thinkingActive;
             // 预览真的上过屏才置 true → 后处理落库时跳过拟人打字延迟（instantRender），
             // 否则用户会看到"预览气泡收回去、再一条条慢慢重弹"的二次播放。
             let streamPreviewShown = false;
-            const streamHooks = streamPreviewEligible ? {
+            let streamThinkingShown = false;
+            let latestStreamPreviewBubbles: string[] = [];
+            let latestNativeReasoning = '';
+            let latestEmbeddedThinking = '';
+            const publishStreamingThinking = () => {
+                const combined = [latestNativeReasoning, latestEmbeddedThinking]
+                    .map(text => text.trim())
+                    .filter(Boolean)
+                    .join('\n\n');
+                if (combined) streamThinkingShown = true;
+                setStreamingThinking(prev => prev === combined ? prev : combined);
+            };
+            const streamHooks = (streamPreviewEligible || streamThinkingEligible) ? {
                 onDelta: (_delta: string, fullText: string) => {
-                    const bubbles = computeStreamPreviewBubbles(fullText);
-                    if (bubbles.length > 0) streamPreviewShown = true;
-                    setStreamingBubbles(prev =>
-                        (prev.length === bubbles.length && prev.every((b, i) => b === bubbles[i])) ? prev : bubbles
-                    );
+                    if (streamPreviewEligible) {
+                        const bubbles = computeStreamPreviewBubbles(fullText);
+                        latestStreamPreviewBubbles = bubbles;
+                        if (bubbles.length > 0) streamPreviewShown = true;
+                        setStreamingBubbles(prev =>
+                            (prev.length === bubbles.length && prev.every((b, i) => b === bubbles[i])) ? prev : bubbles
+                        );
+                    }
+                    if (streamThinkingEligible) {
+                        latestEmbeddedThinking = extractStreamingEmbeddedThinking(fullText);
+                        publishStreamingThinking();
+                    }
+                },
+                onReasoningDelta: (_delta: string, fullReasoning: string) => {
+                    if (!streamThinkingEligible) return;
+                    latestNativeReasoning = fullReasoning;
+                    publishStreamingThinking();
                 },
             } : undefined;
 
@@ -1380,11 +1418,35 @@ export const useChatAI = ({
             // 而是包装 setMessages——后处理第一条真实消息落库上屏的**同一帧**清预览。
             // 交接前预览一直挂着，交接后 instantRender 秒速回填，视觉上是"预览定格成正式消息"。
             let previewHandedOver = false;
+            const previewHandoverIds = new Set<number>();
+            const previewBaselineMaxId = contextMsgs.reduce(
+                (maxId, message) => Math.max(maxId, message.id),
+                Number.NEGATIVE_INFINITY,
+            );
             const setMessagesWithPreviewHandover = (msgs: Message[]) => {
+                const newlyHandedOverIds = findNewStreamPreviewHandoverIds(
+                    msgs,
+                    latestStreamPreviewBubbles,
+                    previewBaselineMaxId,
+                    previewHandoverIds,
+                );
+                const handoverIds = new Set(newlyHandedOverIds);
+                if (streamThinkingShown) {
+                    const thinkingHost = msgs.find(message =>
+                        message.id > previewBaselineMaxId && message.role === 'assistant'
+                    );
+                    if (thinkingHost && !previewHandoverIds.has(thinkingHost.id)) handoverIds.add(thinkingHost.id);
+                }
+                if (handoverIds.size > 0) {
+                    handoverIds.forEach(id => previewHandoverIds.add(id));
+                    // ref 在 setMessages 触发渲染前同步更新，首帧就能关掉正式气泡的 fade-in。
+                    onStreamPreviewHandover?.(char.id, [...handoverIds]);
+                }
                 setMessages(msgs);
                 if (!previewHandedOver) {
                     previewHandedOver = true;
                     setStreamingBubbles([]);
+                    setStreamingThinking('');
                 }
             };
             const rawAiContent = data.choices?.[0]?.message?.content || '';
@@ -1449,6 +1511,7 @@ export const useChatAI = ({
             KeepAlive.stop();
             setIsTyping(false);
             setStreamingBubbles([]);  // 错误/中断路径兜底清预览
+            setStreamingThinking('');
             setRecallStatus('');
             setSearchStatus('');
             setDiaryStatus('');
@@ -1579,6 +1642,7 @@ export const useChatAI = ({
     return {
         isTyping,
         streamingBubbles,
+        streamingThinking,
         recallStatus,
         searchStatus,
         diaryStatus,

--- a/utils/safeApi.stream.test.ts
+++ b/utils/safeApi.stream.test.ts
@@ -95,12 +95,19 @@ describe('SSE 拼装保留思考通道 (reasoning_content)', () => {
             'data: [DONE]\n',
         ];
         vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
-        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: () => {} });
+        const reasoningDeltas: string[] = [];
+        let fullReasoning = '';
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, {
+            onDelta: () => {},
+            onReasoningDelta: (delta, full) => { reasoningDeltas.push(delta); fullReasoning = full; },
+        });
         expect(data.choices[0].message.reasoning_content).toBe('她这句是在逗我玩…');
         expect(data.choices[0].message.content).toBe('哼，看穿你了');
+        expect(reasoningDeltas.join('')).toBe('她这句是在逗我玩…');
+        expect(fullReasoning).toBe('她这句是在逗我玩…');
     });
 
-    it('OpenRouter 形态 delta.reasoning 同样保留；onDelta 只吐正文不吐思考', async () => {
+    it('OpenRouter 形态 delta.reasoning 同样保留，并通过独立回调实时吐出思考', async () => {
         const events = [
             'data: {"choices":[{"delta":{"reasoning":"thinking..."}}]}\n\n',
             'data: {"choices":[{"delta":{"content":"回复正文"}}]}\n\n',
@@ -108,9 +115,16 @@ describe('SSE 拼装保留思考通道 (reasoning_content)', () => {
         ];
         vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
         const deltas: string[] = [];
-        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: (d) => { deltas.push(d); } });
+        const reasoningDeltas: string[] = [];
+        let fullReasoning = '';
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, {
+            onDelta: (d) => { deltas.push(d); },
+            onReasoningDelta: (d, full) => { reasoningDeltas.push(d); fullReasoning = full; },
+        });
         expect(data.choices[0].message.reasoning_content).toBe('thinking...');
         expect(deltas.join('')).toBe('回复正文');
+        expect(reasoningDeltas.join('')).toBe('thinking...');
+        expect(fullReasoning).toBe('thinking...');
     });
 
     it('没有思考通道时不产生空的 reasoning_content 字段', async () => {
@@ -142,9 +156,14 @@ describe('SSE 思考通道的更多字段形状（Claude 官转/CC 渠道）', (
         ];
         vi.stubGlobal('fetch', vi.fn(async () => sseResponse(events)));
         const deltas: string[] = [];
-        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, { onDelta: (d) => { deltas.push(d); } });
+        const reasoningDeltas: string[] = [];
+        const data = await safeFetchJson('https://api.test/v1/chat/completions', { method: 'POST', body: '{}' }, 0, 0, undefined, {
+            onDelta: (d) => { deltas.push(d); },
+            onReasoningDelta: (d) => { reasoningDeltas.push(d); },
+        });
         expect(data.choices[0].message.content).toBe('你好呀');
         expect(data.choices[0].message.reasoning_content).toBe('想一下…');
         expect(deltas.join('')).toBe('你好呀');
+        expect(reasoningDeltas.join('')).toBe('想一下…');
     });
 });

--- a/utils/safeApi.ts
+++ b/utils/safeApi.ts
@@ -81,10 +81,15 @@ export function parseSseToCompletion(raw: string): any | null {
 
 /**
  * OpenAI 兼容 SSE 流的增量拼装器。
- * feedLine 逐行喂入（返回本行带来的正文增量），finish 合成完整 completion 对象。
+ * feedLine 逐行喂入（分别返回本行的正文与思考增量），finish 合成完整 completion 对象。
  * parseSseToCompletion（整包路径）和 readBodyWithStreaming（真流式路径）共用这一份，
  * 保证两条路对 delta / message / tool_calls 分片的处理完全一致。
  */
+interface SseFeedDelta {
+    content: string;
+    reasoning: string;
+}
+
 class SseAssembler {
     content = '';
     private role = 'assistant';
@@ -105,25 +110,26 @@ class SseAssembler {
     // 与其一轮一轮猜, 不如把名单打出来(finish() 附带 + 控制台一行)一次看清。
     private deltaKeys = new Set<string>();
 
-    /** 喂一行 SSE 文本，返回本行带来的正文增量（无正文则空串） */
-    feedLine(line: string): string {
-        if (!line.startsWith('data:')) return '';
+    /** 喂一行 SSE 文本，分别返回正文与思考增量（没有则为空串）。 */
+    feedLine(line: string): SseFeedDelta {
+        if (!line.startsWith('data:')) return { content: '', reasoning: '' };
         const payload = line.slice(5).trim();
-        if (!payload || payload === '[DONE]') return '';
+        if (!payload || payload === '[DONE]') return { content: '', reasoning: '' };
         let chunk: any;
-        try { chunk = JSON.parse(payload); } catch { return ''; }
+        try { chunk = JSON.parse(payload); } catch { return { content: '', reasoning: '' }; }
         return this.feedChunk(chunk);
     }
 
-    feedChunk(chunk: any): string {
+    feedChunk(chunk: any): SseFeedDelta {
         this.gotAnyChunk = true;
         if (!this.firstChunk) this.firstChunk = chunk;
         // OpenAI 流式 usage 在最后一个 chunk（include_usage=true 时），也可能出现在中途；
         // 始终取最后一个非空的 usage，兼容各家代理。
         if (chunk.usage) this.usage = chunk.usage;
         const choice = chunk.choices?.[0];
-        if (!choice) return '';
+        if (!choice) return { content: '', reasoning: '' };
         let delta = '';
+        let reasoningDelta = '';
         // delta 路径（OpenAI 流式常见）
         if (choice.delta) {
             for (const k of Object.keys(choice.delta)) this.deltaKeys.add(k);
@@ -139,11 +145,15 @@ class SseAssembler {
                         this.content += block.text;
                     } else if (block?.type === 'thinking' && typeof block.thinking === 'string') {
                         this.reasoning += block.thinking;
+                        reasoningDelta += block.thinking;
                     }
                 }
             }
             const dr = choice.delta.reasoning_content ?? choice.delta.reasoning ?? choice.delta.thinking;
-            if (typeof dr === 'string') this.reasoning += dr;
+            if (typeof dr === 'string') {
+                this.reasoning += dr;
+                reasoningDelta += dr;
+            }
             if (choice.delta.role) this.role = choice.delta.role;
             if (Array.isArray(choice.delta.tool_calls)) {
                 for (const frag of choice.delta.tool_calls) {
@@ -163,12 +173,19 @@ class SseAssembler {
                 this.content += delta;
             }
             const mr = choice.message.reasoning_content ?? choice.message.reasoning ?? choice.message.thinking;
-            if (typeof mr === 'string') this.reasoning += mr;
+            if (typeof mr === 'string') {
+                this.reasoning += mr;
+                reasoningDelta += mr;
+            }
             if (choice.message.role) this.role = choice.message.role;
             if (Array.isArray(choice.message.tool_calls)) this.toolCalls.push(...choice.message.tool_calls);
         }
         if (choice.finish_reason) this.finishReason = choice.finish_reason;
-        return delta;
+        return { content: delta, reasoning: reasoningDelta };
+    }
+
+    get reasoningContent(): string {
+        return this.reasoning;
     }
 
     finish(): any | null {
@@ -209,6 +226,8 @@ export interface StreamHooks {
      * 调用方每次都应基于 fullText 全量重算（天然处理重试重置）。
      */
     onDelta?: (delta: string, fullText: string) => void;
+    /** 每收到一段原生 reasoning 增量时回调；渠道不发送 reasoning 时不会触发。 */
+    onReasoningDelta?: (delta: string, fullReasoning: string) => void;
     /** 收到第一个正文增量时回调一次（TTFT 参考点） */
     onFirstDelta?: () => void;
 }
@@ -233,14 +252,18 @@ async function readBodyWithStreaming(
     let mode: 'undecided' | 'sse' | 'raw' = 'undecided';
     let sawFirstDelta = false;
 
-    const emit = (delta: string) => {
-        if (!delta) return;
-        if (!sawFirstDelta) {
-            sawFirstDelta = true;
-            if (timing && startedAt) timing.firstDeltaMs = Date.now() - startedAt;
-            try { hooks.onFirstDelta?.(); } catch { /* 回调异常不拦截流 */ }
+    const emit = (delta: SseFeedDelta) => {
+        if (delta.content) {
+            if (!sawFirstDelta) {
+                sawFirstDelta = true;
+                if (timing && startedAt) timing.firstDeltaMs = Date.now() - startedAt;
+                try { hooks.onFirstDelta?.(); } catch { /* 回调异常不拦截流 */ }
+            }
+            try { hooks.onDelta?.(delta.content, asm.content); } catch { /* 回调异常不拦截流 */ }
         }
-        try { hooks.onDelta?.(delta, asm.content); } catch { /* 回调异常不拦截流 */ }
+        if (delta.reasoning) {
+            try { hooks.onReasoningDelta?.(delta.reasoning, asm.reasoningContent); } catch { /* 回调异常不拦截流 */ }
+        }
     };
 
     const consumeLines = () => {

--- a/utils/streamPreview.test.ts
+++ b/utils/streamPreview.test.ts
@@ -1,17 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { computeStreamPreviewBubbles } from './streamPreview';
+import {
+    computeStreamPreviewBubbles,
+    extractStreamingEmbeddedThinking,
+    findNewStreamPreviewHandoverIds,
+} from './streamPreview';
+import type { Message } from '../types';
 
-// 流式预览气泡的过滤策略：宁缺毋滥 —— 指令/语音/翻译/日记/HTML 块一律不预览，
-// 半截行不上屏。预览只影响体感，最终渲染仍由 applyAssistantPostProcessing 负责。
+// 流式预览气泡的过滤策略：普通尾句持续增长；遇到指令/语音/翻译/日记/HTML 块时
+// 只展示控制标记前的安全正文。最终渲染仍由 applyAssistantPostProcessing 负责。
 
 describe('computeStreamPreviewBubbles', () => {
-    it('半截行（无换行）不展示', () => {
-        expect(computeStreamPreviewBubbles('今天天气真好')).toEqual([]);
+    it('无换行的当前尾句也实时展示', () => {
+        expect(computeStreamPreviewBubbles('今天天气真好')).toEqual(['今天天气真好']);
     });
 
-    it('已完成的行逐条成为气泡，最后的半截行被扣住', () => {
+    it('已完成的行逐条成为气泡，最后的尾句持续增长', () => {
         const bubbles = computeStreamPreviewBubbles('今天天气真好\n要不要出去走走\n我在想');
-        expect(bubbles).toEqual(['今天天气真好', '要不要出去走走']);
+        expect(bubbles).toEqual(['今天天气真好', '要不要出去走走', '我在想']);
+    });
+
+    it('未完成尾句只显示控制标记前的安全正文', () => {
+        expect(computeStreamPreviewBubbles('先说一句，然后[[SEARCH: 半截')).toEqual(['先说一句，然后']);
+        expect(computeStreamPreviewBubbles('<think>不能漏')).toEqual([]);
+        expect(computeStreamPreviewBubbles('[html')).toEqual([]);
     });
 
     it('含 [[...]] 指令的行不预览（表情/动作/召回等）', () => {
@@ -29,6 +40,12 @@ describe('computeStreamPreviewBubbles', () => {
         expect(computeStreamPreviewBubbles(text)).toEqual(['先打个字', '再打一行']);
     });
 
+    it('尚未换行、仍在增长的语音/字幕标签不会漏出内容', () => {
+        expect(computeStreamPreviewBubbles('<语')).toEqual([]);
+        expect(computeStreamPreviewBubbles('<语音 emotion="happy">你猜猜')).toEqual([]);
+        expect(computeStreamPreviewBubbles('<语音>Hello</语音><字幕>你好')).toEqual([]);
+    });
+
     it('跨行语音块（未闭合时全部扣住，闭合后仍不预览块内容）', () => {
         const open = '好\n<语音 emotion="sad">I do not wanna\n';
         expect(computeStreamPreviewBubbles(open)).toEqual(['好']);
@@ -39,6 +56,11 @@ describe('computeStreamPreviewBubbles', () => {
     it('日记多行块不泄漏为聊天气泡', () => {
         const text = '我写篇日记去\n[[DIARY_START: 今天 | 开心]]\n# 大标题\n正文絮絮叨叨\n[[DIARY_END]]\n写完了\n';
         expect(computeStreamPreviewBubbles(text)).toEqual(['我写篇日记去', '写完了']);
+    });
+
+    it('飞书/Notion 同构日记块同样不泄漏', () => {
+        const text = '稍等\n[[FS_DIARY_START: 今天 | 平静]]\n不该成为聊天气泡\n[[FS_DIARY_END]]\n好了\n';
+        expect(computeStreamPreviewBubbles(text)).toEqual(['稍等', '好了']);
     });
 
     it('HTML 卡片块不泄漏', () => {
@@ -64,5 +86,51 @@ describe('computeStreamPreviewBubbles', () => {
     it('空文本 / 纯空行返回空数组', () => {
         expect(computeStreamPreviewBubbles('')).toEqual([]);
         expect(computeStreamPreviewBubbles('\n\n')).toEqual([]);
+    });
+});
+
+describe('extractStreamingEmbeddedThinking', () => {
+    it('实时提取仍未闭合的 think 尾块', () => {
+        expect(extractStreamingEmbeddedThinking('<think>刚想到这里')).toBe('刚想到这里');
+    });
+
+    it('合并已闭合块与后续仍在增长的块', () => {
+        expect(extractStreamingEmbeddedThinking(
+            '<think>第一段</think>正文<thinking>第二段还没写完',
+        )).toBe('第一段\n\n第二段还没写完');
+    });
+});
+
+describe('findNewStreamPreviewHandoverIds', () => {
+    const message = (id: number, content: string, type: Message['type'] = 'text'): Message => ({
+        id,
+        charId: 'char-1',
+        role: 'assistant',
+        type,
+        content,
+        timestamp: id,
+    });
+
+    it('只匹配基线后确实展示过的文本，不误伤二次回复和卡片', () => {
+        const messages = [
+            message(10, '旧消息'),
+            message(11, '第一句'),
+            message(12, '表情', 'emoji'),
+            message(13, '第二句'),
+            message(14, '二次调用的新回复'),
+        ];
+
+        expect(findNewStreamPreviewHandoverIds(messages, ['第一句', '第二句'], 10, new Set()))
+            .toEqual([11, 13]);
+    });
+
+    it('多次刷新消息列表时只返回尚未登记的接棒消息', () => {
+        const claimed = new Set([11]);
+        expect(findNewStreamPreviewHandoverIds(
+            [message(10, '旧消息'), message(11, '第一句'), message(12, '第二句')],
+            ['第一句', '第二句'],
+            10,
+            claimed,
+        )).toEqual([12]);
     });
 });

--- a/utils/streamPreview.ts
+++ b/utils/streamPreview.ts
@@ -1,7 +1,7 @@
 /**
  * 流式回复的「预览气泡」计算 —— 纯函数，无副作用。
  *
- * 主聊天路径开启 stream 后，边收流边把**已完成的行**渲染成临时预览气泡
+ * 主聊天路径开启 stream 后，边收流边把已完成行和安全的未完成尾句渲染成临时预览气泡
  * （utils/safeApi.ts StreamHooks.onDelta → hooks/useChatAI.ts → apps/Chat.tsx）。
  * 流结束后仍由既有后处理管线 (applyAssistantPostProcessing) 负责真正的解析、
  * 落库与渲染，预览气泡随即被清掉 —— 预览只影响体感延迟，不改变任何持久化行为。
@@ -15,6 +15,7 @@
  */
 
 import { ChatParser } from './chatParser';
+import type { Message } from '../types';
 
 /** 跨行块规则：open 命中进入抑制态，直到 close 命中（含闭合行本身）。 */
 const BLOCK_RULES: Array<{ open: RegExp; close: RegExp }> = [
@@ -43,14 +44,14 @@ function isLinePreviewable(line: string): boolean {
 /**
  * 从「累计到目前为止的原始流文本」计算当前可展示的预览气泡。
  *
- * 只处理**已完成的行**（最后一个 \n 之前）：半截行不展示，既避免指令标记
- * 打一半就弹出来，也让气泡「一条一条蹦出来」的节奏更像真人打字。
+ * 已完成行按既有规则过滤；未完成尾句也会持续增长，但在 `[`, `<`, `%%`
+ * 这类控制标记前截断，避免半截指令或标签泄漏到聊天气泡。
  */
 export function computeStreamPreviewBubbles(fullText: string): string[] {
     if (!fullText) return [];
     const lastNl = fullText.lastIndexOf('\n');
-    if (lastNl < 0) return [];
-    const completed = fullText.slice(0, lastNl);
+    const completed = lastNl < 0 ? '' : fullText.slice(0, lastNl);
+    const trailing = lastNl < 0 ? fullText : fullText.slice(lastNl + 1);
 
     const kept: string[] = [];
     let inBlockClose: RegExp | null = null;
@@ -72,6 +73,16 @@ export function computeStreamPreviewBubbles(fullText: string): string[] {
         if (!isLinePreviewable(line)) continue;
         kept.push(line);
     }
+
+    // Stream the unfinished tail too, but stop before a possible control/tag prefix.
+    // This keeps ordinary one-paragraph replies live without flashing partial directives.
+    if (!inBlockClose && trailing.trim()) {
+        const markerIndexes = [trailing.indexOf('['), trailing.indexOf('<'), trailing.indexOf('%%')]
+            .filter(index => index >= 0);
+        const safeEnd = markerIndexes.length > 0 ? Math.min(...markerIndexes) : trailing.length;
+        const safeTrailing = trailing.slice(0, safeEnd).trim();
+        if (safeTrailing && isLinePreviewable(safeTrailing)) kept.push(safeTrailing);
+    }
     if (kept.length === 0) return [];
 
     // 与最终管线同一套气泡切分（CJK 空格切点等），再逐条 sanitize + 有效内容校验，
@@ -82,4 +93,57 @@ export function computeStreamPreviewBubbles(fullText: string): string[] {
         if (clean && ChatParser.hasDisplayContent(clean)) bubbles.push(clean);
     }
     return bubbles;
+}
+
+/** 提取普通 content 通道里已闭合或仍在增长的内嵌思考块。 */
+export function extractStreamingEmbeddedThinking(fullText: string): string {
+    if (!fullText) return '';
+    const blocks: string[] = [];
+    const closed = /<(think|thinking|thought)>([\s\S]*?)<\/\1>/gi;
+    let match: RegExpExecArray | null;
+    let lastClosedEnd = 0;
+    while ((match = closed.exec(fullText)) !== null) {
+        const text = match[2].trim();
+        if (text) blocks.push(text);
+        lastClosedEnd = closed.lastIndex;
+    }
+
+    const tail = fullText.slice(lastClosedEnd);
+    const open = tail.match(/<(?:think|thinking|thought)>([\s\S]*)$/i);
+    if (open?.[1].trim()) blocks.push(open[1].trim());
+    return blocks.join('\n\n').trim();
+}
+
+/**
+ * 找出本轮真正由流式预览展示过、随后才落库的消息。
+ *
+ * 后处理可能还会追加二次 LLM 回复、表情或功能卡片；这些内容没有在预览里出现，
+ * 不能一并禁用入场动画。因此按「基线后的 assistant 文本 + 预览正文顺序」精确匹配。
+ * claimedIds 让多次 setMessages（A -> A+B -> A+B+C）只上报新接棒的 id。
+ */
+export function findNewStreamPreviewHandoverIds(
+    messages: Message[],
+    previewBubbles: readonly string[],
+    baselineMaxId: number,
+    claimedIds: ReadonlySet<number>,
+): number[] {
+    if (previewBubbles.length === 0) return [];
+
+    const found: number[] = [];
+    let previewIndex = 0;
+    for (const message of messages) {
+        if (
+            message.id <= baselineMaxId
+            || message.role !== 'assistant'
+            || message.type !== 'text'
+        ) continue;
+
+        if (previewIndex >= previewBubbles.length) break;
+        const persistedText = ChatParser.sanitize(message.content).trim();
+        if (persistedText !== previewBubbles[previewIndex]) continue;
+
+        if (!claimedIds.has(message.id)) found.push(message.id);
+        previewIndex++;
+    }
+    return found;
 }


### PR DESCRIPTION
## What changed

- Stream ordinary ChatApp text incrementally without waiting for a newline.
- Stream supported reasoning fields into the existing thinking-chain card.
- Reuse the formal message component for previews and hand off without replaying entrance animations.
- Keep voice/subtitle blocks, bilingual translation, Notion/Feishu diary blocks, HTML directives, and MCP/tool modes on their existing parsing paths.
- Preserve streamed `tool_calls` and final completion assembly.

## Why

The transport was already SSE, but the UI withheld unfinished lines, so many one-paragraph replies looked non-streaming. Reasoning was accumulated only for the final response and was not emitted to the UI during the stream. The separate preview markup also caused style mismatches and handover flashing.

## User impact

Ordinary text and supported reasoning now visibly grow as chunks arrive. Structured modes remain isolated: control tags are not leaked into preview bubbles, and translation/tool flows keep their original whole-response behavior.

## Validation

- 105 targeted tests passed across streaming, voice tags, translation, MCP, and post-processing.
- Production Vite build passed (5,123 modules transformed).
- `git diff --check` passed.