### PR TITLE
fix(chat): 翻译模式下表情包按原位置插发，不再永远压到最后

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1941,43 +1941,62 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   const hasTranslationTags = /<翻译>\s*<原文>[\s\S]*?<\/原文>\s*<译文>[\s\S]*?<\/译文>\s*<\/翻译>/.test(aiContent);
 
                   if (hasTranslationTags) {
-                      // 表情独立抽出,放在文本之后发送
-                      const bilingualEmojis: string[] = [];
-                      let bEm;
-                      const bEmojiPat = /\[\[SEND_EMOJI:\s*(.*?)\]\]/g;
-                      while ((bEm = bEmojiPat.exec(aiContent)) !== null) {
-                          const name = bEm[1].trim();
-                          if (!bilingualEmojis.includes(name)) bilingualEmojis.push(name);
-                      }
-                      aiContent = aiContent.replace(/\[\[SEND_EMOJI:\s*.*?\]\]/g, '').trim();
+                      // 表情包按模型写的位置原地插发（与 applyAssistantPostProcessing 双语分支同款修复）。
+                      // 旧实现先把所有 [[SEND_EMOJI:]] 抽走、正文发完后统一追加到最后（还去了重），
+                      // 表现为「翻译模式下角色永远最后才发表情包」。
+                      const sendEmojiBubble = async (name: string): Promise<void> => {
+                          const foundEmoji = emojis.find(e => e.name === name);
+                          if (!foundEmoji?.url) return;
+                          const meta = consumeThinkingMeta();
+                          await DB.saveMessage({
+                              charId,
+                              role: 'assistant',
+                              type: 'emoji',
+                              content: foundEmoji.url,
+                              timestamp: baseTimestamp + offset,
+                              ...(meta ? { metadata: meta } : {}),
+                          });
+                          offset += 1;
+                      };
+                      // 翻译标签之外的普通文本段：splitResponse 按出现顺序拆出文字 / 表情逐条发
+                      const renderPlainSegment = async (segment: string): Promise<void> => {
+                          for (const part of ChatParser.splitResponse(segment)) {
+                              if (part.type === 'emoji') {
+                                  await sendEmojiBubble(part.content);
+                                  continue;
+                              }
+                              const cleaned = ChatParser.sanitize(part.content);
+                              if (!cleaned || !ChatParser.hasDisplayContent(cleaned)) continue;
+                              for (const chunk of ChatParser.chunkText(cleaned)) {
+                                  if (!chunk) continue;
+                                  const meta = consumeThinkingMeta();
+                                  await DB.saveMessage({
+                                      charId,
+                                      role: 'assistant',
+                                      type: 'text',
+                                      content: chunk,
+                                      timestamp: baseTimestamp + offset,
+                                      ...(meta ? { metadata: meta } : {}),
+                                  });
+                                  savedPreviewChunks.push(chunk);
+                                  offset += 1;
+                              }
+                          }
+                      };
 
                       const tagPattern = /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*<\/翻译>/g;
                       let lastIndex = 0;
                       let tagMatch;
                       while ((tagMatch = tagPattern.exec(aiContent)) !== null) {
                           const textBefore = aiContent.slice(lastIndex, tagMatch.index).trim();
-                          if (textBefore) {
-                              const cleaned = ChatParser.sanitize(textBefore);
-                              if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
-                                  for (const chunk of ChatParser.chunkText(cleaned)) {
-                                      if (!chunk) continue;
-                                      const meta = consumeThinkingMeta();
-                                      await DB.saveMessage({
-                                          charId,
-                                          role: 'assistant',
-                                          type: 'text',
-                                          content: chunk,
-                                          timestamp: baseTimestamp + offset,
-                                          ...(meta ? { metadata: meta } : {}),
-                                      });
-                                      savedPreviewChunks.push(chunk);
-                                      offset += 1;
-                                  }
-                              }
-                          }
+                          if (textBefore) await renderPlainSegment(textBefore);
 
-                          const originalText = ChatParser.sanitize(tagMatch[1].trim());
-                          const translatedText = ChatParser.sanitize(tagMatch[2].trim());
+                          // 混进 <原文>/<译文> 里的表情标签剥出来，紧跟这条双语气泡之后发
+                          const inlineEmojis: string[] = [];
+                          const stripInlineEmoji = (s: string): string =>
+                              s.replace(/\[\[SEND_EMOJI:\s*(.*?)\]\]/g, (_m, n) => { inlineEmojis.push(String(n).trim()); return ''; });
+                          const originalText = ChatParser.sanitize(stripInlineEmoji(tagMatch[1]).trim());
+                          const translatedText = ChatParser.sanitize(stripInlineEmoji(tagMatch[2]).trim());
                           if (originalText || translatedText) {
                               const biContent = originalText && translatedText
                                   ? `${originalText}\n%%BILINGUAL%%\n${translatedText}`
@@ -1994,46 +2013,13 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                               savedPreviewChunks.push(originalText || translatedText);
                               offset += 1;
                           }
+                          for (const name of inlineEmojis) await sendEmojiBubble(name);
 
                           lastIndex = tagMatch.index + tagMatch[0].length;
                       }
 
                       const textAfter = aiContent.slice(lastIndex).trim();
-                      if (textAfter) {
-                          const cleaned = ChatParser.sanitize(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
-                          if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
-                              for (const chunk of ChatParser.chunkText(cleaned)) {
-                                  if (!chunk) continue;
-                                  const meta = consumeThinkingMeta();
-                                  await DB.saveMessage({
-                                      charId,
-                                      role: 'assistant',
-                                      type: 'text',
-                                      content: chunk,
-                                      timestamp: baseTimestamp + offset,
-                                      ...(meta ? { metadata: meta } : {}),
-                                  });
-                                  savedPreviewChunks.push(chunk);
-                                  offset += 1;
-                              }
-                          }
-                      }
-
-                      for (const emojiName of bilingualEmojis) {
-                          const foundEmoji = emojis.find(e => e.name === emojiName);
-                          if (foundEmoji?.url) {
-                              const meta = consumeThinkingMeta();
-                              await DB.saveMessage({
-                                  charId,
-                                  role: 'assistant',
-                                  type: 'emoji',
-                                  content: foundEmoji.url,
-                                  timestamp: baseTimestamp + offset,
-                                  ...(meta ? { metadata: meta } : {}),
-                              });
-                              offset += 1;
-                          }
-                      }
+                      if (textAfter) await renderPlainSegment(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
                   } else {
                       const responseParts = ChatParser.splitResponse(aiContent);
 

--- a/utils/applyAssistantPostProcessing.test.ts
+++ b/utils/applyAssistantPostProcessing.test.ts
@@ -148,3 +148,75 @@ describe('renderAndPersist 模仿历史渲染格式的引用兜底', () => {
         expect(texts[0].replyTo).toBeFalsy();
     }, 20000);
 });
+
+// 锁住双语（翻译模式）分支的表情包位置修复:
+// 旧实现把所有 [[SEND_EMOJI:]] 先抽出、正文发完后统一追加在最后（且去重），
+// 表现为"翻译模式下角色永远最后才发表情包"。修复后表情包按模型写的位置原地插发。
+describe('renderAndPersist 双语分支表情包顺序', () => {
+    const testEmojis = [
+        { id: 1, name: '开心', url: 'https://example.com/happy.png' },
+        { id: 2, name: '疑惑', url: 'https://example.com/confused.png' },
+    ] as any[];
+
+    const makeBiCtx = (charId: string): PostProcessCtx => {
+        const ctx = makeCtx(charId, []);
+        ctx.emojis = testEmojis as any;
+        ctx.instantRender = true;
+        return ctx;
+    };
+
+    it('表情包按出现位置插发，不再统一挪到最后', async () => {
+        const charId = `c-bi-emoji-${Date.now()}`;
+        const raw = [
+            '[[SEND_EMOJI: 开心]]',
+            '<翻译><原文>Hello there</原文><译文>你好呀</译文></翻译>',
+            '[[SEND_EMOJI: 疑惑]]',
+            '<翻译><原文>What happened</原文><译文>发生什么了</译文></翻译>',
+        ].join('\n');
+
+        await applyAssistantPostProcessing(raw, makeBiCtx(charId));
+
+        const msgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter(m => m.role === 'assistant');
+        expect(msgs.map(m => m.type)).toEqual(['emoji', 'text', 'emoji', 'text']);
+        expect(msgs[0].content).toBe('https://example.com/happy.png');
+        expect(msgs[1].content).toBe('Hello there\n%%BILINGUAL%%\n你好呀');
+        expect(msgs[2].content).toBe('https://example.com/confused.png');
+        expect(msgs[3].content).toBe('What happened\n%%BILINGUAL%%\n发生什么了');
+    }, 20000);
+
+    it('同一个表情包出现两次时不去重，两次都发', async () => {
+        const charId = `c-bi-emoji-dup-${Date.now()}`;
+        const raw = [
+            '[[SEND_EMOJI: 开心]]',
+            '<翻译><原文>Nice</原文><译文>好耶</译文></翻译>',
+            '[[SEND_EMOJI: 开心]]',
+        ].join('\n');
+
+        await applyAssistantPostProcessing(raw, makeBiCtx(charId));
+
+        const msgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter(m => m.role === 'assistant');
+        expect(msgs.map(m => m.type)).toEqual(['emoji', 'text', 'emoji']);
+    }, 20000);
+
+    it('混进 <原文>/<译文> 里的表情标签剥出来紧跟该双语气泡发送', async () => {
+        const charId = `c-bi-emoji-inline-${Date.now()}`;
+        const raw = '<翻译><原文>See you [[SEND_EMOJI: 开心]]</原文><译文>回见</译文></翻译>\n尾巴一句';
+
+        await applyAssistantPostProcessing(raw, makeBiCtx(charId));
+
+        const msgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter(m => m.role === 'assistant');
+        expect(msgs.map(m => m.type)).toEqual(['text', 'emoji', 'text']);
+        expect(msgs[0].content).toBe('See you\n%%BILINGUAL%%\n回见');
+        expect(msgs[2].content).toBe('尾巴一句');
+    }, 20000);
+
+    it('表情包在最后时仍最后发（既有行为不回归）', async () => {
+        const charId = `c-bi-emoji-tail-${Date.now()}`;
+        const raw = '<翻译><原文>Bye</原文><译文>拜拜</译文></翻译>\n[[SEND_EMOJI: 疑惑]]';
+
+        await applyAssistantPostProcessing(raw, makeBiCtx(charId));
+
+        const msgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter(m => m.role === 'assistant');
+        expect(msgs.map(m => m.type)).toEqual(['text', 'emoji']);
+    }, 20000);
+});

--- a/utils/applyAssistantPostProcessing.ts
+++ b/utils/applyAssistantPostProcessing.ts
@@ -517,55 +517,24 @@ export async function applyAssistantPostProcessing(
 
         if (hasTranslationTags) {
             // ─── 双语 ───
-            const bilingualEmojis: string[] = [];
-            let bEm;
-            const bEmojiPat = /\[\[SEND_EMOJI:\s*(.*?)\]\]/g;
-            while ((bEm = bEmojiPat.exec(content)) !== null) {
-                const name = bEm[1].trim();
-                if (!bilingualEmojis.includes(name)) bilingualEmojis.push(name);
-            }
-            content = content.replace(/\[\[SEND_EMOJI:\s*.*?\]\]/g, '').trim();
-            const tagPattern = /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*<\/翻译>/g;
-            let lastIndex = 0;
-            let tagMatch;
-
-            while ((tagMatch = tagPattern.exec(content)) !== null) {
-                const textBefore = content.slice(lastIndex, tagMatch.index).trim();
-                if (textBefore) {
-                    const cleaned = ChatParser.sanitize(textBefore);
-                    if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
-                        const chunks = ChatParser.chunkText(cleaned);
-                        for (const chunk of chunks) {
-                            if (!chunk) continue;
-                            const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
-                            await typingPause(Math.min(Math.max(chunk.length * 50, 500), 2000));
-                            await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: chunk, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
-                            setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                            globalMsgIndex++;
-                        }
+            // 表情包按模型写的位置原地插发。旧实现先把所有 [[SEND_EMOJI:]] 抽走、正文发完后
+            // 统一追加到最后（还去了重），表现为「翻译模式下角色永远最后才发表情包」。
+            const sendEmojiBubble = async (name: string): Promise<void> => {
+                const foundEmoji = emojis.find(e => e.name === name);
+                if (!foundEmoji) return;
+                await typingPause(Math.random() * 500 + 300);
+                await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: takeMeta(mcdInheritMeta) } as any);
+                setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+            };
+            // 翻译标签之外的普通文本段：splitResponse 按出现顺序拆出文字 / 表情逐条发
+            const renderPlainSegment = async (segment: string): Promise<void> => {
+                for (const part of ChatParser.splitResponse(segment)) {
+                    if (part.type === 'emoji') {
+                        await sendEmojiBubble(part.content);
+                        continue;
                     }
-                }
-
-                const originalText = ChatParser.sanitize(tagMatch[1].trim());
-                const translatedText = ChatParser.sanitize(tagMatch[2].trim());
-                if (originalText || translatedText) {
-                    const biContent = originalText && translatedText
-                        ? `${originalText}\n%%BILINGUAL%%\n${translatedText}`
-                        : (originalText || translatedText);
-                    const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
-                    await typingPause(Math.min(Math.max(biContent.length * 30, 400), 2000));
-                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: biContent, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
-                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                    globalMsgIndex++;
-                }
-
-                lastIndex = tagMatch.index + tagMatch[0].length;
-            }
-
-            const textAfter = content.slice(lastIndex).trim();
-            if (textAfter) {
-                const cleaned = ChatParser.sanitize(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
-                if (cleaned && ChatParser.hasDisplayContent(cleaned)) {
+                    const cleaned = ChatParser.sanitize(part.content);
+                    if (!cleaned || !ChatParser.hasDisplayContent(cleaned)) continue;
                     const chunks = ChatParser.chunkText(cleaned);
                     for (const chunk of chunks) {
                         if (!chunk) continue;
@@ -576,16 +545,38 @@ export async function applyAssistantPostProcessing(
                         globalMsgIndex++;
                     }
                 }
+            };
+            const tagPattern = /<翻译>\s*<原文>([\s\S]*?)<\/原文>\s*<译文>([\s\S]*?)<\/译文>\s*<\/翻译>/g;
+            let lastIndex = 0;
+            let tagMatch;
+
+            while ((tagMatch = tagPattern.exec(content)) !== null) {
+                const textBefore = content.slice(lastIndex, tagMatch.index).trim();
+                if (textBefore) await renderPlainSegment(textBefore);
+
+                // 混进 <原文>/<译文> 里的表情标签剥出来，紧跟这条双语气泡之后发
+                const inlineEmojis: string[] = [];
+                const stripInlineEmoji = (s: string): string =>
+                    s.replace(/\[\[SEND_EMOJI:\s*(.*?)\]\]/g, (_m, n) => { inlineEmojis.push(String(n).trim()); return ''; });
+                const originalText = ChatParser.sanitize(stripInlineEmoji(tagMatch[1]).trim());
+                const translatedText = ChatParser.sanitize(stripInlineEmoji(tagMatch[2]).trim());
+                if (originalText || translatedText) {
+                    const biContent = originalText && translatedText
+                        ? `${originalText}\n%%BILINGUAL%%\n${translatedText}`
+                        : (originalText || translatedText);
+                    const replyData = globalMsgIndex === 0 ? aiReplyTarget : undefined;
+                    await typingPause(Math.min(Math.max(biContent.length * 30, 400), 2000));
+                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'text', content: biContent, replyTo: replyData, metadata: takeMeta(mcdInheritMeta) } as any);
+                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
+                    globalMsgIndex++;
+                }
+                for (const name of inlineEmojis) await sendEmojiBubble(name);
+
+                lastIndex = tagMatch.index + tagMatch[0].length;
             }
 
-            for (const emojiName of bilingualEmojis) {
-                const foundEmoji = emojis.find(e => e.name === emojiName);
-                if (foundEmoji) {
-                    await typingPause(Math.random() * 500 + 300);
-                    await DB.saveMessage({ charId: char.id, role: 'assistant', type: 'emoji', content: foundEmoji.url, metadata: takeMeta(mcdInheritMeta) } as any);
-                    setMessages(await DB.getRecentMessagesByCharId(char.id, 200));
-                }
-            }
+            const textAfter = content.slice(lastIndex).trim();
+            if (textAfter) await renderPlainSegment(textAfter.replace(/<\/?翻译>|<\/?原文>|<\/?译文>/g, '').trim());
         } else {
             // ─── normal path (splitResponse → chunkText → per-chunk save) ───
             const parts = ChatParser.splitResponse(content);


### PR DESCRIPTION
双语（翻译模式）渲染分支会先把所有 [[SEND_EMOJI:]] 标签抽出、
正文气泡全部发完后再统一追加在末尾（还会去重合并），导致用户反馈
「翻译模式下角色永远最后才发表情包」，且同一表情多次发送会被吞掉。

修复：
- applyAssistantPostProcessing renderAndPersist 双语分支：翻译标签 之外的文本段改用 ChatParser.splitResponse 按出现顺序拆出文字/表情 逐条落库；混进 <原文>/<译文> 里的表情标签剥出后紧跟该双语气泡发送
- OSContext 主动消息路径的同款双语分支做同样修复
- 补 4 个回归测试锁住表情包顺序 / 不去重 / 内联标签剥离行为


Claude-Session: https://claude.ai/code/session_01E71gBedf3sDKLN9HDx4aLW