### PR TITLE
澄清 Notion Token 新前缀 ntn_，代理不可达时给出可操作的报错提示

### DIFF
--- a/apps/Settings.tsx
+++ b/apps/Settings.tsx
@@ -2807,7 +2807,7 @@ const Settings: React.FC = () => {
                       <div className="space-y-2">
                           <div>
                               <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">Notion Integration Token</label>
-                              <input type="password" value={rtNotionKey} onChange={e => setRtNotionKey(e.target.value)} className="w-full bg-white/80 border border-orange-200 rounded-xl px-3 py-2 text-sm font-mono" placeholder="secret_..." />
+                              <input type="password" value={rtNotionKey} onChange={e => setRtNotionKey(e.target.value)} className="w-full bg-white/80 border border-orange-200 rounded-xl px-3 py-2 text-sm font-mono" placeholder="ntn_... 或 secret_..." />
                           </div>
                           <div>
                               <label className="text-[10px] font-bold text-slate-400 uppercase block mb-1">Database ID</label>
@@ -2822,7 +2822,7 @@ const Settings: React.FC = () => {
                               </p>
                           </div>
                           <p className="text-[10px] text-orange-500/70 leading-relaxed">
-                              1. 在 <a href="https://www.notion.so/my-integrations" target="_blank" className="underline">Notion开发者</a> 创建Integration<br/>
+                              1. 在 <a href="https://www.notion.so/my-integrations" target="_blank" className="underline">Notion开发者</a> 创建Integration（新版 Token 以 ntn_ 开头，老版以 secret_ 开头，都能用）<br/>
                               2. 创建一个日记数据库，添加"Name"(标题)和"Date"(日期)属性<br/>
                               3. 在数据库右上角菜单中 Connect 你的 Integration
                           </p>

--- a/utils/realtimeContext.ts
+++ b/utils/realtimeContext.ts
@@ -822,7 +822,13 @@ export const NotionManager = {
                 return { success: false, message: '返回格式错误' };
             }
         } catch (e: any) {
-            return { success: false, message: `网络错误: ${e.message}` };
+            const msg = String(e?.message || e);
+            // fetch 在请求根本没到达服务器时抛 TypeError（Safari 报 "Load failed"、
+            // Chrome 报 "Failed to fetch"），说明是代理 Worker 不可达，不是 Notion 拒绝了 Key
+            if (/load failed|failed to fetch|networkerror/i.test(msg)) {
+                return { success: false, message: `无法连接到代理服务器 ${NotionManager.WORKER_URL}：请先在浏览器里试试能否直接打开该地址。打不开说明当前网络访问不了它（换网络/开代理后重试），或在「设置 → 网络代理 (Worker)」填入自部署的 Worker 地址` };
+            }
+            return { success: false, message: `网络错误: ${msg}` };
         }
     },
 


### PR DESCRIPTION
- 设置页 Notion Token 占位符和帮助文案标明 ntn_/secret_ 前缀都有效 （Notion 2024-09 起新建 Integration 的 Token 以 ntn_ 开头）
- 测试连接遇到 'Load failed' / 'Failed to fetch' 这类 fetch TypeError 时， 明确提示是代理 Worker 不可达（而非 Key 错误），并给出排查方向


Claude-Session: https://claude.ai/code/session_01BhuZovbXGE1LMc2MWjoiV5