### PR TITLE
fix(chat): 翻译标签掉格式自愈——破标签不再漏进气泡，可救的修回双语泡

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -3180,7 +3180,9 @@ const MessageItem = React.memo(({
     const stripJunk = (s: string) => stripFishCuesForDisplay(s
         .replace(/%%TRANS%%[\s\S]*/gi, '')           // legacy translation marker
         .replace(/%%BILINGUAL%%/gi, '\n')            // raw bilingual marker → newline
-        .replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '')  // stray bilingual XML tags
+        // stray bilingual XML tags — 容错版：全角括号/斜杠、标签内空格、简繁、少写 `>` 的截断形态
+        // (如 `</译文`) 都吃掉。掉格式消息已经按破标签落过库，显示端不容错就会原样漏给用户。
+        .replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, '')
         .replace(/\s*\[(?:聊天|通话|约会)\]\s*/g, '\n')   // source tags leaked from history context
         .replace(/\[\[(?:QU[OA]TE|引用)[：:][\s\S]*?\]\]/g, '')  // residual double-bracket quotes (incl. typos & Chinese)
         .replace(/\[(?:QU[OA]TE|引用)[：:][^\]]*\]/g, '')     // residual single-bracket quotes (incl. typos & Chinese)

--- a/public/instant-worker.deno.bundle.js
+++ b/public/instant-worker.deno.bundle.js
@@ -2414,6 +2414,39 @@ function normalizeVoiceTags(t) {
   result = repairPairedTag(result, /<\/?字幕[^>]*>/g, () => "\u5B57\u5E55", false);
   return result;
 }
+var simpTransTag = (tag) => tag.replace(/譯/g, "\u8BD1");
+function normalizeTranslationTags(t) {
+  if (!/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)/.test(t)) return t;
+  let result = t;
+  result = result.replace(/[<＜]\s*[/／]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `</${simpTransTag(tag)}>`);
+  result = result.replace(/[<＜]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `<${simpTransTag(tag)}>`);
+  result = result.replace(
+    /[<＜]\s*([/／]?)\s*(翻[译譯]|原文|[译譯]文)\s*(?=$|\n|[<＜])/g,
+    (_m, slash, tag) => `<${slash ? "/" : ""}${simpTransTag(tag)}>`
+  );
+  result = repairPairedTag(result, /<\/?原文[^>]*>/g, () => "\u539F\u6587", false);
+  result = repairPairedTag(result, /<\/?译文[^>]*>/g, () => "\u8BD1\u6587", false);
+  result = repairPairedTag(result, /<\/?翻译[^>]*>/g, () => "\u7FFB\u8BD1", false);
+  const HOLD = String.fromCharCode(3);
+  const blocks = [];
+  const hold = (m) => {
+    blocks.push(m);
+    return `${HOLD}${blocks.length - 1}${HOLD}`;
+  };
+  result = result.replace(/<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, hold);
+  result = result.replace(
+    /(?:<翻译>\s*)?<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*(?:<\/翻译>)?/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(
+    /<翻译>\s*(?!<原文>)((?:(?!<\/?翻译>)[\s\S])*?)<\/翻译>\s*<译文>([\s\S]*?)<\/译文>/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(/<译文>[\s\S]*?<\/译文>/g, "");
+  result = result.replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, "");
+  result = result.replace(new RegExp(`${HOLD}(\\d+)${HOLD}`, "g"), (_m, n) => blocks[Number(n)] || "");
+  return result;
+}
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2430,6 +2463,7 @@ function sanitizeForNotification(text) {
   result = replaceHtmlBlocks(result);
   result = replaceEmojiReverseTag(result);
   result = replaceSendEmoji(result);
+  result = normalizeTranslationTags(result);
   result = extractTranslationOriginal(result);
   result = stripTimestamps(result);
   result = stripChineseDate(result);
@@ -2451,6 +2485,7 @@ function sanitizeIntoSegments(text) {
   let cleaned = stripLiteralBackslashN(text);
   cleaned = stripThinkBlocks(cleaned);
   cleaned = normalizeVoiceTags(cleaned);
+  cleaned = normalizeTranslationTags(cleaned);
   const ATOM_MARKER = String.fromCharCode(2);
   const atomBlocks = [];
   const atomSegments = segmentTextWithProtectedBlocks(cleaned, {

--- a/utils/chatParser.ts
+++ b/utils/chatParser.ts
@@ -305,7 +305,8 @@ export const ChatParser = {
         const stripped = text
             .replace(/%%BILINGUAL%%/gi, '')
             .replace(/%%TRANS%%[\s\S]*/gi, '')
-            .replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '')
+            // 容错版 (对齐 MessageItem stripJunk): 截断/全角/简繁的破翻译标签也不算显示内容
+            .replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, '')
             .replace(/^\s*---\s*$/gm, '')
             .replace(/``+/g, '')
             .replace(/(^|\s)`(\s|$)/gm, '$1$2')

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -230,6 +230,68 @@ export function normalizeVoiceTags(t: string): string {
   return result;
 }
 
+// ─── 翻译标签规整 (掉格式自愈) ──────────────────────────────────────────────
+
+const simpTransTag = (tag: string): string => tag.replace(/譯/g, '译');
+
+/**
+ * 把 LLM 写歪的 <翻译>/<原文>/<译文> 标签修回规范形态
+ * `<翻译><原文>X</原文><译文>Y</译文></翻译>`, 让下游所有严格配对正则
+ * (applyAssistantPostProcessing Step 8 双语拆泡 / sanitizeIntoSegments Phase 1.5
+ * 原子保护 / extractTranslationOriginal banner 提取) 都能命中。
+ * 落库前跑一次 (三个 facade 都挂了), 下游不用各自容错。
+ *
+ * 修复的形态 (来自真实掉格式报告 —— 多模型多站点同时出现"掉格式"):
+ *  1. 全角尖括号 / 全角斜杠 / 标签内空格 / 简繁互换: ＜／譯文＞ → </译文>
+ *  2. 截断标签少写 `>`: 行尾/文尾/紧贴下一标签的 `</译文` → `</译文>` (截图报告形态)
+ *  3. 配对修复: 有开无闭 → 末尾补闭合; 孤儿闭合 / 嵌套重复开标签 / 自闭合 → 删除
+ *  4. 结构自愈 → 规范块:
+ *     - 缺外层包裹 / 缺 </翻译>: `<原文>X</原文><译文>Y</译文>` → 补齐 <翻译> 包裹
+ *     - sibling 幻觉: `<翻译>X</翻译><译文>Y</译文>` → 规范块
+ *       (extractTranslationOriginal 注释里记录的已知形态)
+ *  5. 兜底不变量: 自愈后文本里只允许存在规范完整块 —— 仍配不成对的翻译标签
+ *     全部剥除、正文保留 (宁可退化成普通气泡, 也绝不把 `</译文` 这类破标签漏给用户)。
+ */
+export function normalizeTranslationTags(t: string): string {
+  if (!/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)/.test(t)) return t; // fast path
+  let result = t;
+  // 1. 全角尖括号/斜杠 + 标签内空格 + 简繁 → 规范半角简体
+  result = result.replace(/[<＜]\s*[/／]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `</${simpTransTag(tag)}>`);
+  result = result.replace(/[<＜]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `<${simpTransTag(tag)}>`);
+  // 2. 截断补全: 行尾/文尾/紧贴下一个 `<` 处少写 `>` (流截断 / 模型偷懒的高频形态)
+  result = result.replace(
+    /[<＜]\s*([/／]?)\s*(翻[译譯]|原文|[译譯]文)\s*(?=$|\n|[<＜])/g,
+    (_m, slash, tag) => `<${slash ? '/' : ''}${simpTransTag(tag)}>`,
+  );
+  // 3. 配对修复: 先内层 (原文/译文) 再外层 (翻译), 未闭合开标签才能按嵌套顺序补对
+  result = repairPairedTag(result, /<\/?原文[^>]*>/g, () => '原文', false);
+  result = repairPairedTag(result, /<\/?译文[^>]*>/g, () => '译文', false);
+  result = repairPairedTag(result, /<\/?翻译[^>]*>/g, () => '翻译', false);
+  // 4. 结构自愈。先把本来就规范的完整块 (多行/紧凑都算) 用占位符护住原样保留,
+  //    只对剩余的掉格式残局做规范化重写。
+  const HOLD = String.fromCharCode(3);
+  const blocks: string[] = [];
+  const hold = (m: string): string => { blocks.push(m); return `${HOLD}${blocks.length - 1}${HOLD}`; };
+  result = result.replace(/<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, hold);
+  // 4a. 配好的 原文+译文 对 (外层 <翻译> 包裹缺失/只剩半边) → 规范块
+  result = result.replace(
+    /(?:<翻译>\s*)?<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*(?:<\/翻译>)?/g,
+    (_m, a: string, b: string) => hold(`<翻译><原文>${a.trim()}</原文><译文>${b.trim()}</译文></翻译>`),
+  );
+  // 4b. sibling 幻觉形态 <翻译>X</翻译><译文>Y</译文> → 规范块
+  result = result.replace(
+    /<翻译>\s*(?!<原文>)((?:(?!<\/?翻译>)[\s\S])*?)<\/翻译>\s*<译文>([\s\S]*?)<\/译文>/g,
+    (_m, a: string, b: string) => hold(`<翻译><原文>${a.trim()}</原文><译文>${b.trim()}</译文></翻译>`),
+  );
+  // 5. 兜底不变量: 规范块之外不允许残留任何翻译标签。
+  //    配不成对的 <译文> 整块是重复的目标语内容 —— 按 extractTranslationOriginal
+  //    既有策略整块丢弃; 其余散标签 (全角/截断/贴字) 剥掉标签保留正文。
+  result = result.replace(/<译文>[\s\S]*?<\/译文>/g, '');
+  result = result.replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, '');
+  result = result.replace(new RegExp(`${HOLD}(\\d+)${HOLD}`, 'g'), (_m, n) => blocks[Number(n)] || '');
+  return result;
+}
+
 /**
  * 翻译块只保留原文.
  *
@@ -272,7 +334,8 @@ export function sanitizeForNotification(text: string): string {
   // 4. 反向 emoji tag 先于正向 SEND_EMOJI (反向可能也走 SEND_EMOJI 重写, 但这里直接转最终展示)
   result = replaceEmojiReverseTag(result);
   result = replaceSendEmoji(result);
-  // 5. 翻译块保留原文剥译文
+  // 5. 翻译块保留原文剥译文 (先自愈掉格式的标签, 严格提取正则才能命中)
+  result = normalizeTranslationTags(result);
   result = extractTranslationOriginal(result);
   // 6. LLM mimicking 历史的 leak: 时间戳 / 日期 / 角色名 prefix
   result = stripTimestamps(result);
@@ -314,8 +377,10 @@ export function sanitizeForBubble(
   let result = text;
   // 1. 字面 \n 还原
   result = stripLiteralBackslashN(result);
-  // 1.5. 语音标签自愈 — 必须在 chunkText 之前 (下游原子块保护靠配对正则)
+  // 1.5. 语音/翻译标签自愈 — 必须在 chunkText 之前 (下游原子块保护 /
+  //      applyAssistantPostProcessing Step 8 双语拆泡都靠严格配对正则)
   result = normalizeVoiceTags(result);
+  result = normalizeTranslationTags(result);
   // 2. 源标签 / 时间戳 / 业务标签
   result = stripSourceTags(result);
   result = stripTimestamps(result);
@@ -391,6 +456,7 @@ export function sanitizeIntoSegments(text: string): Segment[] {
   let cleaned = stripLiteralBackslashN(text);
   cleaned = stripThinkBlocks(cleaned);
   cleaned = normalizeVoiceTags(cleaned); // 语音标签自愈 — Phase 1.5 的配对保护靠它兜底
+  cleaned = normalizeTranslationTags(cleaned); // 翻译标签自愈 — 同上, Phase 1.5 的 <翻译> 原子保护靠它命中
 
   // Phase 1.5: 原子语义块交给 amsg-instant 标准 protected-block splitter 识别,
   // 再桥回旧 pipeline。这样只替换"如何保护原子块", 不改变后续清洗/分段语义。

--- a/utils/translationTagNormalize.test.ts
+++ b/utils/translationTagNormalize.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeTranslationTags, sanitizeForBubble, sanitizeForNotification, sanitizeIntoSegments } from './sanitize';
+
+// applyAssistantPostProcessing Step 8 的严格双语判定/拆泡正则 (utils/applyAssistantPostProcessing.ts)。
+// 自愈的目标就是让掉格式输出重新命中它 —— 这里用同一条正则做端到端断言。
+const STEP8_RE = /<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/;
+const CANON = (a: string, b: string) => `<翻译><原文>${a}</原文><译文>${b}</译文></翻译>`;
+
+describe('normalizeTranslationTags', () => {
+    it('无翻译标签的文本原样返回 (fast path)', () => {
+        expect(normalizeTranslationTags('普通聊天文本，没有任何标签')).toBe('普通聊天文本，没有任何标签');
+        expect(normalizeTranslationTags('原文和译文这两个词本身不该被动')).toBe('原文和译文这两个词本身不该被动');
+    });
+
+    it('规范块幂等：完整格式不被改坏', () => {
+        const s = CANON('你好！', 'こんにちは！') + CANON('今天做什么？', '今日は何する？');
+        expect(normalizeTranslationTags(s)).toBe(s);
+    });
+
+    // ─── 截图报告形态 ───
+
+    it('尾部截断 `</译文` (少写 > 且丢 </翻译>) → 补全成规范块', () => {
+        const s = '<翻译><原文>如果硬撑着一整天不睡，胃也会难受的。</原文><译文>丸一日無理して起きてたら、胃もキリキリ痛くなっちゃうよ。</译文';
+        const out = normalizeTranslationTags(s);
+        expect(out).toBe(CANON('如果硬撑着一整天不睡，胃也会难受的。', '丸一日無理して起きてたら、胃もキリキリ痛くなっちゃうよ。'));
+        expect(STEP8_RE.test(out)).toBe(true);
+    });
+
+    it('全裸文本只剩孤儿 `</译文` 残尾 → 剥干净，正文保留', () => {
+        const s = '如果硬撑着一整天不睡，胃也会难受的。\n丸一日無理して起きてたら、胃もキリキリ痛くなっちゃうよ。</译文';
+        const out = normalizeTranslationTags(s);
+        expect(out).not.toMatch(/[<＜]/);
+        expect(out).toContain('胃也会难受的。');
+        expect(out).toContain('痛くなっちゃうよ。');
+    });
+
+    // ─── 结构掉格式 ───
+
+    it('缺外层 <翻译> 包裹 → 补齐', () => {
+        const out = normalizeTranslationTags('<原文>你好！</原文>\n<译文>こんにちは！</译文>');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    it('缺 </翻译> 闭合 → 补齐', () => {
+        const out = normalizeTranslationTags('<翻译><原文>你好！</原文><译文>こんにちは！</译文>');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    it('sibling 幻觉形态 <翻译>X</翻译><译文>Y</译文> → 规范块', () => {
+        const out = normalizeTranslationTags('<翻译>你好！</翻译><译文>こんにちは！</译文>');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    it('译文块未闭合 (流截断) → 末尾补闭合再规范化', () => {
+        const out = normalizeTranslationTags('<翻译><原文>你好！</原文><译文>こんにちは！');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    it('多句混合：规范块 + 掉格式块同现，各自修好', () => {
+        const s = CANON('你好！', 'こんにちは！') + '\n<原文>今天做什么？</原文><译文>今日は何する？</译文';
+        const out = normalizeTranslationTags(s);
+        expect(out).toContain(CANON('你好！', 'こんにちは！'));
+        expect(out).toContain(CANON('今天做什么？', '今日は何する？'));
+    });
+
+    // ─── 字形掉格式 ───
+
+    it('全角尖括号 / 全角斜杠 / 标签内空格 → 规范半角', () => {
+        const out = normalizeTranslationTags('＜翻译＞＜原文＞你好！＜／原文＞< 译文 >こんにちは！</ 译文 >＜/翻译＞');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    it('简繁互换 譯文/翻譯 → 规范简体', () => {
+        const out = normalizeTranslationTags('<翻譯><原文>你好！</原文><譯文>こんにちは！</譯文></翻譯>');
+        expect(out).toBe(CANON('你好！', 'こんにちは！'));
+    });
+
+    // ─── 兜底不变量 ───
+
+    it('孤儿闭合 / 配不成对的标签一律剥除，绝不漏给用户', () => {
+        expect(normalizeTranslationTags('前面</翻译>后面')).toBe('前面后面');
+        // 配不成对的 <译文> 整块 = 重复的目标语内容，按 extractTranslationOriginal 既有策略丢弃
+        expect(normalizeTranslationTags('只有译文块<译文>こんにちは！</译文>')).toBe('只有译文块');
+    });
+
+    it('规范多行块（标签间带换行）原样保留，不被压扁', () => {
+        const s = '<翻译>\n<原文>Wait... seriously?</原文>\n<译文>等等…？</译文>\n</翻译>';
+        expect(normalizeTranslationTags(s)).toBe(s);
+    });
+
+    it('自愈后不变量：除规范块外无任何翻译标签残留', () => {
+        const messy = '碎片</译文\n<翻译>半个块<译文>訳</译文>\n＜原文 正文继续';
+        const out = normalizeTranslationTags(messy);
+        const rest = out.replace(/<翻译><原文>[\s\S]*?<\/原文><译文>[\s\S]*?<\/译文><\/翻译>/g, '');
+        expect(rest).not.toMatch(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)/);
+    });
+
+    it('幂等：修复结果再跑一遍不变', () => {
+        const once = normalizeTranslationTags('<原文>你好！</原文><译文>こんにちは！</译文');
+        expect(normalizeTranslationTags(once)).toBe(once);
+    });
+});
+
+describe('facade 集成', () => {
+    it('sanitizeForBubble：掉格式输出修回 Step 8 可命中的规范块', () => {
+        const out = sanitizeForBubble('<翻译><原文>早上好</原文><译文>おはよう</译文');
+        expect(STEP8_RE.test(out)).toBe(true);
+    });
+
+    it('sanitizeForNotification：掉格式块也能提取原文进 banner', () => {
+        const out = sanitizeForNotification('<原文>早上好</原文><译文>おはよう</译文>');
+        expect(out).toBe('早上好');
+    });
+
+    it('sanitizeIntoSegments：修复后整块被 Phase 1.5 原子保护，banner 预览取原文', () => {
+        const segs = sanitizeIntoSegments('<翻译><原文>早上好</原文><译文>おはよう</译文');
+        expect(segs).toHaveLength(1);
+        expect(STEP8_RE.test(segs[0].raw)).toBe(true);
+        expect(segs[0].sanitized).toBe('早上好');
+    });
+});

--- a/worker/instant-push/worker.bundle.js
+++ b/worker/instant-push/worker.bundle.js
@@ -2414,6 +2414,39 @@ function normalizeVoiceTags(t) {
   result = repairPairedTag(result, /<\/?字幕[^>]*>/g, () => "\u5B57\u5E55", false);
   return result;
 }
+var simpTransTag = (tag) => tag.replace(/譯/g, "\u8BD1");
+function normalizeTranslationTags(t) {
+  if (!/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)/.test(t)) return t;
+  let result = t;
+  result = result.replace(/[<＜]\s*[/／]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `</${simpTransTag(tag)}>`);
+  result = result.replace(/[<＜]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `<${simpTransTag(tag)}>`);
+  result = result.replace(
+    /[<＜]\s*([/／]?)\s*(翻[译譯]|原文|[译譯]文)\s*(?=$|\n|[<＜])/g,
+    (_m, slash, tag) => `<${slash ? "/" : ""}${simpTransTag(tag)}>`
+  );
+  result = repairPairedTag(result, /<\/?原文[^>]*>/g, () => "\u539F\u6587", false);
+  result = repairPairedTag(result, /<\/?译文[^>]*>/g, () => "\u8BD1\u6587", false);
+  result = repairPairedTag(result, /<\/?翻译[^>]*>/g, () => "\u7FFB\u8BD1", false);
+  const HOLD = String.fromCharCode(3);
+  const blocks = [];
+  const hold = (m) => {
+    blocks.push(m);
+    return `${HOLD}${blocks.length - 1}${HOLD}`;
+  };
+  result = result.replace(/<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, hold);
+  result = result.replace(
+    /(?:<翻译>\s*)?<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*(?:<\/翻译>)?/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(
+    /<翻译>\s*(?!<原文>)((?:(?!<\/?翻译>)[\s\S])*?)<\/翻译>\s*<译文>([\s\S]*?)<\/译文>/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(/<译文>[\s\S]*?<\/译文>/g, "");
+  result = result.replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, "");
+  result = result.replace(new RegExp(`${HOLD}(\\d+)${HOLD}`, "g"), (_m, n) => blocks[Number(n)] || "");
+  return result;
+}
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2430,6 +2463,7 @@ function sanitizeForNotification(text) {
   result = replaceHtmlBlocks(result);
   result = replaceEmojiReverseTag(result);
   result = replaceSendEmoji(result);
+  result = normalizeTranslationTags(result);
   result = extractTranslationOriginal(result);
   result = stripTimestamps(result);
   result = stripChineseDate(result);
@@ -2451,6 +2485,7 @@ function sanitizeIntoSegments(text) {
   let cleaned = stripLiteralBackslashN(text);
   cleaned = stripThinkBlocks(cleaned);
   cleaned = normalizeVoiceTags(cleaned);
+  cleaned = normalizeTranslationTags(cleaned);
   const ATOM_MARKER = String.fromCharCode(2);
   const atomBlocks = [];
   const atomSegments = segmentTextWithProtectedBlocks(cleaned, {

--- a/worker/instant-push/worker.deno.bundle.js
+++ b/worker/instant-push/worker.deno.bundle.js
@@ -2414,6 +2414,39 @@ function normalizeVoiceTags(t) {
   result = repairPairedTag(result, /<\/?字幕[^>]*>/g, () => "\u5B57\u5E55", false);
   return result;
 }
+var simpTransTag = (tag) => tag.replace(/譯/g, "\u8BD1");
+function normalizeTranslationTags(t) {
+  if (!/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)/.test(t)) return t;
+  let result = t;
+  result = result.replace(/[<＜]\s*[/／]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `</${simpTransTag(tag)}>`);
+  result = result.replace(/[<＜]\s*(翻[译譯]|原文|[译譯]文)\s*[>＞]/g, (_m, tag) => `<${simpTransTag(tag)}>`);
+  result = result.replace(
+    /[<＜]\s*([/／]?)\s*(翻[译譯]|原文|[译譯]文)\s*(?=$|\n|[<＜])/g,
+    (_m, slash, tag) => `<${slash ? "/" : ""}${simpTransTag(tag)}>`
+  );
+  result = repairPairedTag(result, /<\/?原文[^>]*>/g, () => "\u539F\u6587", false);
+  result = repairPairedTag(result, /<\/?译文[^>]*>/g, () => "\u8BD1\u6587", false);
+  result = repairPairedTag(result, /<\/?翻译[^>]*>/g, () => "\u7FFB\u8BD1", false);
+  const HOLD = String.fromCharCode(3);
+  const blocks = [];
+  const hold = (m) => {
+    blocks.push(m);
+    return `${HOLD}${blocks.length - 1}${HOLD}`;
+  };
+  result = result.replace(/<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g, hold);
+  result = result.replace(
+    /(?:<翻译>\s*)?<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*(?:<\/翻译>)?/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(
+    /<翻译>\s*(?!<原文>)((?:(?!<\/?翻译>)[\s\S])*?)<\/翻译>\s*<译文>([\s\S]*?)<\/译文>/g,
+    (_m, a, b) => hold(`<\u7FFB\u8BD1><\u539F\u6587>${a.trim()}</\u539F\u6587><\u8BD1\u6587>${b.trim()}</\u8BD1\u6587></\u7FFB\u8BD1>`)
+  );
+  result = result.replace(/<译文>[\s\S]*?<\/译文>/g, "");
+  result = result.replace(/[<＜]\s*[/／]?\s*(?:翻[译譯]|原文|[译譯]文)\s*[>＞]?/g, "");
+  result = result.replace(new RegExp(`${HOLD}(\\d+)${HOLD}`, "g"), (_m, n) => blocks[Number(n)] || "");
+  return result;
+}
 var extractTranslationOriginal = (t) => {
   let result = t.replace(
     /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/g,
@@ -2430,6 +2463,7 @@ function sanitizeForNotification(text) {
   result = replaceHtmlBlocks(result);
   result = replaceEmojiReverseTag(result);
   result = replaceSendEmoji(result);
+  result = normalizeTranslationTags(result);
   result = extractTranslationOriginal(result);
   result = stripTimestamps(result);
   result = stripChineseDate(result);
@@ -2451,6 +2485,7 @@ function sanitizeIntoSegments(text) {
   let cleaned = stripLiteralBackslashN(text);
   cleaned = stripThinkBlocks(cleaned);
   cleaned = normalizeVoiceTags(cleaned);
+  cleaned = normalizeTranslationTags(cleaned);
   const ATOM_MARKER = String.fromCharCode(2);
   const atomBlocks = [];
   const atomSegments = segmentTextWithProtectedBlocks(cleaned, {


### PR DESCRIPTION
用户反馈（多模型多站点同现）：开启聊天翻译后模型输出掉格式，残缺标签
如 \`</译文\` 原样漏进气泡显示；掉格式的双语内容整体退化成普通文本。
指令注入本身无恙（用户已确认角色可见），是解析端零容错所致：
applyAssistantPostProcessing Step 8 只认严格完整的
\`<翻译><原文>X</原文><译文>Y</译文></翻译>\`，不命中就全文走普通路径，
而 per-chunk sanitize 又刻意保留翻译标签（等 Step 8 接管），破标签就漏了。

对齐 normalizeVoiceTags 的自愈套路，新增 normalizeTranslationTags：
1. 字形规整：全角尖括号/斜杠、标签内空格、简繁互换 → 规范半角简体
2. 截断补全：行尾/文尾少写 \`>\` 的 \`</译文\`（截图报告形态）→ 补全
3. 配对修复（复用 repairPairedTag）：缺闭合补、孤儿闭合/重复开标签删
4. 结构自愈：缺 <翻译> 包裹、缺 </翻译>、sibling 幻觉形态 → 规范块； 本就规范的块（含多行）占位符护住原样保留
5. 兜底不变量：自愈后除规范块外不残留任何翻译标签——配不成对的 <译文> 块按既有策略丢弃（重复目标语），散标签剥掉留正文

挂载点：sanitizeForBubble / sanitizeForNotification / sanitizeIntoSegments 三个 facade 都过一遍，本地路径 Step 8 与 worker Phase 1.5 原子保护 从此都能命中修复后的规范块；worker bundles 已重新构建。

显示端追溯修复：MessageItem stripJunk 与 hasDisplayContent 的散标签 正则放宽为容错版（全角/截断/简繁），昨天起已按破标签落库的历史消息
渲染时也能洗干净。


Claude-Session: https://claude.ai/code/session_01MASvnn9imHZsdcMkuKnvua