### PR TITLE
chore(ci): PR 大小标签排除测试文件

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -23,7 +23,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   label-by-size:
-    name: 按改动规模贴大小标签
+    name: 按改动规模贴大小标签（不含测试）
     # 排在 scope 标签之后，避免两个 job 同时写标签互相覆盖
     needs: [label-by-files]
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: 统计增删行数并贴标签
+      - name: 统计增删行数并贴标签（只算测试以外的改动）
         # https://github.com/CodelyTV/pr-size-labeler
         uses: codelytv/pr-size-labeler@4ec67706cd878fbc1c8db0a5dcd28b6bb412e85a # v1.10.3
         with:
@@ -53,8 +53,25 @@ jobs:
           # 超大 PR 只贴标签，不拦合并
           fail_if_xl: 'false'
           message_if_xl: ''
-          # 构建产物和锁文件不算进改动规模，不然一次 pnpm install 就直接顶到 XL
+          # 这个标签衡量的是「需要人肉 review 的实现改动有多大」，所以下面几类都不计入：
+          #   1. 构建产物和锁文件 —— 不然一次 pnpm install 就直接顶到 XL
+          #   2. 测试文件 —— 补测试是好事，不该让 PR 因为测试写得多就被贴成大 PR
+          # 匹配规则是 action 内部的 bash `[[ $filename == $pattern ]]`（见 src/github.sh），
+          # 注意它是普通字符串通配、不是 pathname 展开，所以 `*` 会跨 `/`：
+          # `*.test.ts` 能盖住 utils/memoryPalace/embedding.test.ts 这种嵌套路径，不用写 `**`。
           files_to_ignore: |
             "pnpm-lock.yaml"
             "public/*.bundle.js"
             "dist/*"
+            "*.test.ts"
+            "*.test.tsx"
+            "*.spec.ts"
+            "*.spec.tsx"
+            "test/*"
+            "*/test/*"
+            "tests/*"
+            "*/tests/*"
+            "__tests__/*"
+            "*/__tests__/*"
+            "test-setup.ts"
+            "vitest.config.ts"


### PR DESCRIPTION
## 为什么

大小标签想表达的是「需要 review 的实现改动有多大」。但补测试也会把行数顶上去，一个小改动配一堆测试就会被贴成大 PR，看标签反而误导。

## 改了什么

`.github/workflows/pr-labeler.yml` 里 `label-by-size` 这个 job，给 `codelytv/pr-size-labeler` 的 `files_to_ignore` 补上测试相关路径：

```
*.test.ts / *.test.tsx / *.spec.ts / *.spec.tsx
test/* / */test/* / tests/* / */tests/* / __tests__/* / */__tests__/*
test-setup.ts / vitest.config.ts
```

原有的 `pnpm-lock.yaml` / `public/*.bundle.js` / `dist/*` 保持不变。顺手把 job 名和 step 名改成「（不含测试）」，免得标签被误读。

`*.tsx` 和 `*.spec.*` 目前仓库里没有对应文件，是顺手加的前向兼容。

## 关于匹配规则

拉了 pin 住的那个 SHA 的 `src/github.sh` 看过源码，过滤逻辑是 bash 的 `[[ $filename == $pattern ]]` —— 普通字符串通配，不是 pathname 展开，所以 `*` 会跨 `/`。写 `*.test.ts` 就能盖住 `utils/memoryPalace/embedding.test.ts` 这种嵌套路径，不需要 `**`。这一点也写进 YAML 注释里了，免得以后有人照 glob 直觉去改。

另外 `xargs` 会剥掉双引号，所以沿用了原文件每行加引号的写法。

## 验证

本地复刻了 action 的参数清洗 + 匹配循环，拿仓库里的真实路径跑了一遍：

- 命中：126 个 `*.test.ts`、`worker/xhs-lite/test/`、`test-setup.ts`、`vitest.config.ts`
- 不误伤：`utils/db.ts`、`components/*.tsx`、`docs/amsg-sw-idb-resilience-spec.md`（名字里有 spec 但不是测试）、`utils/latest/contest.ts`（路径里含 test 子串）

YAML 也过了一遍 parse。

## 一个副作用

纯测试 PR 现在会算成 0 行，落到 `🟢 ■□□□□`。按「标签衡量实现改动规模」的语义这是对的，但如果希望纯测试 PR 别显示成最小档，得换实现方式 —— 这个 action 只支持忽略文件，不支持分开统计两个维度。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pg5PYyRNhNYuQH2m3FWxjg)_