### PR TITLE
feat: 解耦聊天上下文范围并支持 RedNote 链接

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -16,7 +16,7 @@ import TheaterPlayer from '../components/schedule/TheaterPlayer';
 import { formatMessageWithTime, normalizeMessageContent } from '../utils/messageFormat';
 import { getRoomLabel } from '../utils/memoryPalace/types';
 import { XhsMcpClient, extractNotesFromMcpData, normalizeNote } from '../utils/xhsMcpClient';
-import { extractWebpageContent, detectFirstUrl, isXhsUrl, expandShortUrl, type ExtractedWebpage } from '../utils/webpageExtractor';
+import { extractWebpageContent, detectFirstUrl, isXhsUrl, extractXhsNoteId, expandShortUrl, type ExtractedWebpage } from '../utils/webpageExtractor';
 import { isVideoShareUrl, parseVideoShareUrl } from '../utils/videoParser';
 import { isDevDebugAvailable } from '../utils/devDebug';
 import { resolveLifeRecordCard } from '../utils/lifeRecords';
@@ -51,6 +51,14 @@ import { resolveActiveSound, playWhiteboxSound, unlockWhiteboxAudio, parseWhiteb
 import WhiteboxSoundEditor from '../components/chat/WhiteboxSoundEditor';
 import { normalizeTranslationLangLabel } from '../utils/translationLang';
 import { CharacterGroupFilterBar, filterCharactersByGroup, GROUP_FILTER_ALL } from '../components/character/CharacterGroupFilter';
+import {
+    CONTEXT_RANGE_POLICY_VERSION,
+    computeContextRangeSnapshot,
+    countMessagesFrom,
+    getMemoryPalaceHighWaterMarkForContext,
+    loadCharacterContextRange,
+    type ContextRangeMode,
+} from '../utils/chatContextRange';
 
 const VOICE_LANG_LABELS: Record<string, string> = { en: 'English', ja: '日本語', ko: '한국어', fr: 'Français', es: 'Español' };
 type InstantToolUiStatus = {
@@ -135,6 +143,7 @@ const Chat: React.FC = () => {
     const [transferNote, setTransferNote] = useState('');
     const [emojiImportText, setEmojiImportText] = useState('');
     const [settingsContextLimit, setSettingsContextLimit] = useState(500);
+    const [settingsContextRangeMode, setSettingsContextRangeMode] = useState<ContextRangeMode>('manual');
     const [settingsHideSysLogs, setSettingsHideSysLogs] = useState(false);
     const [settingsHtmlModeCustomPrompt, setSettingsHtmlModeCustomPrompt] = useState('');
     const [preserveContext, setPreserveContext] = useState(true);
@@ -183,6 +192,40 @@ const Chat: React.FC = () => {
 
     const char = characters.find(c => c.id === activeCharacterId) || characters[0];
     charRef.current = char; // Keep ref in sync for async callbacks
+    const historyContextRange = useMemo(() => {
+        if (!char) return undefined;
+        return computeContextRangeSnapshot(
+            allHistoryMessages,
+            {
+                ...char,
+                contextRangeMode: settingsContextRangeMode,
+                contextLimit: settingsContextLimit,
+            },
+            getMemoryPalaceHighWaterMarkForContext(char.id),
+        );
+    }, [
+        allHistoryMessages,
+        char,
+        settingsContextLimit,
+        settingsContextRangeMode,
+    ]);
+    useEffect(() => {
+        if (
+            modalType !== 'history-manager'
+            || allHistoryMessages.length === 0
+            || !char?.contextUserStartMessageId
+            || !historyContextRange?.userBreakpointExpired
+        ) return;
+        // 最大范围已经向前越过用户断点：立即清掉持久化断点，防止以后拉大时旧断点复活。
+        updateCharacter(char.id, { contextUserStartMessageId: undefined });
+    }, [
+        modalType,
+        allHistoryMessages.length,
+        char?.id,
+        char?.contextUserStartMessageId,
+        historyContextRange?.userBreakpointExpired,
+        updateCharacter,
+    ]);
     const currentThemeId = char?.bubbleStyle || 'default';
     // 解析逻辑抽到 utils/groupChat/theme.ts（群聊共用），行为不变
     const activeTheme = useMemo(
@@ -658,6 +701,7 @@ const Chat: React.FC = () => {
 
             // Clear messages immediately to prevent showing stale chat from previous character
             setMessages([]);
+            setAllHistoryMessages([]);
             setTotalMsgCount(0);
             // Reset voice map — stale blob: URLs from the previous char are revoked
             // by the cleanup effect and must not be reused against new messages.
@@ -671,6 +715,11 @@ const Chat: React.FC = () => {
             setInput(savedDraft || '');
             if (char) {
                 setSettingsContextLimit(char.contextLimit || 500);
+                setSettingsContextRangeMode(
+                    char.autoArchiveEnabled && char.contextRangeMode === 'adaptive'
+                        ? 'adaptive'
+                        : 'manual',
+                );
                 setSettingsHideSysLogs(char.hideSystemLogs || false);
                 setSettingsHtmlModeCustomPrompt((char as any).htmlModeCustomPrompt || '');
                 clearUnread(char.id);
@@ -773,17 +822,30 @@ const Chat: React.FC = () => {
         }).catch(() => {});
     }, [activeCharacterId, char?.scheduleFeatureEnabled, localDateKey]);
 
+    // 每次真正打开聊天设置时从角色持久化值重新初始化；避免用户在记忆宫殿页
+    // 切换全自动模式后，隐藏着的 Chat 组件仍带着旧拉杆状态。
+    useEffect(() => {
+        if (modalType !== 'chat-settings' || !char) return;
+        setSettingsContextLimit(char.contextLimit || 500);
+        setSettingsContextRangeMode(
+            char.autoArchiveEnabled && char.contextRangeMode === 'adaptive'
+                ? 'adaptive'
+                : 'manual',
+        );
+        setSettingsHideSysLogs(char.hideSystemLogs || false);
+        setSettingsHtmlModeCustomPrompt((char as any).htmlModeCustomPrompt || '');
+    }, [modalType, char?.id]);
+
     // Load all messages when history-manager modal opens
     useEffect(() => {
         if (modalType === 'history-manager' && activeCharacterId) {
             DB.getMessagesByCharId(activeCharacterId, true).then(allMsgs => {
-                const filtered = allMsgs
-                    .filter(m => m.metadata?.source !== 'date' && m.metadata?.source !== 'call')
-                    .filter(m => !(char?.hideSystemLogs && m.role === 'system' && m.type !== 'score_card'));
-                setAllHistoryMessages(filtered);
+                // 范围管理必须使用 AI 可能读取的完整私聊序列，不能先按聊天界面显示偏好
+                // 隐掉系统/约会/通话消息，否则「最近 N 条」起点会与真实 prompt 发生偏移。
+                setAllHistoryMessages(allMsgs);
             });
         }
-    }, [modalType, activeCharacterId, char?.hideSystemLogs]);
+    }, [modalType, activeCharacterId]);
 
     useEffect(() => {
         const savedPrompts = localStorage.getItem('chat_archive_prompts');
@@ -959,11 +1021,11 @@ const Chat: React.FC = () => {
         if (type === 'text') {
             let xhsCardCreated = false;
             let webpageCardCreated = false;
-            const xhsFullMatch = text.match(/xiaohongshu\.com\/(?:discovery\/item|explore|item)\/([a-f0-9]{24})/i);
+            const xhsFullNoteId = extractXhsNoteId(text);
             // 路径宽松接收 '-' / '_'，兼容小红书后续调整短链格式；尾部中文标点不吞入 URL。
             const xhsShortMatch = text.match(/(?:https?:\/\/)?(?:www\.)?xhslink\.com\/[A-Za-z0-9/_-]+/i);
-            if (xhsFullMatch || xhsShortMatch) {
-                let noteId = xhsFullMatch?.[1] || '';
+            if (xhsFullNoteId || xhsShortMatch) {
+                let noteId = xhsFullNoteId || '';
                 let xsecToken = text.match(/xsec_token=([^&\s]+)/)?.[1];
                 let shortLinkError = '';
                 // 短链（xhslink.com）不含 id/token —— 先经 sfworker 展开成真实链接再提取。
@@ -972,7 +1034,7 @@ const Chat: React.FC = () => {
                         // 正则可能匹配到不带协议头的裸链接，补上 https 再展开（否则 new URL 报 Invalid URL）。
                         const shortUrl = /^https?:\/\//i.test(xhsShortMatch[0]) ? xhsShortMatch[0] : `https://${xhsShortMatch[0]}`;
                         const finalUrl = await expandShortUrl(shortUrl);
-                        noteId = finalUrl.match(/(?:discovery\/item|explore|item)\/([a-f0-9]{24})/)?.[1] || '';
+                        noteId = extractXhsNoteId(finalUrl) || '';
                         xsecToken = xsecToken || finalUrl.match(/xsec_token=([^&\s]+)/)?.[1];
                         if (isDevDebugAvailable()) console.log('[卡片调试] 小红书短链展开 →', finalUrl, '| noteId =', noteId);
                     } catch (e) {
@@ -1055,7 +1117,7 @@ const Chat: React.FC = () => {
             // 视频平台链接（抖音/B站/快手…）Jina 基本抓不到东西（SPA+登录墙），
             // 优先走 apizero 视频解析拿标题/作者/封面/热度；失败降级回通用网页抓取。
             const sharedUrl = detectFirstUrl(text);
-            if (sharedUrl && !isXhsUrl(sharedUrl) && !(xhsFullMatch || xhsShortMatch)) {
+            if (sharedUrl && !isXhsUrl(sharedUrl) && !(xhsFullNoteId || xhsShortMatch)) {
                 let webpage: ExtractedWebpage | null = null;
                 if (isVideoShareUrl(sharedUrl)) {
                     try {
@@ -1775,14 +1837,46 @@ const Chat: React.FC = () => {
         }
     };
 
-    const saveSettings = () => {
+    const saveSettings = async () => {
+        const nextMode: ContextRangeMode = char.autoArchiveEnabled
+            ? settingsContextRangeMode
+            : 'manual';
+        const candidate = {
+            ...char,
+            contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            contextRangeMode: nextMode,
+            contextLimit: settingsContextLimit,
+        };
+        let nextUserStart = char.contextUserStartMessageId;
+        try {
+            const range = await loadCharacterContextRange(candidate);
+            if (range.userBreakpointExpired) nextUserStart = undefined;
+        } catch {
+            // 保存其它设置不应被一次范围检查失败阻断；AI 请求时还会再次做同样的安全钳制。
+        }
         updateCharacter(char.id, {
             contextLimit: settingsContextLimit,
+            contextRangeMode: nextMode,
+            contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            contextUserStartMessageId: nextUserStart,
             hideSystemLogs: settingsHideSysLogs,
             htmlModeCustomPrompt: settingsHtmlModeCustomPrompt,
         } as any);
         setModalType('none');
         addToast('设置已保存', 'success');
+    };
+
+    const restoreAdaptiveContext = () => {
+        if (!char.autoArchiveEnabled) return;
+        setSettingsContextRangeMode('adaptive');
+        setSettingsContextLimit(500);
+        updateCharacter(char.id, {
+            contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            contextRangeMode: 'adaptive',
+            contextLimit: 500,
+            contextUserStartMessageId: undefined,
+        });
+        addToast('已恢复全自动记忆的自适应上下文', 'success');
     };
 
     const handleClearHistory = async () => {
@@ -1988,9 +2082,39 @@ const Chat: React.FC = () => {
     };
 
     const handleSetHistoryStart = (messageId: number | undefined) => {
-        updateCharacter(char.id, { hideBeforeMessageId: messageId });
+        if (!messageId) {
+            updateCharacter(char.id, {
+                contextUserStartMessageId: undefined,
+                contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            });
+            setModalType('none');
+            addToast('已清除用户断点，原文范围重新跟随拉杆上限', 'success');
+            return;
+        }
+
+        const range = historyContextRange;
+        const maxStart = range?.maxRangeStartMessageId;
+        const latestId = range?.messages.at(-1)?.id
+            || allHistoryMessages.at(-1)?.id;
+        if (maxStart === undefined || latestId === undefined || messageId < maxStart || messageId > latestId) {
+            const required = countMessagesFrom(allHistoryMessages, messageId);
+            const hint = settingsContextRangeMode === 'adaptive'
+                ? `该消息在全自动记忆当前原文范围之外。请先切换为自定义范围，并将拉杆调至至少 ${required} 条。`
+                : required > 5000
+                    ? '该消息超出上下文拉杆的 5000 条上限，无法设为用户断点。'
+                    : `该消息超出当前拉杆范围，请先将上下文调至至少 ${required} 条。`;
+            addToast(hint, 'error');
+            return;
+        }
+
+        updateCharacter(char.id, {
+            contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            contextRangeMode: char.autoArchiveEnabled ? settingsContextRangeMode : 'manual',
+            contextLimit: settingsContextLimit,
+            contextUserStartMessageId: messageId,
+        });
         setModalType('none');
-        addToast(messageId ? '已隐藏历史消息' : '已恢复全部历史记录', 'success');
+        addToast('已设置 AI 原文读取断点', 'success');
     };
 
     // 跳转到旧消息：加载全量到 messages，再用 windowedFocusMsgId 把 displayMessages
@@ -2768,6 +2892,7 @@ const Chat: React.FC = () => {
                 transferNote={transferNote} setTransferNote={setTransferNote}
                 emojiImportText={emojiImportText} setEmojiImportText={setEmojiImportText}
                 settingsContextLimit={settingsContextLimit} setSettingsContextLimit={setSettingsContextLimit}
+                settingsContextRangeMode={settingsContextRangeMode} setSettingsContextRangeMode={setSettingsContextRangeMode}
                 settingsHideSysLogs={settingsHideSysLogs} setSettingsHideSysLogs={setSettingsHideSysLogs}
                 preserveContext={preserveContext} setPreserveContext={setPreserveContext}
                 editContent={editContent} setEditContent={setEditContent}
@@ -2779,6 +2904,7 @@ const Chat: React.FC = () => {
                 editingPrompt={editingPrompt} setEditingPrompt={setEditingPrompt} isSummarizing={isSummarizing} archiveProgress={archiveProgress}
                 selectedMessage={selectedMessage} selectedEmoji={selectedEmoji} activeCharacter={char} messages={messages}
                 allHistoryMessages={allHistoryMessages}
+                contextRangeSnapshot={historyContextRange}
                 
                 newCategoryName={newCategoryName} setNewCategoryName={setNewCategoryName} onAddCategory={handleAddCategory}
                 newEmojiName={newEmojiName} setNewEmojiName={setNewEmojiName} onRenameEmoji={handleRenameEmoji}
@@ -2789,7 +2915,7 @@ const Chat: React.FC = () => {
                 onSaveSettings={saveSettings} onBgUpload={handleBgUpload} onRemoveBg={() => updateCharacter(char.id, { chatBackground: undefined })}
                 onClearHistory={handleClearHistory} onArchive={handleFullArchive}
                 onCreatePrompt={createNewPrompt} onEditPrompt={editSelectedPrompt} onSavePrompt={handleSavePrompt} onDeletePrompt={handleDeletePrompt}
-                onSetHistoryStart={handleSetHistoryStart} onJumpToMessageInChat={handleJumpToMessageInChat} onEnterSelectionMode={handleEnterSelectionMode}
+                onSetHistoryStart={handleSetHistoryStart} onRestoreAdaptiveContext={restoreAdaptiveContext} onJumpToMessageInChat={handleJumpToMessageInChat} onEnterSelectionMode={handleEnterSelectionMode}
                 onReplyMessage={handleReplyMessage} onEditMessageStart={() => { if (selectedMessage) { setEditContent(selectedMessage.content); setModalType('edit-message'); } }}
                 onConfirmEditMessage={confirmEditMessage} onDeleteMessage={handleDeleteMessage} onCopyMessage={handleCopyMessage} onDeleteEmoji={handleDeleteEmoji} onDeleteCategory={handleDeleteCategory}
                 allCharacters={characters} onSaveCategoryVisibility={handleSaveCategoryVisibility}

--- a/apps/MemoryPalaceApp.tsx
+++ b/apps/MemoryPalaceApp.tsx
@@ -17,6 +17,10 @@ import type { Anticipation, MigrationProgress, DigestResult, MemoryLink, EventBo
 import { confirmExportSafety } from '../utils/exportGuard';
 import type { Message } from '../types';
 import { CharacterGroupFilterBar, filterCharactersByGroup, GROUP_FILTER_ALL } from '../components/character/CharacterGroupFilter';
+import {
+    CONTEXT_RANGE_POLICY_VERSION,
+    DEFAULT_MANUAL_CONTEXT_LIMIT,
+} from '../utils/chatContextRange';
 
 /** 手动总结面板：每页渲染多少条聊天记录（翻页，避免一次性塞几百条 DOM 卡顿） */
 const RANGE_PAGE_SIZE = 100;
@@ -1092,7 +1096,13 @@ export default function MemoryPalaceApp() {
         } else {
             // 关闭 palace 必然连带关闭全自动记忆；同时清空残留的向量召回注入，
             // 否则旧的 memoryPalaceInjection 会被 saveCharacter 持久化并继续注入 prompt。
-            updateCharacter(charId, { memoryPalaceEnabled: false, autoArchiveEnabled: false, memoryPalaceInjection: undefined } as any);
+            updateCharacter(charId, {
+                memoryPalaceEnabled: false,
+                autoArchiveEnabled: false,
+                memoryPalaceInjection: undefined,
+                contextRangeMode: 'manual',
+                contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            } as any);
         }
     };
 
@@ -1102,7 +1112,11 @@ export default function MemoryPalaceApp() {
         if (!target) return;
 
         if (!on) {
-            updateCharacter(charId, { autoArchiveEnabled: false } as any);
+            updateCharacter(charId, {
+                autoArchiveEnabled: false,
+                contextRangeMode: 'manual',
+                contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            } as any);
             addToast('已关闭全自动记忆（palace 向量化仍在正常运行）', 'info');
             return;
         }
@@ -1118,7 +1132,13 @@ export default function MemoryPalaceApp() {
             return;
         }
 
-        updateCharacter(charId, { autoArchiveEnabled: true } as any);
+        updateCharacter(charId, {
+            autoArchiveEnabled: true,
+            contextRangeMode: 'adaptive',
+            contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+            contextLimit: DEFAULT_MANUAL_CONTEXT_LIMIT,
+            contextUserStartMessageId: undefined,
+        } as any);
 
         // 统计未同步消息数并决定是否立即追平历史
         // 口径必须和 pipeline 的缓冲区定义一致：排除热区（最后 200 条），

--- a/components/chat/ChatModals.tsx
+++ b/components/chat/ChatModals.tsx
@@ -5,6 +5,7 @@ import { CharacterProfile, Message, EmojiCategory, DailySchedule, ScheduleSlot, 
 import ScheduleCard from '../schedule/ScheduleCard';
 import EmotionSettingsPanel from './EmotionSettingsPanel';
 import { isTranslationLangPreset, normalizeTranslationLangLabel, TRANSLATION_LANG_MAX_LENGTH, TRANSLATION_LANG_PRESETS } from '../../utils/translationLang';
+import type { ContextRangeMode, ContextRangeSnapshot } from '../../utils/chatContextRange';
 
 interface ChatModalsProps {
     modalType: string;
@@ -18,6 +19,8 @@ interface ChatModalsProps {
     setEmojiImportText: (v: string) => void;
     settingsContextLimit: number;
     setSettingsContextLimit: (v: number) => void;
+    settingsContextRangeMode: ContextRangeMode;
+    setSettingsContextRangeMode: (v: ContextRangeMode) => void;
     settingsHideSysLogs: boolean;
     setSettingsHideSysLogs: (v: boolean) => void;
     preserveContext: boolean;
@@ -51,6 +54,7 @@ interface ChatModalsProps {
     activeCharacter: CharacterProfile;
     messages: Message[];
     allHistoryMessages?: Message[];
+    contextRangeSnapshot?: ContextRangeSnapshot;
 
     // Handlers
     onTransfer: () => void;
@@ -65,6 +69,7 @@ interface ChatModalsProps {
     onSavePrompt: () => void;
     onDeletePrompt: (id: string) => void;
     onSetHistoryStart: (id: number | undefined) => void;
+    onRestoreAdaptiveContext?: () => void;
     onJumpToMessageInChat?: (id: number) => void;
     onEnterSelectionMode: () => void;
     onReplyMessage: () => void;
@@ -213,6 +218,7 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     transferNote, setTransferNote,
     emojiImportText, setEmojiImportText,
     settingsContextLimit, setSettingsContextLimit,
+    settingsContextRangeMode, setSettingsContextRangeMode,
     settingsHideSysLogs, setSettingsHideSysLogs,
     preserveContext, setPreserveContext,
     editContent, setEditContent,
@@ -222,10 +228,11 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     editingPrompt, setEditingPrompt, isSummarizing, archiveProgress,
     selectedMessage, selectedEmoji, selectedCategory, activeCharacter, messages,
     allHistoryMessages = [],
+    contextRangeSnapshot,
     onTransfer, onImportEmoji, onSaveSettings,
     onBgUpload, onRemoveBg, onClearHistory,
     onArchive, onCreatePrompt, onEditPrompt, onSavePrompt, onDeletePrompt,
-    onSetHistoryStart, onJumpToMessageInChat, onEnterSelectionMode, onReplyMessage, onEditMessageStart, onConfirmEditMessage, onDeleteMessage, onCopyMessage, onDeleteEmoji, onDeleteCategory,
+    onSetHistoryStart, onRestoreAdaptiveContext, onJumpToMessageInChat, onEnterSelectionMode, onReplyMessage, onEditMessageStart, onConfirmEditMessage, onDeleteMessage, onCopyMessage, onDeleteEmoji, onDeleteCategory,
     allCharacters = [], onSaveCategoryVisibility,
     translationEnabled, onToggleTranslation, translateSourceLang, translateTargetLang, onSetTranslateSourceLang, onSetTranslateLang,
     xhsEnabled, onToggleXhs,
@@ -242,7 +249,6 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     const [visibilitySelection, setVisibilitySelection] = useState<Set<string>>(new Set());
     const [historyPage, setHistoryPage] = useState(0);
     const [historySearch, setHistorySearch] = useState('');
-    const [pendingHideMsgId, setPendingHideMsgId] = useState<number | null>(null);
     const longPressTimerRef = useRef<number | null>(null);
     const longPressTriggeredRef = useRef(false);
     const HISTORY_PAGE_SIZE = 50;
@@ -258,7 +264,6 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                 setModalType('none');
                 setHistoryPage(0);
                 setHistorySearch('');
-                setPendingHideMsgId(null);
                 onJumpToMessageInChat(msgId);
             }
         }, LONG_PRESS_MS);
@@ -274,7 +279,8 @@ const ChatModals: React.FC<ChatModalsProps> = ({
             longPressTriggeredRef.current = false;
             return;
         }
-        setPendingHideMsgId(msgId);
+        // 范围内直接设置；范围外由上层直接提示先调整拉杆。
+        onSetHistoryStart(msgId);
     };
 
     // 模糊匹配：query 的所有字符按顺序在 content 里出现即算命中（大小写不敏感）。
@@ -382,9 +388,74 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                          {activeCharacter.chatBackground && <button onClick={onRemoveBg} className="text-[10px] text-red-400 mt-1">移除背景</button>}
                      </div>
                      <div>
-                         <label className="text-xs font-bold text-slate-400 uppercase mb-2 block">上下文条数 ({settingsContextLimit})</label>
-                         <input type="range" min="20" max="5000" step="10" value={settingsContextLimit} onChange={e => setSettingsContextLimit(parseInt(e.target.value))} className="w-full h-2 bg-slate-200 rounded-full appearance-none accent-primary" />
-                         <div className="flex justify-between text-[10px] text-slate-400 mt-1"><span>20 (省流)</span><span>5000 (超长记忆)</span></div>
+                         {activeCharacter.autoArchiveEnabled && settingsContextRangeMode === 'adaptive' ? (
+                             <div className="rounded-2xl border border-violet-200 bg-violet-50 p-3.5">
+                                 <div className="flex items-start justify-between gap-3">
+                                     <div>
+                                         <div className="text-xs font-bold text-violet-700">自适应全自动记忆中</div>
+                                         <p className="text-[10px] text-violet-600/80 mt-1 leading-relaxed">
+                                             原文范围自动跟随记忆宫殿水位线，更早内容通过向量记忆召回。非特殊需求请勿调整。
+                                         </p>
+                                         {activeCharacter.contextUserStartMessageId && (
+                                             <p className="text-[10px] text-sky-700 mt-1.5 leading-relaxed">
+                                                 当前另有用户断点，实际原文范围会在自适应上限内进一步缩小。
+                                             </p>
+                                         )}
+                                     </div>
+                                     <div className="shrink-0 flex flex-col gap-1.5">
+                                         <button
+                                             type="button"
+                                             onClick={() => setSettingsContextRangeMode('manual')}
+                                             className="px-3 py-1.5 rounded-xl bg-white border border-violet-200 text-[11px] font-bold text-violet-700"
+                                         >
+                                             自定义范围
+                                         </button>
+                                         {activeCharacter.contextUserStartMessageId && (
+                                             <button
+                                                 type="button"
+                                                 onClick={onRestoreAdaptiveContext}
+                                                 className="px-3 py-1.5 rounded-xl bg-violet-600 text-[11px] font-bold text-white"
+                                             >
+                                                 一键还原
+                                             </button>
+                                         )}
+                                     </div>
+                                 </div>
+                             </div>
+                         ) : (
+                             <>
+                                 <div className="flex items-center justify-between gap-2 mb-2">
+                                     <label className="text-xs font-bold text-slate-400 uppercase">上下文最大条数 ({settingsContextLimit})</label>
+                                     {activeCharacter.autoArchiveEnabled && (
+                                         <button
+                                             type="button"
+                                             onClick={onRestoreAdaptiveContext}
+                                             className="text-[10px] font-bold text-violet-600 bg-violet-50 border border-violet-100 rounded-full px-2.5 py-1"
+                                         >
+                                             一键恢复自适应
+                                         </button>
+                                     )}
+                                 </div>
+                                 <input
+                                     type="range"
+                                     min="20"
+                                     max="5000"
+                                     step="10"
+                                     value={settingsContextLimit}
+                                     onChange={e => {
+                                         setSettingsContextRangeMode('manual');
+                                         setSettingsContextLimit(parseInt(e.target.value));
+                                     }}
+                                     className="w-full h-2 bg-slate-200 rounded-full appearance-none accent-primary"
+                                 />
+                                 <div className="flex justify-between text-[10px] text-slate-400 mt-1"><span>20 (省流)</span><span>5000 (最大范围)</span></div>
+                                 {activeCharacter.autoArchiveEnabled && (
+                                     <p className="text-[10px] text-amber-600 mt-2 leading-relaxed">
+                                         自定义只改变 AI 可直接读取的原文范围，不会回退记忆宫殿水位线，也不会让旧消息重新向量化。
+                                     </p>
+                                 )}
+                             </>
+                         )}
                      </div>
 
                      <div className="pt-2 border-t border-slate-100">
@@ -503,9 +574,9 @@ const ChatModals: React.FC<ChatModalsProps> = ({
 
                      <div className="pt-2 border-t border-slate-100">
                          <button onClick={() => setModalType('history-manager')} className="w-full py-3 bg-slate-50 text-slate-600 font-bold rounded-2xl border border-slate-200 active:scale-95 transition-transform flex items-center justify-center gap-2">
-                             管理上下文 / 隐藏历史
+                             查看原文范围 / 设置用户断点
                          </button>
-                         <p className="text-[10px] text-slate-400 mt-2 text-center">可选择从某条消息开始显示，隐藏之前的记录（不被 AI 读取）。</p>
+                         <p className="text-[10px] text-slate-400 mt-2 text-center">查看拉杆上限、记忆水位线，并可在最大范围内进一步缩小 AI 原文范围。</p>
                      </div>
                      
                      {/* 记忆宫殿：一键向量化所有聊天记录 */}
@@ -635,17 +706,24 @@ const ChatModals: React.FC<ChatModalsProps> = ({
 
             {/* History Manager Modal */}
             <Modal
-                isOpen={modalType === 'history-manager'} title="历史记录断点" onClose={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); setPendingHideMsgId(null); }}
-                footer={<><button onClick={() => onSetHistoryStart(undefined)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">恢复全部</button><button onClick={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); setPendingHideMsgId(null); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">完成</button></>}
+                isOpen={modalType === 'history-manager'} title="AI 原文读取范围" onClose={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); }}
+                footer={<><button onClick={() => onSetHistoryStart(undefined)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">清除用户断点</button><button onClick={() => { setModalType('none'); setHistoryPage(0); setHistorySearch(''); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">完成</button></>}
             >
                 <div className="space-y-2 max-h-[50vh] overflow-y-auto no-scrollbar p-1">
-                    <p className="text-xs text-slate-400 text-center mb-2"><b>短按</b>消息 = 设为隐藏起点（会再次确认） · <b>长按</b>消息 = 跳转到聊天里查看原文</p>
-                    {typeof activeCharacter.hideBeforeMessageId === 'number' && activeCharacter.hideBeforeMessageId > 0 && (
-                        <div className="bg-violet-50 border border-violet-200 rounded-xl p-2.5 text-[11px] text-violet-800 leading-relaxed mb-2">
-                            <b>💡 已经有隐藏起点了</b>：灰色消息是自动/手动归档时标记为"已总结"的，AI 现在看不到原文，但能看到它们的总结。<br/>
-                            <span className="text-violet-600">记忆宫殿的记忆是自动维护的，跟这里无关，不用手动管。</span>
+                    <p className="text-xs text-slate-400 text-center mb-2"><b>短按</b>消息 = 设置用户断点（只能缩小范围） · <b>长按</b>消息 = 跳转查看原文</p>
+                    <div className="grid gap-2 mb-2">
+                        <div className="bg-violet-50 border border-violet-200 rounded-xl p-2.5 text-[11px] text-violet-800 leading-relaxed">
+                            <b>紫色 · 记忆宫殿水位线</b>：此前消息已经处理，不会因调整上下文再次向量化。
                         </div>
-                    )}
+                        <div className="bg-orange-50 border border-orange-200 rounded-xl p-2.5 text-[11px] text-orange-800 leading-relaxed">
+                            <b>橙色 · 最大范围起点</b>：由{contextRangeSnapshot?.mode === 'adaptive' ? '全自动记忆' : `拉杆 ${settingsContextLimit} 条`}决定，用户断点不能越过它读取更早内容。
+                        </div>
+                        {contextRangeSnapshot?.userStartMessageId && (
+                            <div className="bg-sky-50 border border-sky-200 rounded-xl p-2.5 text-[11px] text-sky-800 leading-relaxed">
+                                <b>蓝色 · 用户断点</b>：只在最大范围内进一步隐藏更早原文；被移动中的最大范围越过后会自动失效。
+                            </div>
+                        )}
+                    </div>
                     <div className="sticky top-0 bg-white/95 backdrop-blur-sm z-10 pb-1.5 -mx-1 px-1">
                         <div className="relative">
                             <input
@@ -670,7 +748,10 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                         const limited = query ? filtered.slice(0, HISTORY_SEARCH_MAX) : filtered;
                         const totalPages = Math.max(1, Math.ceil(limited.length / HISTORY_PAGE_SIZE));
                         const pageMessages = limited.slice(historyPage * HISTORY_PAGE_SIZE, (historyPage + 1) * HISTORY_PAGE_SIZE);
-                        const hideCut = activeCharacter.hideBeforeMessageId;
+                        const hwm = contextRangeSnapshot?.hwm || 0;
+                        const maxCut = contextRangeSnapshot?.maxRangeStartMessageId;
+                        const userCut = contextRangeSnapshot?.userStartMessageId;
+                        const effectiveCut = contextRangeSnapshot?.effectiveStartMessageId;
                         return (<>
                             {query && (
                                 <div className="text-xs text-slate-500 px-1 py-1">
@@ -692,13 +773,20 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                                 </div>
                             )}
                             {pageMessages.map(m => {
-                                const isCurrentStart = hideCut === m.id;
-                                const isHidden = !!(hideCut && m.id < hideCut);
-                                const cls = isCurrentStart
-                                    ? 'bg-primary/10 border-primary ring-1 ring-primary'
-                                    : isHidden
-                                        ? 'bg-slate-50 border-slate-100 opacity-55'
-                                        : 'bg-white border-slate-100 hover:bg-slate-50';
+                                const isWatermark = hwm === m.id;
+                                const isMaxStart = maxCut === m.id;
+                                const isUserStart = userCut === m.id;
+                                const isHidden = !!(effectiveCut && m.id < effectiveCut);
+                                const isVectorized = hwm > 0 && m.id <= hwm;
+                                const cls = isUserStart
+                                    ? 'bg-sky-50 border-sky-300 ring-1 ring-sky-300'
+                                    : isMaxStart
+                                        ? 'bg-orange-50 border-orange-300 ring-1 ring-orange-300'
+                                        : isWatermark
+                                            ? 'bg-violet-50 border-violet-300 ring-1 ring-violet-300'
+                                            : isHidden
+                                                ? 'bg-slate-50 border-slate-100 opacity-55'
+                                                : 'bg-white border-slate-100 hover:bg-slate-50';
                                 const contentClass = isHidden ? 'text-slate-400 line-through decoration-slate-300/70' : 'text-slate-500';
                                 return (
                                     <div
@@ -717,8 +805,13 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                                             <div className="font-bold text-slate-600 mb-0.5">{m.role === 'user' ? '我' : activeCharacter.name}</div>
                                             <div className="truncate">{renderHighlighted(m.content || '', query, contentClass)}</div>
                                         </div>
-                                        {isCurrentStart && <span className="text-primary font-bold text-[10px] bg-white px-2 rounded-full border border-primary/20">起点</span>}
-                                        {!isCurrentStart && isHidden && <span className="text-slate-400 font-bold text-[10px] bg-white px-2 rounded-full border border-slate-200">已隐</span>}
+                                        <div className="flex flex-wrap justify-end gap-1 max-w-[42%]">
+                                            {isWatermark && <span className="text-violet-600 font-bold text-[9px] bg-white px-1.5 rounded-full border border-violet-200">水位线</span>}
+                                            {isMaxStart && <span className="text-orange-600 font-bold text-[9px] bg-white px-1.5 rounded-full border border-orange-200">最大范围</span>}
+                                            {isUserStart && <span className="text-sky-600 font-bold text-[9px] bg-white px-1.5 rounded-full border border-sky-200">用户断点</span>}
+                                            {!isWatermark && !isMaxStart && !isUserStart && isHidden && <span className="text-slate-400 font-bold text-[9px] bg-white px-1.5 rounded-full border border-slate-200">AI 不读原文</span>}
+                                            {!isWatermark && !isMaxStart && !isUserStart && isVectorized && !isHidden && <span className="text-violet-400 font-bold text-[9px] bg-white px-1.5 rounded-full border border-violet-100">已向量化</span>}
+                                        </div>
                                     </div>
                                 );
                             })}
@@ -726,46 +819,6 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                                 <div className="flex items-center justify-center px-1 pt-2">
                                     <span className="text-xs text-slate-400">{historyPage + 1} / {totalPages}</span>
                                 </div>
-                            )}
-                        </>);
-                    })()}
-                </div>
-            </Modal>
-
-            {/* Confirm Set Hide Start Point */}
-            <Modal
-                isOpen={pendingHideMsgId !== null}
-                title="设为隐藏起点？"
-                onClose={() => setPendingHideMsgId(null)}
-                footer={<>
-                    <button onClick={() => setPendingHideMsgId(null)} className="flex-1 py-3 bg-slate-100 text-slate-600 font-bold rounded-2xl">取消</button>
-                    <button onClick={() => { if (pendingHideMsgId !== null) onSetHistoryStart(pendingHideMsgId); setPendingHideMsgId(null); }} className="flex-1 py-3 bg-primary text-white font-bold rounded-2xl">确认</button>
-                </>}
-            >
-                <div className="space-y-3 text-xs text-slate-600 leading-relaxed">
-                    {(() => {
-                        const m = allHistoryMessages.find(x => x.id === pendingHideMsgId);
-                        if (!m) return <p>消息不存在</p>;
-                        return (<>
-                            <p>该条之前的消息将被隐藏，不再发送给 AI（你仍能在聊天里翻看）。</p>
-                            <div className="bg-slate-50 border border-slate-200 rounded-xl p-3">
-                                <div className="font-bold text-slate-600 mb-1">{m.role === 'user' ? '我' : activeCharacter.name} <span className="text-slate-400 font-normal text-[10px] ml-1">{new Date(m.timestamp).toLocaleString()}</span></div>
-                                <div className="text-slate-500 line-clamp-3">{m.content}</div>
-                            </div>
-                            {onJumpToMessageInChat && (
-                                <button
-                                    onClick={() => {
-                                        const id = pendingHideMsgId;
-                                        setPendingHideMsgId(null);
-                                        setModalType('none');
-                                        setHistoryPage(0);
-                                        setHistorySearch('');
-                                        if (id !== null) onJumpToMessageInChat(id);
-                                    }}
-                                    className="w-full py-2 text-xs text-indigo-600 bg-indigo-50 hover:bg-indigo-100 rounded-xl transition-colors"
-                                >
-                                    或：跳转到聊天里查看原文
-                                </button>
                             )}
                         </>);
                     })()}

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -24,6 +24,12 @@ import { rewriteStaleWorkerUrl } from '../utils/proxyWorker';
 import { INSTALLED_APPS } from '../constants';
 import { markBackupDone } from '../utils/backupReminder';
 import { normalizeCharacterImpression, normalizeCharacterDefaults } from '../utils/impression';
+import {
+  CONTEXT_RANGE_POLICY_VERSION,
+  DEFAULT_MANUAL_CONTEXT_LIMIT,
+  loadCharacterContextRange,
+  migrateCharacterContextRange,
+} from '../utils/chatContextRange';
 import { isScheduleFeatureOn } from '../utils/scheduleGenerator';
 import { evaluateEmotionBackground } from '../hooks/useChatAI';
 import { CHAT_GEN_EVENTS, setChatViewSnapshot } from '../utils/chatGenEvents';
@@ -661,6 +667,8 @@ Sully是小手机的内置AI。
   // Default theme settings
   bubbleStyle: 'default', // Or specific theme ID if we had one
   contextLimit: 1000,
+  contextRangeMode: 'manual',
+  contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
   
   // Default Room Config
   roomConfig: {
@@ -1403,7 +1411,24 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
             }
         }
 
-        finalChars = finalChars.map(c => normalizeCharacterDefaults(normalizeCharacterImpression(c)));
+        let resetAutoContextCount = 0;
+        let migratedContextCount = 0;
+        finalChars = finalChars.map(c => {
+          const normalized = normalizeCharacterDefaults(normalizeCharacterImpression(c));
+          const migration = migrateCharacterContextRange(normalized);
+          if (migration.migrated) migratedContextCount++;
+          if (migration.resetAutoContext) resetAutoContextCount++;
+          return migration.character;
+        });
+        if (migratedContextCount > 0) {
+          await Promise.all(finalChars.map(c => DB.saveCharacter(c)));
+        }
+        if (resetAutoContextCount > 0) {
+          setTimeout(() => addToast(
+            `上下文范围已升级：${resetAutoContextCount} 个全自动记忆角色已恢复为自适应模式。需要读取更多旧原文时，可在聊天设置中手动调整。`,
+            'info',
+          ), 1200);
+        }
 
         if (finalChars.length > 0) {
           setCharacters(finalChars);
@@ -1924,7 +1949,11 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
 
               // 3. Build prompt & message history — 走和 useChatAI / emotion eval 同一个 helper，
               //    保证三家拿到的"材料"完全一致；区别只在前面追加的"现在主动找用户"那条 hint。
-              const allMsgs = await DB.getRecentMessagesByCharId(charId, char.contextLimit || 500);
+              const proactiveRange = await loadCharacterContextRange(char);
+              if (proactiveRange.userBreakpointExpired) {
+                  updateCharacter(charId, { contextUserStartMessageId: undefined });
+              }
+              const allMsgs = proactiveRange.messages;
               const emojis = await DB.getEmojis();
               const categories = await DB.getEmojiCategories();
 
@@ -1935,7 +1964,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   char, userProfile: currentUserProfile!, groups: currentGroups,
                   emojis, categories,
                   historyMsgs: allMsgs,
-                  contextLimit: char.contextLimit || 500,
+                  contextLimit: Math.max(1, allMsgs.length),
                   realtimeConfig: currentRealtimeConfig,
                   innerState: cachedInnerState,
                   // 实时音乐播放状态 —— OSContext 在 MusicProvider 上层用不了 useMusic()，
@@ -2578,7 +2607,9 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       description: '点击编辑设定...',
       systemPrompt: '',
       memories: [],
-      contextLimit: 500,
+      contextLimit: DEFAULT_MANUAL_CONTEXT_LIMIT,
+      contextRangeMode: 'manual',
+      contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
       emotionConfig: { enabled: true },
     };
     setCharacters(prev => [...prev, newChar]);
@@ -4018,7 +4049,27 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               setAppearancePresets(loadedPresets);
           }
 
-          if (chars.length > 0) setCharacters(chars.map(c => normalizeCharacterDefaults(normalizeCharacterImpression(c))));
+          if (chars.length > 0) {
+              let importedAutoContextCount = 0;
+              let importedContextMigrated = false;
+              const normalizedChars = chars.map(c => {
+                  const normalized = normalizeCharacterDefaults(normalizeCharacterImpression(c));
+                  const migration = migrateCharacterContextRange(normalized);
+                  if (migration.migrated) importedContextMigrated = true;
+                  if (migration.resetAutoContext) importedAutoContextCount++;
+                  return migration.character;
+              });
+              if (importedContextMigrated) {
+                  await Promise.all(normalizedChars.map(c => DB.saveCharacter(c)));
+              }
+              setCharacters(normalizedChars);
+              if (importedAutoContextCount > 0) {
+                  setTimeout(() => addToast(
+                      `导入的旧设置已升级：${importedAutoContextCount} 个全自动记忆角色已使用自适应上下文。`,
+                      'info',
+                  ), 600);
+              }
+          }
           if (groupsList.length > 0) setGroups(groupsList);
           if (themes.length > 0) setCustomThemes(themes);
           if (user) setUserProfile(user);

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -43,6 +43,11 @@ import { applyEmotionEvalRaw, extractAssistantText } from '../utils/emotionApply
 import { announceChatGen, CHAT_GEN_EVENTS } from '../utils/chatGenEvents';
 import { shouldRequestAmbient, buildAmbientEvalSection } from '../utils/roomAmbient';
 import { isEmotionEvalSkipped } from '../utils/devDebug';
+import {
+    computeContextRangeSnapshot,
+    getMemoryPalaceHighWaterMarkForContext,
+    loadCharacterContextRange,
+} from '../utils/chatContextRange';
 
 // ─── 情绪评估（副API，fire & forget）───
 
@@ -520,9 +525,11 @@ export const useChatAI = ({
         const charIdAtMount = char.id;
 
         const runEvalForPushedChar = async (): Promise<void> => {
+            // The listener is keyed by character ID, but settings may change without remounting it.
+            const evalChar = charRef.current?.id === charIdAtMount ? charRef.current : char;
             // 双 gate: 跟 line 613 一致 (schedule feature on + emotionConfig enabled).
             // 关掉的话还是要 clear pending, 否则下次 mount 反复尝试.
-            if (!isScheduleFeatureOn(char) || !char.emotionConfig?.enabled) {
+            if (!isScheduleFeatureOn(evalChar) || !evalChar.emotionConfig?.enabled) {
                 try { await ActiveMsgStore.clearPendingEmotionEval(charIdAtMount); } catch { /* ignore */ }
                 return;
             }
@@ -533,14 +540,17 @@ export const useChatAI = ({
                 return;
             }
             // 评估跟随全局流式开关（与 triggerAI 路径同口径；专用情绪 API 自带 stream 时以它为准）
-            const emotionApi = (char.emotionConfig.api?.baseUrl)
-                ? { ...char.emotionConfig.api, stream: (char.emotionConfig.api as any).stream ?? !!(deps.apiConfig.stream ?? false) }
+            const emotionApi = (evalChar.emotionConfig.api?.baseUrl)
+                ? { ...evalChar.emotionConfig.api, stream: (evalChar.emotionConfig.api as any).stream ?? !!(deps.apiConfig.stream ?? false) }
                 : { baseUrl: deps.apiConfig.baseUrl, apiKey: deps.apiConfig.apiKey, model: deps.apiConfig.model, stream: !!(deps.apiConfig.stream ?? false) };
 
             try {
-                // 重新从 DB 拉 history (push msg 此刻已经在 DB 里, activeMsgRuntime 在 dispatch
-                // 事件前已 await saveMessage). limit 200 跟 sendMessage line 543 同等级别.
-                const contextMsgs = await DB.getRecentMessagesByCharId(charIdAtMount, 200);
+                // 重新从 DB 拉与主聊天一致的「自适应/拉杆最大范围 + 用户断点」。
+                const pushedRange = await loadCharacterContextRange(evalChar);
+                const contextMsgs = pushedRange.messages;
+                if (pushedRange.userBreakpointExpired && updateCharacter) {
+                    updateCharacter(charIdAtMount, { contextUserStartMessageId: undefined });
+                }
 
                 // 跟 sendMessage line 553 同一个 helper, 同一份 ctx → emotion eval 看到的 systemPrompt
                 // + cleanedApiMessages 跟 主 API 调用看到的几乎完全一致 (差别仅在 music live snapshot 时序).
@@ -549,13 +559,13 @@ export const useChatAI = ({
                 const luckinMiniSnap = deps.luckinMiniAppRef?.current;
                 const luckinMiniOpen = !!luckinMiniSnap?.open;
                 const payload = await buildChatRequestPayload({
-                    char,
+                    char: evalChar,
                     userProfile: deps.userProfile,
                     groups: deps.groups,
                     emojis: deps.emojis,
                     categories: deps.categories,
                     historyMsgs: contextMsgs,
-                    contextLimit: 200,
+                    contextLimit: Math.max(1, contextMsgs.length),
                     realtimeConfig: deps.realtimeConfig,
                     innerState: deps.evolvedNarrative || undefined,
                     musicSnapshot: {
@@ -568,8 +578,8 @@ export const useChatAI = ({
                         recentTrackChange: deps.music.recentTrackChange,
                     },
                     translationConfig: deps.translationConfig,
-                    htmlMode: { enabled: !!(char as any).htmlModeEnabled, customPrompt: (char as any).htmlModeCustomPrompt },
-                    thinkingChain: { enabled: !!(char as any).showThinkingChain, customPrompt: (char as any).thinkingChainCustomPrompt },
+                    htmlMode: { enabled: !!(evalChar as any).htmlModeEnabled, customPrompt: (evalChar as any).htmlModeCustomPrompt },
+                    thinkingChain: { enabled: !!(evalChar as any).showThinkingChain, customPrompt: (evalChar as any).thinkingChainCustomPrompt },
                     mcdMiniSnap: mcdMiniOpen ? mcdMiniSnap : undefined,
                     luckinMiniSnap: luckinMiniOpen ? luckinMiniSnap : undefined,
                 });
@@ -581,7 +591,7 @@ export const useChatAI = ({
 
                 setEmotionStatus('evaluating');
                 const innerState = await evaluateEmotionBackground(
-                    char, deps.userProfile, payload.systemPrompt, payload.cleanedApiMessages, emotionApi,
+                    evalChar, deps.userProfile, payload.systemPrompt, payload.cleanedApiMessages, emotionApi,
                 );
                 if (innerState) setEvolvedNarrative(innerState);
                 // 成功后清 pending. 失败不清 → 下次 mount drain 重试.
@@ -711,20 +721,29 @@ export const useChatAI = ({
                 finally { perfStages[label] = Math.round(performance.now() - t0); }
             };
 
-            // 0.9 历史消息加载: AI 上下文以 DB 最新状态为准.
-            // 刚保存消息后 React state 可能还是旧快照; 每次触发都读最近 contextLimit 条,
-            // 避免自动回复 / 手动触发在时序边界漏掉刚写入的消息或派生卡片。
-            const limit = char.contextLimit || 500;
-            const fullHistoryPromise: Promise<Message[] | null> = char.id
-                ? DB.getRecentMessagesByCharId(char.id, limit).catch(e => {
-                    console.error('Failed to load full history from DB, using React state:', e);
-                    return null;
-                })
-                : Promise.resolve(null);
-            const fullHistory = await stageT('dbHistory', fullHistoryPromise);
+            // 0.9 历史消息加载：最大范围与记忆宫殿水位线彻底解耦。
+            // adaptive 从 HWM 之后开始；manual 忽略 HWM 读取最近 N 条完整原文；
+            // 用户断点只可在最大范围内继续收窄，越界后自动失效。
+            const contextRange = char.id
+                ? await stageT('dbHistory', loadCharacterContextRange(char).catch(e => {
+                    console.error('Failed to load context range from DB, using React state:', e);
+                    // 即便 DB 读取失败，降级路径也必须继续遵守水位线/拉杆硬上限，不能把 React
+                    // 缓存里的更早消息意外送回模型。
+                    return computeContextRangeSnapshot(
+                        currentMsgs,
+                        char,
+                        getMemoryPalaceHighWaterMarkForContext(char.id),
+                    );
+                }))
+                : null;
+            if (contextRange?.userBreakpointExpired && updateCharacter) {
+                updateCharacter(char.id, { contextUserStartMessageId: undefined });
+            }
+            const fullHistory = contextRange?.messages || null;
             const contextMsgs = fullHistory || currentMsgs;
+            const limit = Math.max(1, fullHistory ? fullHistory.length : (char.contextLimit || 500));
             if (fullHistory) {
-                console.log(`📊 [Context] Loaded ${fullHistory.length} msgs from DB (React state had ${currentMsgs.length}, contextLimit=${limit})`);
+                console.log(`📊 [Context] Loaded ${fullHistory.length} msgs from DB (React state had ${currentMsgs.length}, mode=${contextRange?.mode}, maxStart=${contextRange?.maxRangeStartMessageId ?? 'none'}, effectiveStart=${contextRange?.effectiveStartMessageId ?? 'none'})`);
             }
 
             // 1. 构造完整 chat 请求载荷（memoryPalace 召回 + system prompt + 双语 / HTML / 思考链 / MCD + 历史）

--- a/types.ts
+++ b/types.ts
@@ -2113,7 +2113,21 @@ export interface CharacterProfile {
   chatFineTune?: ChatFineTuneOverride;
   chatBackground?: string;
   contextLimit?: number;
+  /**
+   * AI 原文读取范围策略：
+   * - adaptive：全自动记忆接管，最大范围从记忆宫殿水位线之后开始；
+   * - manual：用户拉杆决定最多读取最近 contextLimit 条完整原文。
+   */
+  contextRangeMode?: 'adaptive' | 'manual';
+  /** 上下文范围结构版本；用于把旧版「5000 条 + 自动水位隐藏」一次性迁移到自适应模式。 */
+  contextRangePolicyVersion?: number;
+  /**
+   * 用户额外设置的 AI 原文断点。它只能在拉杆/自适应最大范围内进一步缩小，
+   * 不能突破最大范围向更早读取；一旦被移动中的最大范围越过便自动失效。
+   */
+  contextUserStartMessageId?: number;
   hideSystemLogs?: boolean; 
+  /** 旧版归档内部隐藏线；新版 AI 原文范围不再拿它当用户断点。 */
   hideBeforeMessageId?: number; 
   
   dateBackground?: string;

--- a/utils/backupRoundtrip.test.ts
+++ b/utils/backupRoundtrip.test.ts
@@ -145,6 +145,34 @@ describe('v2 真实链路：分片 → 组装 → importFullData', () => {
         expect(profile.perCharAvatars).toEqual(userProfile.perCharAvatars);
     });
 
+    it('AI 原文范围设置随角色备份完整往返', async () => {
+        const char = {
+            id: 'ctx1',
+            name: '上下文角色',
+            avatar: '',
+            description: '',
+            systemPrompt: '',
+            memories: [],
+            contextRangePolicyVersion: 1,
+            contextRangeMode: 'manual',
+            contextLimit: 1200,
+            contextUserStartMessageId: 345,
+        };
+        const zip = new FakeZip();
+        const manifest = await writeV2Backup(zip, { characters: [char] } as any, {});
+        const data = await assembleV2Backup(zip, manifest);
+
+        await DB.importFullData(data as any);
+
+        const restored = (await DB.getRawStoreData('characters')).find((c: any) => c.id === 'ctx1');
+        expect(restored).toMatchObject({
+            contextRangePolicyVersion: 1,
+            contextRangeMode: 'manual',
+            contextLimit: 1200,
+            contextUserStartMessageId: 345,
+        });
+    });
+
     it('formatVersion 3 在组装阶段 abort，DB 未发生任何写（test 12）', async () => {
         await seedStore('gallery', [{ id: 'keep', url: 'x' }]);
         const zip = new FakeZip();

--- a/utils/chatContextRange.test.ts
+++ b/utils/chatContextRange.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import type { CharacterProfile, Message } from '../types';
+import {
+    computeContextRangeSnapshot,
+    migrateCharacterContextRange,
+} from './chatContextRange';
+
+const makeMessages = (from: number, to: number): Message[] =>
+    Array.from({ length: to - from + 1 }, (_, index) => {
+        const id = from + index;
+        return {
+            id,
+            charId: 'char-context',
+            role: id % 2 ? 'user' : 'assistant',
+            type: 'text',
+            content: `message-${id}`,
+            timestamp: id,
+        } as Message;
+    });
+
+const makeChar = (partial: Partial<CharacterProfile>): CharacterProfile => ({
+    id: 'char-context',
+    name: 'Context',
+    avatar: '',
+    description: '',
+    systemPrompt: '',
+    memories: [],
+    contextRangePolicyVersion: 1,
+    ...partial,
+});
+
+describe('AI 原文范围边界', () => {
+    it('自适应最大范围从水位线之后开始', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({ autoArchiveEnabled: true, contextRangeMode: 'adaptive', contextLimit: 5000 }),
+            800,
+        );
+
+        expect(snapshot.maxRangeStartMessageId).toBe(801);
+        expect(snapshot.effectiveStartMessageId).toBe(801);
+        expect(snapshot.messages[0].id).toBe(801);
+        expect(snapshot.messages.at(-1)?.id).toBe(1000);
+    });
+
+    it('范围内用户断点只能把起点向更新消息推进', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'adaptive',
+                contextUserStartMessageId: 900,
+            }),
+            800,
+        );
+
+        expect(snapshot.maxRangeStartMessageId).toBe(801);
+        expect(snapshot.userStartMessageId).toBe(900);
+        expect(snapshot.effectiveStartMessageId).toBe(900);
+        expect(snapshot.messages[0].id).toBe(900);
+    });
+
+    it('用户断点恰好位于最大范围起点时有效且没有越界', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'manual',
+                contextLimit: 500,
+                contextUserStartMessageId: 501,
+            }),
+            800,
+        );
+
+        expect(snapshot.userBreakpointExpired).toBe(false);
+        expect(snapshot.effectiveStartMessageId).toBe(501);
+        expect(snapshot.messages).toHaveLength(500);
+    });
+
+    it('水位线之前的用户断点不能突破自适应最大范围', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'adaptive',
+                contextUserStartMessageId: 700,
+            }),
+            800,
+        );
+
+        expect(snapshot.userBreakpointExpired).toBe(true);
+        expect(snapshot.userStartMessageId).toBeUndefined();
+        expect(snapshot.effectiveStartMessageId).toBe(801);
+        expect(snapshot.messages[0].id).toBe(801);
+    });
+
+    it('手动拉杆忽略水位线并把最近 N 条作为最大范围', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'manual',
+                contextLimit: 500,
+            }),
+            800,
+        );
+
+        expect(snapshot.maxRangeStartMessageId).toBe(501);
+        expect(snapshot.effectiveStartMessageId).toBe(501);
+        expect(snapshot.messages).toHaveLength(500);
+    });
+
+    it('拉杆范围外的旧断点失效，绝不会扩大范围', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1000),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'manual',
+                contextLimit: 500,
+                contextUserStartMessageId: 300,
+            }),
+            800,
+        );
+
+        expect(snapshot.userBreakpointExpired).toBe(true);
+        expect(snapshot.effectiveStartMessageId).toBe(501);
+        expect(snapshot.messages[0].id).toBe(501);
+    });
+
+    it('新消息把拉杆起点推过固定断点后，固定断点失效并跟随拉杆', () => {
+        const snapshot = computeContextRangeSnapshot(
+            makeMessages(1, 1200),
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'manual',
+                contextLimit: 500,
+                contextUserStartMessageId: 700,
+            }),
+            800,
+        );
+
+        expect(snapshot.maxRangeStartMessageId).toBe(701);
+        expect(snapshot.userBreakpointExpired).toBe(true);
+        expect(snapshot.effectiveStartMessageId).toBe(701);
+    });
+
+    it('作为断点的消息被删除后断点失效，不能停在不存在的 ID 上', () => {
+        const messages = makeMessages(1, 1000).filter(message => message.id !== 800);
+        const snapshot = computeContextRangeSnapshot(
+            messages,
+            makeChar({
+                autoArchiveEnabled: true,
+                contextRangeMode: 'manual',
+                contextLimit: 500,
+                contextUserStartMessageId: 800,
+            }),
+            700,
+        );
+
+        expect(snapshot.userBreakpointExpired).toBe(true);
+        expect(snapshot.userStartMessageId).toBeUndefined();
+        expect(snapshot.messages[0].id).toBe(500);
+    });
+});
+
+describe('旧角色上下文迁移', () => {
+    it('全自动用户即使原来拉满 5000 条也回到自适应默认', () => {
+        const result = migrateCharacterContextRange(makeChar({
+            contextRangePolicyVersion: undefined,
+            autoArchiveEnabled: true,
+            contextLimit: 5000,
+            hideBeforeMessageId: 600,
+        }));
+
+        expect(result.migrated).toBe(true);
+        expect(result.resetAutoContext).toBe(true);
+        expect(result.character.contextRangeMode).toBe('adaptive');
+        expect(result.character.contextLimit).toBe(500);
+        expect(result.character.contextUserStartMessageId).toBeUndefined();
+    });
+
+    it('未开全自动的旧用户保留拉杆，并把旧用户断点迁入新字段', () => {
+        const result = migrateCharacterContextRange(makeChar({
+            contextRangePolicyVersion: undefined,
+            autoArchiveEnabled: false,
+            contextLimit: 300,
+            hideBeforeMessageId: 250,
+        }));
+
+        expect(result.character.contextRangeMode).toBe('manual');
+        expect(result.character.contextLimit).toBe(300);
+        expect(result.character.contextUserStartMessageId).toBe(250);
+    });
+
+    it('新字段会随角色设置 JSON 备份往返保留', () => {
+        const original = makeChar({
+            autoArchiveEnabled: true,
+            contextRangeMode: 'manual',
+            contextLimit: 1200,
+            contextUserStartMessageId: 321,
+        });
+        const restored = JSON.parse(JSON.stringify(original)) as CharacterProfile;
+
+        expect(restored.contextRangePolicyVersion).toBe(1);
+        expect(restored.contextRangeMode).toBe('manual');
+        expect(restored.contextLimit).toBe(1200);
+        expect(restored.contextUserStartMessageId).toBe(321);
+    });
+});

--- a/utils/chatContextRange.ts
+++ b/utils/chatContextRange.ts
@@ -1,0 +1,163 @@
+import type { CharacterProfile, Message } from '../types';
+import { DB } from './db';
+
+export const CONTEXT_RANGE_POLICY_VERSION = 1;
+export const DEFAULT_MANUAL_CONTEXT_LIMIT = 500;
+export const MIN_MANUAL_CONTEXT_LIMIT = 20;
+export const MAX_MANUAL_CONTEXT_LIMIT = 5000;
+
+export type ContextRangeMode = 'adaptive' | 'manual';
+
+export interface ContextRangeSnapshot {
+    mode: ContextRangeMode;
+    hwm: number;
+    maxRangeStartMessageId?: number;
+    effectiveStartMessageId?: number;
+    userStartMessageId?: number;
+    userBreakpointExpired: boolean;
+    messages: Message[];
+}
+
+export interface CharacterContextRangeMigration {
+    character: CharacterProfile;
+    migrated: boolean;
+    resetAutoContext: boolean;
+}
+
+const positiveMessageId = (value: unknown): number | undefined =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? Math.floor(value)
+        : undefined;
+
+export const clampManualContextLimit = (value: unknown): number => {
+    const parsed = typeof value === 'number' && Number.isFinite(value)
+        ? Math.floor(value)
+        : DEFAULT_MANUAL_CONTEXT_LIMIT;
+    return Math.max(MIN_MANUAL_CONTEXT_LIMIT, Math.min(MAX_MANUAL_CONTEXT_LIMIT, parsed));
+};
+
+/**
+ * 全自动记忆只在显式 adaptive 时接管范围。关闭全自动后即便旧数据残留 adaptive，
+ * 也按 manual 处理，避免一个已经不存在的自动模式继续限制用户。
+ */
+export const resolveContextRangeMode = (char: CharacterProfile): ContextRangeMode =>
+    char.autoArchiveEnabled && char.contextRangeMode === 'adaptive'
+        ? 'adaptive'
+        : 'manual';
+
+export const getMemoryPalaceHighWaterMarkForContext = (charId: string): number => {
+    try {
+        const value = parseInt(localStorage.getItem(`mp_lastMsgId_${charId}`) || '0', 10);
+        return Number.isFinite(value) && value > 0 ? value : 0;
+    } catch {
+        return 0;
+    }
+};
+
+/**
+ * 一次性迁移旧角色：
+ * - 已开全自动记忆：无论旧拉杆是否为 5000，都回到 adaptive + 默认 500；
+ * - 未开全自动：保留旧拉杆，并把旧版手动断点迁成用户断点。
+ *
+ * hideBeforeMessageId 仍保留给旧归档内部使用，但新版 prompt 不再把它当用户范围。
+ */
+export const migrateCharacterContextRange = (
+    char: CharacterProfile,
+): CharacterContextRangeMigration => {
+    if ((char.contextRangePolicyVersion || 0) >= CONTEXT_RANGE_POLICY_VERSION) {
+        return { character: char, migrated: false, resetAutoContext: false };
+    }
+
+    const resetAutoContext = !!char.autoArchiveEnabled;
+    const next: CharacterProfile = {
+        ...char,
+        contextRangePolicyVersion: CONTEXT_RANGE_POLICY_VERSION,
+        contextRangeMode: resetAutoContext ? 'adaptive' : 'manual',
+        contextLimit: resetAutoContext
+            ? DEFAULT_MANUAL_CONTEXT_LIMIT
+            : clampManualContextLimit(char.contextLimit),
+        contextUserStartMessageId: resetAutoContext
+            ? undefined
+            : positiveMessageId(char.hideBeforeMessageId),
+    };
+
+    return { character: next, migrated: true, resetAutoContext };
+};
+
+const chronologicalPrivateMessages = (messages: Message[]): Message[] =>
+    messages
+        .filter(message => !message.groupId)
+        .slice()
+        .sort((a, b) => a.id - b.id);
+
+/**
+ * 纯边界计算。方向不变式（Message.id 越大越新）：
+ * - 最大范围起点越大，可读范围越小；
+ * - 用户断点只能 >= 最大范围起点；
+ * - 最终起点永远取两者中更大的 id，绝不会越过最大范围向旧消息扩张。
+ */
+export const computeContextRangeSnapshot = (
+    sourceMessages: Message[],
+    char: CharacterProfile,
+    hwm: number,
+): ContextRangeSnapshot => {
+    const allMessages = chronologicalPrivateMessages(sourceMessages);
+    const mode = resolveContextRangeMode(char);
+    const maxRangeMessages = mode === 'adaptive'
+        ? allMessages.filter(message => message.id > hwm)
+        : allMessages.slice(-clampManualContextLimit(char.contextLimit));
+
+    const maxRangeStartMessageId = maxRangeMessages[0]?.id;
+    const latestMessageId = maxRangeMessages[maxRangeMessages.length - 1]?.id;
+    const requestedUserStart = positiveMessageId(char.contextUserStartMessageId);
+    const requestedMessageStillExists = requestedUserStart === undefined
+        || maxRangeMessages.some(message => message.id === requestedUserStart);
+    const userBreakpointExpired = !!requestedUserStart && (
+        maxRangeStartMessageId === undefined
+        || latestMessageId === undefined
+        || requestedUserStart < maxRangeStartMessageId
+        || requestedUserStart > latestMessageId
+        || !requestedMessageStillExists
+    );
+    const userStartMessageId = userBreakpointExpired ? undefined : requestedUserStart;
+    const effectiveStartMessageId = maxRangeStartMessageId === undefined
+        ? undefined
+        : Math.max(maxRangeStartMessageId, userStartMessageId || maxRangeStartMessageId);
+    const messages = effectiveStartMessageId === undefined
+        ? []
+        : maxRangeMessages.filter(message => message.id >= effectiveStartMessageId);
+
+    return {
+        mode,
+        hwm,
+        maxRangeStartMessageId,
+        effectiveStartMessageId,
+        userStartMessageId,
+        userBreakpointExpired,
+        messages,
+    };
+};
+
+/**
+ * AI 上下文读取：
+ * - adaptive 读取水位线后的完整原文；
+ * - manual 忽略水位线，读取完整库最近 N 条；
+ * - 随后再用用户断点收窄。
+ */
+export const loadCharacterContextRange = async (
+    char: CharacterProfile,
+): Promise<ContextRangeSnapshot> => {
+    const hwm = getMemoryPalaceHighWaterMarkForContext(char.id);
+    const mode = resolveContextRangeMode(char);
+    const sourceMessages = mode === 'adaptive'
+        ? (await DB.getMessagesFromId(char.id, hwm + 1)).messages
+        : await DB.getRecentMessagesByCharId(
+            char.id,
+            clampManualContextLimit(char.contextLimit),
+            true,
+        );
+    return computeContextRangeSnapshot(sourceMessages, char, hwm);
+};
+
+export const countMessagesFrom = (messages: Message[], messageId: number): number =>
+    chronologicalPrivateMessages(messages).filter(message => message.id >= messageId).length;

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -912,7 +912,12 @@ ${userProfile.name} 给你反馈时，别当成约束，当成信任——ta 在
         processedExcludeIds?: Set<number>,
     ) => {
         // Filter Logic
-        let effectiveHistory = messages.filter(m => !char.hideBeforeMessageId || m.id >= char.hideBeforeMessageId);
+        // 新版上下文范围由 chatContextRange 先按「自适应/拉杆最大范围」取窗；
+        // 这里只应用用户额外断点。旧角色尚未完成迁移时才回退 hideBeforeMessageId。
+        const userStartMessageId = (char.contextRangePolicyVersion || 0) >= 1
+            ? char.contextUserStartMessageId
+            : char.hideBeforeMessageId;
+        let effectiveHistory = messages.filter(m => !userStartMessageId || m.id >= userStartMessageId);
         // Memory Palace: 过滤已被记忆宫殿处理过的消息（由向量记忆替代，节省 token）
         if (processedExcludeIds && processedExcludeIds.size > 0) {
             effectiveHistory = effectiveHistory.filter(m => !processedExcludeIds.has(m.id));

--- a/utils/webpageExtractor.test.ts
+++ b/utils/webpageExtractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { detectFirstUrl, isXhsUrl, parseWebpageHtml, extractWebpageContent } from './webpageExtractor';
+import { detectFirstUrl, isXhsUrl, extractXhsNoteId, parseWebpageHtml, extractWebpageContent } from './webpageExtractor';
 
 describe('detectFirstUrl', () => {
   it('从一句话里揪出 http(s) 链接', () => {
@@ -26,7 +26,34 @@ describe('isXhsUrl', () => {
   it('识别小红书域名（已有专门 MCP 路径，网页抓取要避开）', () => {
     expect(isXhsUrl('https://www.xiaohongshu.com/explore/abc')).toBe(true);
     expect(isXhsUrl('https://xhslink.com/xxx')).toBe(true);
+    expect(isXhsUrl('https://www.rednote.com/explore/abc')).toBe(true);
     expect(isXhsUrl('https://example.com')).toBe(false);
+    expect(isXhsUrl('https://rednote.com.example.com/explore/abc')).toBe(false);
+    expect(isXhsUrl('https://fake-rednote.com/explore/abc')).toBe(false);
+  });
+});
+
+describe('extractXhsNoteId', () => {
+  const NOTE_ID = '6858ccaa0000000013013c94';
+
+  it('从国内和新版 RedNote 完整链接中提取笔记 ID', () => {
+    expect(extractXhsNoteId(`看看这个 https://www.xiaohongshu.com/explore/${NOTE_ID}?xsec_token=abc`))
+      .toBe(NOTE_ID);
+    expect(extractXhsNoteId(`分享给你 https://www.rednote.com/explore/${NOTE_ID}?xsec_token=abc`))
+      .toBe(NOTE_ID);
+    expect(extractXhsNoteId(`www.rednote.com/discovery/item/${NOTE_ID}`))
+      .toBe(NOTE_ID);
+  });
+
+  it('支持短链展开后落到 rednote.com 的最终链接', () => {
+    expect(extractXhsNoteId(`https://rednote.com/item/${NOTE_ID}?xsec_source=app_share`))
+      .toBe(NOTE_ID);
+  });
+
+  it('不把相似恶意域名或非笔记页面误判成小红书笔记', () => {
+    expect(extractXhsNoteId(`https://rednote.com.example.com/explore/${NOTE_ID}`)).toBeNull();
+    expect(extractXhsNoteId(`https://fake-rednote.com/explore/${NOTE_ID}`)).toBeNull();
+    expect(extractXhsNoteId('https://www.rednote.com/explore')).toBeNull();
   });
 });
 

--- a/utils/webpageExtractor.ts
+++ b/utils/webpageExtractor.ts
@@ -89,9 +89,50 @@ export function detectFirstUrl(text: string): string | null {
   return m[0].replace(/[.,;:!?'")\]]+$/, '');
 }
 
+const XHS_NOTE_PATH_RE = /^\/(?:discovery\/item|explore|item)\/([a-f0-9]{24})(?:[/?#]|$)/i;
+
+function isXhsHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/\.$/, '');
+  return ['xiaohongshu.com', 'xhslink.com', 'rednote.com']
+    .some(domain => host === domain || host.endsWith(`.${domain}`));
+}
+
 /** XHS 链接已有专门的 MCP 卡片路径，网页抓取要避开它，免得抢同一条消息。 */
 export function isXhsUrl(url: string): boolean {
-  return /xiaohongshu\.com|xhslink\.com/i.test(url);
+  try {
+    const parsed = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`);
+    return isXhsHostname(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 从完整分享文案或单个链接中提取小红书笔记 ID。
+ * 同时支持国内域名 xiaohongshu.com 和新版国际域名 rednote.com；
+ * xhslink.com 短链没有 ID，需先 expandShortUrl 后再调用本函数。
+ */
+export function extractXhsNoteId(text: string): string | null {
+  if (!text) return null;
+
+  const candidates: string[] = [...(text.match(/https?:\/\/[^\s，。！？；、"'《》()（）【】]+/ig) || [])];
+  const naked = text.match(/(?:^|[\s，。！？；、"'《》()（）【】])((?:www\.)?(?:xiaohongshu\.com|rednote\.com)\/[^\s，。！？；、"'《》()（）【】]+)/i)?.[1];
+  if (naked) candidates.push(`https://${naked}`);
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = new URL(candidate.replace(/[.,;:!?'")\]]+$/, ''));
+      const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+      const isNoteHost = ['xiaohongshu.com', 'rednote.com']
+        .some(domain => host === domain || host.endsWith(`.${domain}`));
+      if (!isNoteHost) continue;
+      const noteId = parsed.pathname.match(XHS_NOTE_PATH_RE)?.[1];
+      if (noteId) return noteId;
+    } catch {
+      // 忽略文案里的坏链接，继续检查下一个 URL。
+    }
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## 改了什么

- 将 AI 原文读取范围与记忆宫殿高水位线解耦，新增自适应与手动两种范围模式。
- 全自动记忆默认使用自适应范围；手动拉杆只控制模型可读原文，不回退水位线，也不会触发旧消息重新向量化。
- 用户断点只能在拉杆/自适应最大范围内进一步缩小；窗口越过断点后自动失效，范围外操作会提示先调整拉杆。
- 在聊天设置和历史管理中展示水位线、最大范围起点、用户断点及不可读区域，并提供一键恢复自适应。
- 将旧版全自动记忆角色一次性迁移到自适应默认状态并提示用户；新增设置随完整备份导入导出。
- 统一记忆宫殿的“语义上下文”口径：文字、带转写的语音和语义卡片都会参与数量统计、总结与检索；只有纯图片、表情包和没有转写文字的音频资源会被排除。
- 语音会优先读取 `transcript`、`originalText`、`spokenText` 或消息正文，并转换成“语音转写”交给总结模型；blob、data URI 和纯音频 URL 不会进入提示词。
- 小红书解析新增 `rednote.com` 支持，统一提取国内/国际域名及短链展开后的笔记 ID，并用严格 hostname 判断防止相似恶意域名误判。

## 为什么

旧实现把上下文拉杆和记忆宫殿隐藏水位线混在一起，用户调大拉杆时仍无法读取已被水位线隐藏的旧原文，界面却没有清楚表达两条边界。同时，语音消息曾按类型整类排除，即使已有配套文字也无法参与记忆总结；这与卡片作为其他功能汇入聊天的上下文语义不一致。此外，小红书新版 RedNote 域名无法进入既有笔记卡片解析链路。

## 用户影响

- 全自动记忆用户升级后回到安全的自适应默认状态。
- 有特殊需求时可以扩大或缩小原文读取范围，同时不会改变既有向量记忆处理进度。
- 历史断点的有效范围和失效行为可见、可预测。
- 语音配套文字与卡片摘要会像普通聊天文字一样被角色理解和记住。
- `xiaohongshu.com`、`rednote.com` 和短链跳转后的笔记链接均可稳定识别。

## 验证

- `node_modules\.bin\vitest.cmd run`：103 个测试文件、1136 项测试通过。
- 语音、卡片、缓冲区与消息格式专项：24 项测试通过。
- `pnpm.cmd run build`：生产构建通过。
- `git diff --check`：通过。