### PR TITLE
feat(dev-debug): 「合并 system 为一条」开关——A/B 对照中转对多 system 请求的计量

### DIFF
--- a/components/DevDebugPanel.tsx
+++ b/components/DevDebugPanel.tsx
@@ -197,6 +197,7 @@ const DevDebugPanel: React.FC = () => {
     const activeCount = useMemo(
         () => (flags.skipPromptBuild ? 1 : 0)
             + (flags.skipEmotionEval ? 1 : 0)
+            + (flags.mergeSystemMessages ? 1 : 0)
             // 「在录」= 总开关开 且 至少勾了一类——否则浮球红点会骗人「在录」其实 isCaptureEnabled
             // 任何类别都返 false。
             + (flags.captureEnabled && flags.captureLogs.length > 0 ? 1 : 0)
@@ -395,6 +396,13 @@ const DevDebugPanel: React.FC = () => {
                             detail="主回复仍照常发送，但不启动本地或 Instant Push 的 emotion eval。"
                             checked={flags.skipEmotionEval}
                             onChange={(checked) => updateFlag('skipEmotionEval', checked)}
+                        />
+                        <div className="h-px bg-white/10" />
+                        <ToggleRow
+                            title="合并 system 为一条"
+                            detail="排查中转对多条 system 的计量/兼容问题；开着会让前缀缓存失效。"
+                            checked={flags.mergeSystemMessages}
+                            onChange={(checked) => updateFlag('mergeSystemMessages', checked)}
                         />
                         <div className="h-px bg-white/10" />
 

--- a/docs/dev-debug.md
+++ b/docs/dev-debug.md
@@ -59,6 +59,7 @@ isDevDebugAvailable()  // utils/devDebug.ts
 |------|--------|
 | `skipPromptBuild` | `utils/chatRequestPayload.ts:158` |
 | `skipEmotionEval` | `context/OSContext.tsx:1436`、`hooks/useChatAI.ts:439 / 685` |
+| `mergeSystemMessages` | `utils/chatRequestPayload.ts`（fullMessages 组装末尾）+ `utils/systemMessageMerge.ts` |
 | 捕获类 `api` | `utils/safeApi.ts`（调 `appendDevDebugApiLog`，普通聊天直发 + Character 的记忆精炼/归档/导入/批量总结/印象生成，凡走 `safeFetchJson` 的 chat completions 都算） |
 | 捕获类 `instant-push` | `utils/activeMsgRuntime.ts`、`utils/instantPushClient.ts`（调 `appendDevDebugInstantPushLog`） |
 | 捕获类 `lifecycle` | `utils/devDebug.ts` 自带的 `installDevDebugLifecycleCapture()`（`App.tsx` 启动时挂一次，监听器常驻、抓不抓走门禁） |
@@ -130,6 +131,7 @@ sullyos.devDebug.log.v1.<branch>        ← 分类捕获日志（各类混存，
 |------|------|------|--------|
 | `skipPromptBuild` | 行为 | 只发聊天历史，不注入 system prompt | 双语 / MCD / HTML / thinking 等增强全部关掉 |
 | `skipEmotionEval` | 行为 | 主回复照常，但不跑本地 / Instant Push 的 emotion eval | 关掉后情绪不更新 |
+| `mergeSystemMessages` | 行为 | 把聊天请求的多条 `role:system`（稳定前缀 / 易变尾段 / 双语·MCP 提醒条）合并成开头一条再发送（`utils/systemMessageMerge.ts`）。用途：A/B 对照中转适配层对多 system 请求的计量——同一段聊天开关各发一条，对比中转记的 prompt_tokens；合并后骤降 = 中转把「历史后的 system」重复拼接了 | 易变尾段失去 recency 位置、稳定前缀缓存失效；只作临时排障，测完关掉 |
 | `captureEnabled`<br>（记录日志·总开关） | 行为 | 日志录制总闸：关掉时所有捕获类都不抓 | 默认关；关掉只是停录，**不清**已抓日志 |
 | 捕获类 `api` | 捕获 | 抓所有走 `safeFetchJson`（`safeApi`）的 chat completions 请求 + 响应：普通聊天直发，外加 Character 里的记忆精炼/强制归档/导入清洗/批量总结/印象生成。每条带 `durationMs`（最后一次 attempt 从发起到成功/报错的耗时）和 `requestChars`（请求体字符数，messages 折叠后靠它看体积） | 取消勾选只停此后抓取，**不清**已有日志 |
 | 捕获类 `instant-push` | 捕获 | 抓 instant push 通道：经 worker 的 LLM 交换 + SSE 投递结果（超时/收到/失败） | 同上，取消勾选不清日志 |

--- a/utils/chatRequestPayload.ts
+++ b/utils/chatRequestPayload.ts
@@ -24,7 +24,8 @@ import type { LuckinMiniAppSnapshot, LuckinChatState } from './luckinToolBridge'
 import { isMcpChatAvailable } from './mcpClient';
 import { buildMcpSystemBlock, MCP_TAIL_REMINDER } from './mcpToolBridge';
 import type { MusicCfg, Song, LyricLine, MusicPlaybackSnapshot } from '../context/MusicContext';
-import { isPromptBuildSkipped } from './devDebug';
+import { isPromptBuildSkipped, isSystemMessageMergeEnabled } from './devDebug';
+import { mergeSystemMessages } from './systemMessageMerge';
 import { injectWorldbookDepthEntries, resolveWorldbookEntries } from './worldbook';
 import { normalizeTranslationLangLabel } from './translationLang';
 
@@ -356,12 +357,19 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
         fullMessages.push({ role: 'system', content: MCP_TAIL_REMINDER });
     }
 
+    // Dev 开关：多条 system 合并成开头一条，A/B 对照中转适配层对多 system 的计量行为。
+    let finalMessages = fullMessages;
+    if (isSystemMessageMergeEnabled()) {
+        finalMessages = mergeSystemMessages(fullMessages);
+        console.warn(`[DevDebug] Merge system messages: ${fullMessages.length} → ${finalMessages.length} messages (system ${fullMessages.length - finalMessages.length + 1} → 1).`);
+    }
+
     return {
         // 返回给情绪评估 / 调试查看器的仍是"完整拼接"——信息与主 API 完全一致，
         // 只是主 API 的实际消息结构把易变尾段放在历史之后（见上）。
         systemPrompt: systemPrompt + volatileTail,
         cleanedApiMessages: messagesWithWorldbookDepth,
-        fullMessages,
+        fullMessages: finalMessages,
         flags: { bilingualActive, mcdActive, luckinActive, luckinChatActive, mcpChatActive, htmlActive, thinkingActive, promptBuildSkipped: false },
     };
 }

--- a/utils/devDebug.ts
+++ b/utils/devDebug.ts
@@ -40,6 +40,12 @@ export interface DevDebugFlags {
     skipPromptBuild: boolean;
     skipEmotionEval: boolean;
     /**
+     * 把聊天请求里的多条 role:system 合并成开头一条再发送（utils/systemMessageMerge.ts）。
+     * 排查逆向中转对「历史后 system」重复拼接导致 prompt_tokens 膨胀的兼容问题；
+     * 会削弱易变尾段的 recency 注入并破坏前缀缓存，仅作临时 A/B 对照用。
+     */
+    mergeSystemMessages: boolean;
+    /**
      * 日志总开关：关掉时无论勾了哪些类别都不抓，默认关。
      * 跟 captureLogs 配合——是否抓 = captureEnabled && captureLogs.includes(category)。
      */
@@ -81,6 +87,7 @@ const DEV_DEBUG_AVAILABILITY_EVENT = 'sullyos-dev-debug-availability';
 export const DEFAULT_DEV_DEBUG_FLAGS: DevDebugFlags = {
     skipPromptBuild: false,
     skipEmotionEval: false,
+    mergeSystemMessages: false,
     captureEnabled: false,
     captureLogs: [],
     exposeLogDetail: false,
@@ -133,6 +140,7 @@ function normalizeFlags(value: unknown): DevDebugFlags {
     return {
         skipPromptBuild: source.skipPromptBuild === true,
         skipEmotionEval: source.skipEmotionEval === true,
+        mergeSystemMessages: source.mergeSystemMessages === true,
         captureEnabled: source.captureEnabled === true || legacyHasCapture,
         captureLogs,
         exposeLogDetail: source.exposeLogDetail === true,
@@ -251,6 +259,10 @@ export function isPromptBuildSkipped(): boolean {
 
 export function isEmotionEvalSkipped(): boolean {
     return readDevDebugFlags().skipEmotionEval;
+}
+
+export function isSystemMessageMergeEnabled(): boolean {
+    return readDevDebugFlags().mergeSystemMessages;
 }
 
 export function isCaptureEnabled(category: DevDebugCaptureCategory): boolean {

--- a/utils/systemMessageMerge.test.ts
+++ b/utils/systemMessageMerge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { mergeSystemMessages } from './systemMessageMerge';
+
+describe('mergeSystemMessages', () => {
+    it('三段式请求：稳定前缀 + 易变尾段 + 提醒条合并成开头一条，历史顺序不动', () => {
+        const messages = [
+            { role: 'system', content: '稳定前缀' },
+            { role: 'user', content: '你好' },
+            { role: 'assistant', content: '嗨' },
+            { role: 'system', content: '易变尾段' },
+            { role: 'system', content: '[MCP 提醒]' },
+        ];
+        const merged = mergeSystemMessages(messages);
+        expect(merged).toEqual([
+            { role: 'system', content: '稳定前缀\n\n易变尾段\n\n[MCP 提醒]' },
+            { role: 'user', content: '你好' },
+            { role: 'assistant', content: '嗨' },
+        ]);
+        // 原数组不被改动
+        expect(messages).toHaveLength(5);
+    });
+
+    it('只有一条 system 时原样返回（同一引用，不重建）', () => {
+        const messages = [
+            { role: 'system', content: '唯一 system' },
+            { role: 'user', content: 'hi' },
+        ];
+        expect(mergeSystemMessages(messages)).toBe(messages);
+    });
+
+    it('没有 system 时原样返回', () => {
+        const messages = [{ role: 'user', content: 'hi' }];
+        expect(mergeSystemMessages(messages)).toBe(messages);
+    });
+
+    it('空白 system 段被丢弃，不产生多余空行', () => {
+        const messages = [
+            { role: 'system', content: 'A' },
+            { role: 'system', content: '   ' },
+            { role: 'system', content: 'B' },
+        ];
+        expect(mergeSystemMessages(messages)[0].content).toBe('A\n\nB');
+    });
+});

--- a/utils/systemMessageMerge.ts
+++ b/utils/systemMessageMerge.ts
@@ -1,0 +1,32 @@
+/**
+ * 把请求里的多条 role:system 合并成开头一条（dev-debug 排障用）。
+ *
+ * SullyOS 的聊天请求默认是三段式：[稳定 system, ...历史, 易变 system]（外加双语 /
+ * MCP 提醒条也可能是 system）。正规 OpenAI→Claude 兼容层会正确归并多条 system，
+ * 但社区逆向的适配层可能在处理历史之后的 system 时重复拼接前文，导致 prompt_tokens
+ * 异常膨胀。这个纯函数配合 devDebug 的 mergeSystemMessages 开关做 A/B 对照：
+ * 合并后计费骤降 → 中转适配层问题坐实；不变 → 是计量（tokenizer）口径问题。
+ *
+ * 语义代价（所以只做临时开关、默认关）：易变尾段本该贴着生成点注入以获得 recency
+ * 注意力，合并进头部会削弱这一设计，且改变稳定前缀 → 前缀缓存整体失效。
+ */
+
+export interface ChatMessageLike {
+    role: string;
+    content: any;
+}
+
+/**
+ * 所有 system 的内容按出现顺序用空行拼接，放到开头一条；非 system 消息保持相对顺序。
+ * 只有 0/1 条 system 时原样返回（不做无谓的数组重建）。
+ */
+export function mergeSystemMessages<T extends ChatMessageLike>(messages: T[]): T[] {
+    const systems = messages.filter(m => m.role === 'system');
+    if (systems.length <= 1) return messages;
+    const merged = systems
+        .map(m => typeof m.content === 'string' ? m.content : JSON.stringify(m.content))
+        .filter(part => part && part.trim())
+        .join('\n\n');
+    const rest = messages.filter(m => m.role !== 'system');
+    return [{ ...systems[0], content: merged }, ...rest];
+}


### PR DESCRIPTION
聊天请求默认是三段式（稳定 system + 历史 + 易变 system，外加双语/MCP 提醒条）， 正规兼容层会正确归并多条 system；用户报告某家逆向 Claude 线路 prompt_tokens 接近翻倍，怀疑其适配层处理「历史后的 system」时重复拼接了前文。

新增 dev-debug 行为开关 mergeSystemMessages（默认关）：打开后把 fullMessages 里所有 system 按出现顺序拼成开头一条再发送。同一段聊天开关各发一条、对比中转
记的 prompt_tokens 即可定案：骤降 = 适配层重复拼接；不变 = 计量口径问题。

- utils/systemMessageMerge.ts: 纯函数 + 单测
- devDebug 三件套（interface/DEFAULT/normalizeFlags）+ getter + 面板行 + activeCount
- chatRequestPayload: fullMessages 组装末尾按开关应用，命中打 [DevDebug] warn
- docs/dev-debug.md: 开关表与消费点同步


Claude-Session: https://claude.ai/code/session_013q3mXc8m8gP7CgQ4k5EooM