### PR TITLE
修复 Sully 头像并补全剧情模式备份

### DIFF
--- a/components/date/story/StoryTheaterTheme.tsx
+++ b/components/date/story/StoryTheaterTheme.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { Moon, Palette, Sparkle, SquaresFour, Sun, X } from '@phosphor-icons/react';
+import { STORY_THEATER_APPEARANCE_STORAGE_KEY } from '../../../utils/storyTheaterBackup';
 
 export type StoryColorMode = 'light' | 'dark';
 export type StoryDecorMode = 'plain' | 'cinema';
@@ -15,7 +16,7 @@ interface StoryThemeContextValue {
     setDecor: (value: StoryDecorMode) => void;
 }
 
-const STORAGE_KEY = 'sully_story_theater_appearance_v1';
+const STORAGE_KEY = STORY_THEATER_APPEARANCE_STORAGE_KEY;
 const DEFAULT_APPEARANCE: StoryAppearance = { color: 'light', decor: 'plain' };
 const StoryThemeContext = createContext<StoryThemeContextValue | null>(null);
 

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -7,6 +7,8 @@ import { extractImagesInPlace, deepCloneForExport } from '../utils/backupExport'
 import { isBlobRef, getBlobForRef, migrateDataUrlToRef, migrateAppearancePresetBlobRefs, resolveBlobRefsDeep, BLOBREF_PREFIX, deleteBlobRefIfUnreferenced } from '../utils/blobRef';
 import { LEGACY_DEFAULT_WALLPAPER, isLegacyDefaultWallpaper, shouldPreserveLegacyDefaultWallpaper } from '../utils/wallpaperCompat';
 import { migrateSharkpanAssets } from '../utils/sharkpanAssetMigration';
+import { SULLY_DEFAULT_AVATAR_URL, shouldMigrateSullyAvatar } from '../utils/sullyAvatar';
+import { exportStoryTheaterAppearanceSetting, restoreStoryTheaterAppearanceSetting } from '../utils/storyTheaterBackup';
 import { createV2ArrayFieldWriter, writeV2Backup, assembleV2Backup, type BackupManifest, type ZipFileWriter, type ZipFileReader } from '../utils/backupFormat';
 import { encodeVectorsForBackup, encodeVectorsForBackupChunked } from '../utils/memoryPalace/db';
 import { ProactiveChat } from '../utils/proactiveChat';
@@ -589,9 +591,7 @@ const defaultUserProfile: UserProfile = {
 const sullyV2: CharacterProfile = {
   id: 'preset-sully-v2', // Unique ID to prevent duplication
   name: 'Sully',
-  // 本地打包资源（public/sully/head.png），同源加载、不依赖图床/CDN，图床挂了也不受影响。
-  // BASE_URL 前缀兼容 GitHub Pages 的相对 base（见 vite.config.ts）。
-  avatar: `${(import.meta as any).env?.BASE_URL ?? '/'}sully/head.png`,
+  avatar: SULLY_DEFAULT_AVATAR_URL,
   description: 'AI助理 / 电波系黑客猫猫',
   
   systemPrompt: `[Role Definition]
@@ -1371,10 +1371,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                  const isCorrupted = !currentSprites['normal'] || !currentSprites['chibi'];
                  const needsWallUpdate = existingSully.roomConfig?.wallImage !== sullyV2.roomConfig?.wallImage;
                  const needsSkinSets = !existingSully.dateSkinSets || existingSully.dateSkinSets.length === 0;
-                 // 老用户头像仍是旧图床默认图（不稳定，常拉不到）→ 换成本地打包图；
-                 // 用户自己改过头像的（值不等于旧默认）保持不动。
-                 const OLD_SULLY_AVATAR = 'https://sharkpan.xyz/f/BZ3VSa/head.png';
-                 const needsAvatarUpdate = existingSully.avatar === OLD_SULLY_AVATAR;
+                 // 默认头像曾先后使用旧图床和依赖部署根路径的本地地址。
+                 // 这些地址在备份恢复或 GitHub Pages 子路径变化后会 404；统一迁移到资产仓库。
+                 // 用户自己改过的头像不在迁移名单内，保持不动。
+                 const needsAvatarUpdate = shouldMigrateSullyAvatar(existingSully.avatar);
                  // 之前误把家园 chibi 替换成了像素小屋的像素立绘 → 还原为原版 sharkpan 立绘
                  const hasMisplacedPixelChibi = typeof currentSprites['chibi'] === 'string'
                      && currentSprites['chibi'].startsWith('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA4CAYAAABdeLCu');
@@ -3313,6 +3313,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
               })() : undefined,
               bm25Mode: (mode === 'text_only' || mode === 'full') ? (localStorage.getItem('bm25_mode') || undefined) : undefined,
               lastActiveCharId: (mode === 'text_only' || mode === 'full') ? (localStorage.getItem('os_last_active_char_id') || undefined) : undefined,
+              storyTheaterAppearance: (mode === 'text_only' || mode === 'full') ? exportStoryTheaterAppearanceSetting() : undefined,
               eventNotifFlags: (mode === 'text_only' || mode === 'full') ? (() => {
                   const flags: Record<string, string> = {};
                   for (let i = 0; i < localStorage.length; i++) {
@@ -4111,6 +4112,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           }
           if (typeof data.bm25Mode === 'string') localStorage.setItem('bm25_mode', data.bm25Mode);
           if (typeof data.lastActiveCharId === 'string') localStorage.setItem('os_last_active_char_id', data.lastActiveCharId);
+          restoreStoryTheaterAppearanceSetting(data.storyTheaterAppearance);
           if (data.dreamCollection && typeof data.dreamCollection === 'object') localStorage.setItem('os_dream_collection', JSON.stringify(data.dreamCollection));
           if (typeof data.gotchiAccentHue === 'string' && /^\d+$/.test(data.gotchiAccentHue)) localStorage.setItem('tama_accent_hue', data.gotchiAccentHue);
           if (data.eventNotifFlags && typeof data.eventNotifFlags === 'object') {

--- a/types.ts
+++ b/types.ts
@@ -3422,6 +3422,7 @@ export interface FullBackupData {
     browserConfig?: { braveKey?: string; useRealSearch?: boolean };
     bm25Mode?: string;
     lastActiveCharId?: string;
+    storyTheaterAppearance?: string;
     eventNotifFlags?: Record<string, string>;  // sullyos_* 事件通知标记
     hotNewsSnapshots?: HotNewsSnapshot[];
     dreamCollection?: Record<string, { firstAt: number; count: number }>;  // 梦境盲盒收藏册（os_dream_collection，账号级 localStorage）

--- a/utils/backupRoundtrip.test.ts
+++ b/utils/backupRoundtrip.test.ts
@@ -378,7 +378,7 @@ describe('v2 真实链路：向量二进制旁路', () => {
         // 备份只含 vA（新值）+ vC，不含 vB
         const payload = encodeVectorsForBackup([
             { memoryId: 'vA', charId: 'c1', vector: toU8([1, 2, 3, 4]) },
-            { memoryId: 'vC', charId: 'c2', vector: toU8([5, 6, 7, 8]) },
+            { memoryId: 'vC', charId: 'story-theater:backup-entry', vector: toU8([5, 6, 7, 8]) },
         ]);
         const zip = new FakeZip();
         const manifest = await writeV2Backup(zip, { memoryNodes: [{ id: 'n1' }] }, { vectors: payload });
@@ -392,6 +392,7 @@ describe('v2 真实链路：向量二进制旁路', () => {
         // 逐值一致，且 vA 是新值不是旧值
         expect(vecValues(byId.get('vA'))).toEqual([1, 2, 3, 4]);
         expect(vecValues(byId.get('vC'))).toEqual([5, 6, 7, 8]);
+        expect(byId.get('vC').charId).toBe('story-theater:backup-entry');
         // 落库形态是 Uint8Array（紧凑存储）
         expect(byId.get('vA').vector).toBeInstanceOf(Uint8Array);
     });

--- a/utils/db.storyTheater.test.ts
+++ b/utils/db.storyTheater.test.ts
@@ -8,14 +8,25 @@ describe('剧情剧场数据与糯米机原生预设备份', () => {
             id: 'story-backup-entry',
             title: '雨夜车站',
             premise: '三个人错过末班车。',
+            openingMode: 'assistant',
+            mask: { type: 'custom', id: 'story-mask' },
             characterIds: ['char-a', 'char-b'],
             writesToCharacterMemory: false,
             characterMemoryDates: {},
             carryCharacterMemory: true,
             characterContextLimits: { 'char-a': 100, 'char-b': 80 },
             archiveAfter: 30,
+            archiveKeepRecent: 5,
             archiveStrategy: 'summary',
-            archives: [],
+            archives: [{
+                id: 'archive-1',
+                strategy: 'summary',
+                fromMessageId: 1,
+                toMessageId: 2,
+                messageCount: 2,
+                summary: 'Archived scene summary',
+                createdAt: 15,
+            }],
             selectedWorldbookIds: ['book-a'],
             presetId: 'story-backup-preset',
             createdAt: 10,
@@ -40,18 +51,35 @@ describe('剧情剧场数据与糯米机原生预设备份', () => {
         await DB.saveStoryTheater(entry);
         await DB.saveStoryTheaterPreset(preset);
         await DB.saveStoryTheaterMask(mask);
+        const messageId = await DB.saveMessage({
+            charId: `story-theater:${entry.id}`,
+            role: 'assistant',
+            type: 'text',
+            content: 'The restored story floor',
+            timestamp: 30,
+            metadata: {
+                source: 'story_theater',
+                theaterId: entry.id,
+                theaterAffinityInputs: [{ charId: 'char-a', delta: 2, reason: 'noticed change', awareness: 'noticed' }],
+            },
+        });
         const exported = JSON.parse(JSON.stringify(await DB.exportFullData()));
         expect(exported.storyTheaters).toContainEqual(entry);
         expect(exported.storyTheaterPresets).toContainEqual(preset);
         expect(exported.storyTheaterMasks).toContainEqual(mask);
+        expect(exported.messages).toContainEqual(expect.objectContaining({ id: messageId, charId: `story-theater:${entry.id}`, content: 'The restored story floor' }));
 
         await DB.deleteStoryTheater(entry.id);
         await DB.deleteStoryTheaterPreset(preset.id);
         await DB.deleteStoryTheaterMask(mask.id);
+        await DB.deleteMessages([messageId]);
         await DB.importFullData(exported as any);
 
         expect(await DB.getStoryTheaters()).toContainEqual(entry);
         expect(await DB.getStoryTheaterPresets()).toContainEqual(preset);
         expect(await DB.getStoryTheaterMasks()).toContainEqual(mask);
+        const restoredMessages = await DB.getMessagesByCharId(`story-theater:${entry.id}`, true);
+        const restoredFloor = restoredMessages.find(message => message.id === messageId);
+        expect(restoredFloor?.metadata?.theaterAffinityInputs).toEqual([{ charId: 'char-a', delta: 2, reason: 'noticed change', awareness: 'noticed' }]);
     });
 });

--- a/utils/storyTheaterBackup.test.ts
+++ b/utils/storyTheaterBackup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { assembleV2Backup, writeV2Backup } from './backupFormat';
+import { exportStoryTheaterAppearanceSetting, restoreStoryTheaterAppearanceSetting, STORY_THEATER_APPEARANCE_STORAGE_KEY } from './storyTheaterBackup';
+
+describe('story theater local settings backup', () => {
+    it('exports the saved appearance value', () => {
+        localStorage.setItem(STORY_THEATER_APPEARANCE_STORAGE_KEY, '{"color":"dark","decor":"cinema"}');
+        expect(exportStoryTheaterAppearanceSetting()).toBe('{"color":"dark","decor":"cinema"}');
+    });
+
+    it('restores a valid appearance value', () => {
+        const raw = '{"color":"light","decor":"plain"}';
+        expect(restoreStoryTheaterAppearanceSetting(raw)).toBe(true);
+        expect(localStorage.getItem(STORY_THEATER_APPEARANCE_STORAGE_KEY)).toBe(raw);
+    });
+
+    it('does not overwrite the current value with invalid backup data', () => {
+        localStorage.setItem(STORY_THEATER_APPEARANCE_STORAGE_KEY, '{"color":"dark","decor":"plain"}');
+        expect(restoreStoryTheaterAppearanceSetting('{"color":"unknown","decor":"plain"}')).toBe(false);
+        expect(localStorage.getItem(STORY_THEATER_APPEARANCE_STORAGE_KEY)).toBe('{"color":"dark","decor":"plain"}');
+        expect(restoreStoryTheaterAppearanceSetting(undefined)).toBe(false);
+        expect(localStorage.getItem(STORY_THEATER_APPEARANCE_STORAGE_KEY)).toBe('{"color":"dark","decor":"plain"}');
+    });
+
+    it('survives the real v2 ZIP container round-trip', async () => {
+        const raw = '{"color":"dark","decor":"cinema"}';
+        const zip = new JSZip();
+        const manifest = await writeV2Backup(zip as any, { storyTheaterAppearance: raw }, { mode: 'full' });
+        const archive = await zip.generateAsync({ type: 'uint8array' });
+        const loaded = await JSZip.loadAsync(archive);
+        const data = await assembleV2Backup(loaded as any, manifest);
+        localStorage.removeItem(STORY_THEATER_APPEARANCE_STORAGE_KEY);
+        expect(restoreStoryTheaterAppearanceSetting(data.storyTheaterAppearance)).toBe(true);
+        expect(exportStoryTheaterAppearanceSetting()).toBe(raw);
+    });
+});

--- a/utils/storyTheaterBackup.ts
+++ b/utils/storyTheaterBackup.ts
@@ -1,0 +1,28 @@
+export const STORY_THEATER_APPEARANCE_STORAGE_KEY = 'sully_story_theater_appearance_v1';
+
+export function exportStoryTheaterAppearanceSetting(): string | undefined {
+    try {
+        const value = localStorage.getItem(STORY_THEATER_APPEARANCE_STORAGE_KEY);
+        return value || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export function restoreStoryTheaterAppearanceSetting(value: unknown): boolean {
+    if (typeof value !== 'string' || !value) return false;
+    try {
+        const parsed = JSON.parse(value);
+        if (
+            !parsed
+            || (parsed.color !== 'light' && parsed.color !== 'dark')
+            || (parsed.decor !== 'plain' && parsed.decor !== 'cinema')
+        ) {
+            return false;
+        }
+        localStorage.setItem(STORY_THEATER_APPEARANCE_STORAGE_KEY, value);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/utils/sullyAvatar.test.ts
+++ b/utils/sullyAvatar.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { SULLY_DEFAULT_AVATAR_URL, shouldMigrateSullyAvatar } from './sullyAvatar';
+
+const PAGE = 'https://qegj567-cloud.github.io/SullyOS/';
+
+describe('Sully 默认头像迁移', () => {
+    it.each([
+        'https://sharkpan.xyz/f/BZ3VSa/head.png',
+        'sully/head.png',
+        './sully/head.png',
+        '/sully/head.png',
+        '/SullyOS/sully/head.png',
+        'https://qegj567-cloud.github.io/sully/head.png',
+        'https://qegj567-cloud.github.io/SullyOS/sully/head.png',
+    ])('识别旧默认地址 %s', value => {
+        expect(shouldMigrateSullyAvatar(value, PAGE)).toBe(true);
+    });
+
+    it('recognizes legacy GitHub Pages URLs after cross-environment restore', () => {
+        expect(shouldMigrateSullyAvatar('https://qegj567-cloud.github.io/sully/head.png', 'capacitor://localhost/')).toBe(true);
+        expect(shouldMigrateSullyAvatar('https://qegj567-cloud.github.io/SullyOS/sully/head.png', 'http://localhost:5173/')).toBe(true);
+    });
+
+    it('不覆盖当前资产仓库地址或用户自定义头像', () => {
+        expect(shouldMigrateSullyAvatar(SULLY_DEFAULT_AVATAR_URL, PAGE)).toBe(false);
+        expect(shouldMigrateSullyAvatar('https://images.example/custom.png', PAGE)).toBe(false);
+        expect(shouldMigrateSullyAvatar('/custom/sully/head.png', PAGE)).toBe(false);
+    });
+});

--- a/utils/sullyAvatar.ts
+++ b/utils/sullyAvatar.ts
@@ -1,0 +1,34 @@
+export const SULLY_DEFAULT_AVATAR_URL =
+    'https://cdn.jsdelivr.net/gh/qegj567-cloud/SullyOS-assets@main/bgm/SULLY/head.png';
+
+const OLD_SULLY_AVATAR_URL = 'https://sharkpan.xyz/f/BZ3VSa/head.png';
+const LEGACY_LOCAL_PATHS = new Set([
+    '/sully/head.png',
+    '/SullyOS/sully/head.png',
+]);
+const LEGACY_GITHUB_PAGES_HOST = 'qegj567-cloud.github.io';
+
+/**
+ * 只识别 Sully 曾经使用过的默认头像地址。
+ * 用户自定义头像即使文件名同为 head.png，也不会被覆盖。
+ */
+export function shouldMigrateSullyAvatar(value: string | undefined, pageHref?: string): boolean {
+    const avatar = String(value || '').trim();
+    if (!avatar) return false;
+    if (avatar === OLD_SULLY_AVATAR_URL) return true;
+    if (avatar === 'sully/head.png' || avatar === './sully/head.png') return true;
+
+    try {
+        const page = new URL(
+            pageHref || (typeof window !== 'undefined'
+                ? window.location.href
+                : 'https://local.invalid/SullyOS/'),
+        );
+        const resolved = new URL(avatar, page);
+        return LEGACY_LOCAL_PATHS.has(resolved.pathname)
+            && (resolved.origin === page.origin
+                || resolved.hostname === LEGACY_GITHUB_PAGES_HOST);
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## 改动

- 将 Sully 默认头像统一指向 `SullyOS-assets`，并迁移旧图床、错误站点根路径及历史 GitHub Pages 地址。
- 保留用户自定义头像，不对不在迁移名单中的地址做覆盖。
- 将剧情模式的深浅色、花哨/素雅偏好接入完整备份与纯文字备份。
- 扩展剧情备份回归覆盖：剧情条目、楼层、面具、预设、归档摘要、保留最近楼层、关系变化元数据，以及 `story-theater:<剧情ID>` 独立向量分区。

## 原因与影响

头像曾将部署相关的 `BASE_URL` 写入持久化角色资料；从其它构建或备份恢复后可能得到 `/sully/head.png`，在 GitHub Pages 项目子路径下请求到错误站点根目录并返回 404。

剧情主体数据此前已经进入备份，但页面外观偏好使用 `sully_story_theater_appearance_v1`，不在原有 `sullyos_*` 统收范围内。现在完整备份和纯文字备份都可以恢复该设置；纯媒体备份语义保持不变。

## 验证

- `npm run test:run -- utils/storyTheaterBackup.test.ts utils/db.storyTheater.test.ts utils/storyTheaterVectorMemory.test.ts utils/backupRoundtrip.test.ts utils/sullyAvatar.test.ts`
- 5 个测试文件、28 项测试通过。
- `npm run build` 通过。
- `git diff --check` 通过。