### PR TITLE
fix(amsg2): 云端 tool_pack 读回来先解压，带月度总结的角色到点不再解析失败

### DIFF
--- a/public/amsg-worker.bundle.js
+++ b/public/amsg-worker.bundle.js
@@ -8600,6 +8600,13 @@ var amsgHooks = {
       throw fireStateError("task metadata \u7F3A charId", { taskId: ctx.task.id });
     }
     const fail = (reason, extra) => fireStateError(reason, { taskId: ctx.task.id, charId, ...extra });
+    const unpackOrFail = async (label, value) => {
+      try {
+        return await unpackStateValue(value);
+      } catch (error) {
+        throw fail(`${label} \u89E3\u538B\u5931\u8D25\uFF08\u6570\u636E\u635F\u574F\uFF09`, { error: String(error) });
+      }
+    };
     const charRows = await ctx.readState(amsgStateNamespace(charId));
     const taskMeta = ctx.task.metadata ?? {};
     const policy = typeof taskMeta.amsgExpirePolicy === "string" ? taskMeta.amsgExpirePolicy : void 0;
@@ -8622,12 +8629,7 @@ var amsgHooks = {
     }
     const packRow = charRows.find((r) => r.key === AMSG_FIRE_PACK_KEY);
     if (!packRow) throw fail("\u4E91\u7AEF\u6CA1\u6709\u8FD9\u4E2A\u89D2\u8272\u7684 fire_pack");
-    let packJson;
-    try {
-      packJson = await unpackStateValue(packRow.value);
-    } catch (error) {
-      throw fail("fire_pack \u89E3\u538B\u5931\u8D25\uFF08\u6570\u636E\u635F\u574F\uFF09", { error: String(error) });
-    }
+    const packJson = await unpackOrFail("fire_pack", packRow.value);
     const pack = parseFirePack(packJson);
     if (!pack) throw fail(`fire_pack \u89E3\u6790\u5931\u8D25\uFF1A${describeFirePackVersion(packJson)}`);
     const occurrenceMs = Date.parse(String(ctx.task.nextSendAt));
@@ -8656,9 +8658,9 @@ var amsgHooks = {
     const toolConfigRow = globalRows.find((r) => r.key === AMSG_TOOL_CONFIG_KEY);
     if (!toolPackRow) throw fail("\u4E91\u7AEF\u6CA1\u6709\u8FD9\u4E2A\u89D2\u8272\u7684 tool_pack");
     if (!toolConfigRow) throw fail("\u4E91\u7AEF\u6CA1\u6709 tool_config");
-    const toolPack = parseToolPack(toolPackRow.value);
+    const toolPack = parseToolPack(await unpackOrFail("tool_pack", toolPackRow.value));
     if (!toolPack) throw fail("tool_pack \u89E3\u6790\u5931\u8D25\uFF08\u683C\u5F0F\u4E0D\u5BF9\u6216\u6570\u636E\u635F\u574F\uFF09");
-    const toolConfig = parseToolConfig(toolConfigRow.value);
+    const toolConfig = parseToolConfig(await unpackOrFail("tool_config", toolConfigRow.value));
     if (!toolConfig) throw fail("tool_config \u89E3\u6790\u5931\u8D25\uFF08\u683C\u5F0F\u4E0D\u5BF9\u6216\u6570\u636E\u635F\u574F\uFF09");
     const mcpServers = filterMcpServersForChar(toolConfig.mcpServers, charId);
     const mcpResolve = mcpServers.length ? buildMcpNameMap(mcpServers, { maxNameLen: MCP_FIRE_NAME_BUDGET }) : null;

--- a/utils/amsgToolPack.ts
+++ b/utils/amsgToolPack.ts
@@ -8,9 +8,9 @@
  *     XHS MCP 配置、代理 worker 地址——即 agenticTools 各工具从 realtimeConfig
  *     里读的那个子集，多一分都不上云。
  *
- * 两份都由前端在 amsgStateSync 冲刷时与 fire_pack 同批 putClientState；worker 在
- * onBeforeFire 读出、parse 失败一律回退成「无工具数据」（工具会以 not_configured /
- * no_logs 的正常路径回给 LLM，不会炸 fire 链）。
+ * 两份都由前端在 amsgStateSync 冲刷时与 fire_pack 同批 putClientState（tool_pack
+ * 上传前过 packStateValue，够大会压成 gz1: 前缀）；worker 在 onBeforeFire 先解压再
+ * 解析，任何一份解不出来都按云端状态异常抛 AMSG2_FIRE_STATE_MISSING 硬失败，不降级。
  *
  * 环境无关叶子模块：不 import 任何带浏览器依赖的东西（会进 worker bundle）。
  */

--- a/worker/amsg/src/index.test.ts
+++ b/worker/amsg/src/index.test.ts
@@ -369,6 +369,63 @@ describe('onBeforeFire 四道门', () => {
     await expect(amsgHooks.onBeforeFire(ctx)).rejects.toThrow(/AMSG2_FIRE_STATE_MISSING/);
   });
 
+  it('前端压过的 tool_pack 照常读出来（带几条月度总结就到压缩量级）', async () => {
+    // 空记忆的 tool_pack 一百来字节、压完反而更大，packStateValue 会原样放行；
+    // 攒了几条月度总结的角色轻松过千字节、必然被压——正是活跃用户的常态形状。
+    const months = ['2026-05', '2026-06', '2026-07'];
+    const bulky = JSON.stringify({
+      ...JSON.parse(toolPackValue),
+      activeMemoryMonths: months,
+      memories: months.map((date) => ({
+        date,
+        summary: '这个月聊了很多工作上的压力，也一起看了两场电影，月底约好下次去海边散心。'.repeat(3),
+      })),
+    });
+    const packed = await packStateValue(bulky);
+    expect(packed.startsWith('gz1:'), '这个量级应该压得动').toBe(true);
+    const { ctx, scratch } = makeCtx({
+      charRows: [
+        { key: AMSG_FIRE_PACK_KEY, value: firePackValue() },
+        { key: AMSG_TOOL_PACK_KEY, value: packed },
+      ],
+    });
+    fired(await amsgHooks.onBeforeFire(ctx));
+    // 光不抛错不够：得确认解出来的是真数据（recall 按这些月份找总结全靠它）
+    expect((scratch.fire as any).toolCtx.char.activeMemoryMonths).toEqual(months);
+  });
+
+  it('压过的 tool_pack 坏掉 → 抛错（和 fire_pack 同款语义，不降级成无工具数据）', async () => {
+    const { ctx } = makeCtx({
+      charRows: [
+        { key: AMSG_FIRE_PACK_KEY, value: firePackValue() },
+        { key: AMSG_TOOL_PACK_KEY, value: 'gz1:bm90LWd6aXAtYXQtYWxs' },
+      ],
+    });
+    await expect(amsgHooks.onBeforeFire(ctx)).rejects.toThrow(/AMSG2_FIRE_STATE_MISSING/);
+  });
+
+  it('压过的 tool_config 也照常读出来（今天前端没压它，但读侧不该赌客户端压哪份）', async () => {
+    const bulky = mcpToolConfigValue({
+      mcpServers: [{
+        id: 'srv-memory',
+        name: '记忆库',
+        url: 'https://mcp.example.com/mcp',
+        tools: [{
+          name: 'search_memory',
+          description: '按关键词在长期记忆库里检索过往对话的要点，返回最相关的几条。'.repeat(8),
+          inputSchema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+        }],
+      }],
+    });
+    const packed = await packStateValue(bulky);
+    expect(packed.startsWith('gz1:'), '这个量级应该压得动').toBe(true);
+    const { ctx, scratch } = makeCtx({
+      globalRows: [{ key: AMSG_TOOL_CONFIG_KEY, value: packed }],
+    });
+    fired(await amsgHooks.onBeforeFire(ctx));
+    expect((scratch.fire as any).mcpResolve.get('search_memory').toolName).toBe('search_memory');
+  });
+
   it('云端没有 tool_pack → 抛错（和 fire_pack 同批上传，缺了就是状态异常，不给空壳继续）', async () => {
     const { ctx } = makeCtx({ charRows: [{ key: AMSG_FIRE_PACK_KEY, value: firePackValue() }] });
     await expect(amsgHooks.onBeforeFire(ctx)).rejects.toThrow(/tool_pack/);

--- a/worker/amsg/src/index.ts
+++ b/worker/amsg/src/index.ts
@@ -793,6 +793,18 @@ export const amsgHooks = {
     const fail = (reason: string, extra?: Record<string, unknown>) =>
       fireStateError(reason, { taskId: ctx.task.id, charId, ...extra });
 
+    // 前端上传的云端状态可能被 packStateValue 压过（值以 gz1: 开头），读回来统一先过
+    // 一遍解压——没压过的原样穿过去，读侧不用赌客户端到底压了哪几份。带月度总结的
+    // tool_pack 就在压缩量级上，漏掉这一步整条 fire 链会卡死在「解析失败」。
+    // 解压失败说明数据真损坏了，和解析失败同款硬失败语义。
+    const unpackOrFail = async (label: string, value: string): Promise<string> => {
+      try {
+        return await unpackStateValue(value);
+      } catch (error) {
+        throw fail(`${label} 解压失败（数据损坏）`, { error: String(error) });
+      }
+    };
+
     const charRows = await ctx.readState(amsgStateNamespace(charId));
 
     const taskMeta = (ctx.task.metadata ?? {}) as Record<string, unknown>;
@@ -824,13 +836,7 @@ export const amsgHooks = {
     if (!packRow) throw fail('云端没有这个角色的 fire_pack');
 
     // 大值分块由 amsg-server 2.6.0-next.4+ 在存储层透明处理，readState 拿到的已是拼回的原文。
-    // 前端压过之后值以 gz1: 开头，unpackStateValue 按前缀解；内容太短没压的原样穿过去。
-    let packJson: string;
-    try {
-      packJson = await unpackStateValue(packRow.value);
-    } catch (error) {
-      throw fail('fire_pack 解压失败（数据损坏）', { error: String(error) });
-    }
+    const packJson = await unpackOrFail('fire_pack', packRow.value);
     const pack = parseFirePack(packJson);
     // 失败原因写清楚：升 fire_pack 版本要 worker bundle 和前端一起动，而设置页的版本门槛
     // 读的是上游 amsg-server 库的版本号，只改 SullyOS 自己这份 worker 代码时它不会亮。
@@ -887,10 +893,11 @@ export const amsgHooks = {
     if (!toolConfigRow) throw fail('云端没有 tool_config');
 
     // 两份数据和 fire_pack 同批原子上传（activeMsgClient 的 putClientStateOrThrow），
-    // 所以走到这里必然都在；解析不出来就是云端状态坏了，硬失败不降级。
-    const toolPack = parseToolPack(toolPackRow.value);
+    // 所以走到这里必然都在；和 fire_pack 一样先解压再解析（tool_pack 攒上几条月度总结
+    // 就会被前端压缩）。解析不出来就是云端状态坏了，硬失败不降级。
+    const toolPack = parseToolPack(await unpackOrFail('tool_pack', toolPackRow.value));
     if (!toolPack) throw fail('tool_pack 解析失败（格式不对或数据损坏）');
-    const toolConfig = parseToolConfig(toolConfigRow.value);
+    const toolConfig = parseToolConfig(await unpackOrFail('tool_config', toolConfigRow.value));
     if (!toolConfig) throw fail('tool_config 解析失败（格式不对或数据损坏）');
 
     // 通用 MCP：提示词块 / tools 数组与凭据同源同拍（都来自这一行 tool_config），

--- a/worker/amsg/worker.bundle.js
+++ b/worker/amsg/worker.bundle.js
@@ -8600,6 +8600,13 @@ var amsgHooks = {
       throw fireStateError("task metadata \u7F3A charId", { taskId: ctx.task.id });
     }
     const fail = (reason, extra) => fireStateError(reason, { taskId: ctx.task.id, charId, ...extra });
+    const unpackOrFail = async (label, value) => {
+      try {
+        return await unpackStateValue(value);
+      } catch (error) {
+        throw fail(`${label} \u89E3\u538B\u5931\u8D25\uFF08\u6570\u636E\u635F\u574F\uFF09`, { error: String(error) });
+      }
+    };
     const charRows = await ctx.readState(amsgStateNamespace(charId));
     const taskMeta = ctx.task.metadata ?? {};
     const policy = typeof taskMeta.amsgExpirePolicy === "string" ? taskMeta.amsgExpirePolicy : void 0;
@@ -8622,12 +8629,7 @@ var amsgHooks = {
     }
     const packRow = charRows.find((r) => r.key === AMSG_FIRE_PACK_KEY);
     if (!packRow) throw fail("\u4E91\u7AEF\u6CA1\u6709\u8FD9\u4E2A\u89D2\u8272\u7684 fire_pack");
-    let packJson;
-    try {
-      packJson = await unpackStateValue(packRow.value);
-    } catch (error) {
-      throw fail("fire_pack \u89E3\u538B\u5931\u8D25\uFF08\u6570\u636E\u635F\u574F\uFF09", { error: String(error) });
-    }
+    const packJson = await unpackOrFail("fire_pack", packRow.value);
     const pack = parseFirePack(packJson);
     if (!pack) throw fail(`fire_pack \u89E3\u6790\u5931\u8D25\uFF1A${describeFirePackVersion(packJson)}`);
     const occurrenceMs = Date.parse(String(ctx.task.nextSendAt));
@@ -8656,9 +8658,9 @@ var amsgHooks = {
     const toolConfigRow = globalRows.find((r) => r.key === AMSG_TOOL_CONFIG_KEY);
     if (!toolPackRow) throw fail("\u4E91\u7AEF\u6CA1\u6709\u8FD9\u4E2A\u89D2\u8272\u7684 tool_pack");
     if (!toolConfigRow) throw fail("\u4E91\u7AEF\u6CA1\u6709 tool_config");
-    const toolPack = parseToolPack(toolPackRow.value);
+    const toolPack = parseToolPack(await unpackOrFail("tool_pack", toolPackRow.value));
     if (!toolPack) throw fail("tool_pack \u89E3\u6790\u5931\u8D25\uFF08\u683C\u5F0F\u4E0D\u5BF9\u6216\u6570\u636E\u635F\u574F\uFF09");
-    const toolConfig = parseToolConfig(toolConfigRow.value);
+    const toolConfig = parseToolConfig(await unpackOrFail("tool_config", toolConfigRow.value));
     if (!toolConfig) throw fail("tool_config \u89E3\u6790\u5931\u8D25\uFF08\u683C\u5F0F\u4E0D\u5BF9\u6216\u6570\u636E\u635F\u574F\uFF09");
     const mcpServers = filterMcpServersForChar(toolConfig.mcpServers, charId);
     const mcpResolve = mcpServers.length ? buildMcpNameMap(mcpServers, { maxNameLen: MCP_FIRE_NAME_BUDGET }) : null;


### PR DESCRIPTION
fix #481

## 问题

用户普遍反馈主动消息报 `AMSG2_FIRE_STATE_MISSING: tool_pack 解析失败（格式不对或数据损坏）`，任务重试 3 次后标 failed，整条主动消息停摆。

根因是一条压缩不对称：a25e658 起前端上传 fire_pack / tool_pack 前会过 `packStateValue` 压缩（够大就带 `gz1:` 前缀），但 worker 读回来只给 fire_pack 加了解压，tool_pack 直接 `JSON.parse`。

| 角色状态 | tool_pack 体积 | 结果 |
|---------|--------------|------|
| 空记忆新角色 | 约 100 字节，压完更大 → 不压 | 正常 |
| 带几条月度总结 | 轻松过千字节 → 必压缩 | 到点必炸，重试无效 |

越活跃的用户中招越狠，正好对上「普遍出现」的反馈面。

## 改法

三份云端状态（fire_pack / tool_pack / tool_config）读回来统一先过 `unpackStateValue` 再解析：没压过的原样穿过去，读侧不再赌客户端到底压了哪几份。解压失败和解析失败同款硬失败语义，报错带具体 error。

新增三条回归测试：压过的 tool_pack / tool_config 照常读出来（修之前分别精准挂在原 892 / 894 行，与线上日志同源）、压坏的 tool_pack 抛错不降级。全量 2299 条测试通过。

顺带把 `utils/amsgToolPack.ts` 头部过时注释（「parse 失败回退成无工具数据」）改成现在的硬失败行为。

## 发布注意

- 只动 worker 侧，bundle 已重打；D1 里已压好的数据换上新 worker 即可直接读，无需重传
- 用户需在设置页重新粘贴部署 worker（原地换代码，不用重订推送），贴完点一次「重新连接并验证」
- 已被标 failed 的任务不会复活，需要用户重新排

https://claude.ai/code/session_01T6Z3bzeKPu6jHyVuM3SuyW