### PR TITLE
fix: disambiguate story memory ownership

### DIFF
--- a/components/date/story/StoryTheaterSession.tsx
+++ b/components/date/story/StoryTheaterSession.tsx
@@ -10,6 +10,8 @@ import {
     buildBareTheaterActorContext,
     buildStoryAffinityAwarenessReminder,
     buildStoryBackstageAftermathReminder,
+    buildStoryActorMemoryEnvelope,
+    buildStoryArchiveMemoryEnvelope,
     buildStoryMultiAffinityGuide,
     buildStoryHistory,
     buildStoryMiniTheaterReminder,
@@ -403,7 +405,8 @@ const StoryTheaterSession: React.FC<Props> = ({ entry, preset, masks, onBack, on
             let recalled = '';
             const embedding = memoryPalaceConfig.embedding;
             if (actor.memoryPalaceEnabled && embedding?.baseUrl && embedding?.apiKey) {
-                recalled = await retrieveMemories(recent, actor.id, embedding, actor.activeBuffs?.[0]?.name, actor.personalityStyle || 'emotional', actor.ruminationTendency ?? 0.3, query, mask.name, remoteVectorConfig, actor.name);
+                const rawRecall = await retrieveMemories(recent, actor.id, embedding, actor.activeBuffs?.[0]?.name, actor.personalityStyle || 'emotional', actor.ruminationTendency ?? 0.3, query, userProfile.name, remoteVectorConfig, actor.name);
+                recalled = buildStoryActorMemoryEnvelope(actor.name, rawRecall, userProfile.name, mask.name);
             }
             const theaterActor = { ...actor, memoryPalaceInjection: recalled };
             const core = ContextBuilder.buildCoreContext(theaterActor, userProfile, true, recalled, {
@@ -411,7 +414,7 @@ const StoryTheaterSession: React.FC<Props> = ({ entry, preset, masks, onBack, on
                 skipWorldbookIds: allBookIds,
                 headerOverride: `[剧情角色：${actor.name}]`,
             }, { skipTimeAwareness: true });
-            blocks.push(`${core}\n${formatActorRecentMessages(actor, recent)}`.trim());
+            blocks.push(`${core}\n${formatActorRecentMessages(actor, recent, userProfile.name, mask.name)}`.trim());
         }
         return blocks.join('\n\n---\n\n');
     }, [actors, entry.carryCharacterMemory, entry.characterContextLimits, mask.name, memoryPalaceConfig.embedding, remoteVectorConfig, userProfile]);
@@ -425,7 +428,8 @@ const StoryTheaterSession: React.FC<Props> = ({ entry, preset, masks, onBack, on
         let recalled = '';
         const embedding = memoryPalaceConfig.embedding;
         if (maskCharacter.memoryPalaceEnabled && embedding?.baseUrl && embedding?.apiKey) {
-            recalled = await retrieveMemories(recent, maskCharacter.id, embedding, maskCharacter.activeBuffs?.[0]?.name, maskCharacter.personalityStyle || 'emotional', maskCharacter.ruminationTendency ?? 0.3, query, mask.name, remoteVectorConfig, maskCharacter.name);
+            const rawRecall = await retrieveMemories(recent, maskCharacter.id, embedding, maskCharacter.activeBuffs?.[0]?.name, maskCharacter.personalityStyle || 'emotional', maskCharacter.ruminationTendency ?? 0.3, query, userProfile.name, remoteVectorConfig, maskCharacter.name);
+            recalled = buildStoryActorMemoryEnvelope(maskCharacter.name, rawRecall, userProfile.name, mask.name);
         }
         const skipWorldbookIds = new Set([
             ...(maskCharacter.mountedWorldbooks || []).map(book => book.id),
@@ -436,7 +440,7 @@ const StoryTheaterSession: React.FC<Props> = ({ entry, preset, masks, onBack, on
             skipWorldbookIds,
             headerOverride: `[你当前身份的既有记忆：${maskCharacter.name}]`,
         }, { skipTimeAwareness: true });
-        return `${core}\n${formatActorRecentMessages(maskCharacter, recent)}`.trim();
+        return `${core}\n${formatActorRecentMessages(maskCharacter, recent, userProfile.name, mask.name)}`.trim();
     }, [actors, characters, entry.carryCharacterMemory, entry.characterContextLimits, mask.characterId, mask.name, memoryPalaceConfig.embedding, remoteVectorConfig, userProfile]);
 
     const independentRecall = useCallback(async (query: string, recent: Message[]): Promise<string> => {
@@ -583,7 +587,7 @@ const StoryTheaterSession: React.FC<Props> = ({ entry, preset, masks, onBack, on
             const scenario = [
                 `### 当前剧情\n标题：${entry.title}\n前提：${entry.premise || '沿用已经发生的正文自然继续。'}`,
                 summaries ? `### 常驻事件盒\n${summaries}` : '',
-                vectorRecall ? `### 本剧情独立向量召回\n${vectorRecall}` : '',
+                vectorRecall ? buildStoryArchiveMemoryEnvelope(vectorRecall) : '',
             ].filter(Boolean).join('\n\n');
             const worldbookSlots = buildTheaterWorldbookSlots(selectedBooks, visibleHistory.slice(-20).map(message => ({ role: message.role, content: message.content })), mask.name, actors.map(actor => actor.name));
             const compiled = compileStoryPreset({

--- a/utils/storyTheater.test.ts
+++ b/utils/storyTheater.test.ts
@@ -7,6 +7,8 @@ import {
     applyStoryPresetChoice,
     BUILTIN_NIGHT_SCREENING_PRESET,
     buildStoryMiniTheaterReminder,
+    buildStoryActorMemoryEnvelope,
+    buildStoryArchiveMemoryEnvelope,
     buildStoryAffinityAwarenessReminder,
     buildStoryBackstageAftermathReminder,
     buildStoryMultiAffinityGuide,
@@ -27,7 +29,43 @@ import {
     resolveStoryTheaterMask,
     selectStoryArchiveBatch,
     storyTheaterMemoryRecipientIds,
+    formatActorRecentMessages,
 } from './storyTheater';
+
+describe('多人剧情记忆的人称与归属', () => {
+    it('把每位角色的召回包进具名专属信封，并阻止把“你”重绑定到面具', () => {
+        const result = buildStoryActorMemoryEnvelope('林星', '我记得你那天留下了伞。', '条条', 'Noir');
+
+        expect(result).toContain('林星 的专属既有记忆');
+        expect(result).toContain('第一人称“我/我的”，默认指「林星」');
+        expect(result).toContain('第二人称“你/你的”');
+        expect(result).toContain('原互动对象「条条」');
+        expect(result).toContain('不得因此把记忆里的“你”改指为「Noir」');
+        expect(result).toContain('不得归给、共享给或改写成其他角色的亲历记忆');
+    });
+
+    it('近期原文显式标出记忆中的你，不把 user 行伪装成当前面具', () => {
+        const actor = { id: 'lin', name: '林星' } as CharacterProfile;
+        const messages = [
+            { id: 1, charId: 'lin', role: 'user', type: 'text', content: '把伞递给他。', timestamp: 1 },
+            { id: 2, charId: 'lin', role: 'assistant', type: 'text', content: '我接住了。', timestamp: 2 },
+        ] as Message[];
+
+        const result = formatActorRecentMessages(actor, messages, '条条', 'Noir');
+        expect(result).toContain('林星 最近携带的专属原文上下文');
+        expect(result).toContain('记忆中的你（条条）：把伞递给他。');
+        expect(result).toContain('林星：我接住了。');
+        expect(result).toContain('不得把下列“记忆中的你”重新解释成当前身份');
+    });
+
+    it('把独立剧情向量召回标成共享档案而不是某个角色的脑内记忆', () => {
+        const result = buildStoryArchiveMemoryEnvelope('我在雨里等你。');
+
+        expect(result).toContain('本剧情共享档案召回');
+        expect(result).toContain('不属于任何一位角色的个人记忆');
+        expect(result).toContain('不得擅自把“我/你”归给当前面具或任一角色');
+    });
+});
 
 describe('糯米机原生剧情预设边界', () => {
     it('内置 V6.14 已经是精简的原生文档', () => {

--- a/utils/storyTheater.ts
+++ b/utils/storyTheater.ts
@@ -786,6 +786,47 @@ export const buildBareTheaterActorContext = (char: CharacterProfile): string => 
     char.worldview?.trim() ? `- 世界观：\n${char.worldview.trim()}` : '',
 ].filter(Boolean).join('\n');
 
+export const buildStoryActorMemoryEnvelope = (
+    characterName: string,
+    recalled: string,
+    originalUserName: string,
+    currentIdentityName: string,
+): string => {
+    const content = recalled.trim();
+    if (!content) return '';
+    const owner = characterName.trim() || '当前角色';
+    const originalUser = originalUserName.trim() || '原本的你';
+    const currentIdentity = currentIdentityName.trim() || originalUser;
+    const identityReminder = currentIdentity === originalUser
+        ? `- 本剧情当前的“你”仍是「${originalUser}」。`
+        : `- 本剧情当前执笔身份是「${currentIdentity}」，不得因此把记忆里的“你”改指为「${currentIdentity}」。`;
+
+    return [
+        `### ${owner} 的专属既有记忆`,
+        `归属规则：以下内容只属于角色「${owner}」，不得归给、共享给或改写成其他角色的亲历记忆。`,
+        `- 记忆片段里的第一人称“我/我的”，默认指「${owner}」。`,
+        `- 记忆片段里的第二人称“你/你的”，若片段没有另行点名，默认指形成记忆时的原互动对象「${originalUser}」。`,
+        identityReminder,
+        `【${owner}专属记忆开始】`,
+        content,
+        `【${owner}专属记忆结束】`,
+    ].join('\n');
+};
+
+export const buildStoryArchiveMemoryEnvelope = (recalled: string): string => {
+    const content = recalled.trim();
+    if (!content) return '';
+    return [
+        '### 本剧情共享档案召回',
+        '归属规则：以下内容是本剧情自己的叙事档案，只用于承接已经发生的剧情；它不属于任何一位角色的个人记忆，也不得写入或冒充角色的神经链接记忆。',
+        '- 片段中的第一、第二人称只保留原文叙事视角；应依据片段内明确出现的姓名与事件判断身份。',
+        '- 无法从片段确定指代时，保持模糊，不得擅自把“我/你”归给当前面具或任一角色。',
+        '【本剧情共享档案开始】',
+        content,
+        '【本剧情共享档案结束】',
+    ].join('\n');
+};
+
 export const buildTheaterPersona = (mask: ResolvedStoryTheaterMask): string => [
     '### 你当前执笔的身份',
     `- 名字：${mask.name || '你'}`,
@@ -969,14 +1010,24 @@ export const parseStoryDisplayBlocks = (content: string): StoryDisplayBlock[] =>
     return blocks;
 };
 
-export const formatActorRecentMessages = (char: CharacterProfile, messages: Message[]): string => {
+export const formatActorRecentMessages = (
+    char: CharacterProfile,
+    messages: Message[],
+    originalUserName?: string,
+    currentIdentityName?: string,
+): string => {
     if (messages.length === 0) return '';
+    const originalUser = originalUserName?.trim() || '你';
+    const currentIdentity = currentIdentityName?.trim() || originalUser;
     const rows = messages.map(message => {
-        const speaker = message.role === 'user' ? '你' : message.role === 'assistant' ? char.name : '系统';
+        const speaker = message.role === 'user' ? `记忆中的你（${originalUser}）` : message.role === 'assistant' ? char.name : '系统';
         const clean = String(message.content || '').replace(/data:[^\s]+/gi, '[媒体]').slice(0, 4000);
         return `- [${new Date(message.timestamp).toLocaleString()}] ${speaker}：${clean}`;
     });
-    return `### ${char.name} 最近携带的原文上下文（${messages.length} 条）\n${rows.join('\n')}`;
+    const identityReminder = currentIdentity === originalUser
+        ? ''
+        : `\n当前执笔身份是「${currentIdentity}」；不得把下列“记忆中的你”重新解释成当前身份。`;
+    return `### ${char.name} 最近携带的专属原文上下文（${messages.length} 条）\n以下记录只属于「${char.name}」与原互动对象「${originalUser}」，不得并入其他角色的经历。${identityReminder}\n${rows.join('\n')}`;
 };
 
 export const buildStoryHistory = (messages: Message[]): StoryApiMessage[] => messages


### PR DESCRIPTION
Wrap each character recall with explicit owner and pronoun semantics, keep original-user references separate from the active mask, and label theater vector recall as shared narrative archive rather than personal character memory.