### PR TITLE
fix(api-log): 落单 ``` 围栏不再吞掉后续所有块——围栏必须成对才生效

### DIFF
--- a/utils/apiCallLog.test.ts
+++ b/utils/apiCallLog.test.ts
@@ -233,3 +233,29 @@ describe('buildPromptBreakdown · 围栏感知与固定块', () => {
         expect(isFixedPromptBlockLabel('[Background Context: Recent Group Activi')).toBe(false);
     });
 });
+
+// 落单围栏防吞噬：用户数据里奇数个 ``` 不能把后面所有块头吞进上一块
+// （实测事故：记忆摘要带半个围栏 → 62K「记忆系统」行吞掉对话历史+评估框架）。
+describe('buildPromptBreakdown · 落单围栏', () => {
+    it('奇数个 ``` 时最后一个不算开栏，后续块头照常识别', () => {
+        const sys = [
+            '### 记忆系统 (Memory Bank)',
+            '- 某条记忆里带了半个围栏 ```',
+            '### 表达底线 (Anti-Filler)',
+            '正文',
+            '## 任务',
+            '评估任务说明',
+        ].join('\n');
+        const labels = buildPromptBreakdown({ messages: [{ role: 'system', content: sys }, { role: 'user', content: 'hi' }] })!
+            .map(b => b.label);
+        expect(labels).toContain('表达底线 (Anti-Filler)');
+        expect(labels).toContain('任务');
+    });
+
+    it('成对围栏仍然屏蔽示例块头', () => {
+        const sys = '### 规则\n```\n## 示例标题\n```\n### 下一块\n正文';
+        const labels = buildPromptBreakdown({ messages: [{ role: 'system', content: sys }, { role: 'user', content: 'hi' }] })!
+            .map(b => b.label);
+        expect(labels).toEqual(['规则', '下一块', '聊天历史·用户消息 ×1']);
+    });
+});

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -268,6 +268,18 @@ const matchBlockHeader = (line: string): string | null => {
 };
 
 /**
+ * 计算哪些行是有效的 ``` 围栏开合线。围栏必须**成对**才生效：用户数据（记忆
+ * 摘要等）里落单的半个 ``` 会把围栏状态永久翻转，后面所有块头全被吞进上一块
+ * （实测：62K 的「记忆系统」行吞掉了对话历史+评估框架）。奇数个时最后一个不算。
+ */
+function fenceToggleLines(lines: string[]): Set<number> {
+    const indices: number[] = [];
+    lines.forEach((line, i) => { if (/^\s*```/.test(line)) indices.push(i); });
+    if (indices.length % 2 === 1) indices.pop();
+    return new Set(indices);
+}
+
+/**
  * 把一条 system 消息按块头切开。``` 围栏内的行不算块头——行为规范里的日记
  * 示例（`## 今天的小确幸` 等）都在代码块里，不加围栏感知会被误切成独立块。
  * 一个块头都没有的短消息（双语 / MCP 尾部提醒等）整条算一块，取首行当名字。
@@ -278,8 +290,11 @@ function splitSystemBlocks(text: string): PromptBlockStat[] {
     let chars = 0;
     let sawHeader = false;
     let inFence = false;
-    for (const line of text.split('\n')) {
-        if (/^\s*```/.test(line)) inFence = !inFence;
+    const lines = text.split('\n');
+    const fenceAt = fenceToggleLines(lines);
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (fenceAt.has(i)) inFence = !inFence;
         const header = inFence ? null : matchBlockHeader(line);
         if (header) {
             if (chars > 0) out.push({ label, chars });
@@ -350,9 +365,11 @@ export function buildPromptBreakdown(body: unknown): PromptBlockStat[] | undefin
         const HUGE_USER_MSG_SPLIT_CHARS = 8000;
         const countBlockHeaders = (text: string): number => {
             let n = 0, inFence = false;
-            for (const line of text.split('\n')) {
-                if (/^\s*```/.test(line)) inFence = !inFence;
-                if (!inFence && matchBlockHeader(line)) n++;
+            const lines = text.split('\n');
+            const fenceAt = fenceToggleLines(lines);
+            for (let i = 0; i < lines.length; i++) {
+                if (fenceAt.has(i)) inFence = !inFence;
+                if (!inFence && matchBlockHeader(lines[i])) n++;
             }
             return n;
         };


### PR DESCRIPTION
围栏感知上线后，用户数据（记忆摘要等）里落单的半个 ``` 会把围栏状态
永久翻转：实测一条情绪评估记录里 62K 的「记忆系统」行吞掉了对话历史、
评估任务框架和全部固定块，看起来像评估没带上下文。改为预扫配对：奇数
个围栏行时最后一个不算开栏，成对围栏仍正常屏蔽示例块头。


Claude-Session: https://claude.ai/code/session_013q3mXc8m8gP7CgQ4k5EooM