### PR TITLE
feat(chat): 语音消息加「收到就自动播放」开关，默认不自动播

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -42,6 +42,7 @@ import { useChatAI } from '../hooks/useChatAI';
 import { cleanTextForTts, parseVoiceOutput } from '../utils/minimaxTts';
 import { collectVoiceBatchSubtitle, isPoisonedVoiceSubtitle } from '../utils/voiceSubtitle';
 import { synthesizeSpeechDetailed, characterHasVoice } from '../utils/ttsRouter';
+import { shouldAutoPlayGeneratedVoice } from '../utils/voicePlayback';
 import { resolveMiniMaxApiKey } from '../utils/minimaxApiKey';
 import { resolveFishAudioApiKey, stripFishMarkupForDisplay, cleanTextForTtsFish } from '../utils/fishAudioTts';
 import { resolveTtsProvider } from '../utils/ttsProvider';
@@ -462,12 +463,15 @@ const Chat: React.FC = () => {
             setVoiceDataMap(prev => ({ ...prev, [msg.id]: { url: blobUrl, originalText, spokenText: storedSpokenText, lang: storedLang } }));
             // Persist so the voice bar survives leaving and re-entering the chat.
             persistVoice(msg.id, blobUrl, blob, originalText, storedSpokenText, storedLang);
-            // Auto-play
-            if (!chatAudioRef.current) chatAudioRef.current = new Audio();
-            chatAudioRef.current.src = blobUrl;
-            chatAudioRef.current.onended = () => setPlayingMsgId(null);
-            chatAudioRef.current.play().catch(() => {});
-            setPlayingMsgId(msg.id);
+            // 合成完是否立刻播（规则和来由见 shouldAutoPlayGeneratedVoice）：
+            // AI 自动发来的默认不响、等用户点；用户自己点着要的一定响。
+            if (shouldAutoPlayGeneratedVoice({ autoTriggered, autoPlayEnabled: char.chatVoiceAutoPlay })) {
+                if (!chatAudioRef.current) chatAudioRef.current = new Audio();
+                chatAudioRef.current.src = blobUrl;
+                chatAudioRef.current.onended = () => setPlayingMsgId(null);
+                chatAudioRef.current.play().catch(() => {});
+                setPlayingMsgId(msg.id);
+            }
         } catch (err: any) {
             addToast(`语音生成失败: ${err?.message || '未知错误'}`, 'error');
         } finally {
@@ -2805,6 +2809,8 @@ const Chat: React.FC = () => {
                 setHtmlModeCustomPrompt={setSettingsHtmlModeCustomPrompt}
                 chatVoiceEnabled={!!char.chatVoiceEnabled}
                 onToggleChatVoice={() => updateCharacter(char.id, { chatVoiceEnabled: !char.chatVoiceEnabled })}
+                chatVoiceAutoPlay={!!char.chatVoiceAutoPlay}
+                onToggleChatVoiceAutoPlay={() => updateCharacter(char.id, { chatVoiceAutoPlay: !char.chatVoiceAutoPlay })}
                 chatVoiceLang={char.chatVoiceLang || ''}
                 onSetChatVoiceLang={(lang: string) => updateCharacter(char.id, { chatVoiceLang: lang })}
                 voiceAvailable={characterHasVoice(char, apiConfig)}

--- a/components/chat/ChatModals.tsx
+++ b/components/chat/ChatModals.tsx
@@ -95,6 +95,8 @@ interface ChatModalsProps {
     // Voice TTS
     chatVoiceEnabled?: boolean;
     onToggleChatVoice?: () => void;
+    chatVoiceAutoPlay?: boolean;
+    onToggleChatVoiceAutoPlay?: () => void;
     chatVoiceLang?: string;
     onSetChatVoiceLang?: (lang: string) => void;
     // Voice generation from long-press
@@ -230,7 +232,7 @@ const ChatModals: React.FC<ChatModalsProps> = ({
     translationEnabled, onToggleTranslation, translateSourceLang, translateTargetLang, onSetTranslateSourceLang, onSetTranslateLang,
     xhsEnabled, onToggleXhs,
     htmlModeEnabled, onToggleHtmlMode, htmlModeCustomPrompt, setHtmlModeCustomPrompt,
-    chatVoiceEnabled, onToggleChatVoice, chatVoiceLang, onSetChatVoiceLang,
+    chatVoiceEnabled, onToggleChatVoice, chatVoiceAutoPlay, onToggleChatVoiceAutoPlay, chatVoiceLang, onSetChatVoiceLang,
     onGenerateVoice, voiceAvailable, onDownloadVoice, voiceDownloadable,
     scheduleData, isScheduleGenerating, onScheduleEdit, onScheduleDelete, onScheduleReroll, onScheduleCoverChange,
     onScheduleStyleChange, onPlayTheater,
@@ -483,6 +485,19 @@ const ChatModals: React.FC<ChatModalsProps> = ({
                          <p className="text-[10px] text-slate-400 mt-1 leading-relaxed">
                              开启后，AI 回复自动生成语音条（需配置 MiniMax 和角色语音）。
                          </p>
+                         {chatVoiceEnabled && (
+                             <div className="mt-3 pt-3 border-t border-slate-100">
+                                 <div className="flex justify-between items-center cursor-pointer" onClick={onToggleChatVoiceAutoPlay}>
+                                     <label className="text-[10px] font-bold text-slate-400 uppercase pointer-events-none">收到就自动播放</label>
+                                     <div className={`w-9 h-5 rounded-full p-1 transition-colors flex items-center ${chatVoiceAutoPlay ? 'bg-emerald-400' : 'bg-slate-200'}`}>
+                                         <div className={`w-3 h-3 bg-white rounded-full shadow-sm transition-transform ${chatVoiceAutoPlay ? 'translate-x-4' : ''}`}></div>
+                                     </div>
+                                 </div>
+                                 <p className="text-[10px] text-slate-400 mt-1 leading-relaxed">
+                                     关闭时语音条照常出现，点一下才播放（也可以点「转文字」直接看内容）。
+                                 </p>
+                             </div>
+                         )}
                          {chatVoiceEnabled && (
                              <div className="mt-3">
                                  <label className="text-[10px] font-bold text-slate-400 mb-1.5 block">语音语种</label>

--- a/types.ts
+++ b/types.ts
@@ -2248,6 +2248,9 @@ export interface CharacterProfile {
 
   // Chat & Date voice TTS settings
   chatVoiceEnabled?: boolean;
+  // 收到语音是否自动播放。默认关（不填 = 不自动播）：语音条照常出现，点一下才响。
+  // 只管 AI 自动发来的语音；用户主动点「转换语音」/ 点空语音条生成的，仍然生成完就播。
+  chatVoiceAutoPlay?: boolean;
   chatVoiceLang?: string;
   dateVoiceEnabled?: boolean;
   dateVoiceLang?: string;

--- a/utils/characterCard.ts
+++ b/utils/characterCard.ts
@@ -43,6 +43,7 @@ export const CARD_STRIPPED_FIELDS = [
   'dateVoiceLang',
   'callVoiceLang',
   'chatVoiceEnabled',
+  'chatVoiceAutoPlay',
   'dateVoiceEnabled',
 
   // 4) 运行时状态残留

--- a/utils/voicePlayback.test.ts
+++ b/utils/voicePlayback.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { shouldAutoPlayGeneratedVoice } from './voicePlayback';
+
+// 语音条合成完的播放时机。以前是无条件播（收到 AI 语音就直接响），
+// 用户「有时候不想听」没有出口 —— 这里把两条规则钉住：
+// 自动来的默认不响、用户自己点的一定响。
+describe('shouldAutoPlayGeneratedVoice', () => {
+  it('AI 自动发来的语音：没开开关 → 不播', () => {
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: true })).toBe(false);
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: true, autoPlayEnabled: false })).toBe(false);
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: true, autoPlayEnabled: undefined })).toBe(false);
+  });
+
+  it('AI 自动发来的语音：开了「收到就自动播放」→ 播', () => {
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: true, autoPlayEnabled: true })).toBe(true);
+  });
+
+  it('用户主动点的（转换语音 / 点空语音条）：不管开关都播', () => {
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: false })).toBe(true);
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: false, autoPlayEnabled: false })).toBe(true);
+    expect(shouldAutoPlayGeneratedVoice({ autoTriggered: false, autoPlayEnabled: true })).toBe(true);
+  });
+});

--- a/utils/voicePlayback.ts
+++ b/utils/voicePlayback.ts
@@ -1,0 +1,18 @@
+/**
+ * 聊天语音条：合成完要不要立刻响。
+ *
+ * 两条规则各有来由，别合并简化：
+ *  - AI 自动发来的语音（收到消息就顺手合成的），默认**不**自动播。用户不一定方便听声，
+ *    语音条会照常出现，想听点一下就是了。角色开了「收到就自动播放」才恢复合成即播。
+ *  - 用户主动要的语音（长按「转换语音」、点还没合成的空语音条），无论开关怎么设都播——
+ *    他点这一下的意思就是「我现在要听」，还要再点一次播放属于白跑一趟。
+ */
+export function shouldAutoPlayGeneratedVoice(opts: {
+  /** 这次合成是 AI 消息到达后自动触发的（false = 用户主动点的） */
+  autoTriggered: boolean;
+  /** 角色的「收到就自动播放」开关，未设置视作关 */
+  autoPlayEnabled?: boolean;
+}): boolean {
+  if (!opts.autoTriggered) return true;
+  return !!opts.autoPlayEnabled;
+}


### PR DESCRIPTION
## 起因

用户反馈：「语音消息只能自动播放吗，我有时候不想听语音，他都自动播放出来了」。

以前开了语音消息的角色，AI 发来的语音条合成完就直接出声，不想听的时候没有出口——唯一的办法是把整个「语音消息」开关关掉，但那样角色就完全不发语音了。

## 改后是怎样的

聊天设置 →「语音消息」下面多了一个「收到就自动播放」开关，**默认关闭**：

| | 语音条 | 声音 |
|---|---|---|
| 默认（开关关） | 照常出现，可点「转文字」看内容 | 点一下才播 |
| 开关打开 | 照常出现 | 收到即播（原来的行为） |

开关按角色单独记，分享角色卡时不会带出去（已加进 `CARD_STRIPPED_FIELDS`）。

**一条例外**：用户主动要的语音不受开关管——长按「转换语音」、点还没合成的空语音条，都还是生成完就播。点这一下的意思本来就是「我现在要听」，再要求点第二次是白跑一趟。

见面（DateSession）和电话（CallApp）的语音没动，那两处本身就是「正在通话中」，该播。

## 实现

播放时机的两条规则抽成纯函数 `utils/voicePlayback.ts:shouldAutoPlayGeneratedVoice`，配 `utils/voicePlayback.test.ts` 钉住（旧的无条件播行为过不了这三个 case）。`apps/Chat.tsx` 的合成收尾处调用它决定要不要 `play()`。

https://claude.ai/code/session_014cdc6dXNpTJFBp4mFxjVGp