### PR TITLE
fix(instant-push): 订阅失败时「发送中…」指示灯卡死 + 能力检测文案细分

### DIFF
--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -634,9 +634,11 @@ export const useChatAI = ({
         onInstantPosted?: () => void,
         opts?: { skipEmotionInjection?: boolean },
     ) => {
-        if (isTyping || !char) return;
+        // 早退路径也要熄「发送准备中」灯: caller (Chat.tsx) 是先 setInstantSendingActive(true)
+        // 再调 triggerAI 的, 这里 return 掉而不通知的话指示灯会永远亮着。
+        if (isTyping || !char) { onInstantPosted?.(); return; }
         const effectiveApi = overrideApiConfig || apiConfig;
-        if (!effectiveApi.baseUrl) { alert("请先在设置中配置 API URL"); return; }
+        if (!effectiveApi.baseUrl) { alert("请先在设置中配置 API URL"); onInstantPosted?.(); return; }
 
         // 重 roll（回溯重生）时不带入上一轮的情绪余波：清掉 buff 注入（buffInjection/activeBuffs）和
         // 意识流（innerState/evolvedNarrative），让主回复与情绪评估两边都从干净状态独立重新生成——
@@ -1510,6 +1512,11 @@ export const useChatAI = ({
         } finally {
             KeepAlive.stop();
             setIsTyping(false);
+            // 兜底熄「发送准备中」灯 (幂等, 正常路径 deliver() 前已熄过)。不加的话
+            // config-missing / subscription-failed / 拼 context 阶段 throw 这些没走到
+            // POST 的路径都不会调 onInstantPosted, 头部「发送中…」徽章会卡死到刷新
+            // —— 2026-07 安卓用户实测: 订阅失败弹了错, 但三个小点到角色回复了都不消失。
+            onInstantPosted?.();
             setStreamingBubbles([]);  // 错误/中断路径兜底清预览
             setStreamingThinking('');
             setRecallStatus('');

--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -5,6 +5,7 @@ import { appendDevDebugInstantPushLog, appendDevDebugLog, makeDebugLogger } from
 import {
   SUBSCRIBE_SETTLE_MS,
   bytesToB64u,
+  describePushCapabilityGap,
   isDeadPushEndpoint,
   subscribeWithRetry,
 } from './pushSubscribeShared';
@@ -565,8 +566,9 @@ export async function getOrCreateInstantSubscription(
   if (pub.length < 60) {
     return { sub: null, reason: 'VAPID 公钥未配置, 请到 Settings → Instant Push 生成并保存' };
   }
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    return { sub: null, reason: '当前浏览器不支持 Service Worker 或 Push API' };
+  const capabilityGap = describePushCapabilityGap();
+  if (capabilityGap) {
+    return { sub: null, reason: capabilityGap };
   }
 
   const reg = await navigator.serviceWorker.ready;

--- a/utils/proactivePushConfig.ts
+++ b/utils/proactivePushConfig.ts
@@ -40,6 +40,7 @@ import { KeepAlive } from './keepAlive';
 import {
   SUBSCRIBE_SETTLE_MS,
   bytesToB64u,
+  describePushCapabilityGap,
   isDeadPushEndpoint,
   subscribeWithRetry,
 } from './pushSubscribeShared';
@@ -116,8 +117,9 @@ interface SubscribeAttempt {
 }
 
 export async function getOrCreateSubscription(vapidPublicKey: string): Promise<SubscribeAttempt> {
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    return { sub: null, reason: '当前浏览器不支持 Service Worker 或 Push API' };
+  const capabilityGap = describePushCapabilityGap();
+  if (capabilityGap) {
+    return { sub: null, reason: capabilityGap };
   }
 
   const reg = await navigator.serviceWorker.ready;
@@ -315,11 +317,9 @@ export async function ensureSubscribed(): Promise<SubscribeResult> {
   if (!isPushVapidReady()) {
     return { ok: false, reason: 'VAPID 公钥未配置, 请到 Settings → Instant Push 生成' };
   }
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    return { ok: false, reason: '当前浏览器不支持 Service Worker 或 Push API' };
-  }
-  if (typeof Notification === 'undefined') {
-    return { ok: false, reason: '当前环境没有 Notification API' };
+  const capabilityGap = describePushCapabilityGap();
+  if (capabilityGap) {
+    return { ok: false, reason: capabilityGap };
   }
 
   // Request permission first so the popup is tied to the user's click.
@@ -404,8 +404,9 @@ export async function resetSubscription(): Promise<{ ok: boolean; reason?: strin
   if (!isPushVapidReady()) {
     return { ok: false, reason: 'VAPID 公钥未配置, 请到 Settings → Instant Push 生成' };
   }
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    return { ok: false, reason: '当前浏览器不支持 Service Worker 或 Push API' };
+  const capabilityGap = describePushCapabilityGap();
+  if (capabilityGap) {
+    return { ok: false, reason: capabilityGap };
   }
 
   const reg = await navigator.serviceWorker?.ready?.catch(() => null);
@@ -460,8 +461,9 @@ export async function deepResetSubscription(): Promise<{ ok: boolean; reason?: s
   if (!isPushVapidReady()) {
     return { ok: false, reason: 'VAPID 公钥未配置, 请到 Settings → Instant Push 生成' };
   }
-  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
-    return { ok: false, reason: '当前浏览器不支持 Service Worker 或 Push API' };
+  const capabilityGap = describePushCapabilityGap();
+  if (capabilityGap) {
+    return { ok: false, reason: capabilityGap };
   }
 
   // 1) 拿现有 sub 的 endpoint, 通知 Worker 删 D1 行 (best-effort)

--- a/utils/pushSubscribeShared.ts
+++ b/utils/pushSubscribeShared.ts
@@ -49,6 +49,30 @@ export function isDeadPushEndpoint(endpoint: string | null | undefined): boolean
 }
 
 /**
+ * Web Push 三件套能力检测: Service Worker / PushManager / Notification。
+ * 全齐返回 null; 缺任何一个返回可直接展示给用户的原因文案。
+ *
+ * 为什么要细分: X浏览器 / Via 这类 WebView 壳浏览器常见「SW 能注册成功但没有
+ * PushManager / Notification」(2026-07 用户实测: 诊断里 sw: active、notif:
+ * unsupported, 却被报"不支持 Service Worker") —— 笼统文案会把用户引去查 SW /
+ * 重装 PWA, 实际是内核没有 Web Push 能力, 只能换浏览器。Notification 也必须
+ * 在这里查掉: 只查 PushManager 的话, 后续 `Notification.permission` 在没有该
+ * API 的环境会直接 ReferenceError。
+ */
+export function describePushCapabilityGap(): string | null {
+  const swSupported = typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+  const pushSupported = typeof window !== 'undefined' && 'PushManager' in window;
+  const notifSupported = typeof Notification !== 'undefined';
+  if (swSupported && pushSupported && notifSupported) return null;
+  const missing = [
+    !swSupported ? 'Service Worker' : '',
+    !pushSupported ? 'Push API' : '',
+    !notifSupported ? '系统通知接口 (Notification)' : '',
+  ].filter(Boolean).join('、');
+  return `当前浏览器缺少 ${missing}，内核没有网页推送能力（X浏览器 / Via 等 WebView 壳浏览器的通病）—— 请换 Chrome / Edge / Firefox 等完整内核浏览器`;
+}
+
+/**
  * Translate the browser's raw subscribe() rejection into a Chinese,
  * end-user-actionable hint.  The common cases on Android phones without
  * Google Play Services (or in third-party Chromium-based browsers that


### PR DESCRIPTION
用户反馈 (安卓 REDMI, X浏览器/Via/Edge): instant push 触发后三个小点到角色 回复了都不消失, CF 实时日志无事件; 诊断里 sw: active 却报「不支持 Service Worker 或 Push API」。

两个问题:

1. 指示灯卡死 —— onInstantPosted (熄灭「发送准备中」) 只在成功走到 deliver() 前一刻才被调用。config-missing / subscription-failed / 拼 context 阶段 throw 这些没走到 POST 的路径统统不会熄灯, 徽章卡死到 刷新。修复: triggerAI 外层 finally 兜底调 onInstantPosted (幂等), 两处早退 return 也补上。

2. 能力检测误导 —— X浏览器/Via 这类 WebView 壳能注册 SW 但没有 PushManager/Notification, 笼统文案把用户引去查 SW/重装 PWA。新增共享 describePushCapabilityGap(): SW / Push API / Notification 三项分开检 测, 缺哪个说哪个并明确建议换完整内核浏览器; 同时堵住 Notification 缺 失环境下后续 Notification.permission 直接 ReferenceError 的隐患。 instant + proactive 两条订阅路径共 5 处检测点统一换用。

测试: pnpm vitest run 1017/1017 通过; tsc 对改动文件无新增报错。


Claude-Session: https://claude.ai/code/session_01PbPMrduu7TW3RKuTMTrBcQ