### PR TITLE
fix(chat): 心象卡片也不随微调挪窝——包装层被贴边/缩进移动时反向 margin 钉回原位

### DIFF
--- a/utils/chatFineTuneCss.test.ts
+++ b/utils/chatFineTuneCss.test.ts
@@ -17,6 +17,18 @@ describe('buildChatFineTuneCss', () => {
         expect(css).not.toContain('margin-right: 0');
     });
 
+    it('心象卡片钉回默认位置：贴边补 48px、缩进补 48-indent、没动不出规则', () => {
+        const snapCss = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_ai', chatSnapToEdge: true });
+        expect(snapCss).toContain('.sully-psyche { margin-left: 48px !important; }');
+        const indentCss = buildChatFineTuneCss({ chatBubbleIndent: 60 });
+        expect(indentCss).toContain('.sully-psyche { margin-left: -12px !important; }');
+        // 贴边只作用于用户侧时，AI 包装层只受缩进影响 → 按缩进补
+        const mixedCss = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_user', chatSnapToEdge: true, chatBubbleIndent: 28 });
+        expect(mixedCss).toContain('.sully-psyche { margin-left: 20px !important; }');
+        // 包装层没动（只改字号/对齐）→ 不出心象规则
+        expect(buildChatFineTuneCss({ chatBubbleFontSize: 14, chatAvatarAlign: 'top' })).not.toContain('sully-psyche');
+    });
+
     it('贴边/缩进的选择器都 :not() 绕开 HTML 卡片包装（卡片不随美化挪窝）', () => {
         const css = buildChatFineTuneCss({ chatAvatarVisibility: 'hide_both', chatSnapToEdge: true, chatBubbleIndent: 60 });
         const wrapRules = css.split('\n').filter(line => line.includes('.ml-12') || line.includes('.mr-12'));

--- a/utils/chatFineTuneCss.ts
+++ b/utils/chatFineTuneCss.ts
@@ -47,6 +47,10 @@ const USER_BODY = '.sully-chat-root .sully-bubble-user > div[class~="select-text
 // 的默认位置就是"视觉居中"的约定，:not() 绕开让它不随美化挪窝。
 const AI_WRAP = '.sully-chat-root .group.justify-start [class~="max-w-[72%]"].ml-12:not(.sully-html-wrap)';
 const USER_WRAP = '.sully-chat-root .group.justify-end [class~="max-w-[72%]"].mr-12:not(.sully-html-wrap)';
+// 心象卡片（思考链，仅 AI 侧）与气泡共用包装层，:not() 绕不开——包装层被贴边/缩进挪动时
+// 给它一个反向 margin 抵消，钉回默认位置（ml-12 = 48px），与 HTML 卡片同一"模块不挪窝"约定。
+const AI_PSYCHE = '.sully-chat-root .group.justify-start .sully-psyche';
+const DEFAULT_WRAP_MARGIN = 48;
 
 const hideRule = (sel: string) =>
     `${sel} { display: none !important; visibility: hidden !important; opacity: 0 !important; pointer-events: none !important; }`;
@@ -89,6 +93,15 @@ export function buildChatFineTuneCss(theme: Pick<OSTheme,
     if (indent > 0) {
         if (!(theme.chatSnapToEdge && hideAi)) rules.push(`${AI_WRAP} { margin-left: ${indent}px !important; }`);
         if (!(theme.chatSnapToEdge && hideUser)) rules.push(`${USER_WRAP} { margin-right: ${indent}px !important; }`);
+    }
+
+    // ── 心象卡片钉回默认位置 ──
+    // AI 侧包装层被挪动多少，就给心象反向补多少：贴边时包装层 48→0（补 48px），
+    // 缩进时 48→indent（补 48-indent，可为负）。包装层没动就不出规则。
+    if (theme.chatSnapToEdge && hideAi) {
+        rules.push(`${AI_PSYCHE} { margin-left: ${DEFAULT_WRAP_MARGIN}px !important; }`);
+    } else if (indent > 0) {
+        rules.push(`${AI_PSYCHE} { margin-left: ${DEFAULT_WRAP_MARGIN - indent}px !important; }`);
     }
 
     // ── 正文字号 / 行距（沿用社区版的四层选择器：容器/内层行/内联继承/引用行）──


### PR DESCRIPTION
心象卡片（思考链 .sully-psyche）渲染在气泡上方、与气泡共用 max-w-[72%]
包装层，没法像 HTML 卡片那样 :not() 绕开（会把气泡一起绕开）。改为：包装
层被挪多少就给心象反向补多少——贴边时包装层 48→0 补 48px，缩进时 48→
indent 补 48-indent（可为负），包装层没动就不出规则。与 HTML 卡片同一
"模块不挪窝"约定，气泡照常贴边/缩进。

补单测：贴边补 48 / 缩进 60 补 -12 / 混合场景按实际位移补 / 只改字号对齐
不出心象规则。


Claude-Session: https://claude.ai/code/session_01B18LgGKuZScVyPMJp5NeN2