### PR TITLE
fix(api-log): 情绪评估类巨型 user 消息也拆块——构成面板不再显示「用户消息 ×1 · 100%」

### DIFF
--- a/utils/apiCallLog.test.ts
+++ b/utils/apiCallLog.test.ts
@@ -145,3 +145,34 @@ describe('buildPromptBreakdown', () => {
         expect(blocks[blocks.length - 1].label).toContain('其余');
     });
 });
+
+// 情绪评估形态：完整上下文打包成一条巨型 user 消息——必须拆块，否则面板只显示
+// 「用户消息 ×1 · 100%」，用户会误以为评估请求里没有角色设定。
+describe('buildPromptBreakdown · 巨型 user 消息拆块', () => {
+    it('超阈值且含多个块头的 user 消息按 system 同款规则拆开', () => {
+        const evalPrompt = [
+            '你是一个角色情绪分析系统。请分析角色「Noir」当前的情绪底色状态。',
+            '## 角色此刻看到的完整上下文（与主 API 发送的 system prompt 完全一致）',
+            `### 你的身份 (Character)\n${'设'.repeat(6000)}`,
+            '## 完整对话历史（与主 API 看到的消息历史完全一致）',
+            `${'[用户]: 在吗\n'.repeat(300)}`,
+            '## 任务\n基于以上对话……',
+        ].join('\n');
+        const blocks = buildPromptBreakdown({ messages: [{ role: 'user', content: evalPrompt }] })!;
+        const labels = blocks.map(b => b.label);
+        expect(labels.some(l => l.startsWith('角色此刻看到的完整上下文'))).toBe(true);
+        expect(labels.some(l => l.startsWith('你的身份'))).toBe(true);
+        expect(labels.some(l => l === '任务')).toBe(true);
+        expect(labels.some(l => l.startsWith('聊天历史·用户消息'))).toBe(false);
+    });
+
+    it('普通短 user 消息仍走角色聚合，不拆', () => {
+        const blocks = buildPromptBreakdown({
+            messages: [
+                { role: 'user', content: '## 今天的计划\n买菜' },
+                { role: 'user', content: '在吗' },
+            ],
+        })!;
+        expect(blocks).toEqual([{ label: '聊天历史·用户消息 ×2', chars: '## 今天的计划\n买菜'.length + 2 }]);
+    });
+});

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -306,12 +306,22 @@ export function buildPromptBreakdown(body: unknown): PromptBlockStat[] | undefin
 
         const out: PromptBlockStat[] = [];
         let userChars = 0, userCount = 0, asstChars = 0, asstCount = 0, otherChars = 0, otherCount = 0;
+        // 情绪评估等路径把「完整 system prompt + 展平历史 + 任务说明」整个打包成一条
+        // user 消息发送——不拆的话构成面板只会显示「用户消息 ×1 · 100%」，看不出内里。
+        // 巨型且含多个块头的 user 消息按 system 同款规则拆块；普通聊天消息不受影响。
+        const HUGE_USER_MSG_SPLIT_CHARS = 8000;
+        const countBlockHeaders = (text: string): number =>
+            text.split('\n').reduce((n, line) => n + (/^\s*(#{2,3}\s+.+|\[System:[^\]]*\])/.test(line) ? 1 : 0), 0);
         for (const msg of messages) {
             const text = contentToText(msg?.content);
             if (msg?.role === 'system') {
                 out.push(...splitSystemBlocks(text));
             } else if (msg?.role === 'user') {
-                userChars += text.length; userCount++;
+                if (text.length > HUGE_USER_MSG_SPLIT_CHARS && countBlockHeaders(text) >= 2) {
+                    out.push(...splitSystemBlocks(text));
+                } else {
+                    userChars += text.length; userCount++;
+                }
             } else if (msg?.role === 'assistant') {
                 asstChars += text.length; asstCount++;
             } else {


### PR DESCRIPTION
情绪评估把完整 system prompt + 展平历史 + 任务说明打包成一条 user 消息发送， 旧统计只对 role:system 分块，评估记录展开后只有一行 100%，用户误以为评估
请求里缺角色设定。现在超 8000 字且含 ≥2 个块头的 user 消息按 system 同款
规则拆块，评估记录展开后与主请求同构；普通聊天消息不受影响。


Claude-Session: https://claude.ai/code/session_013q3mXc8m8gP7CgQ4k5EooM