### PR TITLE
feat: add synchronized schedule card theming

### DIFF
--- a/components/schedule/ScheduleAppearanceButton.tsx
+++ b/components/schedule/ScheduleAppearanceButton.tsx
@@ -1,0 +1,377 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+    ArrowCounterClockwise,
+    Check,
+    Copy,
+    GearSix,
+    X,
+} from '@phosphor-icons/react';
+import type { ScheduleCardAppearance } from '../../types';
+import { useOS } from '../../context/OSContext';
+import {
+    SCHEDULE_CARD_PRESETS,
+    SCHEDULE_CSS_SCOPE_HINT,
+    SCHEDULE_CSS_SCOPE_REGEX,
+    resolveScheduleCardPalette,
+} from '../../utils/scheduleAppearance';
+import {
+    runCssRenderabilityCheck,
+    validateScopedCss,
+} from '../../utils/scopedCss';
+
+const CSS_TEMPLATES = [
+    {
+        name: '柔光玻璃',
+        code: `.sully-schedule-root{
+  backdrop-filter:blur(18px) saturate(1.25)!important;
+  box-shadow:0 18px 50px rgba(43,25,68,.22),inset 0 1px 0 rgba(255,255,255,.22)!important;
+}
+.sully-schedule-item-current{
+  box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--schedule-accent) 30%,transparent)!important;
+}`,
+    },
+    {
+        name: '纸胶带',
+        code: `.sully-schedule-root{border-radius:18px!important;box-shadow:0 12px 28px rgba(86,62,42,.16)!important;}
+.sully-schedule-header::after{
+  content:"";position:absolute;top:-7px;left:50%;width:72px;height:18px;
+  transform:translateX(-50%) rotate(-2deg);background:rgba(255,244,197,.68);
+  box-shadow:0 2px 4px rgba(91,72,51,.08);
+}
+.sully-schedule-activity{font-family:"Songti SC",serif!important;letter-spacing:.04em!important;}`,
+    },
+    {
+        name: '夜光边框',
+        code: `.sully-schedule-root{
+  border:1px solid color-mix(in srgb,var(--schedule-accent) 58%,transparent)!important;
+  box-shadow:0 0 28px color-mix(in srgb,var(--schedule-accent) 24%,transparent),inset 0 0 20px rgba(255,255,255,.035)!important;
+}
+.sully-schedule-time,.sully-schedule-activity{
+  text-shadow:0 0 10px color-mix(in srgb,var(--schedule-accent) 38%,transparent)!important;
+}`,
+    },
+];
+
+const AI_PROMPT = `你是 CSS 设计师，请为 SullyOS 的日程卡片写一段自定义 CSS。
+只能使用以 .sully-schedule-* 开头的选择器；覆盖内联样式时使用 !important。
+
+可用钩子：
+- .sully-schedule-root：所有日程卡根节点
+- .sully-schedule-card：完整日程卡
+- .sully-schedule-widget：桌面日程卡
+- .sully-schedule-header：卡片头部
+- .sully-schedule-cover：角色看板图
+- .sully-schedule-list：日程列表
+- .sully-schedule-item：单条日程
+- .sully-schedule-item-current：当前日程
+- .sully-schedule-time：时间
+- .sully-schedule-activity：活动标题
+- .sully-schedule-description：活动描述
+- .sully-schedule-timeline：底部时间线
+- .sully-schedule-settings：右上角设置按钮
+
+可以使用这些变量：
+--schedule-bg、--schedule-text、--schedule-accent、--schedule-accent-soft、--schedule-base、--schedule-line。
+
+请直接输出完整 CSS，不要写解释。我想要的风格是：______`;
+
+function defaultDraft(current?: ScheduleCardAppearance): ScheduleCardAppearance {
+    return {
+        preset: current?.preset || 'original',
+        background: current?.background || '#21192b',
+        textColor: current?.textColor || '#f8f3ff',
+        accentColor: current?.accentColor || '#c9a7ff',
+        customCss: current?.customCss || '',
+    };
+}
+
+export const ScheduleCustomCssStyle: React.FC = () => {
+    const { theme } = useOS();
+    const css = theme.scheduleCardAppearance?.customCss || '';
+    const validation = useMemo(
+        () => validateScopedCss(css, SCHEDULE_CSS_SCOPE_REGEX, SCHEDULE_CSS_SCOPE_HINT),
+        [css],
+    );
+    if (!css.trim() || !validation.isValid) return null;
+    return <style>{css}</style>;
+};
+
+const ScheduleAppearanceButton: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
+    const { theme, updateTheme, addToast } = useOS();
+    const [open, setOpen] = useState(false);
+    const [draft, setDraft] = useState<ScheduleCardAppearance>(() =>
+        defaultDraft(theme.scheduleCardAppearance)
+    );
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!open) return;
+        setDraft(defaultDraft(theme.scheduleCardAppearance));
+    }, [open, theme.scheduleCardAppearance]);
+
+    useEffect(() => {
+        if (!open) return;
+        const previous = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => { document.body.style.overflow = previous; };
+    }, [open]);
+
+    const validation = useMemo(
+        () => validateScopedCss(
+            draft.customCss || '',
+            SCHEDULE_CSS_SCOPE_REGEX,
+            SCHEDULE_CSS_SCOPE_HINT,
+        ),
+        [draft.customCss],
+    );
+    const preview = resolveScheduleCardPalette(draft, theme.hue, theme.contentColor || '#ffffff');
+
+    const stop: React.MouseEventHandler = event => {
+        event.preventDefault();
+        event.stopPropagation();
+    };
+
+    const save = async () => {
+        const renderability = runCssRenderabilityCheck(draft.customCss || '', validation);
+        if (!renderability.ok) {
+            addToast(renderability.message, 'error');
+            return;
+        }
+        await updateTheme({ scheduleCardAppearance: { ...draft } });
+        addToast('日程卡片样式已同步', 'success');
+        setOpen(false);
+    };
+
+    const reset = async () => {
+        await updateTheme({ scheduleCardAppearance: undefined });
+        addToast('已还原原版日程卡片', 'success');
+        setOpen(false);
+    };
+
+    const copyPrompt = async () => {
+        try {
+            await navigator.clipboard.writeText(AI_PROMPT);
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1400);
+        } catch {
+            addToast('复制失败，请手动选择文本', 'error');
+        }
+    };
+
+    const panel = open ? createPortal(
+        <div
+            className="fixed inset-0 z-[1900] flex items-end justify-center bg-black/45 backdrop-blur-sm"
+            onMouseDown={event => {
+                if (event.target === event.currentTarget) setOpen(false);
+            }}
+            onClick={event => event.stopPropagation()}
+        >
+            <div
+                className="w-full max-w-[620px] max-h-[88vh] overflow-y-auto rounded-t-[28px] bg-[#fbfafc] text-slate-800 shadow-2xl"
+                style={{ paddingBottom: 'max(24px, env(safe-area-inset-bottom))' }}
+                onMouseDown={event => event.stopPropagation()}
+            >
+                <div className="sticky top-0 z-10 flex items-center justify-between gap-3 px-5 py-4 bg-[#fbfafc]/95 backdrop-blur border-b border-slate-200/70">
+                    <div>
+                        <div className="text-[10px] font-bold tracking-[.2em] uppercase text-violet-400">Schedule skin</div>
+                        <h2 className="text-base font-black mt-0.5">日程卡片美化</h2>
+                    </div>
+                    <button
+                        className="w-9 h-9 rounded-full grid place-items-center bg-slate-100 text-slate-500"
+                        onClick={() => setOpen(false)}
+                        aria-label="关闭日程卡片设置"
+                    >
+                        <X size={17} />
+                    </button>
+                </div>
+
+                <div className="p-5 space-y-7">
+                    <section>
+                        <div className="mb-3">
+                            <h3 className="text-sm font-bold">配色</h3>
+                            <p className="text-[11px] text-slate-400 mt-1">桌面、房间和聊天里的日程卡会一起变化。</p>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2.5">
+                            {SCHEDULE_CARD_PRESETS.map(preset => {
+                                const selected = (draft.preset || 'original') === preset.id;
+                                const palette = resolveScheduleCardPalette(
+                                    { ...draft, preset: preset.id },
+                                    theme.hue,
+                                    theme.contentColor || '#ffffff',
+                                );
+                                return (
+                                    <button
+                                        key={preset.id}
+                                        className={`relative overflow-hidden rounded-2xl p-3 text-left min-h-[82px] transition-transform active:scale-[.98] ${
+                                            selected ? 'ring-2 ring-violet-400 ring-offset-2' : ''
+                                        }`}
+                                        style={{ background: palette.background, color: palette.text }}
+                                        onClick={() => setDraft(current => ({ ...current, preset: preset.id }))}
+                                    >
+                                        <span className="block text-sm font-black" style={{ color: palette.accent }}>{preset.name}</span>
+                                        <span className="block text-[10px] mt-1 opacity-60">{preset.description}</span>
+                                        <span className="absolute right-3 bottom-3 flex gap-1">
+                                            <i className="w-3 h-3 rounded-full border border-black/10" style={{ background: palette.text }} />
+                                            <i className="w-3 h-3 rounded-full border border-black/10" style={{ background: palette.accent }} />
+                                        </span>
+                                        {selected && <Check size={15} weight="bold" className="absolute right-3 top-3" />}
+                                    </button>
+                                );
+                            })}
+                            <button
+                                className={`rounded-2xl min-h-[82px] p-3 text-left border-2 border-dashed ${
+                                    draft.preset === 'custom'
+                                        ? 'border-violet-400 bg-violet-50'
+                                        : 'border-slate-200 bg-white'
+                                }`}
+                                onClick={() => setDraft(current => ({ ...current, preset: 'custom' }))}
+                            >
+                                <span className="block text-sm font-black text-slate-700">自定义配色</span>
+                                <span className="block text-[10px] text-slate-400 mt-1">背景 · 文字 · 强调色</span>
+                            </button>
+                        </div>
+                    </section>
+
+                    {draft.preset === 'custom' && (
+                        <section className="rounded-2xl border border-slate-200 bg-white p-4">
+                            <div
+                                className="h-20 rounded-xl mb-4 p-3 flex flex-col justify-between"
+                                style={{ background: preview.background, color: preview.text }}
+                            >
+                                <span className="text-[9px] uppercase tracking-[.2em] opacity-55">Daily schedule</span>
+                                <b style={{ color: preview.accent }}>08:30 · 今天的日程</b>
+                            </div>
+                            <div className="grid grid-cols-3 gap-3">
+                                {([
+                                    ['background', '背景', draft.background || '#21192b'],
+                                    ['textColor', '文字', draft.textColor || '#f8f3ff'],
+                                    ['accentColor', '强调', draft.accentColor || '#c9a7ff'],
+                                ] as const).map(([key, label, value]) => (
+                                    <label key={key} className="text-[11px] text-slate-500">
+                                        <span className="block mb-1.5">{label}</span>
+                                        <span className="flex items-center gap-2 rounded-xl border border-slate-200 p-2">
+                                            <input
+                                                type="color"
+                                                value={value}
+                                                onChange={event => setDraft(current => ({
+                                                    ...current,
+                                                    [key]: event.target.value,
+                                                }))}
+                                                className="w-7 h-7 rounded border-0 bg-transparent p-0"
+                                            />
+                                            <span className="font-mono text-[9px]">{value}</span>
+                                        </span>
+                                    </label>
+                                ))}
+                            </div>
+                        </section>
+                    )}
+
+                    <section>
+                        <div className="flex items-start justify-between gap-3 mb-3">
+                            <div>
+                                <h3 className="text-sm font-bold">自定义 CSS</h3>
+                                <p className="text-[11px] text-slate-400 mt-1">类似白框美化，只作用于日程卡。</p>
+                            </div>
+                            <button
+                                onClick={copyPrompt}
+                                className="shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-xl bg-violet-50 text-violet-600 text-[11px] font-bold"
+                            >
+                                {copied ? <Check size={13} /> : <Copy size={13} />}
+                                {copied ? '已复制' : '复制 AI 提示词'}
+                            </button>
+                        </div>
+                        <div className="flex gap-2 overflow-x-auto no-scrollbar mb-3">
+                            {CSS_TEMPLATES.map(template => (
+                                <button
+                                    key={template.name}
+                                    className="shrink-0 px-3 py-2 rounded-xl border border-slate-200 bg-white text-[11px] font-bold text-slate-600"
+                                    onClick={() => setDraft(current => ({ ...current, customCss: template.code }))}
+                                >
+                                    {template.name}
+                                </button>
+                            ))}
+                            <button
+                                className="shrink-0 px-3 py-2 rounded-xl border border-slate-200 bg-white text-[11px] font-bold text-slate-400"
+                                onClick={() => setDraft(current => ({ ...current, customCss: '' }))}
+                            >
+                                清空 CSS
+                            </button>
+                        </div>
+                        <textarea
+                            value={draft.customCss || ''}
+                            onChange={event => setDraft(current => ({ ...current, customCss: event.target.value }))}
+                            rows={11}
+                            spellCheck={false}
+                            className="w-full resize-y rounded-2xl border border-slate-200 bg-[#17141d] p-4 font-mono text-[11px] leading-5 text-violet-100 outline-none focus:border-violet-400"
+                            placeholder=".sully-schedule-root {&#10;  border-radius: 20px !important;&#10;}"
+                        />
+                        {!validation.isValid && (
+                            <div className="mt-2 rounded-xl bg-rose-50 px-3 py-2 text-[11px] leading-5 text-rose-600">
+                                {validation.errors[0]}
+                            </div>
+                        )}
+                        <details className="mt-3 text-[11px] text-slate-500">
+                            <summary className="cursor-pointer font-bold">查看可用 CSS 钩子</summary>
+                            <p className="mt-2 leading-5">
+                                root、card、widget、header、cover、list、item、item-current、time、
+                                activity、description、timeline、settings，均以 <code>.sully-schedule-</code> 开头。
+                                内联颜色需要用 <code>!important</code> 覆盖。
+                            </p>
+                        </details>
+                    </section>
+                </div>
+
+                <div className="sticky bottom-0 flex gap-2 px-5 pt-3 pb-1 bg-[#fbfafc]/95 backdrop-blur border-t border-slate-200/70">
+                    <button
+                        className="h-12 px-4 rounded-2xl bg-slate-100 text-slate-500 font-bold text-xs flex items-center gap-2"
+                        onClick={reset}
+                    >
+                        <ArrowCounterClockwise size={15} />
+                        还原
+                    </button>
+                    <button
+                        className="h-12 flex-1 rounded-2xl bg-slate-900 text-white font-bold text-sm disabled:opacity-40"
+                        disabled={!validation.isValid}
+                        onClick={save}
+                    >
+                        保存并同步
+                    </button>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    ) : null;
+
+    return (
+        <>
+            <button
+                type="button"
+                className={`sully-schedule-settings grid place-items-center rounded-full border transition-all active:scale-90 ${
+                    compact ? 'w-7 h-7' : 'w-8 h-8'
+                }`}
+                style={{
+                    color: 'var(--schedule-text)',
+                    background: 'color-mix(in srgb, var(--schedule-text) 10%, transparent)',
+                    borderColor: 'var(--schedule-line)',
+                }}
+                onPointerDown={event => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }}
+                onClick={event => {
+                    stop(event);
+                    setOpen(true);
+                }}
+                aria-label="日程卡片设置"
+                title="日程卡片设置"
+            >
+                <GearSix size={compact ? 13 : 15} weight="bold" />
+            </button>
+            {panel}
+        </>
+    );
+};
+
+export default ScheduleAppearanceButton;

--- a/components/schedule/ScheduleCard.tsx
+++ b/components/schedule/ScheduleCard.tsx
@@ -3,6 +3,9 @@ import React, { useState, useRef, useEffect } from 'react';
 import { DailySchedule, ScheduleSlot, CharacterProfile } from '../../types';
 import { getCurrentScheduleSlotIndex, getScheduleWallClock } from '../../utils/scheduleTime';
 import { resolveCharTimeZone, tzShortLabel } from '../../utils/timezone';
+import { useOS } from '../../context/OSContext';
+import { resolveScheduleCardPalette } from '../../utils/scheduleAppearance';
+import ScheduleAppearanceButton, { ScheduleCustomCssStyle } from './ScheduleAppearanceButton';
 
 interface ScheduleCardProps {
     schedule: DailySchedule | null;
@@ -42,7 +45,7 @@ const useTickingNow = (): Date => {
 const ScheduleCard: React.FC<ScheduleCardProps> = ({
     schedule,
     character,
-    contentColor = '#ffffff',
+    contentColor: inheritedContentColor = '#ffffff',
     compact = false,
     onEdit,
     onDelete,
@@ -51,6 +54,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
     onPlayTheater,
     isGenerating = false,
 }) => {
+    const { theme } = useOS();
     const [editingIdx, setEditingIdx] = useState<number | null>(null);
     const [editTime, setEditTime] = useState('');
     const [editActivity, setEditActivity] = useState('');
@@ -143,21 +147,37 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
         e.target.value = '';
     };
 
-    // Accent color derived from theme
-    const accentHsl = `hsl(${character?.themeColor || 260}, 70%, 65%)`;
-    const accentBg = `hsl(${character?.themeColor || 260}, 50%, 20%)`;
-    const cardBg = `hsl(${character?.themeColor || 260}, 40%, 12%)`;
+    const palette = resolveScheduleCardPalette(
+        theme.scheduleCardAppearance,
+        character?.themeColor || theme.hue || 260,
+        inheritedContentColor,
+    );
+    const contentColor = palette.text;
+    const accentHsl = palette.accent;
+    const accentBg = palette.accentSoft;
+    const cardBg = palette.base;
+    const scheduleVars = {
+        '--schedule-bg': palette.background,
+        '--schedule-text': palette.text,
+        '--schedule-accent': palette.accent,
+        '--schedule-accent-soft': palette.accentSoft,
+        '--schedule-base': palette.base,
+        '--schedule-line': palette.line,
+    } as React.CSSProperties;
 
     return (
         <div
-            className="relative rounded-3xl overflow-hidden shadow-2xl border border-white/10"
+            className="sully-schedule-root sully-schedule-card relative rounded-3xl overflow-hidden shadow-2xl"
             style={{
-                background: `linear-gradient(145deg, ${cardBg}, hsl(${character?.themeColor || 260}, 35%, 8%))`,
+                ...scheduleVars,
+                background: palette.background,
                 color: contentColor,
+                border: `1px solid ${palette.line}`,
             }}
         >
+            <ScheduleCustomCssStyle />
             {/* Header */}
-            <div className="relative px-5 pt-5 pb-3 flex items-start justify-between">
+            <div className="sully-schedule-header relative px-5 pt-5 pb-3 flex items-start justify-between">
                 <div>
                     <div className="flex items-center gap-2 mb-1">
                         <span className="text-[10px] font-bold tracking-[0.2em] uppercase opacity-50">Daily</span>
@@ -176,9 +196,15 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                     </div>
                 </div>
                 <div className="flex flex-col items-end gap-1">
-                    <span className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-white/20" style={{ background: accentBg }}>
-                        {formatDate(wallClock)}
-                    </span>
+                    <div className="flex items-center gap-1.5">
+                        <span
+                            className="text-[10px] font-bold px-2 py-0.5 rounded-full border"
+                            style={{ background: accentBg, borderColor: palette.line }}
+                        >
+                            {formatDate(wallClock)}
+                        </span>
+                        <ScheduleAppearanceButton compact />
+                    </div>
                     {charTzName && (
                         <span className="text-[9px] font-bold opacity-40 tracking-wide">
                             {charTzName}
@@ -188,8 +214,8 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                         <button
                             onClick={onReroll}
                             disabled={isGenerating}
-                            className="text-[10px] font-bold px-2 py-0.5 rounded-full border border-white/20 hover:border-white/40 transition-all active:scale-95 disabled:opacity-30"
-                            style={{ background: accentBg }}
+                            className="text-[10px] font-bold px-2 py-0.5 rounded-full border transition-all active:scale-95 disabled:opacity-30"
+                            style={{ background: accentBg, borderColor: palette.line }}
                         >
                             {isGenerating ? '生成中...' : '↻ 重新生成'}
                         </button>
@@ -200,7 +226,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
             {/* Content: Character Image Banner on top, Schedule List below */}
             <div className="flex flex-col">
                 {/* Character Image Banner */}
-                <div className="relative w-full h-32 overflow-hidden flex-shrink-0">
+                <div className="sully-schedule-cover relative w-full h-32 overflow-hidden flex-shrink-0">
                     {(coverImage || charAvatar) ? (
                         <img
                             src={coverImage || charAvatar}
@@ -236,7 +262,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                 </div>
 
                 {/* Schedule List */}
-                <div className="px-5 pb-5 pt-1 space-y-1 min-w-0">
+                <div className="sully-schedule-list px-5 pb-5 pt-1 space-y-1 min-w-0">
                     {isGenerating && !schedule ? (
                         <div className="py-12 text-center">
                             <div className="inline-block w-6 h-6 border-2 border-white/20 border-t-white/60 rounded-full animate-spin mb-3"></div>
@@ -251,7 +277,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
 
                             if (isEditing && !compact) {
                                 return (
-                                    <div key={idx} className="p-3 rounded-xl border border-white/20" style={{ background: accentBg }}>
+                                    <div key={idx} className="sully-schedule-item p-3 rounded-xl border" style={{ background: accentBg, borderColor: palette.line }}>
                                         <div className="flex gap-2 mb-2">
                                             <input
                                                 type="time"
@@ -310,15 +336,15 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                             return (
                                 <div
                                     key={idx}
-                                    className={`relative flex items-start gap-3 py-2 px-3 rounded-xl transition-all ${
-                                        isCurrent ? 'border border-white/20' : 'border border-transparent'
+                                    className={`sully-schedule-item ${isCurrent ? 'sully-schedule-item-current' : ''} relative flex items-start gap-3 py-2 px-3 rounded-xl transition-all ${
+                                        isCurrent ? 'border' : 'border border-transparent'
                                     } ${editable ? 'cursor-pointer hover:bg-white/5 select-none' : ''}`}
-                                    style={isCurrent ? { background: accentBg } : {}}
+                                    style={isCurrent ? { background: accentBg, borderColor: palette.line } : {}}
                                     {...pressHandlers}
                                 >
                                     {/* Time */}
                                     <div className="flex flex-col items-center w-12 flex-shrink-0">
-                                        <span className={`text-xs font-mono font-bold ${isPast ? 'opacity-30' : isCurrent ? 'opacity-100' : 'opacity-60'}`}>
+                                        <span className={`sully-schedule-time text-xs font-mono font-bold ${isPast ? 'opacity-30' : isCurrent ? 'opacity-100' : 'opacity-60'}`}>
                                             {slot.startTime}
                                         </span>
                                         {isCurrent && (
@@ -329,12 +355,12 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                                     </div>
 
                                     {/* Timeline dot + line */}
-                                    <div className="flex flex-col items-center pt-1.5 flex-shrink-0">
+                                    <div className="sully-schedule-timeline flex flex-col items-center pt-1.5 flex-shrink-0">
                                         <div
                                             className={`w-2.5 h-2.5 rounded-full border-2 ${isPast ? 'opacity-30' : ''}`}
                                             style={{
-                                                borderColor: isCurrent ? accentHsl : 'rgba(255,255,255,0.3)',
-                                                background: isCurrent ? accentHsl : (isPast ? 'rgba(255,255,255,0.15)' : 'transparent'),
+                                                borderColor: isCurrent ? accentHsl : palette.line,
+                                                background: isCurrent ? accentHsl : (isPast ? palette.line : 'transparent'),
                                             }}
                                         />
                                         {idx < schedule.slots.length - 1 && (
@@ -346,10 +372,10 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                                     <div className={`flex-1 min-w-0 ${isPast ? 'opacity-30' : ''}`}>
                                         <div className="flex items-center gap-1.5">
                                             {slot.emoji && <span className="text-sm flex-shrink-0">{slot.emoji}</span>}
-                                            <span className={`text-sm font-bold ${isCurrent ? '' : ''}`}>{slot.activity}</span>
+                                            <span className="sully-schedule-activity text-sm font-bold">{slot.activity}</span>
                                         </div>
                                         {slot.description && (
-                                            <p className="text-[11px] opacity-50 mt-0.5 leading-tight">{slot.description}</p>
+                                            <p className="sully-schedule-description text-[11px] opacity-50 mt-0.5 leading-tight">{slot.description}</p>
                                         )}
                                     </div>
 
@@ -360,8 +386,8 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
                                             <button
                                                 className={`w-7 h-7 rounded-full flex items-center justify-center text-xs transition-all ${isFuture ? 'cursor-not-allowed' : 'active:scale-90'}`}
                                                 style={{
-                                                    background: isFuture ? 'rgba(255,255,255,0.06)' : (slot.theater ? accentHsl : 'rgba(255,255,255,0.12)'),
-                                                    color: isFuture ? 'rgba(255,255,255,0.28)' : (slot.theater ? cardBg : contentColor),
+                                                    background: isFuture ? 'color-mix(in srgb, var(--schedule-text) 6%, transparent)' : (slot.theater ? accentHsl : 'color-mix(in srgb, var(--schedule-text) 12%, transparent)'),
+                                                    color: isFuture ? 'color-mix(in srgb, var(--schedule-text) 28%, transparent)' : (slot.theater ? cardBg : contentColor),
                                                 }}
                                                 title={isFuture ? '还没到这个时间哦' : (slot.theater ? '重看小剧场' : '窥视这一刻')}
                                                 onPointerDown={(e) => { e.stopPropagation(); cancelLongPress(); }}

--- a/components/schedule/ScheduleHomeWidget.tsx
+++ b/components/schedule/ScheduleHomeWidget.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { CharacterProfile, DailySchedule, ScheduleSlot } from '../../types';
 import ScheduleCard from './ScheduleCard';
 import { getCurrentScheduleSlotIndex, getScheduleWallClock } from '../../utils/scheduleTime';
+import { useOS } from '../../context/OSContext';
+import { resolveScheduleCardPalette } from '../../utils/scheduleAppearance';
+import ScheduleAppearanceButton, { ScheduleCustomCssStyle } from './ScheduleAppearanceButton';
 
 interface ScheduleSquareWidgetProps {
     schedule: DailySchedule | null;
@@ -13,33 +16,61 @@ interface ScheduleSquareWidgetProps {
 export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
     schedule,
     character,
-    contentColor = '#ffffff',
+    contentColor: inheritedContentColor = '#ffffff',
     onOpen,
 }) => {
+    const { theme } = useOS();
     const currentIdx = schedule ? getCurrentScheduleSlotIndex(schedule.slots, character) : -1;
     const currentSlot = currentIdx >= 0 ? schedule!.slots[currentIdx] : null;
     const nextSlot = schedule && currentIdx < schedule.slots.length - 1
         ? schedule.slots[currentIdx + 1]
         : null;
 
-    const accentHsl = `hsl(${character?.themeColor ?? 260}, 70%, 65%)`;
-    const accentSoft = `hsla(${character?.themeColor ?? 260}, 70%, 55%, 0.32)`;
-    const cardBg = `hsl(${character?.themeColor ?? 260}, 38%, 12%)`;
+    const palette = resolveScheduleCardPalette(
+        theme.scheduleCardAppearance,
+        character?.themeColor ?? theme.hue ?? 260,
+        inheritedContentColor,
+    );
+    const contentColor = palette.text;
+    const accentHsl = palette.accent;
+    const accentSoft = palette.accentSoft;
+    const cardBg = palette.base;
+    const scheduleVars = {
+        '--schedule-bg': palette.background,
+        '--schedule-text': palette.text,
+        '--schedule-accent': palette.accent,
+        '--schedule-accent-soft': palette.accentSoft,
+        '--schedule-base': palette.base,
+        '--schedule-line': palette.line,
+    } as React.CSSProperties;
 
     const now = getScheduleWallClock(character);
     const timeLabel = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
 
     return (
-        <button
+        <div
             onClick={onOpen}
-            className="relative w-full h-full rounded-[1.75rem] overflow-hidden cursor-pointer transition-transform duration-200 active:scale-[0.98] animate-fade-in text-left"
+            onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onOpen();
+                }
+            }}
+            role="button"
+            tabIndex={0}
+            className="sully-schedule-root sully-schedule-widget relative w-full h-full rounded-[1.75rem] overflow-hidden cursor-pointer transition-transform duration-200 active:scale-[0.98] animate-fade-in text-left"
             style={{
-                background: `linear-gradient(155deg, ${cardBg}, hsl(${character?.themeColor ?? 260}, 32%, 7%))`,
-                border: '1px solid rgba(255,255,255,0.14)',
+                ...scheduleVars,
+                background: palette.background,
+                border: `1px solid ${palette.line}`,
                 boxShadow: '0 8px 30px rgba(0,0,0,0.24), inset 0 1px 0 rgba(255,255,255,0.07)',
                 color: contentColor,
             }}
         >
+            <ScheduleCustomCssStyle />
+            <div className="absolute top-2 right-2 z-20">
+                <ScheduleAppearanceButton compact />
+            </div>
             {/* Background avatar */}
             {character?.avatar && (
                 <img
@@ -64,7 +95,7 @@ export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
             />
 
             {/* Top row: NOW badge + time */}
-            <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-3 pt-3 z-10">
+            <div className="sully-schedule-header absolute top-0 left-0 right-0 flex items-center justify-between pl-3 pr-11 pt-3 z-10">
                 <span
                     className="text-[8.5px] font-bold tracking-[0.22em] uppercase px-1.5 py-0.5 rounded-full"
                     style={{
@@ -75,7 +106,7 @@ export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
                 >
                     {currentSlot ? 'Now' : 'Idle'}
                 </span>
-                <span className="text-[10px] font-mono opacity-65 tracking-wider drop-shadow">
+                <span className="sully-schedule-time text-[10px] font-mono opacity-65 tracking-wider drop-shadow">
                     {currentSlot ? currentSlot.startTime : timeLabel}
                 </span>
             </div>
@@ -92,12 +123,12 @@ export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
                     {currentSlot?.emoji && (
                         <span className="text-xl shrink-0 drop-shadow-md">{currentSlot.emoji}</span>
                     )}
-                    <span className="text-[13px] font-bold truncate drop-shadow-md leading-tight">
+                    <span className="sully-schedule-activity text-[13px] font-bold truncate drop-shadow-md leading-tight">
                         {currentSlot?.activity || (schedule ? '休息中' : '未生成')}
                     </span>
                 </div>
                 {nextSlot ? (
-                    <div className="text-[9.5px] opacity-55 truncate leading-tight">
+                    <div className="sully-schedule-description text-[9.5px] opacity-55 truncate leading-tight">
                         <span className="opacity-70 mr-1">→ {nextSlot.startTime}</span>
                         {nextSlot.activity}
                     </div>
@@ -117,7 +148,7 @@ export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
                     <path strokeLinecap="round" strokeLinejoin="round" d="M3 7.5V5a2 2 0 0 1 2-2h2.5M21 7.5V5a2 2 0 0 0-2-2h-2.5M3 16.5V19a2 2 0 0 0 2 2h2.5M21 16.5V19a2 2 0 0 1-2 2h-2.5" />
                 </svg>
             </div>
-        </button>
+        </div>
     );
 };
 
@@ -133,19 +164,40 @@ interface ScheduleHomeWidgetProps {
 export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
     schedule,
     character,
-    contentColor = '#ffffff',
+    contentColor: inheritedContentColor = '#ffffff',
     onOpen,
     acnh = false,
     paper = false,
 }) => {
+    const { theme } = useOS();
     const currentIdx = schedule ? getCurrentScheduleSlotIndex(schedule.slots, character) : -1;
     const currentSlot = currentIdx >= 0 ? schedule!.slots[currentIdx] : null;
     const nextSlot = schedule && currentIdx < schedule.slots.length - 1
         ? schedule.slots[currentIdx + 1]
         : null;
 
-    const accentHsl = paper ? '#788369' : `hsl(${character?.themeColor ?? 260}, 70%, 65%)`;
-    const accentSoft = paper ? 'rgba(120,131,105,0.14)' : `hsla(${character?.themeColor ?? 260}, 70%, 55%, 0.28)`;
+    const palette = resolveScheduleCardPalette(
+        theme.scheduleCardAppearance,
+        character?.themeColor ?? theme.hue ?? 260,
+        inheritedContentColor,
+    );
+    const effectivePaper = paper && palette.isOriginal;
+    const effectiveAcnh = acnh && palette.isOriginal;
+    const contentColor = palette.text;
+    const accentHsl = effectivePaper ? '#788369' : palette.accent;
+    const accentSoft = effectivePaper ? 'rgba(120,131,105,0.14)' : palette.accentSoft;
+    const scheduleVars = {
+        '--schedule-bg': effectiveAcnh
+            ? 'rgb(247,243,223)'
+            : effectivePaper
+                ? 'rgba(224,221,215,0.40)'
+                : palette.background,
+        '--schedule-text': effectiveAcnh ? '#725d42' : palette.text,
+        '--schedule-accent': effectiveAcnh ? '#5a9e1e' : accentHsl,
+        '--schedule-accent-soft': effectiveAcnh ? '#dff0c8' : accentSoft,
+        '--schedule-base': effectiveAcnh ? '#f7f3df' : effectivePaper ? '#e0ddd7' : palette.base,
+        '--schedule-line': effectiveAcnh ? '#e8e2d6' : effectivePaper ? 'rgba(91,72,51,0.07)' : palette.line,
+    } as React.CSSProperties;
 
     const now = getScheduleWallClock(character);
     const timeLabel = `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`;
@@ -153,13 +205,26 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
     const timelineSlots = schedule?.slots ?? [];
 
     // 动森：全新奶油布局（不复用暗底版式）
-    if (acnh) {
+    if (effectiveAcnh) {
         return (
-            <button onClick={onOpen}
-                className="w-full text-left rounded-3xl overflow-hidden active:scale-[0.98] transition-transform relative"
-                style={{ background: 'rgb(247,243,223)', border: '2px solid #e8e2d6', boxShadow: '0 6px 18px rgba(61,52,40,0.12)' }}>
+            <div
+                onClick={onOpen}
+                onKeyDown={event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        onOpen();
+                    }
+                }}
+                role="button"
+                tabIndex={0}
+                className="sully-schedule-root sully-schedule-widget w-full shrink-0 text-left rounded-3xl overflow-hidden active:scale-[0.98] transition-transform relative"
+                style={{ ...scheduleVars, background: 'rgb(247,243,223)', border: '2px solid #e8e2d6', boxShadow: '0 6px 18px rgba(61,52,40,0.12)', color: '#725d42' }}>
+                <ScheduleCustomCssStyle />
+                <div className="absolute right-3 top-3 z-20" style={{ '--schedule-text': '#725d42', '--schedule-line': 'rgba(91,72,51,.16)' } as React.CSSProperties}>
+                    <ScheduleAppearanceButton compact />
+                </div>
                 <div className="flex flex-col p-4 gap-3">
-                    <div className="flex items-center gap-2">
+                    <div className="sully-schedule-header flex items-center gap-2 pr-8">
                         <span className="text-[12px] font-extrabold" style={{ color: '#725d42' }}>🍃 今日日程</span>
                         <div className="h-[2px] flex-1 rounded-full" style={{ background: '#e8e2d6' }} />
                         <span className="text-[11px] font-bold" style={{ color: '#9f927d' }}>{timeLabel}</span>
@@ -177,24 +242,24 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                                     style={{ background: currentSlot ? '#dff0c8' : '#efe7d4', color: currentSlot ? '#5a9e1e' : '#9f927d' }}>
                                     {currentSlot ? '现在' : '休息'}
                                 </span>
-                                <span className="text-[10px] font-bold" style={{ color: '#9f927d' }}>{currentSlot ? currentSlot.startTime : timeLabel}</span>
+                                <span className="sully-schedule-time text-[10px] font-bold" style={{ color: '#9f927d' }}>{currentSlot ? currentSlot.startTime : timeLabel}</span>
                                 <span className="text-[9px] ml-auto shrink-0 truncate max-w-[40%] font-bold" style={{ color: '#b3a88e' }}>{character?.name || '—'}</span>
                             </div>
                             <div className="flex items-center gap-1.5 min-w-0">
                                 {currentSlot?.emoji && <span className="text-base shrink-0">{currentSlot.emoji}</span>}
-                                <span className="text-[15px] font-bold truncate leading-tight" style={{ color: '#725d42' }}>
+                                <span className="sully-schedule-activity text-[15px] font-bold truncate leading-tight" style={{ color: '#725d42' }}>
                                     {currentSlot?.activity || (schedule ? '休息中 · 暂无安排' : '尚未生成日程')}
                                 </span>
                             </div>
                             {nextSlot && (
-                                <div className="text-[10.5px] mt-0.5 truncate" style={{ color: '#a89878' }}>
+                                <div className="sully-schedule-description text-[10.5px] mt-0.5 truncate" style={{ color: '#a89878' }}>
                                     → {nextSlot.startTime} {nextSlot.emoji ? `${nextSlot.emoji} ` : ''}{nextSlot.activity}
                                 </div>
                             )}
                         </div>
                     </div>
                     {timelineSlots.length > 0 && (
-                        <div className="flex items-end gap-1.5 pt-0.5">
+                        <div className="sully-schedule-timeline flex items-end gap-1.5 pt-0.5">
                             {timelineSlots.slice(0, 10).map((slot, i) => {
                                 const isCur = i === currentIdx;
                                 const isPast = currentIdx >= 0 && i < currentIdx;
@@ -208,25 +273,36 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                         </div>
                     )}
                 </div>
-            </button>
+            </div>
         );
     }
 
     return (
-        <button
+        <div
             onClick={onOpen}
-            className="w-full group text-left rounded-3xl overflow-hidden transition-transform duration-200 active:scale-[0.98] relative"
-            style={paper ? {
+            onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onOpen();
+                }
+            }}
+            role="button"
+            tabIndex={0}
+            className="sully-schedule-root sully-schedule-widget w-full shrink-0 group text-left rounded-3xl overflow-hidden transition-transform duration-200 active:scale-[0.98] relative"
+            style={effectivePaper ? {
+                ...scheduleVars,
                 background: 'rgba(224,221,215,0.40)',
                 border: '1px solid rgba(91,72,51,0.07)',
                 boxShadow: '0 5px 16px rgba(91,72,51,0.055)',
                 color: contentColor,
-            } : acnh ? {
-                background: 'rgb(247,243,223)',
-                border: '2px solid #e8e2d6',
-                boxShadow: '0 6px 18px rgba(61,52,40,0.12)',
+            } : !palette.isOriginal ? {
+                ...scheduleVars,
+                background: palette.background,
+                border: `1px solid ${palette.line}`,
+                boxShadow: '0 8px 32px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.08)',
                 color: contentColor,
             } : {
+                ...scheduleVars,
                 background: 'rgba(255,255,255,0.08)',
                 backdropFilter: 'blur(24px) saturate(1.4)',
                 WebkitBackdropFilter: 'blur(24px) saturate(1.4)',
@@ -235,8 +311,12 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                 color: contentColor,
             }}
         >
+            <ScheduleCustomCssStyle />
+            <div className="absolute right-3 top-3 z-20">
+                <ScheduleAppearanceButton compact />
+            </div>
             {/* Blurred avatar glow（动森奶油底下省略，避免糊脏） */}
-            {!acnh && !paper && character?.avatar && (
+            {!effectivePaper && palette.isOriginal && character?.avatar && (
                 <div
                     className="absolute inset-0 opacity-25 pointer-events-none"
                     style={{
@@ -250,30 +330,30 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
             )}
             {/* Accent corner glow */}
             <div
-                className={`absolute -top-12 -right-12 w-32 h-32 rounded-full pointer-events-none ${paper ? 'opacity-10' : 'opacity-40'}`}
+                className={`absolute -top-12 -right-12 w-32 h-32 rounded-full pointer-events-none ${effectivePaper ? 'opacity-10' : 'opacity-40'}`}
                 style={{ background: `radial-gradient(circle, ${accentHsl}, transparent 70%)` }}
             />
             {/* Accent vertical stripe */}
             <div
                 className="absolute left-0 top-0 bottom-0 w-[3px]"
-                style={{ background: paper ? 'linear-gradient(to bottom, #788369, rgba(120,131,105,0.12))' : `linear-gradient(to bottom, ${accentHsl}, transparent)` }}
+                style={{ background: effectivePaper ? 'linear-gradient(to bottom, #788369, rgba(120,131,105,0.12))' : `linear-gradient(to bottom, ${accentHsl}, transparent)` }}
             />
 
             <div className="relative flex flex-col p-4 gap-3">
                 {/* Header row: label + character name + time */}
-                <div className="flex items-center gap-2 text-[9px] tracking-[0.22em] uppercase opacity-60">
+                <div className="sully-schedule-header flex items-center gap-2 pr-8 text-[9px] tracking-[0.22em] uppercase opacity-60">
                     <span className="font-bold">Daily Schedule</span>
                     <div className="h-px flex-1" style={{ background: contentColor, opacity: 0.25 }}></div>
-                    <span className="font-mono tracking-wider opacity-80">{timeLabel}</span>
+                    <span className="sully-schedule-time font-mono tracking-wider opacity-80">{timeLabel}</span>
                 </div>
 
                 {/* Main row: avatar | activity */}
                 <div className="flex items-center gap-4">
                     <div
-                        className={`w-[72px] h-[72px] shrink-0 rounded-2xl overflow-hidden relative ${paper ? 'bg-[#ded2c1]' : 'bg-slate-800/60'}`}
+                        className={`w-[72px] h-[72px] shrink-0 rounded-2xl overflow-hidden relative ${effectivePaper ? 'bg-[#ded2c1]' : 'bg-slate-800/60'}`}
                         style={{
-                            border: paper ? '1px solid rgba(91,72,51,0.14)' : '1.5px solid rgba(255,255,255,0.24)',
-                            boxShadow: paper ? '0 6px 16px rgba(91,72,51,0.13)' : '0 6px 18px rgba(0,0,0,0.3)',
+                            border: effectivePaper ? '1px solid rgba(91,72,51,0.14)' : `1.5px solid ${palette.line}`,
+                            boxShadow: effectivePaper ? '0 6px 16px rgba(91,72,51,0.13)' : '0 6px 18px rgba(0,0,0,0.3)',
                         }}
                     >
                         {character?.avatar ? (
@@ -296,9 +376,9 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                             <span
                                 className="text-[9px] font-bold tracking-[0.22em] uppercase px-1.5 py-0.5 rounded-full"
                                 style={{
-                                    background: currentSlot ? accentSoft : paper ? 'rgba(91,72,51,0.07)' : 'rgba(255,255,255,0.14)',
+                                    background: currentSlot ? accentSoft : effectivePaper ? 'rgba(91,72,51,0.07)' : 'color-mix(in srgb, var(--schedule-text) 14%, transparent)',
                                     color: currentSlot ? accentHsl : undefined,
-                                    border: paper ? '1px solid rgba(91,72,51,0.10)' : '1px solid rgba(255,255,255,0.16)',
+                                    border: effectivePaper ? '1px solid rgba(91,72,51,0.10)' : `1px solid ${palette.line}`,
                                 }}
                             >
                                 {currentSlot ? 'Now' : 'Idle'}
@@ -312,14 +392,14 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                         </div>
                         <div className="flex items-center gap-1.5 min-w-0">
                             {currentSlot?.emoji && (
-                                <span className={`text-lg shrink-0 ${paper ? '' : 'drop-shadow-md'}`}>{currentSlot.emoji}</span>
+                                <span className={`text-lg shrink-0 ${effectivePaper ? '' : 'drop-shadow-md'}`}>{currentSlot.emoji}</span>
                             )}
-                            <span className={`text-[15px] font-bold truncate leading-tight ${paper ? '' : 'drop-shadow-md'}`}>
+                            <span className={`sully-schedule-activity text-[15px] font-bold truncate leading-tight ${effectivePaper ? '' : 'drop-shadow-md'}`}>
                                 {currentSlot?.activity || (schedule ? '休息中 · 暂无安排' : '尚未生成日程')}
                             </span>
                         </div>
                         {(currentSlot?.description || nextSlot) && (
-                            <div className="text-[10.5px] opacity-55 truncate mt-0.5 leading-snug">
+                            <div className="sully-schedule-description text-[10.5px] opacity-55 truncate mt-0.5 leading-snug">
                                 {currentSlot?.description ? (
                                     currentSlot.description
                                 ) : nextSlot ? (
@@ -335,7 +415,7 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                     {/* Open indicator */}
                     <div
                         className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center opacity-70 group-hover:opacity-100 transition-opacity self-start"
-                        style={{ background: paper ? 'rgba(120,131,105,0.10)' : 'rgba(255,255,255,0.14)', border: paper ? '1px solid rgba(91,72,51,0.11)' : '1px solid rgba(255,255,255,0.2)' }}
+                        style={{ background: effectivePaper ? 'rgba(120,131,105,0.10)' : 'color-mix(in srgb, var(--schedule-text) 14%, transparent)', border: effectivePaper ? '1px solid rgba(91,72,51,0.11)' : `1px solid ${palette.line}` }}
                     >
                         <svg viewBox="0 0 24 24" fill="none" strokeWidth={2.2} stroke="currentColor" className="w-3.5 h-3.5">
                             <path strokeLinecap="round" strokeLinejoin="round" d="M3 7.5V5a2 2 0 0 1 2-2h2.5M21 7.5V5a2 2 0 0 0-2-2h-2.5M3 16.5V19a2 2 0 0 0 2 2h2.5M21 16.5V19a2 2 0 0 1-2 2h-2.5" />
@@ -345,7 +425,7 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
 
                 {/* Timeline footer */}
                 {timelineSlots.length > 0 && (
-                    <div className="flex items-center gap-1.5 pt-1">
+                    <div className="sully-schedule-timeline flex items-center gap-1.5 pt-1">
                         {timelineSlots.slice(0, 10).map((slot, i) => {
                             const isCurrent = i === currentIdx;
                             const isPast = currentIdx >= 0 && i < currentIdx;
@@ -357,8 +437,8 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                                     <div
                                         className="w-full h-[3px] rounded-full transition-all"
                                         style={{
-                                            background: isCurrent ? accentHsl : isPast ? (paper ? 'rgba(91,72,51,0.22)' : 'rgba(255,255,255,0.32)') : (paper ? 'rgba(91,72,51,0.10)' : 'rgba(255,255,255,0.14)'),
-                                            boxShadow: isCurrent && !paper ? `0 0 8px ${accentHsl}` : 'none',
+                                            background: isCurrent ? accentHsl : isPast ? (effectivePaper ? 'rgba(91,72,51,0.22)' : 'color-mix(in srgb, var(--schedule-text) 32%, transparent)') : (effectivePaper ? 'rgba(91,72,51,0.10)' : 'color-mix(in srgb, var(--schedule-text) 14%, transparent)'),
+                                            boxShadow: isCurrent && !effectivePaper ? `0 0 8px ${accentHsl}` : 'none',
                                         }}
                                     ></div>
                                     <span
@@ -376,7 +456,7 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
                     </div>
                 )}
             </div>
-        </button>
+        </div>
     );
 };
 

--- a/types.ts
+++ b/types.ts
@@ -69,6 +69,26 @@ export interface DesktopDecoration {
   flip?: boolean;
 }
 
+export type ScheduleCardPresetId =
+  | 'original'
+  | 'cream'
+  | 'sakura'
+  | 'mint'
+  | 'twilight'
+  | 'midnight'
+  | 'custom';
+
+/** 全局日程卡片皮肤：所有桌面组件、房间页与聊天日程弹窗共用。 */
+export interface ScheduleCardAppearance {
+  preset?: ScheduleCardPresetId;
+  /** preset='custom' 时使用；支持颜色或 CSS 渐变。 */
+  background?: string;
+  textColor?: string;
+  accentColor?: string;
+  /** 仅允许 .sully-schedule-* 作用域的进阶美化。 */
+  customCss?: string;
+}
+
 export interface OSTheme {
   hue: number;
   saturation: number;
@@ -96,6 +116,8 @@ export interface OSTheme {
   preserveCustomIconOutlines?: boolean;
   /** 默认皮肤桌面「正在播放」音乐卡片改用浅色系样式（新安装默认 true）。 */
   nowPlayingWidgetLight?: boolean;
+  /** 日程卡片统一皮肤：桌面、全屏、房间与聊天内同步。 */
+  scheduleCardAppearance?: ScheduleCardAppearance;
   desktopDecorations?: DesktopDecoration[];
   customFont?: string;
   hideStatusBar?: boolean;

--- a/utils/scheduleAppearance.test.ts
+++ b/utils/scheduleAppearance.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { validateScopedCss } from './scopedCss';
+import {
+    resolveScheduleCardPalette,
+    SCHEDULE_CSS_SCOPE_HINT,
+    SCHEDULE_CSS_SCOPE_REGEX,
+} from './scheduleAppearance';
+
+describe('resolveScheduleCardPalette', () => {
+    it('keeps the original card tied to the current theme', () => {
+        const palette = resolveScheduleCardPalette(undefined, 212, '#f4f1eb');
+
+        expect(palette.preset).toBe('original');
+        expect(palette.isOriginal).toBe(true);
+        expect(palette.text).toBe('#f4f1eb');
+        expect(palette.accent).toBe('hsl(212, 70%, 65%)');
+        expect(palette.background).toContain('hsl(212');
+    });
+
+    it('uses the complete preset color pairing', () => {
+        const palette = resolveScheduleCardPalette({ preset: 'sakura' }, 30, '#ffffff');
+
+        expect(palette.isOriginal).toBe(false);
+        expect(palette.background).toContain('#fff3f7');
+        expect(palette.text).toBe('#623d50');
+        expect(palette.accent).toBe('#c85d8b');
+        expect(palette.line).toBe('rgba(98, 61, 80, 0.16)');
+    });
+
+    it('keeps all three user-defined colors', () => {
+        const palette = resolveScheduleCardPalette({
+            preset: 'custom',
+            background: '#112233',
+            textColor: '#ddeeff',
+            accentColor: '#66ccaa',
+        });
+
+        expect(palette).toMatchObject({
+            preset: 'custom',
+            background: '#112233',
+            base: '#112233',
+            text: '#ddeeff',
+            accent: '#66ccaa',
+            isOriginal: false,
+        });
+    });
+});
+
+describe('schedule custom CSS scope', () => {
+    it('accepts schedule hooks and rejects styles that leak into the app', () => {
+        const valid = validateScopedCss(
+            '.sully-schedule-root { border-radius: 22px !important; }\n.sully-schedule-item-current { opacity: 1; }',
+            SCHEDULE_CSS_SCOPE_REGEX,
+            SCHEDULE_CSS_SCOPE_HINT,
+        );
+        const leaking = validateScopedCss(
+            '.sully-chat-root { display: none; }',
+            SCHEDULE_CSS_SCOPE_REGEX,
+            SCHEDULE_CSS_SCOPE_HINT,
+        );
+
+        expect(valid.isValid).toBe(true);
+        expect(valid.importantCount).toBe(1);
+        expect(leaking.isValid).toBe(false);
+    });
+});

--- a/utils/scheduleAppearance.ts
+++ b/utils/scheduleAppearance.ts
@@ -1,0 +1,132 @@
+import type {
+    ScheduleCardAppearance,
+    ScheduleCardPresetId,
+} from '../types';
+
+export interface ScheduleCardPreset {
+    id: Exclude<ScheduleCardPresetId, 'custom'>;
+    name: string;
+    description: string;
+    background: string;
+    base: string;
+    text: string;
+    accent: string;
+}
+
+export interface ScheduleCardPalette {
+    preset: ScheduleCardPresetId;
+    background: string;
+    base: string;
+    text: string;
+    accent: string;
+    accentSoft: string;
+    line: string;
+    isOriginal: boolean;
+}
+
+export const SCHEDULE_CARD_PRESETS: ScheduleCardPreset[] = [
+    {
+        id: 'original',
+        name: '原版星夜',
+        description: '跟随角色主题色',
+        background: '',
+        base: '',
+        text: '#ffffff',
+        accent: '',
+    },
+    {
+        id: 'cream',
+        name: '奶油信笺',
+        description: '暖白与焦糖棕',
+        background: 'linear-gradient(145deg, #fffaf0, #f0dfc9)',
+        base: '#f0dfc9',
+        text: '#584337',
+        accent: '#b96f4b',
+    },
+    {
+        id: 'sakura',
+        name: '樱桃牛乳',
+        description: '浅粉与莓果红',
+        background: 'linear-gradient(145deg, #fff3f7, #f5dce8)',
+        base: '#f5dce8',
+        text: '#623d50',
+        accent: '#c85d8b',
+    },
+    {
+        id: 'mint',
+        name: '薄荷清晨',
+        description: '雾绿与深松石',
+        background: 'linear-gradient(145deg, #ecfbf5, #cee9df)',
+        base: '#cee9df',
+        text: '#284b46',
+        accent: '#2c9a83',
+    },
+    {
+        id: 'twilight',
+        name: '暮光紫',
+        description: '柔紫与月光白',
+        background: 'linear-gradient(145deg, #352747, #191321)',
+        base: '#191321',
+        text: '#f6edff',
+        accent: '#d3a7ff',
+    },
+    {
+        id: 'midnight',
+        name: '午夜青',
+        description: '墨蓝与冷青光',
+        background: 'linear-gradient(145deg, #14252d, #071117)',
+        base: '#071117',
+        text: '#edfafa',
+        accent: '#70d9cf',
+    },
+];
+
+function hexToRgba(hex: string, alpha: number): string {
+    const match = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+    if (!match) return `color-mix(in srgb, ${hex} ${Math.round(alpha * 100)}%, transparent)`;
+    const value = Number.parseInt(match[1], 16);
+    return `rgba(${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}, ${alpha})`;
+}
+
+export function resolveScheduleCardPalette(
+    appearance: ScheduleCardAppearance | undefined,
+    hue: number = 260,
+    fallbackText: string = '#ffffff',
+): ScheduleCardPalette {
+    const presetId = appearance?.preset || 'original';
+    if (presetId === 'original') {
+        const accent = `hsl(${hue}, 70%, 65%)`;
+        return {
+            preset: 'original',
+            background: `linear-gradient(145deg, hsl(${hue}, 40%, 12%), hsl(${hue}, 35%, 8%))`,
+            base: `hsl(${hue}, 40%, 12%)`,
+            text: fallbackText,
+            accent,
+            accentSoft: `hsla(${hue}, 70%, 55%, 0.28)`,
+            line: 'rgba(255,255,255,0.16)',
+            isOriginal: true,
+        };
+    }
+
+    const preset = presetId === 'custom'
+        ? null
+        : SCHEDULE_CARD_PRESETS.find(item => item.id === presetId) || SCHEDULE_CARD_PRESETS[0];
+    const background = preset?.background || appearance?.background || '#21192b';
+    const base = preset?.base || appearance?.background || '#21192b';
+    const text = preset?.text || appearance?.textColor || '#f8f3ff';
+    const accent = preset?.accent || appearance?.accentColor || '#c9a7ff';
+    return {
+        preset: presetId,
+        background,
+        base,
+        text,
+        accent,
+        accentSoft: hexToRgba(accent, 0.18),
+        line: hexToRgba(text, 0.16),
+        isOriginal: false,
+    };
+}
+
+export const SCHEDULE_CSS_SCOPE_REGEX = /^\.sully-schedule-[\w-]+\b/;
+
+export const SCHEDULE_CSS_SCOPE_HINT = '`.sully-schedule-*`';


### PR DESCRIPTION
本分支两轮改动说明：

记忆导入与召回修补（04aade3）：支持外部原始记忆导入、尽量只整理时间而不删改压缩内容；清洗后复用自动总结管线写入向量记忆并建立神经关联；加入本轮召回记忆查看、搜索、原地修订及重新向量化，包含盒子子节点与归档状态提示。

日程卡美化（本提交）：在桌面小卡和完整卡右上角加入设置入口；提供原版及五套成对配色、自定义背景/文字/强调色、作用域自定义 CSS、模板与 AI 提示词；样式通过全局主题同步到桌面、聊天和房间，且保留原版纸感与动森外观。

回归修复：处理桌面网格压缩、设置保存点击穿透、移动端布局及键盘交互；新增配色和 CSS 作用域测试。

验证：npm run build；npm run test:run -- utils/scheduleAppearance.test.ts；手机端实际界面与同步交互复查。