### PR TITLE
fix(chat): HTML 卡片不随聊天细节微调挪窝——贴边/缩进选择器绕开卡片包装层

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -1697,6 +1697,9 @@ const MessageItem = React.memo(({
     }
 
     const showPendingDots = isUser && isPending && pendingIndicator;
+    // HTML 卡片（280px 定宽模块）默认位置就是"视觉居中"的约定：包装层打上 sully-html-wrap，
+    // 让「聊天细节微调」的贴边/缩进规则 :not() 绕开它——美化怎么开卡片都不挪窝。
+    const isHtmlCard = m.type === 'html_card';
     const commonLayout = (content: React.ReactNode) => (
             <div className={`flex items-end ${isUser ? 'justify-end' : 'justify-start'} ${marginBottom} px-3 group select-none relative transition-[padding] duration-300 ${selectionMode ? 'pl-12' : ''}`}>
                 {selectionMode && (
@@ -1731,7 +1734,7 @@ const MessageItem = React.memo(({
                     Added min-w-0 to prevent flexbox overflow issues.
                     Added explicit margins to clear absolute avatars.
                 */}
-                <div className={`relative max-w-[72%] min-w-0 ${!isUser ? 'ml-12' : 'mr-12'}`}>
+                <div className={`relative max-w-[72%] min-w-0 ${!isUser ? 'ml-12' : 'mr-12'} ${isHtmlCard ? 'sully-html-wrap' : ''}`}>
                     <div
                         aria-hidden="true"
                         className={`absolute -right-10 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full flex items-center justify-center pointer-events-none transition-all duration-150 ${isReplyReady ? 'bg-indigo-500 text-white shadow-md shadow-indigo-200' : 'bg-white/90 text-slate-400 shadow-sm'}`}

--- a/utils/chatFineTuneCss.test.ts
+++ b/utils/chatFineTuneCss.test.ts
@@ -13,8 +13,15 @@ describe('buildChatFineTuneCss', () => {
         const css = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_ai', chatSnapToEdge: true });
         expect(css).toContain('.group.justify-start > [class~="absolute"][class~="z-0"] { display: none');
         expect(css).not.toContain('.group.justify-end > [class~="absolute"][class~="z-0"] { display: none');
-        expect(css).toContain('.ml-12 { margin-left: 0 !important; }');
+        expect(css).toContain('.ml-12:not(.sully-html-wrap) { margin-left: 0 !important; }');
         expect(css).not.toContain('margin-right: 0');
+    });
+
+    it('贴边/缩进的选择器都 :not() 绕开 HTML 卡片包装（卡片不随美化挪窝）', () => {
+        const css = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_both', chatSnapToEdge: true, chatBubbleIndent: 60 });
+        const wrapRules = css.split('\n').filter(line => line.includes('.ml-12') || line.includes('.mr-12'));
+        expect(wrapRules.length).toBeGreaterThan(0);
+        for (const rule of wrapRules) expect(rule).toContain(':not(.sully-html-wrap)');
     });
 
     it('顶部对齐 + 垂直微调', () => {

--- a/utils/chatFineTuneCss.ts
+++ b/utils/chatFineTuneCss.ts
@@ -43,8 +43,10 @@ const AI_AVATAR = '.sully-chat-root .group.justify-start > [class~="absolute"][c
 const USER_AVATAR = '.sully-chat-root .group.justify-end > [class~="absolute"][class~="z-0"]';
 const AI_BODY = '.sully-chat-root .sully-bubble-ai > div[class~="select-text"]';
 const USER_BODY = '.sully-chat-root .sully-bubble-user > div[class~="select-text"]';
-const AI_WRAP = '.sully-chat-root .group.justify-start [class~="max-w-[72%]"].ml-12';
-const USER_WRAP = '.sully-chat-root .group.justify-end [class~="max-w-[72%]"].mr-12';
+// 贴边/缩进只该动普通气泡：HTML 卡片（280px 定宽模块，包装层带 .sully-html-wrap）
+// 的默认位置就是"视觉居中"的约定，:not() 绕开让它不随美化挪窝。
+const AI_WRAP = '.sully-chat-root .group.justify-start [class~="max-w-[72%]"].ml-12:not(.sully-html-wrap)';
+const USER_WRAP = '.sully-chat-root .group.justify-end [class~="max-w-[72%]"].mr-12:not(.sully-html-wrap)';
 
 const hideRule = (sel: string) =>
     `${sel} { display: none !important; visibility: hidden !important; opacity: 0 !important; pointer-events: none !important; }`;


### PR DESCRIPTION
角色发的 HTML 卡片（280px 定宽模块）走普通气泡的 commonLayout，微调 CSS 的贴边/缩进规则会命中它的 max-w-[72%] 包装层：开「隐藏头像+贴边」卡片跟
着贴死左边缘、开「气泡缩进」也跟着挪，破坏了卡片"视觉居中"的默认观感。

- MessageItem 给 html_card 的包装层打 .sully-html-wrap 标记
- 贴边/缩进的 AI_WRAP/USER_WRAP 选择器加 :not(.sully-html-wrap)， 卡片永远待在默认位置，美化随便开
- 字号/行距/头像对齐本就不影响卡片（iframe 隔离、不带 .sully-bubble 类）， 隐藏头像仍生效（只是卡片不去填头像空位）
- 补单测：贴边/缩进生成的每条 wrap 规则都必须带 :not(.sully-html-wrap)


Claude-Session: https://claude.ai/code/session_01B18LgGKuZScVyPMJp5NeN2