### PR TITLE
feat(chat): HTML / 心象卡片默认改为水平居中，「贴气泡列」降为可选项

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -3054,7 +3054,7 @@ const Chat: React.FC = () => {
                             charAvatar={char.avatar}
                             charName={char.name}
                             userAvatar={userProfile.perCharAvatars?.[char.id] || userProfile.avatar}
-                            moduleAlign={mergedFineTune.chatModuleAlign || 'default'}
+                            moduleAlign={mergedFineTune.chatModuleAlign || 'center'}
                             onLongPress={handleMessageLongPress}
                             onReply={handleQuickReply}
                             selectionMode={selectionMode}

--- a/components/appearance/ChatAppearanceEditor.tsx
+++ b/components/appearance/ChatAppearanceEditor.tsx
@@ -24,7 +24,7 @@ const FINE_TUNE_DEFAULTS: Required<ChatFineTuneFields> = {
     chatBubbleLineHeight: 0,
     chatBubbleIndent: 0,
     chatSnapToEdge: false,
-    chatModuleAlign: 'default',
+    chatModuleAlign: 'center',
 };
 
 const presets: Array<{ name: string; desc: string; config: Partial<OSTheme> }> = [

--- a/components/chat/ChatFineTunePanel.tsx
+++ b/components/chat/ChatFineTunePanel.tsx
@@ -82,8 +82,8 @@ export const ChatFineTunePanel: React.FC<Props> = ({ value, onChange }) => {
             <div>
                 <h3 className="text-[11px] font-bold text-slate-500 mb-2">HTML / 心象卡片位置</h3>
                 <div className="flex gap-2 flex-wrap">
-                    <OptionButton active={(value.chatModuleAlign || 'default') === 'default'} label="默认位置" desc="贴气泡列，不随贴边挪" onClick={() => onChange({ chatModuleAlign: 'default' })} />
-                    <OptionButton active={value.chatModuleAlign === 'center'} label="水平居中" desc="卡片类内容居中显示" onClick={() => onChange({ chatModuleAlign: 'center' })} />
+                    <OptionButton active={(value.chatModuleAlign || 'center') === 'center'} label="水平居中（默认）" desc="卡片类内容居中显示" onClick={() => onChange({ chatModuleAlign: 'center' })} />
+                    <OptionButton active={value.chatModuleAlign === 'anchor'} label="贴气泡列" desc="跟气泡同侧，旧版观感" onClick={() => onChange({ chatModuleAlign: 'anchor' })} />
                 </div>
                 <p className="mt-1.5 text-[10px] text-slate-400">角色发的 HTML 卡片和心象（思考链）卡片的横向位置。预览里看不到卡片，进聊天看效果。</p>
             </div>

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -1228,8 +1228,8 @@ interface MessageItemProps {
     bubbleVariant?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios';
     messageSpacing?: 'compact' | 'default' | 'spacious';
     showTimestamp?: 'always' | 'hover' | 'never';
-    /** HTML 卡片 / 心象卡片的出现位置（聊天细节微调 chatModuleAlign，全局+角色覆盖合并后的生效值） */
-    moduleAlign?: 'default' | 'center';
+    /** HTML 卡片 / 心象卡片的出现位置（聊天细节微调 chatModuleAlign 合并后的生效值）。缺省 = 居中 */
+    moduleAlign?: 'anchor' | 'center';
     /** 流式预览无缝接棒时，正式消息首帧已经可见，不应再次从透明态淡入。 */
     suppressEntranceAnimation?: boolean;
     /** Instant Push 准备中：在用户气泡左侧渲染 dot pulse */
@@ -1282,7 +1282,7 @@ const MessageItem = React.memo(({
     bubbleVariant = 'modern',
     messageSpacing = 'default',
     showTimestamp = 'always',
-    moduleAlign = 'default',
+    moduleAlign = 'center',
     suppressEntranceAnimation = false,
     isPending = false,
     pendingIndicator = true,
@@ -1706,9 +1706,9 @@ const MessageItem = React.memo(({
     // HTML 卡片（280px 定宽模块）默认位置就是"视觉居中"的约定：包装层打上 sully-html-wrap，
     // 让「聊天细节微调」的贴边/缩进规则 :not() 绕开它——美化怎么开卡片都不挪窝。
     const isHtmlCard = m.type === 'html_card';
-    // 聊天细节微调 chatModuleAlign='center'：HTML 卡片 / 心象卡片改为水平居中。
+    // 聊天细节微调 chatModuleAlign：HTML 卡片 / 心象卡片默认水平居中，'anchor' 才贴气泡列。
     // 心象居中时抽出到气泡行上方的独立行（不带 .group 类，注入的钉位 CSS 自然不命中）。
-    const centerModules = moduleAlign === 'center';
+    const centerModules = moduleAlign !== 'anchor';
     // 心象卡片（思考链）：默认渲染在气泡包装层内、气泡上方；居中模式挪到独立行。
     const thinkingChainNode = !isUser && m.metadata?.thinkingChain ? (
         <div className={`relative w-full ${selectionMode ? 'pl-7' : ''}`}>

--- a/types.ts
+++ b/types.ts
@@ -111,9 +111,10 @@ export interface OSTheme {
   chatBubbleIndent?: number;
   /** 隐藏头像的一侧是否贴边（收回头像空位） */
   chatSnapToEdge?: boolean;
-  /** HTML 卡片 / 心象卡片的出现位置：默认（贴气泡列的头像位，不随贴边/缩进挪动）/ 水平居中。
-   *  经 MessageItem 布局属性生效（不走注入 CSS），同属聊天细节微调字段、可按角色覆盖 */
-  chatModuleAlign?: 'default' | 'center';
+  /** HTML 卡片 / 心象卡片的出现位置：缺省/'center' = 水平居中（默认），'anchor' = 贴气泡列
+   *  （头像位，不随贴边/缩进挪动，即旧版观感）。经 MessageItem 布局属性生效（不走注入 CSS），
+   *  同属聊天细节微调字段、可按角色覆盖 */
+  chatModuleAlign?: 'anchor' | 'center';
   chatBubbleStyle?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios';
   chatMessageSpacing?: 'compact' | 'default' | 'spacious';
   chatShowTimestamp?: 'always' | 'hover' | 'never';

--- a/utils/chatFineTuneCss.test.ts
+++ b/utils/chatFineTuneCss.test.ts
@@ -115,9 +115,10 @@ describe('mergeChatFineTune', () => {
         expect(buildChatFineTuneCss(merged)).toBe('');
     });
 
-    it('chatModuleAlign 参与合并但不生成 CSS（经 MessageItem 布局属性生效）', () => {
-        const merged = mergeChatFineTune({ chatModuleAlign: 'default' }, { enabled: true, chatModuleAlign: 'center' });
-        expect(merged.chatModuleAlign).toBe('center');
+    it('chatModuleAlign 参与合并但不生成 CSS（经 MessageItem 布局属性生效，缺省=居中）', () => {
+        const merged = mergeChatFineTune({ chatModuleAlign: 'center' }, { enabled: true, chatModuleAlign: 'anchor' });
+        expect(merged.chatModuleAlign).toBe('anchor');
         expect(buildChatFineTuneCss({ chatModuleAlign: 'center' })).toBe('');
+        expect(buildChatFineTuneCss({ chatModuleAlign: 'anchor' })).toBe('');
     });
 });


### PR DESCRIPTION
产品拍板：卡片模块开箱即居中，不用任何人去设置。chatModuleAlign 语义
改为缺省/'center' = 居中（默认）、'anchor' = 贴气泡列（旧版观感，仍受
钉位规则保护不随贴边/缩进挪动）。字段尚未发版，值改名无迁移负担。

- MessageItem 缺省 center；面板选项改「水平居中（默认）/ 贴气泡列」
- 预设铺默认值同步 center；合并/无 CSS 语义单测更新


Claude-Session: https://claude.ai/code/session_01B18LgGKuZScVyPMJp5NeN2