### PR TITLE
feat(api-log): 构成面板合并固定提示词为一行 + 分块器围栏感知

### DIFF
--- a/components/settings/ApiCallLogModal.tsx
+++ b/components/settings/ApiCallLogModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import Modal from '../os/Modal';
 import { DB } from '../../utils/db';
-import { isSameCoreModel } from '../../utils/apiCallLog';
+import { isSameCoreModel, isFixedPromptBlockLabel } from '../../utils/apiCallLog';
 import type { ApiCallLogEntry, PromptBlockStat } from '../../utils/apiCallLog';
 
 interface ApiCallLogModalProps {
@@ -239,7 +239,16 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
  */
 const PromptBreakdownView: React.FC<{ blocks: PromptBlockStat[]; promptTokens?: number }> = ({ blocks, promptTokens }) => {
     const totalChars = blocks.reduce((sum, b) => sum + b.chars, 0) || 1;
-    const rows = [...blocks].sort((a, b) => b.chars - a.chars);
+    // 写死的固定骨架块（行为规范/表达底线/钢印等）合并成一行——它们不随用户数据
+    // 变化、也没有可优化空间，散成一堆小行只会淹没真正有信息量的数据块。
+    const fixed = blocks.filter(b => isFixedPromptBlockLabel(b.label));
+    const merged: PromptBlockStat[] = fixed.length >= 2
+        ? [
+            ...blocks.filter(b => !isFixedPromptBlockLabel(b.label)),
+            { label: `固定提示词（规则/格式，共 ${fixed.length} 块）`, chars: fixed.reduce((s, b) => s + b.chars, 0) },
+        ]
+        : blocks;
+    const rows = [...merged].sort((a, b) => b.chars - a.chars);
     const fmt = (n: number) => n.toLocaleString('en-US');
     return (
         <div className="mt-2 pt-2 border-t border-slate-100 space-y-1.5" onClick={(ev) => ev.stopPropagation()}>

--- a/utils/apiCallLog.test.ts
+++ b/utils/apiCallLog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scanSseForLog, coreModelName, isSameCoreModel, buildPromptBreakdown } from './apiCallLog';
+import { scanSseForLog, coreModelName, isSameCoreModel, buildPromptBreakdown, isFixedPromptBlockLabel } from './apiCallLog';
 
 // 锁住 API 调用记录的 SSE 兜底解析：流式响应 JSON.parse 必然失败，
 // 后端自报 model（首个非空）与 usage（末个非空）从 data: 行里扫出来。
@@ -197,5 +197,39 @@ describe('buildPromptBreakdown · 单条提示词标注', () => {
             ],
         })!;
         expect(blocks.map(b => b.label)).toContain('聊天历史·用户消息 ×1');
+    });
+});
+
+// 围栏感知 + 固定块识别：行为规范里的日记示例（``` 内的 ## 行）不能被切成独立块；
+// 固定骨架块名能被 isFixedPromptBlockLabel 识别（展示层据此合并）。
+describe('buildPromptBreakdown · 围栏感知与固定块', () => {
+    it('``` 代码块内的 ##/### 行不开新块', () => {
+        const sys = [
+            '### 聊天 App 行为规范 (Chat App Rules)',
+            '规则正文',
+            '```',
+            '## 今天的小确幸',
+            '### 小标题（会变成彩色卡片）',
+            '```',
+            '规则继续',
+            '### 表达底线 (Anti-Filler)',
+            '正文',
+        ].join('\n');
+        const labels = buildPromptBreakdown({ messages: [{ role: 'system', content: sys }, { role: 'user', content: 'hi' }] })!
+            .map(b => b.label);
+        expect(labels).toEqual([
+            '聊天 App 行为规范 (Chat App Rules)',
+            '表达底线 (Anti-Filler)',
+            '聊天历史·用户消息 ×1',
+        ]);
+    });
+
+    it('固定骨架块名识别，数据块不误伤', () => {
+        expect(isFixedPromptBlockLabel('聊天 App 行为规范 (Chat App Rules)')).toBe(true);
+        expect(isFixedPromptBlockLabel('最后，回到你自己')).toBe(true);
+        expect(isFixedPromptBlockLabel('[MCP 工具 ON · 永远用角色语气回复别空回')).toBe(true);
+        expect(isFixedPromptBlockLabel('记忆系统 (Memory Bank)')).toBe(false);
+        expect(isFixedPromptBlockLabel('底色认知 (Resident Knowledge)')).toBe(false);
+        expect(isFixedPromptBlockLabel('[Background Context: Recent Group Activi')).toBe(false);
     });
 });

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -261,8 +261,15 @@ function contentToText(content: unknown): string {
 
 const BLOCK_LABEL_MAX = 40;
 
+/** 行是块头？返回块名（`## / ### 标题` 或 `[System: …]`），否则 null。 */
+const matchBlockHeader = (line: string): string | null => {
+    const m = line.match(/^\s*#{2,3}\s+(.+?)\s*$/) || line.match(/^\s*(\[System:[^\]]*\])/);
+    return m ? m[1].trim() : null;
+};
+
 /**
- * 把一条 system 消息按块头切开：`## / ### 标题` 行或 `[System: …]` 行开新块。
+ * 把一条 system 消息按块头切开。``` 围栏内的行不算块头——行为规范里的日记
+ * 示例（`## 今天的小确幸` 等）都在代码块里，不加围栏感知会被误切成独立块。
  * 一个块头都没有的短消息（双语 / MCP 尾部提醒等）整条算一块，取首行当名字。
  */
 function splitSystemBlocks(text: string): PromptBlockStat[] {
@@ -270,11 +277,13 @@ function splitSystemBlocks(text: string): PromptBlockStat[] {
     let label = '（开头·未分块部分）';
     let chars = 0;
     let sawHeader = false;
+    let inFence = false;
     for (const line of text.split('\n')) {
-        const header = line.match(/^\s*#{2,3}\s+(.+?)\s*$/) || line.match(/^\s*(\[System:[^\]]*\])/);
+        if (/^\s*```/.test(line)) inFence = !inFence;
+        const header = inFence ? null : matchBlockHeader(line);
         if (header) {
             if (chars > 0) out.push({ label, chars });
-            label = header[1].trim().slice(0, BLOCK_LABEL_MAX);
+            label = header.slice(0, BLOCK_LABEL_MAX);
             chars = line.length + 1;
             sawHeader = true;
         } else {
@@ -288,6 +297,35 @@ function splitSystemBlocks(text: string): PromptBlockStat[] {
     }
     return out;
 }
+
+/**
+ * 已知的「写死的固定骨架」块名前缀（规则/格式/钢印类，内容不随用户数据变化）。
+ * 构成面板的展示层把命中的块合并成一行「固定提示词」，突出真正能优化的数据块。
+ * 新增固定提示词块时记得把块头加进来（漏加只是显示散一点，无功能影响）。
+ */
+const FIXED_PROMPT_LABEL_PREFIXES = [
+    '聊天 App 行为规范',
+    '表达底线',
+    '🎤 语音消息功能',
+    '关于对方的表达',
+    '最后，回到你自己',
+    '【音乐互动工具】',
+    '关于《彼方》',
+    '[MCP 工具 ON',
+    '[Reminder:',
+    // 思考链提示词（thinkingChainPrompt.ts）的章节头
+    '语言铁律',
+    '你不是在演',
+    '起点:你本来在干嘛',
+    '同时被激活的多个东西',
+    '别急着安慰',
+    '别造谣',
+    '温度:脑内比嘴上更吵',
+    'Thinking 写法总则',
+];
+
+export const isFixedPromptBlockLabel = (label: string): boolean =>
+    FIXED_PROMPT_LABEL_PREFIXES.some(prefix => label.startsWith(prefix));
 
 const MAX_BREAKDOWN_BLOCKS = 48;
 
@@ -310,8 +348,14 @@ export function buildPromptBreakdown(body: unknown): PromptBlockStat[] | undefin
         // user 消息发送——不拆的话构成面板只会显示「用户消息 ×1 · 100%」，看不出内里。
         // 巨型且含多个块头的 user 消息按 system 同款规则拆块；普通聊天消息不受影响。
         const HUGE_USER_MSG_SPLIT_CHARS = 8000;
-        const countBlockHeaders = (text: string): number =>
-            text.split('\n').reduce((n, line) => n + (/^\s*(#{2,3}\s+.+|\[System:[^\]]*\])/.test(line) ? 1 : 0), 0);
+        const countBlockHeaders = (text: string): number => {
+            let n = 0, inFence = false;
+            for (const line of text.split('\n')) {
+                if (/^\s*```/.test(line)) inFence = !inFence;
+                if (!inFence && matchBlockHeader(line)) n++;
+            }
+            return n;
+        };
         for (const msg of messages) {
             const text = contentToText(msg?.content);
             if (msg?.role === 'system') {


### PR DESCRIPTION
- 分块器加 ``` 围栏感知：行为规范里的日记示例（## 今天的小确幸 / ### 小标题）是代码块内的示例文本，之前被误切成独立块。
- 展示层把已知固定骨架块（行为规范/表达底线/语音功能/钢印/思考链章节等） 合并成一行「固定提示词（规则/格式，共 N 块）」——它们不随用户数据变化、 没有优化空间，散成小行只会淹没记忆/群聊背景这些真正能动手的数据块。 识别清单收口在 apiCallLog.ts 的 FIXED_PROMPT_LABEL_PREFIXES，存储仍是 逐块原始统计，合并只发生在渲染层，历史记录不受影响。


Claude-Session: https://claude.ai/code/session_013q3mXc8m8gP7CgQ4k5EooM