### PR TITLE
笔友会：创作人格档案支持手动编辑

### DIFF
--- a/apps/NovelApp.tsx
+++ b/apps/NovelApp.tsx
@@ -47,6 +47,27 @@ const NovelApp: React.FC = () => {
     const [showPersonaModal, setShowPersonaModal] = useState(false);
     const [libraryPersonaChar, setLibraryPersonaChar] = useState<CharacterProfile | null>(null);
     const [libraryGroupId, setLibraryGroupId] = useState(GROUP_FILTER_ALL); // 角色库的分组筛选
+    const [isEditingPersona, setIsEditingPersona] = useState(false);
+    const [personaDraft, setPersonaDraft] = useState('');
+
+    // 弹窗展示期间角色可能被 updateCharacter 更新（如保存档案后），始终从 characters 取最新数据
+    const libraryChar = useMemo(() => libraryPersonaChar ? (characters.find(c => c.id === libraryPersonaChar.id) || libraryPersonaChar) : null, [libraryPersonaChar, characters]);
+
+    const closePersonaModal = () => { setShowPersonaModal(false); setIsEditingPersona(false); };
+
+    const startEditPersona = () => {
+        if (!libraryChar) return;
+        setPersonaDraft(libraryChar.writerPersona || analyzeWriterPersonaSimple(libraryChar));
+        setIsEditingPersona(true);
+    };
+
+    const savePersonaDraft = () => {
+        if (!libraryChar) return;
+        if (!personaDraft.trim()) { addToast('档案内容不能为空', 'error'); return; }
+        updateCharacter(libraryChar.id, { writerPersona: personaDraft.trim(), writerPersonaGeneratedAt: Date.now() });
+        setIsEditingPersona(false);
+        addToast('创作档案已保存', 'success');
+    };
 
     // Dialog
     const [confirmDialog, setConfirmDialog] = useState<{ isOpen: boolean; title: string; message: string; variant: 'danger' | 'warning' | 'info'; confirmText?: string; onConfirm: () => void; } | null>(null);
@@ -231,9 +252,26 @@ const NovelApp: React.FC = () => {
                     </section>
                 </div>
 
-                <Modal isOpen={showPersonaModal} title={libraryPersonaChar?.name || '角色风格'} onClose={() => setShowPersonaModal(false)}>
+                <Modal isOpen={showPersonaModal} title={libraryChar?.name || '角色风格'} onClose={closePersonaModal} footer={
+                    isEditingPersona ? (<>
+                        <button onClick={() => setIsEditingPersona(false)} className="flex-1 py-3 bg-slate-100 text-slate-500 font-bold rounded-2xl active:scale-95 transition-transform">取消</button>
+                        <button onClick={savePersonaDraft} className="flex-1 py-3 bg-slate-800 text-white font-bold rounded-2xl active:scale-95 transition-transform">保存</button>
+                    </>) : (<>
+                        <button onClick={startEditPersona} className="flex-1 py-3 bg-indigo-50 text-indigo-600 font-bold rounded-2xl active:scale-95 transition-transform">编辑档案</button>
+                        <button onClick={closePersonaModal} className="flex-1 py-3 bg-slate-100 text-slate-500 font-bold rounded-2xl active:scale-95 transition-transform">关闭</button>
+                    </>)
+                }>
                     <div className="max-h-[60vh] overflow-y-auto space-y-4 p-1">
-                        {libraryPersonaChar ? <div className="bg-slate-50 p-4 rounded-xl border border-slate-100 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">{libraryPersonaChar.writerPersona || analyzeWriterPersonaSimple(libraryPersonaChar)}</div> : null}
+                        {libraryChar ? (
+                            isEditingPersona ? (
+                                <div className="space-y-2">
+                                    <textarea value={personaDraft} onChange={e => setPersonaDraft(e.target.value)} className="w-full h-64 bg-slate-50 border border-slate-200 rounded-xl p-3 text-sm leading-relaxed resize-none outline-none focus:border-slate-400 font-mono" />
+                                    <button onClick={() => setPersonaDraft(analyzeWriterPersonaSimple(libraryChar))} className="text-xs text-slate-400 underline">重置为自动分析</button>
+                                </div>
+                            ) : (
+                                <div className="bg-slate-50 p-4 rounded-xl border border-slate-100 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">{libraryChar.writerPersona || analyzeWriterPersonaSimple(libraryChar)}</div>
+                            )
+                        ) : null}
                     </div>
                 </Modal>
             </div>

--- a/components/novel/NovelWriter.tsx
+++ b/components/novel/NovelWriter.tsx
@@ -41,16 +41,43 @@ interface PersonaPanelProps {
     updateCharacter: (id: string, updates: Partial<CharacterProfile>) => void;
 }
 
-const PersonaPanel: React.FC<PersonaPanelProps> = ({ 
-    char, userProfile, targetCharId, isTyping, setIsTyping, setConfirmDialog, addToast, apiConfig, updateCharacter 
+const PersonaPanel: React.FC<PersonaPanelProps> = ({
+    char, userProfile, targetCharId, isTyping, setIsTyping, setConfirmDialog, addToast, apiConfig, updateCharacter
 }) => {
     const rawPersona = char.writerPersona || analyzeWriterPersonaSimple(char);
     const sections = parsePersonaMarkdown(rawPersona);
-    
+    const [isEditing, setIsEditing] = useState(false);
+    const [draft, setDraft] = useState('');
+
+    // 切换共创者时退出编辑，避免草稿写进另一个角色
+    useEffect(() => { setIsEditing(false); }, [char.id]);
+
+    const saveDraft = () => {
+        if (!draft.trim()) { addToast('档案内容不能为空', 'error'); return; }
+        updateCharacter(char.id, { writerPersona: draft.trim(), writerPersonaGeneratedAt: Date.now() });
+        setIsEditing(false);
+        addToast('创作档案已保存', 'success');
+    };
+
+    if (isEditing) {
+        return (
+            <div className="bg-gradient-to-b from-slate-50 to-white border-b border-black/5 overflow-hidden">
+                <div className="max-h-[45vh] overflow-y-auto p-4 overscroll-contain">
+                    <textarea value={draft} onChange={e => setDraft(e.target.value)} className="w-full h-56 bg-white border border-slate-200 rounded-2xl p-3 text-sm leading-relaxed resize-none outline-none focus:border-slate-400" />
+                    <button onClick={() => setDraft(analyzeWriterPersonaSimple(char))} className="text-xs text-slate-400 underline mt-1">重置为自动分析</button>
+                </div>
+                <div className="px-4 py-3 border-t border-slate-100 bg-white/80 flex gap-2">
+                    <button onClick={() => setIsEditing(false)} className="flex-1 bg-slate-100 text-slate-500 py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-transform">取消</button>
+                    <button onClick={saveDraft} className="flex-1 bg-slate-800 text-white py-2.5 rounded-xl text-sm font-bold active:scale-95 transition-transform">保存</button>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="bg-gradient-to-b from-slate-50 to-white border-b border-black/5 overflow-hidden">
             <div className="max-h-[45vh] overflow-y-auto p-4 space-y-3 overscroll-contain">
-                {sections.length === 0 ? <div className="text-center py-8 text-slate-400 text-sm">暂无详细风格数据<br/><span className="text-xs">点击下方按钮生成</span></div> : 
+                {sections.length === 0 ? <div className="text-center py-8 text-slate-400 text-sm">暂无详细风格数据<br/><span className="text-xs">点击下方按钮生成</span></div> :
                     sections.map((sec, idx) => (
                         <div key={idx} className="bg-white p-4 rounded-2xl border border-slate-100 shadow-sm">
                             <div className="flex items-center gap-2 mb-2 pb-2 border-b border-slate-100"><span className="text-base">{sec.icon}</span><h4 className="text-sm font-bold text-slate-800">{sec.title}</h4></div>
@@ -59,8 +86,9 @@ const PersonaPanel: React.FC<PersonaPanelProps> = ({
                     ))
                 }
             </div>
-            <div className="px-4 py-3 border-t border-slate-100 bg-white/80">
-                <button onClick={async () => { 
+            <div className="px-4 py-3 border-t border-slate-100 bg-white/80 flex gap-2">
+                <button onClick={() => { setDraft(rawPersona); setIsEditing(true); }} disabled={isTyping} className="flex-1 bg-white border border-slate-200 text-slate-600 py-2.5 rounded-xl text-sm font-bold transition-all active:scale-95 hover:bg-slate-50 disabled:opacity-50">手动编辑</button>
+                <button onClick={async () => {
                     if(!targetCharId) return; 
                     setConfirmDialog({ 
                         isOpen: true, 
@@ -82,7 +110,7 @@ const PersonaPanel: React.FC<PersonaPanelProps> = ({
                             } 
                         } 
                     }); 
-                }} disabled={isTyping} className="w-full bg-gradient-to-r from-indigo-500 to-purple-500 hover:from-indigo-600 hover:to-purple-600 text-white py-2.5 rounded-xl text-sm font-bold transition-all flex items-center justify-center gap-2 shadow-sm disabled:opacity-50">
+                }} disabled={isTyping} className="flex-1 bg-gradient-to-r from-indigo-500 to-purple-500 hover:from-indigo-600 hover:to-purple-600 text-white py-2.5 rounded-xl text-sm font-bold transition-all flex items-center justify-center gap-2 shadow-sm disabled:opacity-50">
                     {isTyping ? <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div> : <>深度分析写作风格</>}
                 </button>
             </div>


### PR DESCRIPTION
修复用户反馈：角色创作档案只能自动生成、无法修改的问题。
（Simple 档案为固定模板，仅审美一栏随角色变化，用户无法自定义其余维度）

- 角色库档案弹窗新增「编辑档案」：文本框直接改全文，可一键重置为自动分析
- 写作页 PersonaPanel 新增「手动编辑」按钮，与深度分析并列
- 保存写入 char.writerPersona，buildPrompt 已优先使用该字段，编辑立即生效
- 弹窗内角色数据改为从 characters 实时查找，保存后立刻展示新档案
- 切换共创者时自动退出编辑态，防止草稿写错角色


Claude-Session: https://claude.ai/code/session_01R7znCMcKHU9qEiZE4xXzmm