### PR TITLE
feat: 完善语音卡片记忆统计与心象复制

### DIFF
--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -1,7 +1,7 @@
 
 
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Message, ChatTheme } from '../../types';
 import { tryParseLifeSimResetCard } from '../../utils/lifeSimChatCard';
 import { VALID_INTERJECTION_TAGS, cleanVoiceMarkupForDisplay } from '../../utils/minimaxTts';
@@ -419,15 +419,140 @@ export const ThinkingChainBlock: React.FC<{
     onOpenSettings?: () => void;
 }> = ({ chain, styleId, customColors, onOpenSettings }) => {
     const [expanded, setExpanded] = useState(false);
+    const [copyState, setCopyState] = useState<'idle' | 'ok' | 'error'>('idle');
+    const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pointerIdRef = useRef<number | null>(null);
+    const pointerStartRef = useRef({ x: 0, y: 0 });
+    const suppressNextClickRef = useRef(false);
+    const lastCopyAtRef = useRef(0);
     const trimmed = (chain || '').trim();
-    if (!trimmed) return null;
     const spec = resolveThinkingChainStyle(styleId, customColors);
     const firstLine = trimmed.replace(/\s+/g, ' ').slice(0, 38);
     const hasMore = trimmed.length > 38;
+
+    const clearCopyTimer = () => {
+        if (copyTimerRef.current) {
+            clearTimeout(copyTimerRef.current);
+            copyTimerRef.current = null;
+        }
+    };
+
+    useEffect(() => () => {
+        clearCopyTimer();
+        if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
+    }, []);
+
+    if (!trimmed) return null;
+
+    const copyThinkingChain = async () => {
+        let success = false;
+        try {
+            if (!navigator.clipboard?.writeText) throw new Error('Clipboard API unavailable');
+            await navigator.clipboard.writeText(trimmed);
+            success = true;
+        } catch {
+            // iOS PWA / 非安全上下文可能拒绝 Clipboard API，保留 textarea 兜底。
+            let textarea: HTMLTextAreaElement | null = null;
+            try {
+                textarea = document.createElement('textarea');
+                textarea.value = trimmed;
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'fixed';
+                textarea.style.opacity = '0';
+                textarea.style.pointerEvents = 'none';
+                document.body.appendChild(textarea);
+                textarea.select();
+                textarea.setSelectionRange(0, textarea.value.length);
+                success = document.execCommand('copy');
+            } catch {
+                success = false;
+            } finally {
+                textarea?.remove();
+            }
+        }
+
+        setCopyState(success ? 'ok' : 'error');
+        if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current);
+        feedbackTimerRef.current = setTimeout(() => setCopyState('idle'), 1600);
+    };
+
+    const triggerCopy = (suppressNextClick = true) => {
+        clearCopyTimer();
+        suppressNextClickRef.current = suppressNextClick;
+        const now = Date.now();
+        if (now - lastCopyAtRef.current < 800) return;
+        lastCopyAtRef.current = now;
+        try { navigator.vibrate?.(20); } catch { /* vibration is optional */ }
+        void copyThinkingChain();
+    };
+
+    const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        if (e.button !== 0) return;
+        pointerIdRef.current = e.pointerId;
+        pointerStartRef.current = { x: e.clientX, y: e.clientY };
+        suppressNextClickRef.current = false;
+        clearCopyTimer();
+        copyTimerRef.current = setTimeout(() => triggerCopy(true), 550);
+    };
+
+    const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        if (pointerIdRef.current !== e.pointerId) return;
+        const dx = e.clientX - pointerStartRef.current.x;
+        const dy = e.clientY - pointerStartRef.current.y;
+        if (Math.abs(dx) > 10 || Math.abs(dy) > 10) clearCopyTimer();
+    };
+
+    const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        if (pointerIdRef.current !== e.pointerId) return;
+        pointerIdRef.current = null;
+        clearCopyTimer();
+    };
+
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.stopPropagation();
+        if (suppressNextClickRef.current) {
+            suppressNextClickRef.current = false;
+            e.preventDefault();
+            return;
+        }
+        setExpanded(v => !v);
+    };
+
+    const copyStatusLabel = copyState === 'ok'
+        ? '已复制'
+        : copyState === 'error'
+            ? '复制失败'
+            : expanded ? spec.silenceLabel : spec.listenLabel;
+
     return (
         <div
             className="sully-psyche relative mb-2 w-full max-w-full select-text cursor-pointer group"
-            onClick={(e) => { e.stopPropagation(); setExpanded(v => !v); }}
+            role="button"
+            tabIndex={0}
+            aria-label="心象：点击展开，长按复制全文"
+            title="长按复制心象全文"
+            onClick={handleClick}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerEnd}
+            onPointerCancel={(e) => handlePointerEnd(e)}
+            onContextMenu={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                // 触屏长按随后可能再派发 contextmenu，时间闸避免复制两次；
+                // 鼠标右键不会产生 click，因此不要吞掉下一次正常左键点击。
+                triggerCopy(pointerIdRef.current !== null);
+            }}
+            onKeyDown={(e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                setExpanded(v => !v);
+            }}
+            style={{ touchAction: 'pan-y', WebkitTouchCallout: 'none' }}
         >
             <div
                 className="sully-psyche-card relative overflow-hidden px-4 py-2.5 transition-all duration-300"
@@ -497,7 +622,7 @@ export const ThinkingChainBlock: React.FC<{
                         className="ml-auto text-[10px] tracking-[0.18em] transition-opacity opacity-65 group-hover:opacity-100"
                         style={{ color: spec.subtext }}
                     >
-                        {expanded ? spec.silenceLabel : spec.listenLabel}
+                        {copyStatusLabel}
                     </span>
                 </div>
 

--- a/types.ts
+++ b/types.ts
@@ -3051,7 +3051,7 @@ export interface GameSession {
     lastPlayedAt: number;
 }
 
-export type MessageType = 'text' | 'image' | 'emoji' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'luckin_card' | 'html_card' | 'news_card' | 'vr_card' | 'trpg_card' | 'novel_card' | 'world_card' | 'sim_card' | 'phone_card' | 'webpage_card' | 'theater_card' | 'room_card' | 'life_card' | 'group_topic_card';
+export type MessageType = 'text' | 'image' | 'emoji' | 'voice' | 'interaction' | 'transfer' | 'system' | 'social_card' | 'chat_forward' | 'xhs_card' | 'score_card' | 'music_card' | 'mcd_card' | 'luckin_card' | 'html_card' | 'news_card' | 'vr_card' | 'trpg_card' | 'novel_card' | 'world_card' | 'sim_card' | 'phone_card' | 'webpage_card' | 'theater_card' | 'room_card' | 'life_card' | 'group_topic_card';
 
 export interface Message {
     id: number;

--- a/utils/memoryPalace/bufferCount.test.ts
+++ b/utils/memoryPalace/bufferCount.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { countUnprocessedBufferMessages } from './bufferCount';
+import { isMessageSemanticallyRelevant } from '../messageFormat';
 
 /** 造一批 id 连续、内容非空的文本消息 */
 const makeMsgs = (n: number, startId = 1) =>
@@ -36,5 +37,23 @@ describe('countUnprocessedBufferMessages（记忆宫殿未同步口径）', () =
         const correct = countUnprocessedBufferMessages(msgs, 0, 200); // 正确 = 50
         expect(correct).toBe(50);
         expect(correct).not.toBe(naive); // 若有人改回裸过滤，这一行会挂
+    });
+
+    it('语音转写与 metadata 卡片进入同一水位线统计，纯媒体不计数', () => {
+        const mixed = [
+            { id: 1, type: 'text', content: '文字' },
+            { id: 2, type: 'voice', content: '语音配套文字' },
+            { id: 3, type: 'xhs_card', content: '', metadata: { xhsNote: { title: '卡片标题' } } },
+            { id: 4, type: 'image', content: 'data:image/png;base64,AAAA' },
+            { id: 5, type: 'emoji', content: 'blob:emoji' },
+            { id: 6, type: 'voice', content: 'blob:voice' },
+            { id: 7, type: 'text', content: '热区一' },
+            { id: 8, type: 'text', content: '热区二' },
+        ] as any;
+        const semantic = mixed.filter(isMessageSemanticallyRelevant);
+
+        expect(semantic.map((m: any) => m.id)).toEqual([1, 2, 3, 7, 8]);
+        expect(countUnprocessedBufferMessages(semantic, 0, 2)).toBe(3);
+        expect(countUnprocessedBufferMessages(semantic, 1, 2)).toBe(2);
     });
 });

--- a/utils/memoryPalace/pipeline.ts
+++ b/utils/memoryPalace/pipeline.ts
@@ -1150,7 +1150,7 @@ const PROCESS_RATIO = 0.85;
  * 计算当前"真正可被 pipeline 处理"的缓冲区消息数。
  *
  * 与 processNewMessages 的口径完全一致：
- *   - 只数语义相关消息（排除纯图片/语音/表情）
+ *   - 只数语义相关消息（排除纯图片/表情和无转写的纯音频；保留有文字的语音与卡片）
  *   - 排除最后 HOT_ZONE_SIZE 条（热区永远不会被处理）
  *   - 只数 id > 高水位标记的部分
  *
@@ -1548,8 +1548,8 @@ export async function processNewMessages(
 
     try {
         // 1. 加载全部消息（含已处理的），计算热区和缓冲区
-        //    过滤：保留任何有语义的消息类型（text / score_card / system / transfer / interaction），
-        //    只排除纯视觉/音频类（image / emoji / voice）—— 后者经 normalize 变短占位，对 LLM 无增益
+        //    过滤：保留任何有语义的消息类型（文字、带转写的语音、卡片、系统事件等），
+        //    只排除纯视觉资源和无转写的纯音频，避免 URL / base64 污染 LLM。
         const allMessages = await DB.getMessagesByCharId(charId, true);
         const textMessages = allMessages
             .filter(m => isMessageSemanticallyRelevant(m))

--- a/utils/memoryPalace/querySanitizer.test.ts
+++ b/utils/memoryPalace/querySanitizer.test.ts
@@ -32,15 +32,30 @@ describe('sanitizeQuerySourceMessages', () => {
         expect(out[0].content).toBe('你看这张图');
     });
 
-    it('表情包 / 语音消息整条丢弃', () => {
+    it('表情包 / 无转写的纯音频资源整条丢弃', () => {
         const out = sanitizeQuerySourceMessages([
             msg({ type: 'emoji', content: 'https://img.host/sticker.png' }),
-            // 'voice' 不在 MessageType 联合里，但运行时存在（messageFormat 同款处理）
-            msg({ type: 'voice' as any, content: 'blob:xxx' }),
+            msg({ type: 'voice', content: 'blob:xxx' }),
             msg({ content: '晚安' }),
         ]);
         expect(out).toHaveLength(1);
         expect(out[0].content).toBe('晚安');
+    });
+
+    it('有配套文字的语音按转写内容参与记忆检索', () => {
+        const out = sanitizeQuerySourceMessages([
+            msg({ type: 'voice', content: '今天下班路上看见了一只很像你的猫' }),
+            msg({
+                type: 'voice',
+                content: 'blob:voice-audio',
+                metadata: { transcript: '别忘了明天一起去看电影' },
+            }),
+        ]);
+
+        expect(out).toHaveLength(2);
+        expect(out[0].content).toContain('今天下班路上看见了一只很像你的猫');
+        expect(out[1].content).toContain('别忘了明天一起去看电影');
+        expect(out.every(item => item.content.startsWith('[语音转写]'))).toBe(true);
     });
 
     it('文本里粘贴的 data URI 被剥掉，其余文字保留', () => {

--- a/utils/memoryPalace/querySanitizer.test.ts
+++ b/utils/memoryPalace/querySanitizer.test.ts
@@ -86,6 +86,24 @@ describe('sanitizeQuerySourceMessages', () => {
         expect(out[0].content).toContain('阿汐');
     });
 
+    it('正文为空但 metadata 有内容的卡片仍参与统计与记忆上下文', () => {
+        const xhs = msg({
+            type: 'xhs_card',
+            content: '',
+            metadata: {
+                xhsNote: {
+                    title: '今天遇到一只很亲人的小猫',
+                    desc: '它一路跟着我走到了地铁口。',
+                    author: '路边观察员',
+                },
+            },
+        });
+        const out = sanitizeQuerySourceMessages([xhs], '阿澄', '小鱼');
+        expect(out).toHaveLength(1);
+        expect(out[0].content).toContain('今天遇到一只很亲人的小猫');
+        expect(out[0].content).toContain('它一路跟着我走到了地铁口');
+    });
+
     it('空消息丢弃；没有 type 字段的合成消息按文本处理', () => {
         const out = sanitizeQuerySourceMessages([
             msg({ content: '   ' }),

--- a/utils/memoryPalace/querySanitizer.ts
+++ b/utils/memoryPalace/querySanitizer.ts
@@ -28,7 +28,8 @@ const DATA_URI_RE = /data:[a-z0-9.+-]+\/[a-z0-9.+-]+[;,]\S*/gi;
 /**
  * 把原始消息列表清洗成「可以安全参与检索 query 构建」的列表：
  *
- * 1. 丢掉无语义消息（image/emoji/voice 及空消息）—— 与入库口径一致
+ * 1. 丢掉无语义消息（image/emoji、无转写的纯音频及空消息）—— 与入库口径一致
+ *    有配套文字的 voice 会转成「语音转写」继续参与检索
  * 2. 卡片/系统类消息经 normalizeMessageContent 翻成可读文本
  *    （music_card 的 content 可能是占位符、score_card 可能是 JSON）
  * 3. 剥离所有 data URI；剥完变空的消息一并丢掉

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -25,6 +25,35 @@ export function stickerNameFromUrl(emojis: Emoji[], url: string): string {
 }
 
 /**
+ * 语音消息的音频资源与转写文本可能分别落在 content / metadata 中。
+ * 记忆链路只取可理解的文字，绝不把 blob、data URI 或纯音频 URL 当成上下文。
+ */
+export function getVoiceTranscript(msg: Message): string {
+    const meta = msg.metadata || {};
+    const candidates = [
+        meta.transcript,
+        meta.originalText,
+        meta.spokenText,
+        meta.text,
+        msg.content,
+    ];
+    for (const candidate of candidates) {
+        if (typeof candidate !== 'string') continue;
+        const trimmed = candidate.trim();
+        if (!trimmed) continue;
+        if (/^(?:blob:|data:audio\/)/i.test(trimmed)) continue;
+        if (/^https?:\/\/\S+$/i.test(trimmed)) continue;
+        const cleaned = trimmed
+            .replace(/<\/?(?:语音|語音|字幕)[^>]*>/g, ' ')
+            .replace(/%%BILINGUAL%%/gi, '\n')
+            .replace(/[ \t]{2,}/g, ' ')
+            .trim();
+        if (cleaned) return cleaned;
+    }
+    return '';
+}
+
+/**
  * 把「窥视的是哪个具体时间」组成一句人话：日期相对词 + 时段词 + 时刻。
  * 例：今天上午08:00 / 昨天晚上21:30 / 6月25日下午14:00。
  * 用于小剧场卡片注入——晚上看上午的内容时，不能含糊说"刚刚/刚才"，要落到具体时间。
@@ -70,10 +99,13 @@ export function normalizeMessageContent(
 ): string {
     const type = msg.type as string;
 
-    // 纯视觉/音频类：给个占位，别让 URL / base64 污染 LLM 上下文
+    // 纯视觉类给占位；语音优先使用配套转写，避免把音频资源地址送进上下文。
     if (type === 'image') return '[图片]';
     if (type === 'emoji') return '[表情包]';
-    if (type === 'voice') return '[语音]';
+    if (type === 'voice') {
+        const transcript = getVoiceTranscript(msg);
+        return transcript ? `[语音转写] ${transcript}` : '[语音]';
+    }
 
     // 系统交互事件
     if (type === 'interaction') return `[系统: ${userName}戳了${charName}一下]`;
@@ -331,12 +363,13 @@ export function formatMessageWithTime(
  * 判断一条消息是否"对 palace / archive 有语义价值"。
  *
  * pipeline 以前的过滤是 `type === 'text'`，这会漏掉 score_card / system /
- * transfer / interaction 等有内容的事件；纯二进制类型（image/emoji/voice）
- * 通过 normalize 会变成短占位符，LLM 看到也没帮助，直接过滤掉。
+ * transfer / interaction 等有内容的事件；image/emoji 这类纯视觉资源直接过滤。
+ * voice 只要带转写文字就属于语义上下文，应该与文字和卡片一起参与统计与总结。
  */
 export function isMessageSemanticallyRelevant(msg: Message): boolean {
     const type = msg.type as string;
-    if (type === 'image' || type === 'emoji' || type === 'voice') return false;
+    if (type === 'image' || type === 'emoji') return false;
+    if (type === 'voice') return !!getVoiceTranscript(msg);
     // 有内容或有结构化 metadata 才算
     return !!(msg.content?.trim() || msg.metadata?.scoreCard || msg.metadata?.amount || msg.metadata?.song || msg.metadata?.trpg || msg.metadata?.webpage);
 }

--- a/utils/messageFormat.ts
+++ b/utils/messageFormat.ts
@@ -370,6 +370,11 @@ export function isMessageSemanticallyRelevant(msg: Message): boolean {
     const type = msg.type as string;
     if (type === 'image' || type === 'emoji') return false;
     if (type === 'voice') return !!getVoiceTranscript(msg);
+    // 卡片是其它功能汇入聊天的结构化上下文；即使 content 为空，只要专用格式化器
+    // 能从 metadata 生成可读摘要，也必须参与缓冲区计数和记忆总结。
+    if (type?.endsWith('_card')) {
+        return !!normalizeMessageContent(msg, '角色', '用户').trim();
+    }
     // 有内容或有结构化 metadata 才算
     return !!(msg.content?.trim() || msg.metadata?.scoreCard || msg.metadata?.amount || msg.metadata?.song || msg.metadata?.trpg || msg.metadata?.webpage);
 }

--- a/utils/messageItemModuleLayout.test.ts
+++ b/utils/messageItemModuleLayout.test.ts
@@ -91,4 +91,20 @@ describe('MessageItem module layout', () => {
         expect(markup).toContain('alt="avatar"');
         expect(markup).toContain('https://example.com/char.png');
     });
+
+    it('心象卡片提供长按复制提示与独立交互入口', () => {
+        const markup = renderMessage({
+            id: 4,
+            charId: 'char-1',
+            role: 'assistant',
+            type: 'text',
+            content: '回复正文',
+            timestamp: 4,
+            metadata: { thinkingChain: '这是可以一键复制的完整心象。' },
+        });
+
+        expect(markup).toContain('aria-label="心象：点击展开，长按复制全文"');
+        expect(markup).toContain('title="长按复制心象全文"');
+        expect(markup).toContain('这是可以一键复制的完整心象');
+    });
 });


### PR DESCRIPTION
## 改动
- 语音消息只要带有可读转写文字，就会进入上下文统计、记忆缓冲区、总结与向量检索；纯音频资源地址不会混入提示词
- 卡片统一视为其它功能汇入聊天的结构化上下文，并格式化为可读文字摘要参与统计与记忆
- 即使卡片正文为空，只要 metadata 能生成可读摘要（例如小红书卡片），也不会被遗漏
- 图片、表情包、无转写的纯音频仍不计入语义消息数
- 心象卡片支持长按约 0.55 秒直接复制全文；成功后卡片显示“已复制”反馈
- 支持鼠标右键复制，并为 iOS PWA / 旧 WebView 增加剪贴板降级方案
- 滑动时会取消长按，且心象手势不会误触外层消息菜单

## 水位线安全性
- 待处理统计与真正推进水位线的 pipeline 共用同一个语义消息过滤器
- 聊天设置每次打开、一键追平每轮及结束后都会重新计算待处理条数
- 已有 HWM 不会因升级倒退；`id <= HWM` 的旧内容不会重新处理
- 新纳入的语音转写/卡片只会在尚未处理且离开最近 200 条热区后进入缓冲区

## 验证
- `npm.cmd test -- --run`：103 个测试文件、1139 条测试全部通过
- 心象交互与水位线针对性测试：17 条全部通过
- `npm.cmd run build`：通过
- `git diff --check`：通过