### PR TITLE
chore(ci): PR 自动贴标签 + 锁文件本地依赖守卫

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,74 @@
+# PR 改了哪些文件 → 自动贴哪些 scope 标签
+#
+# 规则说明：
+#   - any-glob-to-any-file：改动里只要有一个文件命中，就贴这个标签
+#   - all-globs-to-all-files：改动里所有文件都命中，才贴这个标签
+#   - 只加不删（没开 sync-labels），手动贴的标签不会被冲掉
+#
+# 新增标签前先确认仓库里已经有同名 label，否则会被自动创建成灰色无描述的。
+
+'scope: amsg':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'worker/amsg/**'
+          - 'utils/amsg*'
+          - 'utils/activeMsg*'
+          - 'components/chat/ActiveMsg*'
+          - 'components/settings/ActiveMsg*'
+
+'scope: instant-push':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'worker/instant-push/**'
+          - 'worker/proactive-push/**'
+          - 'utils/instant*'
+          - 'utils/proactive*'
+
+'scope: pushSubscription':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'utils/pushSubscribeShared.ts'
+          - 'utils/pushVapid.ts'
+
+'scope: sw':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'worker/sw-keep-alive.ts'
+          - 'public/sw-keep-alive.js'
+          - 'public/*.bundle.js'
+          - 'utils/swVersion.ts'
+          - 'utils/*WorkerVersion.ts'
+
+'scope: indexedDb':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'utils/db.ts'
+          - 'utils/db.*.ts'
+
+'scope: xhs':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'apps/Xhs*.tsx'
+          - 'worker/xhs-lite/**'
+
+'scope: mcd':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'components/mcd/**'
+          - 'utils/mcd*'
+
+'scope: vrWorld':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'apps/VRWorldApp.tsx'
+
+'scope: diary':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'apps/JournalApp.tsx'
+
+# 整个 PR 只动了文档才算文档 PR，顺手改一句 README 不会被贴上
+documentation:
+  - changed-files:
+      - all-globs-to-all-files:
+          - '**/*.md'

--- a/.github/workflows/on-close-cleanup.yml
+++ b/.github/workflows/on-close-cleanup.yml
@@ -1,0 +1,28 @@
+name: 关闭时清理流程标签
+
+# issue / PR 一关闭，就把「还在走流程」类的标签摘掉，
+# 已关闭列表里不会再留着一堆 needs xxx。
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  remove-pending-labels:
+    name: 摘掉 needs 系列标签
+    runs-on: ubuntu-latest
+    steps:
+      - name: 移除标签
+        # https://github.com/actions-cool/issues-helper
+        uses: actions-cool/issues-helper@a610082f8ac0cf03e357eb8dd0d5e2ba075e017e # v3.6.0
+        with:
+          actions: remove-labels
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number || github.event.pull_request.number }}
+          labels: 'needs triage,needs info,needs design'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,60 @@
+name: PR 自动打标签
+
+# 用 pull_request_target 是为了让来自 fork 的 PR 也拿得到写标签的权限。
+# 这里的两个 action 都只读 PR 的文件清单、不检出也不执行 PR 里的代码，所以是安全的。
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-by-files:
+    name: 按改动文件贴 scope 标签
+    runs-on: ubuntu-latest
+    steps:
+      - name: 按 .github/labeler.yml 的映射贴标签
+        # https://github.com/actions/labeler
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  label-by-size:
+    name: 按改动规模贴大小标签
+    # 排在 scope 标签之后，避免两个 job 同时写标签互相覆盖
+    needs: [label-by-files]
+    runs-on: ubuntu-latest
+    if: always()
+
+    # 打标签走的是 issues API，要额外给 issues 写权限
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: 统计增删行数并贴标签
+        # https://github.com/CodelyTV/pr-size-labeler
+        uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: '🟩 ●□□□□'
+          xs_max_size: '20'
+          s_label: '🟩 ●●□□□'
+          s_max_size: '100'
+          m_label: '🟨 ●●●□□'
+          m_max_size: '500'
+          l_label: '🟧 ●●●●□'
+          l_max_size: '1000'
+          xl_label: '🟥 ●●●●●'
+          # 超大 PR 只贴标签，不拦合并
+          fail_if_xl: 'false'
+          message_if_xl: ''
+          # 构建产物和锁文件不算进改动规模，不然一次 pnpm install 就直接顶到 XL
+          files_to_ignore: |
+            "pnpm-lock.yaml"
+            "public/*.bundle.js"
+            "dist/*"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -42,13 +42,13 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: '🟢 ■□□□□'
-          xs_max_size: '20'
+          xs_max_size: '50'
           s_label: '🟢 ■■□□□'
-          s_max_size: '100'
+          s_max_size: '500'
           m_label: '🟡 ■■■□□'
-          m_max_size: '500'
+          m_max_size: '1000'
           l_label: '🟠 ■■■■□'
-          l_max_size: '1000'
+          l_max_size: '2500'
           xl_label: '🔴 ■■■■■'
           # 超大 PR 只贴标签，不拦合并
           fail_if_xl: 'false'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -41,15 +41,15 @@ jobs:
         uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          xs_label: '🟩 ●□□□□'
+          xs_label: '🟢 ■□□□□'
           xs_max_size: '20'
-          s_label: '🟩 ●●□□□'
+          s_label: '🟢 ■■□□□'
           s_max_size: '100'
-          m_label: '🟨 ●●●□□'
+          m_label: '🟡 ■■■□□'
           m_max_size: '500'
-          l_label: '🟧 ●●●●□'
+          l_label: '🟠 ■■■■□'
           l_max_size: '1000'
-          xl_label: '🟥 ●●●●●'
+          xl_label: '🔴 ■■■■■'
           # 超大 PR 只贴标签，不拦合并
           fail_if_xl: 'false'
           message_if_xl: ''

--- a/.github/workflows/pr-lockfile-guard.yml
+++ b/.github/workflows/pr-lockfile-guard.yml
@@ -1,0 +1,27 @@
+name: 锁文件检查
+
+# 只在 PR 动到 pnpm-lock.yaml 时跑，几秒钟出结果。
+on:
+  pull_request:
+    paths:
+      - 'pnpm-lock.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  check-local-links:
+    name: 禁止指向仓库外的本地依赖
+    runs-on: ubuntu-latest
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 脚本零依赖，不用 pnpm install
+      - name: 检查 pnpm-lock.yaml
+        run: node scripts/check-lockfile-links.mjs

--- a/scripts/check-lockfile-links.mjs
+++ b/scripts/check-lockfile-links.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * 检查 pnpm-lock.yaml 里有没有指向仓库外的本地依赖（link:../xxx）。
+ *
+ * 背景：本地联调时把依赖临时改成 `link:../ReiStandard` 这种兄弟目录引用，
+ * 一旦跟着 lockfile 提交上去，Netlify / CI 的 `--frozen-lockfile` 安装会直接失败
+ * （那个目录只存在于本地机器上）。
+ *
+ * 判定规则：把 link 目标按所属 importer 目录解析一次，
+ * 解析后仍跳出仓库根目录的才算违规。
+ * 仓库内的 workspace 互链（`.` ↔ `worker/*`）是正常写法，放行。
+ *
+ * 用法：
+ *   node scripts/check-lockfile-links.mjs            # 检查 ./pnpm-lock.yaml
+ *   node scripts/check-lockfile-links.mjs 某个.yaml   # 检查指定文件
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * 从 lockfile 文本里找出所有指向仓库外的 link 依赖。
+ * @param {string} lockfileText pnpm-lock.yaml 的完整内容
+ * @returns {{ line: number, importer: string, target: string, raw: string }[]}
+ */
+export function findExternalLinks(lockfileText) {
+  const violations = [];
+  let inImporters = false;
+  let currentImporter = '.';
+
+  lockfileText.split('\n').forEach((line, index) => {
+    // 进入 importers: 段
+    if (/^importers:\s*$/.test(line)) {
+      inImporters = true;
+      currentImporter = '.';
+      return;
+    }
+    // 碰到下一个顶层键（packages: / snapshots: ...）就离开 importers 段
+    if (inImporters && /^[^\s#]/.test(line)) {
+      inImporters = false;
+    }
+    if (!inImporters) return;
+
+    // 缩进 2 空格的键是 importer 目录，形如 `  .:` 或 `  worker/instant-push:`
+    const importerMatch = line.match(/^ {2}(\S.*?):\s*$/);
+    if (importerMatch) {
+      currentImporter = importerMatch[1].replace(/['"]/g, '');
+      return;
+    }
+
+    const linkMatch = line.match(/link:(\S+)/);
+    if (!linkMatch) return;
+
+    const target = linkMatch[1].replace(/['"]/g, '');
+    const resolved = path.posix.normalize(path.posix.join(currentImporter, target));
+    if (resolved.startsWith('..')) {
+      violations.push({
+        line: index + 1,
+        importer: currentImporter,
+        target,
+        raw: line.trim(),
+      });
+    }
+  });
+
+  return violations;
+}
+
+function main() {
+  const lockfilePath = process.argv[2] ?? 'pnpm-lock.yaml';
+  let text;
+  try {
+    text = readFileSync(lockfilePath, 'utf8');
+  } catch {
+    console.error(`读不到 ${lockfilePath}，跳过检查。`);
+    process.exit(0);
+  }
+
+  const violations = findExternalLinks(text);
+  if (violations.length === 0) {
+    console.log(`${lockfilePath} 干净，没有指向仓库外的本地依赖。`);
+    return;
+  }
+
+  console.error(`${lockfilePath} 里有 ${violations.length} 处指向仓库外的本地依赖：\n`);
+  for (const v of violations) {
+    console.error(`  第 ${v.line} 行（importer: ${v.importer}）: ${v.raw}`);
+  }
+  console.error(
+    '\n这种引用只在你自己机器上有效，装依赖时会因为找不到目录而失败。' +
+      '\n把依赖改回正常的版本号（例如 npm 上的版本），重新 pnpm install 生成 lockfile 再提交。',
+  );
+  process.exit(1);
+}
+
+// 直接执行时才跑检查，被 import 时只导出函数
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-lockfile-links.test.ts
+++ b/scripts/check-lockfile-links.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+// @ts-expect-error 纯 JS 脚本，没有类型声明
+import { findExternalLinks } from './check-lockfile-links.mjs';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+describe('lockfile 本地依赖检查', () => {
+  it('仓库当前的 pnpm-lock.yaml 是干净的', () => {
+    const text = readFileSync(path.join(repoRoot, 'pnpm-lock.yaml'), 'utf8');
+    expect(findExternalLinks(text)).toEqual([]);
+  });
+
+  it('抓得到指向仓库外兄弟目录的 link', () => {
+    const lockfile = [
+      'lockfileVersion: 9.0',
+      '',
+      'importers:',
+      '',
+      '  .:',
+      '    devDependencies:',
+      "      '@rei-standard/amsg-server':",
+      '        specifier: link:../ReiStandard/packages/amsg-server',
+      '        version: link:../ReiStandard/packages/amsg-server',
+      '',
+      'packages: {}',
+    ].join('\n');
+
+    const violations = findExternalLinks(lockfile);
+    expect(violations).toHaveLength(2);
+    expect(violations[0].importer).toBe('.');
+    expect(violations[0].target).toBe('../ReiStandard/packages/amsg-server');
+  });
+
+  it('子包里跳出仓库根的 link 同样算违规', () => {
+    const lockfile = [
+      'importers:',
+      '',
+      '  worker/instant-push:',
+      '    dependencies:',
+      '      some-lib:',
+      '        version: link:../../../some-lib',
+      '',
+      'packages: {}',
+    ].join('\n');
+
+    const violations = findExternalLinks(lockfile);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].importer).toBe('worker/instant-push');
+  });
+
+  it('仓库内的 workspace 互链放行', () => {
+    const lockfile = [
+      'importers:',
+      '',
+      '  .:',
+      '    dependencies:',
+      '      instant-push:',
+      '        version: link:worker/instant-push',
+      '',
+      '  worker/instant-push:',
+      '    dependencies:',
+      '      sullyos:',
+      '        version: link:../..',
+      '',
+      'packages: {}',
+    ].join('\n');
+
+    expect(findExternalLinks(lockfile)).toEqual([]);
+  });
+
+  it('importers 段之外出现 link 字样不误报', () => {
+    const lockfile = [
+      'importers:',
+      '',
+      '  .:',
+      '    dependencies:',
+      '      normal-lib:',
+      '        version: 1.2.3',
+      '',
+      'snapshots:',
+      '',
+      '  fake-pkg@1.0.0:',
+      '    resolution: link:../whatever',
+    ].join('\n');
+
+    expect(findExternalLinks(lockfile)).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: [
       'utils/**/*.test.ts',
       'worker/**/*.test.ts',
+      'scripts/**/*.test.ts',
     ],
     // 排除 React 组件 / 浏览器集成测 (没装 jsdom)
     exclude: ['node_modules', '**/node_modules/**', '.worktrees', 'dist'],


### PR DESCRIPTION
仿照隔壁 SillyTavern 的仓库自动化，挑了几个对单人开发也有用的搬过来。

## 改后是怎样的

**开 PR / 推新提交时**

- 自动贴大小标签，按增删总行数分五档：`🟢 ■□□□□`(≤50) / `🟢 ■■□□□`(≤500) / `🟡 ■■■□□`(≤1000) / `🟠 ■■■■□`(≤2500) / `🔴 ■■■■■`(2500 以上)。`pnpm-lock.yaml`、`public/*.bundle.js`、`dist/` 不计入，不然一次装依赖就顶到最大档。超大 PR 只贴标签，不拦合并。
- 自动贴 scope 标签，映射表在 `.github/labeler.yml`。例如改 `worker/amsg/**` 贴 `scope: amsg`、改 `apps/Xhs*` 贴 `scope: xhs`。只加不删，手动贴的标签不会被冲掉；整个 PR 全是 md 才会被认成 `documentation`。

**PR 动到 `pnpm-lock.yaml` 时**

跑一遍锁文件检查，拦住 `link:../ReiStandard` 这类指向仓库外的本地依赖 —— 这种引用只在本机有效，跟着锁文件提交会让 Netlify / CI 的 `--frozen-lockfile` 安装失败。命中会挂 CI 并报出具体行号。仓库内的 workspace 互链（`.` ↔ `worker/*`）照常放行。

本地随时可以自查：`node scripts/check-lockfile-links.mjs`

**issue / PR 关闭时**

自动摘掉 `needs triage` / `needs info` / `needs design`，已关闭列表里不再留一堆流程标签。

## 说明

- 五个大小标签和 `scope: amsg` 已经在仓库里建好了
- 检查脚本配了 5 个测试（`scripts/check-lockfile-links.test.ts`），覆盖「仓库外 link 必挂 / workspace 互链放行 / 当前锁文件干净」；vitest 的 include 相应加了 `scripts/**`
- 第三方 action 都 pin 到 commit SHA，官方 `actions/*` 沿用仓库现有的 `@v4` 写法
- 贴标签的 workflow 用 `pull_request_target` 触发，两个 action 都只读 PR 的文件清单，不检出也不执行 PR 里的代码
- 这些 workflow 要合并进 master 之后才会生效，本 PR 自己身上不会有标签

https://claude.ai/code/session_01B6VuzGJD29fg8YHA889fBm