### PR TITLE
补上整个剧情删除与隔离清理

### DIFF
--- a/components/date/story/StoryTheater.tsx
+++ b/components/date/story/StoryTheater.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ArrowLeft, Database, DownloadSimple, FilmSlate, Plus, UploadSimple, UsersThree } from '@phosphor-icons/react';
+import { ArrowLeft, Database, DownloadSimple, FilmSlate, Plus, SpinnerGap, Trash, UploadSimple, UsersThree, X } from '@phosphor-icons/react';
 import { useOS } from '../../../context/OSContext';
 import type { StoryTheaterEntry, StoryTheaterMask, StoryTheaterMaskSelection, StoryTheaterPreset } from '../../../types';
 import { DB } from '../../../utils/db';
@@ -21,6 +21,7 @@ import StoryTheaterEditor from './StoryTheaterEditor';
 import StoryTheaterSession from './StoryTheaterSession';
 import StoryVectorMemoryPanel from './StoryVectorMemoryPanel';
 import { StoryAppearanceButton, StoryTheaterThemeProvider } from './StoryTheaterTheme';
+import { deleteStoryTheaterData } from '../../../utils/storyTheaterDeletion';
 
 interface Props {
     onSwitchCompanion: () => void;
@@ -30,7 +31,7 @@ interface Props {
 type View = 'list' | 'editor' | 'session' | 'preset' | 'masks' | 'vectors';
 
 const StoryTheaterContent: React.FC<Props> = ({ onSwitchCompanion, onClose }) => {
-    const { characters, userProfile, addToast } = useOS();
+    const { characters, userProfile, addToast, remoteVectorConfig } = useOS();
     const [view, setView] = useState<View>('list');
     const [entries, setEntries] = useState<StoryTheaterEntry[]>([]);
     const [customPresets, setCustomPresets] = useState<StoryTheaterPreset[]>([]);
@@ -38,6 +39,8 @@ const StoryTheaterContent: React.FC<Props> = ({ onSwitchCompanion, onClose }) =>
     const [activeEntry, setActiveEntry] = useState<StoryTheaterEntry | null>(null);
     const [editingPreset, setEditingPreset] = useState<StoryTheaterPreset | null>(null);
     const [maskLocked, setMaskLocked] = useState(false);
+    const [deletingEntry, setDeletingEntry] = useState<StoryTheaterEntry | null>(null);
+    const [deletingStory, setDeletingStory] = useState(false);
     const importInput = useRef<HTMLInputElement>(null);
     const presets = useMemo(() => withBuiltInStoryPresets(customPresets), [customPresets]);
 
@@ -116,6 +119,28 @@ const StoryTheaterContent: React.FC<Props> = ({ onSwitchCompanion, onClose }) =>
         }
         addToast('原创身份已移出面具箱', 'info');
     }, [activeEntry, addToast]);
+
+    const confirmDeleteEntry = useCallback(async () => {
+        if (!deletingEntry || deletingStory) return;
+        setDeletingStory(true);
+        try {
+            const result = await deleteStoryTheaterData(deletingEntry, remoteVectorConfig);
+            setEntries(current => current.filter(item => item.id !== deletingEntry.id));
+            if (activeEntry?.id === deletingEntry.id) setActiveEntry(null);
+            setDeletingEntry(null);
+            setView('list');
+            addToast(
+                result.remoteVectorDeleteFailures > 0
+                    ? `剧情已删除；${result.remoteVectorDeleteFailures} 条远端向量暂未同步，请检查网络`
+                    : `整个剧情「${deletingEntry.title}」已删除`,
+                result.remoteVectorDeleteFailures > 0 ? 'info' : 'success',
+            );
+        } catch (error: any) {
+            addToast(error?.message || '删除整个剧情失败', 'error');
+        } finally {
+            setDeletingStory(false);
+        }
+    }, [activeEntry?.id, addToast, deletingEntry, deletingStory, remoteVectorConfig]);
 
     const selectMask = useCallback((selection: StoryTheaterMaskSelection) => {
         if (maskLocked) return;
@@ -230,6 +255,7 @@ const StoryTheaterContent: React.FC<Props> = ({ onSwitchCompanion, onClose }) =>
                                 <time className='text-[9px] text-slate-400'>{new Date(item.updatedAt).toLocaleDateString()}</time>
                             </button>
                             {hasVectorArchive && <button onClick={() => { setActiveEntry(item); setView('vectors'); }} className='w-10 h-10 shrink-0 rounded-full bg-white border border-slate-200 grid place-items-center text-violet-600' title='查看本剧情向量记忆' aria-label='查看本剧情向量记忆'><Database size={17} /></button>}
+                            <button onClick={() => setDeletingEntry(item)} className='w-10 h-10 shrink-0 rounded-full grid place-items-center text-rose-400 active:bg-rose-50' title='删除整个剧情' aria-label={`删除剧情 ${item.title}`}><Trash size={17} /></button>
                         </div>;
                     })}</div>}
                 </section>
@@ -242,6 +268,15 @@ const StoryTheaterContent: React.FC<Props> = ({ onSwitchCompanion, onClose }) =>
                 </section>
             </div>
         </main>
+        {deletingEntry && <div className='fixed inset-0 z-[95] flex items-end justify-center overflow-y-auto overscroll-contain bg-slate-950/35' onClick={() => !deletingStory && setDeletingEntry(null)} role='presentation'>
+            <div className='story-safe-sheet w-full sm:max-w-sm rounded-t-[28px] bg-stone-100 px-5 pt-5 shadow-2xl' onClick={event => event.stopPropagation()} role='dialog' aria-modal='true' aria-labelledby='delete-story-title'>
+                <div className='flex items-start gap-4'><div className='min-w-0 flex-1'><div className='text-[9px] uppercase tracking-[.2em] font-bold text-rose-500'>Delete theater</div><h2 id='delete-story-title' className='mt-1 text-lg font-semibold'>删除整个剧情？</h2></div><button disabled={deletingStory} onClick={() => setDeletingEntry(null)} className='w-9 h-9 shrink-0 rounded-full bg-white border border-slate-200 grid place-items-center text-slate-400 disabled:opacity-30' aria-label='关闭删除确认'><X size={16} /></button></div>
+                <p className='mt-4 text-[11px] leading-6 text-slate-600'>「{deletingEntry.title}」的楼层、事件盒、关系备注和本剧情独立向量会一起删除。</p>
+                {deletingEntry.writesToCharacterMemory && <p className='mt-2 text-[10px] leading-5 text-amber-700'>角色侧仍能定位到的剧情镜像也会删除；已经被记忆宫殿总结成长期记忆的内容不会反向改写。</p>}
+                <p className='mt-2 text-[10px] leading-5 text-slate-400'>其它剧情、普通聊天与角色原有向量记忆不会受影响。删除后无法恢复。</p>
+                <div className='mt-5 grid grid-cols-2 gap-3'><button disabled={deletingStory} onClick={() => setDeletingEntry(null)} className='h-12 rounded-2xl border border-slate-200 bg-white text-xs font-bold text-slate-600 disabled:opacity-30'>取消</button><button disabled={deletingStory} onClick={() => void confirmDeleteEntry()} className='h-12 rounded-2xl bg-rose-600 text-white text-xs font-bold disabled:opacity-40'>{deletingStory ? <SpinnerGap size={17} className='mx-auto animate-spin' /> : '删除整个剧情'}</button></div>
+            </div>
+        </div>}
     </div>;
 };
 

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -1960,6 +1960,11 @@ export const DB = {
       const db = await openDB();
       const transaction = db.transaction(STORE_STORY_THEATERS, 'readwrite');
       transaction.objectStore(STORE_STORY_THEATERS).delete(id);
+      return new Promise((resolve, reject) => {
+          transaction.oncomplete = () => resolve();
+          transaction.onerror = () => reject(transaction.error);
+          transaction.onabort = () => reject(transaction.error || new Error('deleteStoryTheater aborted'));
+      });
   },
 
   getStoryTheaterPresets: async (): Promise<StoryTheaterPreset[]> => {

--- a/utils/storyTheaterDeletion.test.ts
+++ b/utils/storyTheaterDeletion.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { StoryTheaterEntry } from '../types';
+import type { MemoryNode } from './memoryPalace/types';
+import { MemoryLinkDB, MemoryNodeDB, MemoryVectorDB } from './memoryPalace/db';
+import { DB } from './db';
+import { storyTheaterThreadId } from './storyTheater';
+import { deleteStoryTheaterData } from './storyTheaterDeletion';
+import { listStoryVectorMemories } from './storyTheaterVectorMemory';
+
+const ENTRY_A = 'story-delete-a';
+const ENTRY_B = 'story-delete-b';
+const ACTOR_ID = 'story-delete-char';
+const NODE_A = 'story-node-a';
+const NODE_B = 'story-node-b';
+const LINK_A = 'story-link-a';
+
+const entry = (id: string): StoryTheaterEntry => ({
+    id,
+    title: id,
+    premise: '',
+    openingMode: 'user',
+    mask: { type: 'user' },
+    characterIds: [ACTOR_ID],
+    writesToCharacterMemory: true,
+    characterMemoryDates: {},
+    carryCharacterMemory: true,
+    characterContextLimits: { [ACTOR_ID]: 100 },
+    archiveAfter: 20,
+    archiveKeepRecent: 5,
+    archiveStrategy: 'vector',
+    archives: [],
+    selectedWorldbookIds: [],
+    createdAt: 1,
+    updatedAt: 1,
+});
+
+const node = (id: string, entryId: string): MemoryNode => ({
+    id,
+    charId: storyTheaterThreadId(entryId),
+    content: id,
+    room: 'living_room',
+    tags: ['剧情'],
+    importance: 5,
+    mood: 'neutral',
+    embedded: true,
+    createdAt: 1,
+    lastAccessedAt: 1,
+    accessCount: 0,
+});
+
+describe('删除整个剧情', () => {
+    const messageIds: number[] = [];
+
+    afterEach(async () => {
+        if (messageIds.length > 0) await DB.deleteMessages(messageIds.splice(0));
+        await DB.deleteStoryTheater(ENTRY_A);
+        await DB.deleteStoryTheater(ENTRY_B);
+        await Promise.all([
+            MemoryLinkDB.delete(LINK_A),
+            MemoryVectorDB.delete(NODE_A),
+            MemoryVectorDB.delete(NODE_B),
+            MemoryNodeDB.delete(NODE_A),
+            MemoryNodeDB.delete(NODE_B),
+        ]);
+    });
+
+    it('只清理选中剧情的条目、楼层、角色镜像与向量分区', async () => {
+        const entryA = entry(ENTRY_A);
+        const entryB = entry(ENTRY_B);
+        await DB.saveStoryTheater(entryA);
+        await DB.saveStoryTheater(entryB);
+
+        const mirrorA = await DB.saveMessage({ charId: ACTOR_ID, role: 'assistant', type: 'text', content: 'mirror-a', metadata: { source: 'story_theater_memory', theaterId: entryA.id } });
+        const centralA = await DB.saveMessage({ charId: storyTheaterThreadId(entryA.id), role: 'assistant', type: 'text', content: 'central-a', metadata: { source: 'story_theater', theaterId: entryA.id, theaterMirrorIds: { actor: mirrorA } } });
+        const mirrorB = await DB.saveMessage({ charId: ACTOR_ID, role: 'assistant', type: 'text', content: 'mirror-b', metadata: { source: 'story_theater_memory', theaterId: entryB.id } });
+        messageIds.push(mirrorA, centralA, mirrorB);
+
+        await MemoryNodeDB.save(node(NODE_A, entryA.id));
+        await MemoryNodeDB.save(node(NODE_B, entryB.id));
+        await MemoryVectorDB.save({ memoryId: NODE_A, charId: storyTheaterThreadId(entryA.id), vector: [0.1], dimensions: 1, model: 'test' });
+        await MemoryVectorDB.save({ memoryId: NODE_B, charId: storyTheaterThreadId(entryB.id), vector: [0.2], dimensions: 1, model: 'test' });
+        await MemoryLinkDB.save({ id: LINK_A, sourceId: NODE_A, targetId: NODE_B, type: 'temporal', strength: 0.5 });
+
+        const result = await deleteStoryTheaterData(entryA);
+
+        expect(result).toEqual({ deletedMessageCount: 2, deletedVectorCount: 1, remoteVectorDeleteFailures: 0 });
+        expect((await DB.getStoryTheaters()).map(item => item.id)).not.toContain(entryA.id);
+        expect((await DB.getStoryTheaters()).map(item => item.id)).toContain(entryB.id);
+        expect(await DB.getMessagesByCharId(storyTheaterThreadId(entryA.id), true)).toHaveLength(0);
+        expect((await DB.getMessagesByCharId(ACTOR_ID, true)).some(message => message.id === mirrorA)).toBe(false);
+        expect((await DB.getMessagesByCharId(ACTOR_ID, true)).some(message => message.id === mirrorB)).toBe(true);
+        expect(await listStoryVectorMemories(entryA.id)).toHaveLength(0);
+        expect(await listStoryVectorMemories(entryB.id)).toHaveLength(1);
+        expect(await MemoryLinkDB.getByNodeId(NODE_B)).toHaveLength(0);
+    });
+});

--- a/utils/storyTheaterDeletion.ts
+++ b/utils/storyTheaterDeletion.ts
@@ -1,0 +1,55 @@
+import type { StoryTheaterEntry } from '../types';
+import type { RemoteVectorConfig } from './memoryPalace/types';
+import { DB } from './db';
+import { storyTheaterMemoryRecipientIds, storyTheaterThreadId } from './storyTheater';
+import { deleteStoryVectorMemory, listStoryVectorMemories } from './storyTheaterVectorMemory';
+
+export interface DeleteStoryTheaterResult {
+    deletedMessageCount: number;
+    deletedVectorCount: number;
+    remoteVectorDeleteFailures: number;
+}
+
+export async function deleteStoryTheaterData(
+    entry: StoryTheaterEntry,
+    remoteVectorConfig?: RemoteVectorConfig,
+): Promise<DeleteStoryTheaterResult> {
+    const threadId = storyTheaterThreadId(entry.id);
+    const recipientIds = storyTheaterMemoryRecipientIds(entry);
+    const [centralMessages, recipientMessages, vectorNodes] = await Promise.all([
+        DB.getMessagesByCharId(threadId, true),
+        Promise.all(recipientIds.map(id => DB.getMessagesByCharId(id, true))),
+        listStoryVectorMemories(entry.id),
+    ]);
+
+    const messageIds = new Set<number>();
+    for (const message of centralMessages) {
+        messageIds.add(message.id);
+        const mirrorIds = Object.values((message.metadata?.theaterMirrorIds || {}) as Record<string, number>);
+        for (const id of mirrorIds) {
+            const numericId = Number(id);
+            if (Number.isFinite(numericId) && numericId > 0) messageIds.add(numericId);
+        }
+    }
+    for (const message of recipientMessages.flat()) {
+        if (message.metadata?.source === 'story_theater_memory' && message.metadata?.theaterId === entry.id) {
+            messageIds.add(message.id);
+        }
+    }
+
+    let remoteVectorDeleteFailures = 0;
+    for (const node of vectorNodes) {
+        const result = await deleteStoryVectorMemory(entry.id, node.id, remoteVectorConfig);
+        if (result.remoteDeleted === false) remoteVectorDeleteFailures += 1;
+    }
+
+    if (messageIds.size > 0) await DB.deleteMessages([...messageIds]);
+    await DB.deleteStoryTheater(entry.id);
+    try { localStorage.removeItem(`mp_lastMsgId_${threadId}`); } catch { /* storage unavailable */ }
+
+    return {
+        deletedMessageCount: messageIds.size,
+        deletedVectorCount: vectorNodes.length,
+        remoteVectorDeleteFailures,
+    };
+}


### PR DESCRIPTION
## 做了什么

- 在每条剧情旁增加始终可见的“删除整个剧情”入口，不再藏在长按操作里
- 增加二次确认，明确会删除和不会影响的内容
- 完整清理剧情条目、全部楼层、事件盒、关系备注、角色侧可定位镜像，以及该剧情独立向量分区
- 保持其它剧情、普通聊天、角色原有向量记忆不受影响
- 等待 IndexedDB 删除事务真正完成后再更新界面

## 为什么

小手机用户目前找不到删除整条剧情的办法；即使只删除列表项，也会留下楼层、角色镜像或向量数据。这个改动同时补上可发现入口与数据级完整清理。

## 验证

- `npm run test:run -- utils/storyTheaterDeletion.test.ts utils/storyTheaterVectorMemory.test.ts utils/db.storyTheater.test.ts`（3 个文件、5 项测试通过）
- `npm run build` 通过
- 360×520 小屏路径验证：入口可见、取消保留、确认后清空，控制台无报错