### PR TITLE
fix(chat): 情绪评估失败不再静默——流式被拒自动降级重发 + 失败弹 toast

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1587,12 +1587,27 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           setLastMsgTimestamp(Date.now());
       };
 
+      // 情绪评估失败 → toast 告知（每角色 60s 冷却防刷屏）。评估失败过去只写 console，
+      // 用户侧表现是「情绪徽章闪一下就灭、情绪永不更新、没有任何报错」（真实反馈），
+      // 完全没法自查。事件来源：evaluateEmotionBackground（本地请求失败/空响应）、
+      // applyEmotionEvalRaw（解析全灭/落库失败）、activeMsgRuntime（worker 推回空结果）。
+      const emotionFailToastAt: Record<string, number> = {};
+      const emotionFailHandler = (e: Event) => {
+          const { charId, charName, reason } = ((e as CustomEvent).detail || {}) as { charId?: string; charName?: string; reason?: string };
+          if (!charId) return;
+          const now = Date.now();
+          if (now - (emotionFailToastAt[charId] || 0) < 60_000) return;
+          emotionFailToastAt[charId] = now;
+          addToast(`${charName || '角色'}的情绪评估失败：${reason || '未知原因'}（不影响聊天回复）`, 'error');
+      };
+
       window.addEventListener('active-msg-received', handler);
       window.addEventListener('active-msg-progress', progressHandler);
       window.addEventListener('active-msg-open', openHandler);
       window.addEventListener('emotion-updated', buffSyncHandler);
       window.addEventListener(CHAT_GEN_EVENTS.replyArrived, chatReplyArrivedHandler);
       window.addEventListener(CHAT_GEN_EVENTS.replyEnd, chatReplyEndHandler);
+      window.addEventListener(CHAT_GEN_EVENTS.emotionFailed, emotionFailHandler);
       document.addEventListener('visibilitychange', onVisible);
       return () => {
           window.removeEventListener('active-msg-received', handler);
@@ -1601,6 +1616,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           window.removeEventListener('emotion-updated', buffSyncHandler);
           window.removeEventListener(CHAT_GEN_EVENTS.replyArrived, chatReplyArrivedHandler);
           window.removeEventListener(CHAT_GEN_EVENTS.replyEnd, chatReplyEndHandler);
+          window.removeEventListener(CHAT_GEN_EVENTS.emotionFailed, emotionFailHandler);
           document.removeEventListener('visibilitychange', onVisible);
       };
   }, [sendProactiveNativeNotification]);

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -324,23 +324,43 @@ export async function evaluateEmotionBackground(
             'Authorization': `Bearer ${api.apiKey || 'sk-none'}`
         };
 
-        const data = await safeFetchJson(`${baseUrl}/chat/completions`, {
-            method: 'POST',
-            headers,
-            body: JSON.stringify({
-                model: api.model,
-                messages: [{ role: 'user', content: prompt }],
-                temperature: 0.85,
-                // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小 (1k~2k), eval 的
-                // injection+innerState 很长, 会被截断成半截 JSON → buff 静默丢失.
-                max_tokens: 8000,
-                // 跟随全局流式开关（响应由 safeFetchJson 透明拼装，下游 JSON 解析不变）。
-                // 好处: ①评估动辄生成 4~5k token、跑 30~46s，非流式最容易撞网关超时；
-                // ②中转若按流式/非流式分渠道池，评估与主聊天落同一池，行为可对比。
-                stream: !!api.stream,
-                ...(api.stream ? { stream_options: { include_usage: true } } : {}),
-            })
-        }, 2, 0, { appName: '消息', charId: charData.id, charName: charData.name, purpose: '情绪评估' });
+        const evalBody = {
+            model: api.model,
+            messages: [{ role: 'user', content: prompt }],
+            temperature: 0.85,
+            // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小 (1k~2k), eval 的
+            // injection+innerState 很长, 会被截断成半截 JSON → buff 静默丢失.
+            max_tokens: 8000,
+        };
+        const evalMeta = { appName: '消息', charId: charData.id, charName: charData.name, purpose: '情绪评估' };
+        let data: any;
+        try {
+            data = await safeFetchJson(`${baseUrl}/chat/completions`, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    ...evalBody,
+                    // 跟随全局流式开关（响应由 safeFetchJson 透明拼装，下游 JSON 解析不变）。
+                    // 好处: ①评估动辄生成 4~5k token、跑 30~46s，非流式最容易撞网关超时；
+                    // ②中转若按流式/非流式分渠道池，评估与主聊天落同一池，行为可对比。
+                    stream: !!api.stream,
+                    ...(api.stream ? { stream_options: { include_usage: true } } : {}),
+                })
+            }, 2, 0, evalMeta);
+        } catch (e: any) {
+            if (!api.stream) throw e;
+            // 流式自愈: 个别中转/模型对 stream / stream_options 直接 4xx。主聊天的透明流式
+            // 升级层有「用升级前原 body 重发」的回退 (OSContext), 但评估请求自带 stream:true
+            // 不经过升级层, 没有这层兜底 —— 这里补上同等待遇: 非流式重发一次, 行为退回
+            // 「评估跟随流式开关」(32c7be7) 之前。评估失败过去被静默吞掉, 用户只看到
+            // 情绪徽章闪一下就灭、情绪永不更新 (真实反馈), 这类形状问题必须能自愈。
+            console.warn('🎭 [Emotion] streamed eval failed, retrying non-stream:', e?.message);
+            data = await safeFetchJson(`${baseUrl}/chat/completions`, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ ...evalBody, stream: false })
+            }, 1, 0, evalMeta);
+        }
 
         // 排查贩子降级路由用：把评估实际落到的后端和 token 计数打出来，
         // 和主聊天的 🔢 [Token Usage] 一对比就能看出哪个请求被挤进了备用渠道。
@@ -353,11 +373,19 @@ export async function evaluateEmotionBackground(
                 finish_reason: data.choices?.[0]?.finish_reason,
                 has_message: !!data.choices?.[0]?.message,
             }));
+            announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
+                charId: charData.id, charName: charData.name,
+                reason: `评估模型没有输出内容 (finish_reason: ${data.choices?.[0]?.finish_reason ?? '?'})`,
+            });
             return null;
         }
         return await applyEmotionEvalRaw(raw, charData);
     } catch (e: any) {
         console.warn('🎭 [Emotion] Evaluation failed:', e.message);
+        announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
+            charId: charData.id, charName: charData.name,
+            reason: e?.message || '请求失败',
+        });
         return null;
     } finally {
         announceChatGen(CHAT_GEN_EVENTS.emotionEnd, { charId: charData.id, charName: charData.name });

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -10,6 +10,7 @@ import {
 import { runPendingToolCalls } from './instantToolRunner';
 import { drainPendingDiaries } from './pendingDiary';
 import { applyEmotionEvalRaw } from './emotionApply';
+import { CHAT_GEN_EVENTS } from './chatGenEvents';
 import { processNewMessages } from './memoryPalace/pipeline';
 import { loadMusicHooks } from '../context/MusicContext';
 import type { XhsNote } from './realtimeContext';
@@ -460,6 +461,15 @@ const flushInboxToChatImpl = async () => {
         } catch (e) {
           console.warn('[flush:emotion_update] apply failed', e);
         }
+      } else {
+        // worker 端评估失败/空结果时 emotionRaw 是空串（worker 无论成败都推一条用来熄灯）。
+        // 过去这里静默跳过 —— 用户只看到「情绪更新中」灭了、情绪没变、无任何报错（真实反馈）。
+        // 派发失败事件让 OSContext 弹 toast；具体报错在 worker 日志（[emotion-eval] LLM call failed）。
+        try {
+          window.dispatchEvent(new CustomEvent(CHAT_GEN_EVENTS.emotionFailed, {
+            detail: { charId: message.charId, charName: '', reason: '云端情绪评估无输出（副 API 报错或模型没返回内容，可查 worker 日志）' },
+          }));
+        } catch { /* SSR-safe */ }
       }
       // 无论成功与否都通知 useChatAI 熄灭 "情绪更新中" 徽章 (buff 已落 / 或这轮没结果).
       try {

--- a/utils/chatGenEvents.ts
+++ b/utils/chatGenEvents.ts
@@ -26,11 +26,19 @@ export const CHAT_GEN_EVENTS = {
     emotionStart: 'chat-gen-emotion-start',
     /** 情绪评估结束（instant 路径由 worker 推回，结束信号是既有的 'instant-emotion-done'） */
     emotionEnd: 'chat-gen-emotion-end',
+    /**
+     * 情绪评估失败（本地 fetch 报错 / 云端 worker 空结果 / 输出解析全灭）。
+     * 过去失败只写 console.warn，用户侧表现是「情绪不更新但没任何报错」，完全没法自查
+     * （真实用户反馈）。OSContext 监听本事件弹 toast（每角色带冷却），detail.reason 带人话原因。
+     */
+    emotionFailed: 'chat-gen-emotion-failed',
 } as const;
 
 export interface ChatGenDetail {
     charId: string;
     charName: string;
+    /** emotionFailed 专用：失败原因（人话，可直接展示给用户） */
+    reason?: string;
 }
 
 export function announceChatGen(event: string, detail: ChatGenDetail): void {

--- a/utils/emotionApply.test.ts
+++ b/utils/emotionApply.test.ts
@@ -207,3 +207,40 @@ describe('extractAssistantText — 响应形态兜底', () => {
         expect(extractAssistantText(null)).toBe('');
     });
 });
+
+describe('applyEmotionEvalRaw — 失败可见性 (chat-gen-emotion-failed)', () => {
+    // 评估失败过去只写 console.warn，用户侧「情绪不更新但没报错」没法自查（真实反馈）。
+    // 锁住：解析全灭时必须派发失败事件（OSContext 监听弹 toast）。
+    it('解析全灭 → 派发 chat-gen-emotion-failed，detail 带 charId/reason', async () => {
+        const dispatched: any[] = [];
+        (globalThis as any).window = {
+            dispatchEvent: (e: any) => { dispatched.push(e); return true; },
+        };
+        try {
+            const inner = await applyEmotionEvalRaw('完全不是 JSON 的输出', makeChar());
+            expect(inner).toBeNull();
+            const failed = dispatched.find((e) => e.type === 'chat-gen-emotion-failed');
+            expect(failed).toBeTruthy();
+            expect(failed.detail.charId).toBe('char-1');
+            expect(failed.detail.charName).toBe('测试角色');
+            expect(typeof failed.detail.reason).toBe('string');
+        } finally {
+            delete (globalThis as any).window;
+        }
+    });
+
+    it('解析成功（即使 salvage）不派发失败事件', async () => {
+        const dispatched: any[] = [];
+        (globalThis as any).window = {
+            dispatchEvent: (e: any) => { dispatched.push(e); return true; },
+        };
+        try {
+            await applyEmotionEvalRaw(JSON.stringify(VALID), makeChar());
+            expect(dispatched.some((e) => e.type === 'chat-gen-emotion-failed')).toBe(false);
+            // 正常路径照旧广播 emotion-updated
+            expect(dispatched.some((e) => e.type === 'emotion-updated')).toBe(true);
+        } finally {
+            delete (globalThis as any).window;
+        }
+    });
+});

--- a/utils/emotionApply.ts
+++ b/utils/emotionApply.ts
@@ -1,6 +1,19 @@
 import { DB } from './db';
 import type { CharacterProfile, CharacterBuff } from '../types';
 import { landAmbientEventFromEval } from './roomAmbient';
+import { CHAT_GEN_EVENTS } from './chatGenEvents';
+
+// 情绪评估失败的用户可见信号（OSContext 监听弹 toast）。本函数是本地 / instant(worker)
+// 两条路径的共用落点，在这里派发能覆盖「worker 推回的 raw 解析全灭」这类云端失败。
+const announceEmotionFailed = (charData: CharacterProfile, reason: string): void => {
+    try {
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent(CHAT_GEN_EVENTS.emotionFailed, {
+                detail: { charId: charData.id, charName: charData.name, reason },
+            }));
+        }
+    } catch { /* SSR / 测试环境无 window */ }
+};
 
 // 角色「最后一次内心独白(InnerState)」的轻量缓存（localStorage）。
 // innerState 是瞬时产物，这里在情绪评估落地的共用点顺手缓存一份，供别处（如查手机首页）读取，
@@ -344,6 +357,7 @@ export async function applyEmotionEvalRaw(
         const result = parseEmotionEvalOutput(rawText || '');
         if (!result) {
             console.warn('🎭 [Emotion] Could not parse eval output (all repairs + salvage failed):', (rawText || '').slice(0, 300));
+            announceEmotionFailed(charData, '评估模型的输出不是可解析的 JSON（模型掉格式，可换个评估模型试试）');
             return null;
         }
         if (result.salvaged) {
@@ -405,6 +419,7 @@ export async function applyEmotionEvalRaw(
         return innerStateOut;
     } catch (e: any) {
         console.warn('🎭 [Emotion] applyEmotionEvalRaw failed:', e?.message);
+        announceEmotionFailed(charData, `评估结果落库失败：${e?.message || '未知错误'}`);
         return null;
     }
 }


### PR DESCRIPTION
用户反馈：这两天情绪突然不刷新，发完消息「情绪更新中」徽章闪一下就灭，
没有任何报错，主聊天 API 正常。排查结论：情绪评估失败在两条路径上都被
完全吞掉（只写 console.warn），用户既看不到失败、也看不到原因——
「闪一下就消失」正是评估瞬间失败后 finally 熄灯的样子。

两处修复：

1) 流式自愈（疑似本次回归主因）：32c7be7 起评估请求跟随全局流式开关
   （stream:true + stream_options），但 OSContext 的透明流式升级层只对
   「被它升级的请求」有 4xx 回退，评估自带 stream:true 不经过升级层、
   没有任何兜底——个别中转/模型对 stream_options 直接 400 时，评估从此
   每条必挂。现在 evaluateEmotionBackground 首次失败且开着流式时，
   自动用非流式 body 重发一次（行为退回 32c7be7 之前），与主链路
   「升级只能赚不能赔」的原则对齐。

2) 失败可见性：新增 CHAT_GEN_EVENTS.emotionFailed 事件，三类失败点全部
   派发（本地请求失败/空响应、输出解析全灭/落库失败、instant worker
   推回空结果），OSContext 统一监听弹 toast（每角色 60s 冷却防刷屏），
   附人话原因——用户下次遇到能直接截图反馈，不再是「没报错但就是不动」。

emotionApply 新增两条测试锁行为：解析全灭必派发失败事件、正常路径不派发。


Claude-Session: https://claude.ai/code/session_01MASvnn9imHZsdcMkuKnvua