### PR TITLE
fix(life-records): 堵住代记去重网的两个洞 + 提示词补「一件事只记一次」

### DIFF
--- a/utils/lifeRecords.test.ts
+++ b/utils/lifeRecords.test.ts
@@ -213,6 +213,47 @@ describe('executeLifeDirectives 代记指令', () => {
         const starts = (await DB.getAllLifeRecords()).filter(r => r.module === 'period' && r.kind === 'start');
         expect(starts).toHaveLength(1);
     });
+
+    it('start → 同日 end → 模型再发 START：同日兜底判重，不再重复入库（用户实报）', async () => {
+        // 沿用上个用例写入的今日 start；补一条今日 end，把状态机推进「已不在经期」的盲区——
+        // 旧逻辑此时会放行重复 start，真重复入库。
+        const charC = mkChar({ name: 'C' });
+        await executeLifeDirectives('[[LIFE:PERIOD_END]]', charC, noToast);
+        const st = computePeriodStatus(await DB.getAllLifeRecords(), null, lifeToday());
+        expect(st.inPeriod).toBe(false);
+
+        const charD = mkChar({ name: 'D' });
+        await executeLifeDirectives('[[LIFE:PERIOD_START]]', charD, noToast);
+        const starts = (await DB.getAllLifeRecords()).filter(r => r.module === 'period' && r.kind === 'start');
+        expect(starts).toHaveLength(1);
+        const msgs = await DB.getMessagesByCharId(charD.id, true);
+        expect(msgs.find((m: Message) => m.type === 'life_card')!.metadata.duplicate).toBe(true);
+    });
+
+    it('EXERCISE 同日同活动、时长写法不同：判重不重复入库（用户实报）', async () => {
+        const charE = mkChar({ name: 'E' });
+        await executeLifeDirectives('[[LIFE:EXERCISE|跑步|30分钟]]', charE, noToast);
+        // 模型下一轮换个时长写法 / 干脆省略时长 —— 旧判据要求时长逐字一致，全都漏网
+        const charF = mkChar({ name: 'F' });
+        await executeLifeDirectives('[[LIFE:EXERCISE|跑步|半小时]]', charF, noToast);
+        await executeLifeDirectives('[[LIFE:EXERCISE|跑步]]', charF, noToast);
+        const runs = (await DB.getAllLifeRecords()).filter(r => r.module === 'exercise' && r.payload.activity === '跑步');
+        expect(runs).toHaveLength(1);
+        const msgs = await DB.getMessagesByCharId(charF.id, true);
+        expect(msgs.filter((m: Message) => m.type === 'life_card' && m.metadata.duplicate)).toHaveLength(2);
+
+        // 不同活动照常入库，不受影响
+        await executeLifeDirectives('[[LIFE:EXERCISE|瑜伽]]', charF, noToast);
+        const yoga = (await DB.getAllLifeRecords()).filter(r => r.module === 'exercise' && r.payload.activity === '瑜伽');
+        expect(yoga).toHaveLength(1);
+    });
+
+    it('注入的代记说明包含「一件事只记一次」防重复明示', async () => {
+        const char = mkChar();
+        const s = await buildLifeRecordInjection(char, '洛洛');
+        expect(s).toContain('一件事只记一次');
+        expect(s).toContain('已经记过了');
+    });
 });
 
 describe('全局隐藏模块（长按页签隐藏）', () => {

--- a/utils/lifeRecords.ts
+++ b/utils/lifeRecords.ts
@@ -320,6 +320,7 @@ export const buildLifeRecordInjection = async (char: CharacterProfile, userName:
     if (tools.length > 0) {
         s += `**代记工具**：只有当 ${userName} 在对话中**明确说出**以下事实时，才单独起一行输出对应指令、帮 TA 顺手记一笔（一次一条）：\n${tools.join('\n')}\n`;
         s += `TA 只是暗示、开玩笑、或在说过去 / 别人的事时，一律不要记录。记录成功后系统会插入一张卡片，TA 可以确认或否决；被否决说明你理解错了。平时不要把这些指令挂在嘴边，也不要替 TA 补记你只是猜测的事。\n`;
+        s += `**一件事只记一次**：上面摘要里已经出现的状态（如「生理期第 N 天」「今日已练」「✓已服」、已列出的支出）都说明这件事**已经记过了**——不要再输出指令重复记，也不要因为翻到 TA 之前提过这件事就补记。聊天记录里出现过的 [生活记录：…] 卡片就是你之前记的。只有 TA 明确说**又**发生了新的一次（比如「晚上又跑了一次」），才再记一条。\n`;
     }
 
     // 否决反馈（一次性）：上次代记被用户否决 → 告诉角色它弄错了，注入后即清除
@@ -381,6 +382,11 @@ const findDuplicate = async (
     const eff = effective(records);
     switch (d.module) {
         case 'period': {
+            // 同日同类兜底（先于状态机）：今天已经有同类事件就绝不再写一条。
+            // 状态机有判不出重复的盲区——比如 start → 误记了同日 end → 模型下轮又发
+            // start，此时 inPeriod=false、旧逻辑放行 → 真重复入库（用户实报）。
+            const sameDay = eff.filter(r => r.module === 'period' && r.kind === d.kind && r.date === today).pop();
+            if (sameDay) return byName(sameDay);
             const settings = await DB.getLifeRecordSettings().catch(() => null);
             const st = computePeriodStatus(records, settings, today);
             if (d.kind === 'start' && st.inPeriod) {
@@ -414,9 +420,12 @@ const findDuplicate = async (
             return rec ? byName(rec) : { byName: '你自己' };
         }
         case 'exercise': {
+            // 只按「同日 + 同活动」判重，不再要求时长逐字一致——模型下一轮把「30分钟」
+            // 写成「半小时」或干脆省略是常态，旧判据一漏就真重复入库（用户实报）。
+            // 同一活动一天真练两次的场景走面板手动补记（卡片会说明已有记录）。
+            // 与药盒同口径：同日同名即重。
             const rec = eff.filter(r => r.module === 'exercise' && r.date === today
-                && r.payload.activity === d.payload.activity
-                && (r.payload.duration || '') === (d.payload.duration || '')).pop();
+                && r.payload.activity === d.payload.activity).pop();
             return rec ? byName(rec) : null;
         }
     }


### PR DESCRIPTION
用户反馈（华为+Edge）：锻炼和经期都出现重复记录——角色记过一次（甚至用户
已确认）后，下一轮生成又记一次。弱模型重复输出 [[LIFE:]] 指令本是预期内
（findDuplicate 去重层就是为此设计的），这次是去重网本身漏了：

1) 锻炼：旧判据要求「同日 + 同活动 + 时长逐字一致」。模型下一轮把
   「30分钟」写成「半小时」或干脆省略时长是常态，一漏就真重复入库。
   改为「同日 + 同活动」即判重（与药盒同日同名的口径一致）；同一活动
   一天真练两次的场景走面板手动补记，卡片会说明已有记录。

2) 经期：判重完全依赖状态机 inPeriod，有盲区——start 后被记了同日 end
   （模型误发或用户手记），inPeriod 变 false，下一轮再发 START 就被放行
   重复入库。加「同日同类事件」兜底判重，先于状态机生效。

3) 提示词：代记说明只教了「什么时候记」，从没教「什么时候不要再记」。
   补一段明示：摘要里已有的状态（生理期第 N 天/今日已练/✓已服/已列支出）
   都说明记过了，聊天里的 [生活记录：…] 卡片就是你之前记的，只有 TA 明确
   说又发生新的一次才再记。

新增 3 条测试锁行为（两个实报场景 + 注入文案），全量 1055 绿。


Claude-Session: https://claude.ai/code/session_01MASvnn9imHZsdcMkuKnvua