### PR TITLE
私聊群聊背景注入：发言人标真实名字，补全框定语

### DIFF
--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -29,6 +29,7 @@ import { CHAT_GEN_EVENTS, setChatViewSnapshot } from '../utils/chatGenEvents';
 import { buildChatRequestPayload } from '../utils/chatRequestPayload';
 import { extractHtmlBlocks } from '../utils/htmlPrompt';
 import { loadMusicPlaybackSnapshot } from './MusicContext';
+import { setCharNameRegistry } from '../utils/charNameRegistry';
 import { setMinimaxRegion } from '../utils/minimaxEndpoint';
 import { setTtsProvider, setVoicePromptOverrides } from '../utils/ttsProvider';
 import { LocalNotifications } from '@capacitor/local-notifications';
@@ -1626,6 +1627,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
   // Refs to avoid stale closures in proactive callback
   const charactersRef = useRef(characters);
   charactersRef.current = characters;
+
+  // 同步 charId → 角色名 注册表，让 utils 层（群聊背景注入等）能标出真实发言人名。
+  useEffect(() => {
+    setCharNameRegistry(characters);
+  }, [characters]);
   const apiConfigRef = useRef(apiConfig);
   apiConfigRef.current = apiConfig;
 

--- a/utils/charNameRegistry.ts
+++ b/utils/charNameRegistry.ts
@@ -1,0 +1,22 @@
+/**
+ * 模块级 charId → 角色名 注册表 — 与 MusicContext 的播放快照同一模式。
+ *
+ * 动机：私聊 prompt 的群聊背景注入（chatPrompts.buildSystemPromptParts）需要把
+ * 群消息的发言人标成真实角色名，但它位于 utils 层、拿不到 OSContext 的 characters
+ * state，而给 buildChatRequestPayload 的所有调用方（useChatAI / 主动消息 /
+ * worldHome / 彼方 …）逐一穿参代价太高。OSProvider 在 characters 变化时把
+ * 名字表写到这里，utils 层按需读取。
+ */
+
+let __charNames: Record<string, string> = {};
+
+export const setCharNameRegistry = (chars: Array<{ id: string; name: string }>): void => {
+    const next: Record<string, string> = {};
+    for (const c of chars) {
+        if (c?.id && c?.name) next[c.id] = c.name;
+    }
+    __charNames = next;
+};
+
+export const getCharNameById = (id: string | undefined | null): string | null =>
+    (id && __charNames[id]) || null;

--- a/utils/chatPrompts.groupContext.test.ts
+++ b/utils/chatPrompts.groupContext.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { ChatPrompts } from './chatPrompts';
+import { DB } from './db';
+import { setCharNameRegistry, getCharNameById } from './charNameRegistry';
+
+// 群聊背景注入的发言人标注：之前所有角色发言（包括收到注入的角色自己）都被匿名成
+// "Member"，私聊被问起群里的事时角色分不清谁说了什么、认不出自己的发言。
+// 修复后：user 显示用户名，注入对象自己的发言标「你（名字）」，其他成员经
+// charNameRegistry 解析出真实名字，查不到的兜底「群友」。
+
+const charA = { id: 'char-a', name: '阿一' } as any;
+const userProfile = { name: '条条' } as any;
+const groups = [{ id: 'g-test', name: '深夜茶话会', members: ['char-a', 'char-b'] }] as any;
+
+describe('群聊背景注入 · 发言人真实标注', () => {
+    it('charNameRegistry 基本行为', () => {
+        setCharNameRegistry([{ id: 'x', name: '小明' }]);
+        expect(getCharNameById('x')).toBe('小明');
+        expect(getCharNameById('missing')).toBeNull();
+        expect(getCharNameById(null)).toBeNull();
+    });
+
+    it('注入块标注：用户名 / 你（自己） / 真实成员名 / 未知兜底群友', async () => {
+        setCharNameRegistry([
+            { id: 'char-a', name: '阿一' },
+            { id: 'char-b', name: '阿二' },
+        ]);
+        await DB.saveMessage({ charId: 'user', groupId: 'g-test', role: 'user', type: 'text', content: '今晚吃火锅吗' } as any);
+        await DB.saveMessage({ charId: 'char-a', groupId: 'g-test', role: 'assistant', type: 'text', content: '我要毛肚' } as any);
+        await DB.saveMessage({ charId: 'char-b', groupId: 'g-test', role: 'assistant', type: 'text', content: '加宽粉' } as any);
+        await DB.saveMessage({ charId: 'char-ghost', groupId: 'g-test', role: 'assistant', type: 'text', content: '幽灵发言' } as any);
+
+        const parts = await ChatPrompts.buildSystemPromptParts(
+            charA, userProfile, groups, [], [], [],
+        );
+        const injected = parts.volatileState;
+
+        expect(injected).toContain('你亲历的近期群聊');
+        expect(injected).toContain('条条: 今晚吃火锅吗');
+        expect(injected).toContain('你（阿一）: 我要毛肚');
+        expect(injected).toContain('阿二: 加宽粉');
+        expect(injected).toContain('群友: 幽灵发言');
+        expect(injected).not.toContain('Member');
+    });
+});

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -14,6 +14,7 @@ import { FISH_VOICE_ACTING_GUIDE } from './fishAudioTts';
 import { getTtsProvider, getVoicePromptOverride } from './ttsProvider';
 import { resolveCharTimeZone, nowInTimeZone } from './timezone';
 import { buildLifeRecordInjection } from './lifeRecords';
+import { getCharNameById } from './charNameRegistry';
 
 // 语音格式指导按当前 TTS 服务商二选一：用 MiniMax 才注入 MiniMax 那套（含 <#秒#> 停顿标记），
 // 用鱼声则注入鱼声版（去掉 MiniMax 专属标记，改用标点 / 省略号控制停顿）。
@@ -285,11 +286,20 @@ export const ChatPrompts = {
                 allGroupMsgs.sort((a, b) => a.timestamp - b.timestamp);
                 const recentGroupMsgs = allGroupMsgs;
                 if (recentGroupMsgs.length === 0) return '';
+                // 发言人标真实名字：匿名成 Member 会让角色分不清哪句是谁说的、
+                // 甚至认不出自己的发言，私聊被问起群里的事就接不住。
+                const speakerOf = (m: Message): string => {
+                    if (m.role === 'user') return userProfile.name;
+                    if (m.charId === char.id) return `你（${char.name}）`;
+                    return getCharNameById(m.charId) || '群友';
+                };
                 const groupLogStr = recentGroupMsgs.map(m => {
                     const dateStr = new Date(m.timestamp).toLocaleString([], {month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit'});
-                    return `[${dateStr}] [Group: ${m.groupName}] ${m.role === 'user' ? userProfile.name : 'Member'}: ${summarizeGroupMsgContent(m)}`;
+                    return `[${dateStr}] [群：${m.groupName}] ${speakerOf(m)}: ${summarizeGroupMsgContent(m)}`;
                 }).join('\n');
-                return `\n### [Background Context: Recent Group Activities]\n(注意：你是以下群聊的成员...)\n${groupLogStr}\n`;
+                return `\n### 【群聊背景 · 你亲历的近期群聊】
+（以下是你所在群里最近的真实聊天记录，按时间排序，发言人已标注；标「你」的就是你自己说的话。这些事你都亲身经历、记得清楚——私聊里对方问起或话题相关时，自然地接上就好，不要装作不知道；也不必刻意逐条汇报群里的动静。）
+${groupLogStr}\n`;
             } catch (e) {
                 console.error("Failed to load group context", e);
                 return '';


### PR DESCRIPTION
修复用户反馈「群里刚说的事私聊角色不知道，只记得成盒后的旧内容」。
私聊 prompt 的群聊背景通道本来就是实时的，但两处工程缺陷让模型经常
接不住：

- 发言人全部匿名成 Member（包括正在私聊的角色自己的发言），模型分不清 谁说了什么、认不出自己说过的话，被问起群里的事就装不知道
- 框定语在源码里字面上是「(注意：你是以下群聊的成员...)」——残缺的 省略号，没有告诉模型这些是它亲历的、可以自然引用

修复：
- 新增 charNameRegistry（模块级 charId→名字表，OSProvider 随 characters 变化同步写入，与音乐播放快照同一模式），utils 层免穿参读取
- 注入日志发言人：user 显示用户名；注入对象自己的发言标「你（名字）」； 其他成员解析真实名字；查不到兜底「群友」
- 框定语补全：明确这些是角色亲历并记得的群聊、可自然接上，同时保留 不必刻意汇报的分寸提示

新增注入标注集成测试 2 例（含 Member 不再出现的回归断言）。


Claude-Session: https://claude.ai/code/session_01R7znCMcKHU9qEiZE4xXzmm