### PR TITLE
fix(pixel-home): 捏人器上传像素小人压缩落库 + 失败可见，修「上传的图裂开」

### DIFF
--- a/apps/pixelHome/PixelCharEditor.tsx
+++ b/apps/pixelHome/PixelCharEditor.tsx
@@ -14,6 +14,7 @@ import {
   FRONT_HAIR_COUNT, BACK_HAIR_COUNT, EYE_COUNT,
   FRONT_HAIR_NAMES, BACK_HAIR_NAMES, EYE_NAMES,
 } from './pixelCharGenerator';
+import { processImage } from '../../utils/file';
 
 interface Props {
   initial?: PixelCharConfig | null;
@@ -35,6 +36,7 @@ const PixelCharEditor: React.FC<Props> = ({ initial, target = 'char', targetLabe
   const [drawMode, setDrawMode] = useState(false);
   const [drawColor, setDrawColor] = useState('#ff4757');
   const [isEraser, setIsEraser] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   const uploadRef = useRef<HTMLInputElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -128,14 +130,19 @@ const PixelCharEditor: React.FC<Props> = ({ initial, target = 'char', targetLabe
   }, []);
 
   const handleUploadSprite = useCallback(async (file: File) => {
-    if (!file.type.match(/^image\/(png|jpeg|webp|gif)/)) return;
-    const dataUri = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as string);
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
-    setConfig(prev => ({ ...prev, customSprite: dataUri }));
+    setUploadError(null);
+    try {
+      // 统一走 processImage 而不是直接 readAsDataURL：
+      //  · 手机原图动辄 5~10MB，base64 后更大，整段塞进配置 JSON 会撑爆 iOS Safari 的
+      //    IndexedDB 配额和内存（保存静默失败 / 渲染裂图）。小人展示尺寸只有 24~40px，
+      //    压到 ≤256px 绰绰有余，透明通道（PNG/WebP）会保留。
+      //  · 不支持的格式（如 HEIC）解码失败会抛可读错误，不再静默没反应。
+      //  · GIF 原样保留（不压缩，动图不丢帧）。
+      const dataUri = await processImage(file, { maxWidth: 256, quality: 0.92 });
+      setConfig(prev => ({ ...prev, customSprite: dataUri }));
+    } catch (e: any) {
+      setUploadError(e?.message || '图片处理失败，请换一张试试');
+    }
   }, []);
 
   const clearCustomSprite = useCallback(() => {
@@ -254,6 +261,9 @@ const PixelCharEditor: React.FC<Props> = ({ initial, target = 'char', targetLabe
               </button>
             )}
           </div>
+        )}
+        {uploadError && (
+          <span className="text-[10px] text-red-400">上传失败：{uploadError}</span>
         )}
         <input ref={uploadRef} type="file" accept="image/png,image/webp,image/jpeg,image/gif" className="hidden"
           onChange={e => { if (e.target.files?.[0]) { handleUploadSprite(e.target.files[0]); e.target.value = ''; } }} />

--- a/apps/pixelHome/PixelHomeView.tsx
+++ b/apps/pixelHome/PixelHomeView.tsx
@@ -107,16 +107,23 @@ const PixelHomeView: React.FC<Props> = ({ charId, charName, charAvatar, userName
 
   // 保存像素小人（按 editorTarget 分别存到角色/用户 key）
   const handleSaveChar = useCallback(async (cfg: PixelCharConfig, imageUri: string) => {
-    if (editorTarget === 'user') {
-      await DB.saveAsset(`pixel_char_user`, JSON.stringify(cfg));
-      setPixelUserConfig(cfg);
-      setPixelUserSprite(imageUri);
-      addToast?.('你的像素形象已保存', 'success');
-    } else {
-      await DB.saveAsset(`pixel_char_${charId}`, JSON.stringify(cfg));
-      setPixelCharConfig(cfg);
-      setPixelCharSprite(imageUri);
-      addToast?.(`${charName}的像素形象已保存`, 'success');
+    try {
+      if (editorTarget === 'user') {
+        await DB.saveAsset(`pixel_char_user`, JSON.stringify(cfg));
+        setPixelUserConfig(cfg);
+        setPixelUserSprite(imageUri);
+        addToast?.('你的像素形象已保存', 'success');
+      } else {
+        await DB.saveAsset(`pixel_char_${charId}`, JSON.stringify(cfg));
+        setPixelCharConfig(cfg);
+        setPixelCharSprite(imageUri);
+        addToast?.(`${charName}的像素形象已保存`, 'success');
+      }
+    } catch (err) {
+      // 写库失败（多为存储配额不足）如实报错，别让用户以为存上了、下次进来形象又没了
+      console.error('❌ [PixelHome] 像素形象保存失败:', err);
+      addToast?.('像素形象保存失败，可能是存储空间不足', 'error');
+      return;
     }
     setViewMode('map');
   }, [charId, charName, editorTarget, addToast]);

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1118,8 +1118,15 @@ export const DB = {
 
   saveAsset: async (id: string, data: string): Promise<void> => {
     const db = await openDB();
-    const transaction = db.transaction(STORE_ASSETS, 'readwrite');
-    transaction.objectStore(STORE_ASSETS).put({ id, data });
+    // 等事务真正落盘并把失败抛出去：旧实现发完 put 就返回，配额不足（iOS Safari 常见）
+    // 时写入静默丢失，调用方还以为保存成功了。
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(STORE_ASSETS, 'readwrite');
+        transaction.objectStore(STORE_ASSETS).put({ id, data });
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error || new Error('IndexedDB transaction aborted'));
+    });
   },
 
   getAssetRaw: async (id: string): Promise<any | null> => {


### PR DESCRIPTION
用户反馈像素家园自定义上传的像素小人会裂图。排查发现捏人器的
「直接上传像素小人」是全应用唯一不做任何预处理的图片入口：原图
直接 readAsDataURL 塞进配置 JSON（手机照片轻松 5~10MB base64），
一路埋雷——

- iOS Safari 配额/内存压力下 IndexedDB 写入失败，而 DB.saveAsset 发完 put 就返回、不等事务完成也不抛错，保存静默丢失，用户看到 「已保存」下次进来却是裂图/回退默认形象
- 超大 data URI 常驻 React state + <img>，低内存设备渲染易白图
- HEIC 等不支持格式被 file.type 正则静默吞掉，毫无反馈

修复：
- PixelCharEditor 上传改走 processImage（与家具上传同管线）： 压到 ≤256px（展示尺寸仅 24~40px），PNG/WebP 保留透明通道， GIF 原样保留动图；解码失败在按钮下方显示可读错误
- DB.saveAsset 等事务 oncomplete 才 resolve，onerror/onabort 抛出， 配额不足不再静默丢数据
- PixelHomeView 保存像素形象失败时弹错误 toast，不再假装成功

E2E 验证（Playwright + Chromium）：7MB/1500px 噪声图上传 → 落库 配置从 9.7MB 降到 244KB，刷新后正常渲染；伪造 HEIC → 显示
「上传失败：图片加载失败」。全量 vitest 1059 用例通过。


Claude-Session: https://claude.ai/code/session_01E71gBedf3sDKLN9HDx4aLW