### PR TITLE
修复：记忆宫殿水位线清库残留自愈 + 「加载历史消息」幽灵按钮

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -620,7 +620,12 @@ const Chat: React.FC = () => {
             const chatScopeMsgs = recent
                 .filter(m => m.metadata?.source !== 'date' && m.metadata?.source !== 'call')
                 .filter(m => !(currentChar?.hideSystemLogs && m.role === 'system' && m.type !== 'score_card'));
-            setTotalMsgCount(totalCount);
+            // totalCount 走 charId 索引全量计数，包含群聊消息（以及上面被过滤的约会/通话
+            // 消息）——它们永远不会出现在单聊列表里。直接拿它算「加载历史消息」会出现
+            // 有计数、点击却加载不出任何东西的幽灵按钮。倒序游标没取满 fetchLimit 条
+            // 即说明该角色的单聊消息已全部在手，此时把总数钳到实际可展示的条数。
+            const exhausted = recent.length < fetchLimit;
+            setTotalMsgCount(exhausted ? chatScopeMsgs.length : totalCount);
             setMessages(chatScopeMsgs.slice(-requestedVisibleCount));
         };
         try {

--- a/utils/db.hwmSelfHeal.test.ts
+++ b/utils/db.hwmSelfHeal.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { DB } from './db';
+
+// 记忆宫殿水位线自愈：浏览器清掉 IndexedDB（消息自增 id 归零重计）但 localStorage
+// 幸存时，残留的 mp_lastMsgId_ 高水位会把该角色所有新消息（含刚发的那条）从
+// hwm 过滤读取里挡掉 —— 请求只剩 system 消息、上游 400。不变式：合法水位是某条
+// 既有消息的 id，新消息的自增 id 必然大于它；出现新 id ≤ 水位即证明水位失效。
+describe('saveMessage 记忆宫殿水位线自愈', () => {
+    it('残留高水位 ≥ 新消息 id → 落库时自动移除，该消息能被默认读取到', async () => {
+        localStorage.setItem('mp_lastMsgId_char-stale', '99999');
+        const id = await DB.saveMessage({ charId: 'char-stale', role: 'user', type: 'text', content: '你好' } as any);
+        expect(id).toBeLessThan(99999);
+        expect(localStorage.getItem('mp_lastMsgId_char-stale')).toBeNull();
+        // 水位清掉后，默认（hwm 过滤）读取要能看到这条消息 —— 之前 400 的根因就是这里读出空数组
+        const msgs = await DB.getRecentMessagesByCharId('char-stale', 10);
+        expect(msgs.map(m => m.content)).toContain('你好');
+    });
+
+    it('正常水位（小于新消息 id）原样保留', async () => {
+        localStorage.setItem('mp_lastMsgId_char-ok', '1');
+        const id = await DB.saveMessage({ charId: 'char-ok', role: 'user', type: 'text', content: 'hi' } as any);
+        expect(id).toBeGreaterThan(1);
+        expect(localStorage.getItem('mp_lastMsgId_char-ok')).toBe('1');
+    });
+
+    it('群聊消息同时校验并清理失效的群水位键', async () => {
+        localStorage.setItem('mp_lastMsgId_group_g1', '99999');
+        await DB.saveMessage({ charId: 'char-x', groupId: 'g1', role: 'user', type: 'text', content: 'g' } as any);
+        expect(localStorage.getItem('mp_lastMsgId_group_g1')).toBeNull();
+    });
+});

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -723,7 +723,23 @@ export const DB = {
         const timestamp = typeof msg.timestamp === 'number' ? msg.timestamp : Date.now();
         const { timestamp: _ignored, ...payload } = msg;
         const request = store.add({ ...payload, timestamp });
-        request.onsuccess = () => resolve(request.result as number);
+        request.onsuccess = () => {
+            const newId = request.result as number;
+            // 水位线自愈：新消息的自增 id 必然大于既有一切消息 id，也就必然大于水位线
+            // （水位线本身是某条旧消息的 id）。出现 newId ≤ 水位线，只有一种可能——
+            // IndexedDB 被浏览器清过、自增计数器归零，而 localStorage 里的记忆宫殿水位
+            // 是清库前残留的。不清掉它，该角色所有新消息都会被 hwm 过滤挡在 AI 上下文
+            // 之外（请求只剩 system → 上游 400）。此处直接移除失效水位。
+            try {
+                const staleKeys = [`mp_lastMsgId_${msg.charId}`];
+                if (msg.groupId) staleKeys.push(`mp_lastMsgId_group_${msg.groupId}`);
+                for (const key of staleKeys) {
+                    const hwm = parseInt(localStorage.getItem(key) || '0', 10) || 0;
+                    if (hwm >= newId) localStorage.removeItem(key);
+                }
+            } catch { /* localStorage 不可用时静默跳过 */ }
+            resolve(newId);
+        };
         request.onerror = () => reject(request.error);
     });
   },


### PR DESCRIPTION
浏览器（安卓 Edge 等）因存储压力清掉站点 IndexedDB 但保留 localStorage 时， mp_lastMsgId_<charId> 高水位残留而消息自增 id 归零重计，导致该角色所有
新消息（含刚发的那条）被 hwm 过滤挡在 AI 上下文之外 —— 请求只剩两条
system 消息，上游报 400「at least one contents field is required」。 清空聊天/换模型/删设定/重装 PWA 都不碰 localStorage，因此全部无效。

- saveMessage 自愈：合法水位是某条既有消息的 id，新消息自增 id 必然 大于它；出现新 id ≤ 水位即证明水位来自被清掉的旧库，落库时直接移除 （单聊键 + 群聊键都查）。用户发一条消息即恢复正常，无需手动排查
- Chat 单窗「加载历史消息」按钮：totalCount 走 charId 索引全量计数， 包含群聊与约会/通话消息，它们永远不会出现在单聊列表 —— 会出现有 计数、点击却加载不出任何内容的幽灵按钮。倒序游标读尽时把总数钳到 实际可展示条数，按钮随之消失

新增水位线自愈测试 3 例。


Claude-Session: https://claude.ai/code/session_01R7znCMcKHU9qEiZE4xXzmm