### PR TITLE
fix: support mobile xhslink.cn shares

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -16,7 +16,7 @@ import TheaterPlayer from '../components/schedule/TheaterPlayer';
 import { formatMessageWithTime, normalizeMessageContent } from '../utils/messageFormat';
 import { getRoomLabel } from '../utils/memoryPalace/types';
 import { XhsMcpClient, extractNotesFromMcpData, normalizeNote } from '../utils/xhsMcpClient';
-import { extractWebpageContent, detectFirstUrl, isXhsUrl, extractXhsNoteId, expandShortUrl, type ExtractedWebpage } from '../utils/webpageExtractor';
+import { extractWebpageContent, detectFirstUrl, detectXhsShortUrl, isXhsUrl, extractXhsNoteId, expandShortUrl, type ExtractedWebpage } from '../utils/webpageExtractor';
 import { isVideoShareUrl, parseVideoShareUrl } from '../utils/videoParser';
 import { isDevDebugAvailable } from '../utils/devDebug';
 import { resolveLifeRecordCard } from '../utils/lifeRecords';
@@ -1022,18 +1022,16 @@ const Chat: React.FC = () => {
             let xhsCardCreated = false;
             let webpageCardCreated = false;
             const xhsFullNoteId = extractXhsNoteId(text);
-            // 路径宽松接收 '-' / '_'，兼容小红书后续调整短链格式；尾部中文标点不吞入 URL。
-            const xhsShortMatch = text.match(/(?:https?:\/\/)?(?:www\.)?xhslink\.com\/[A-Za-z0-9/_-]+/i);
-            if (xhsFullNoteId || xhsShortMatch) {
+            // 同时识别桌面/旧版 xhslink.com 与手机版新版 xhslink.cn。
+            const xhsShortUrl = detectXhsShortUrl(text);
+            if (xhsFullNoteId || xhsShortUrl) {
                 let noteId = xhsFullNoteId || '';
                 let xsecToken = text.match(/xsec_token=([^&\s]+)/)?.[1];
                 let shortLinkError = '';
-                // 短链（xhslink.com）不含 id/token —— 先经 sfworker 展开成真实链接再提取。
-                if (!noteId && xhsShortMatch) {
+                // 短链（xhslink.com / xhslink.cn）不含 id/token —— 先经 sfworker 展开成真实链接再提取。
+                if (!noteId && xhsShortUrl) {
                     try {
-                        // 正则可能匹配到不带协议头的裸链接，补上 https 再展开（否则 new URL 报 Invalid URL）。
-                        const shortUrl = /^https?:\/\//i.test(xhsShortMatch[0]) ? xhsShortMatch[0] : `https://${xhsShortMatch[0]}`;
-                        const finalUrl = await expandShortUrl(shortUrl);
+                        const finalUrl = await expandShortUrl(xhsShortUrl);
                         noteId = extractXhsNoteId(finalUrl) || '';
                         xsecToken = xsecToken || finalUrl.match(/xsec_token=([^&\s]+)/)?.[1];
                         if (isDevDebugAvailable()) console.log('[卡片调试] 小红书短链展开 →', finalUrl, '| noteId =', noteId);
@@ -1117,7 +1115,7 @@ const Chat: React.FC = () => {
             // 视频平台链接（抖音/B站/快手…）Jina 基本抓不到东西（SPA+登录墙），
             // 优先走 apizero 视频解析拿标题/作者/封面/热度；失败降级回通用网页抓取。
             const sharedUrl = detectFirstUrl(text);
-            if (sharedUrl && !isXhsUrl(sharedUrl) && !(xhsFullNoteId || xhsShortMatch)) {
+            if (sharedUrl && !isXhsUrl(sharedUrl) && !(xhsFullNoteId || xhsShortUrl)) {
                 let webpage: ExtractedWebpage | null = null;
                 if (isVideoShareUrl(sharedUrl)) {
                     try {

--- a/utils/videoParser.test.ts
+++ b/utils/videoParser.test.ts
@@ -73,6 +73,7 @@ describe('isVideoShareUrl', () => {
         expect(isVideoShareUrl('https://example.com/article')).toBe(false);
         expect(isVideoShareUrl('https://www.xiaohongshu.com/explore/abc')).toBe(false); // XHS 走专门卡片路径
         expect(isVideoShareUrl('https://xhslink.com/abc')).toBe(false);
+        expect(isVideoShareUrl('http://xhslink.cn/o/abc')).toBe(false);
         expect(isVideoShareUrl('not a url')).toBe(false);
         expect(isVideoShareUrl('')).toBe(false);
         // 域名后缀不能被前缀仿冒

--- a/utils/webpageExtractor.test.ts
+++ b/utils/webpageExtractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { detectFirstUrl, isXhsUrl, extractXhsNoteId, parseWebpageHtml, extractWebpageContent } from './webpageExtractor';
+import { detectFirstUrl, detectXhsShortUrl, isXhsUrl, extractXhsNoteId, parseWebpageHtml, extractWebpageContent } from './webpageExtractor';
 
 describe('detectFirstUrl', () => {
   it('从一句话里揪出 http(s) 链接', () => {
@@ -26,10 +26,28 @@ describe('isXhsUrl', () => {
   it('识别小红书域名（已有专门 MCP 路径，网页抓取要避开）', () => {
     expect(isXhsUrl('https://www.xiaohongshu.com/explore/abc')).toBe(true);
     expect(isXhsUrl('https://xhslink.com/xxx')).toBe(true);
+    expect(isXhsUrl('http://xhslink.cn/o/3hJ4anvedNl')).toBe(true);
     expect(isXhsUrl('https://www.rednote.com/explore/abc')).toBe(true);
     expect(isXhsUrl('https://example.com')).toBe(false);
     expect(isXhsUrl('https://rednote.com.example.com/explore/abc')).toBe(false);
     expect(isXhsUrl('https://fake-rednote.com/explore/abc')).toBe(false);
+  });
+});
+
+describe('detectXhsShortUrl', () => {
+  it('识别手机版 xhslink.cn 完整分享文案', () => {
+    const text = '办公室的领导看着不苟言笑 http://xhslink.cn/o/3hJ4anvedNl 存下链接，去【小红书】阅读全文~';
+    expect(detectXhsShortUrl(text)).toBe('http://xhslink.cn/o/3hJ4anvedNl');
+  });
+
+  it('继续兼容 xhslink.com 和不带协议的短链', () => {
+    expect(detectXhsShortUrl('https://xhslink.com/a/AbC_123-xy')).toBe('https://xhslink.com/a/AbC_123-xy');
+    expect(detectXhsShortUrl('看看 xhslink.cn/o/AbC123')).toBe('https://xhslink.cn/o/AbC123');
+  });
+
+  it('不接受相似恶意域名', () => {
+    expect(detectXhsShortUrl('https://xhslink.cn.example.com/o/AbC123')).toBeNull();
+    expect(detectXhsShortUrl('https://fake-xhslink.cn/o/AbC123')).toBeNull();
   });
 });
 

--- a/utils/webpageExtractor.ts
+++ b/utils/webpageExtractor.ts
@@ -90,11 +90,38 @@ export function detectFirstUrl(text: string): string | null {
 }
 
 const XHS_NOTE_PATH_RE = /^\/(?:discovery\/item|explore|item)\/([a-f0-9]{24})(?:[/?#]|$)/i;
+const XHS_SHORT_HOSTS = ['xhslink.com', 'xhslink.cn'];
 
 function isXhsHostname(hostname: string): boolean {
   const host = hostname.toLowerCase().replace(/\.$/, '');
-  return ['xiaohongshu.com', 'xhslink.com', 'rednote.com']
+  return ['xiaohongshu.com', 'rednote.com', ...XHS_SHORT_HOSTS]
     .some(domain => host === domain || host.endsWith(`.${domain}`));
+}
+
+/**
+ * 从分享文案中提取小红书短链。
+ * 桌面/旧版常见 xhslink.com，手机版新版会生成 xhslink.cn。
+ */
+export function detectXhsShortUrl(text: string): string | null {
+  if (!text) return null;
+
+  const candidates: string[] = [...(text.match(/https?:\/\/[^\s，。！？；、"'《》()（）【】]+/ig) || [])];
+  const naked = text.match(/(?:^|[\s，。！？；、"'《》()（）【】])((?:www\.)?xhslink\.(?:com|cn)\/[A-Za-z0-9/_-]+)/i)?.[1];
+  if (naked) candidates.push(`https://${naked}`);
+
+  for (const candidate of candidates) {
+    try {
+      const cleaned = candidate.replace(/[.,;:!?'")\]]+$/, '');
+      const parsed = new URL(cleaned);
+      const host = parsed.hostname.toLowerCase().replace(/\.$/, '');
+      if (XHS_SHORT_HOSTS.some(domain => host === domain || host.endsWith(`.${domain}`))) {
+        return cleaned;
+      }
+    } catch {
+      // 忽略坏链接，继续检查下一个 URL。
+    }
+  }
+  return null;
 }
 
 /** XHS 链接已有专门的 MCP 卡片路径，网页抓取要避开它，免得抢同一条消息。 */
@@ -110,7 +137,7 @@ export function isXhsUrl(url: string): boolean {
 /**
  * 从完整分享文案或单个链接中提取小红书笔记 ID。
  * 同时支持国内域名 xiaohongshu.com 和新版国际域名 rednote.com；
- * xhslink.com 短链没有 ID，需先 expandShortUrl 后再调用本函数。
+ * xhslink.com / xhslink.cn 短链没有 ID，需先 expandShortUrl 后再调用本函数。
  */
 export function extractXhsNoteId(text: string): string | null {
   if (!text) return null;
@@ -136,7 +163,7 @@ export function extractXhsNoteId(text: string): string | null {
 }
 
 /**
- * 经 sfworker 展开短链（xhslink.com 等），返回跟随 HTTP 重定向后的最终 URL。
+ * 经 sfworker 展开短链（xhslink.com / xhslink.cn 等），返回跟随 HTTP 重定向后的最终 URL。
  * 小红书短链不含 note id / xsec_token，展开后才拿得到。
  */
 export async function expandShortUrl(url: string): Promise<string> {


### PR DESCRIPTION
## What changed
- recognize the mobile `xhslink.cn` short-link domain as Xiaohongshu
- route `.cn` shares through short-link expansion and XHS Lite instead of generic webpage extraction
- keep `.com`, RedNote, and spoof-domain protections intact

## Root cause
Mobile Xiaohongshu currently copies `xhslink.cn` links, while the inbound chat router only recognized `xhslink.com`. The link therefore fell through to `webpage_card` and never called XHS Lite.

## Validation
- 27 focused Vitest checks passed
- production Vite build passed
- the reported `xhslink.cn` URL was verified to expand through the project Worker to a note URL containing a note ID and `xsec_token`