### PR TITLE
fix(amsg2): 开启通知与推送时也做僵尸端点重试，不再把死地址登记进 worker

### DIFF
--- a/utils/activeMsgClient.test.ts
+++ b/utils/activeMsgClient.test.ts
@@ -807,47 +807,89 @@ describe('dropStaleSubscription（① 死端点 / 公钥不一致先退订）', 
   });
 });
 
+// 回归守卫（补）：建订阅这一步不许走 ReiClient.subscribePush——那是裸的
+// pushManager.subscribe()，刚退订完的窗口期里浏览器会吐 permanently-removed.invalid
+// 哨兵，它照单收下。死端点一旦被登记进 worker，用户看到「订阅已准备完成」，到点却一条
+// 都收不到，两边都没有任何报错。这一组钉住「走带重试的共用实现」。
 describe('ActiveMsgClient.ensurePushSubscription（① 不再无条件复用旧订阅）', () => {
-  const stubPushEnv = (existing: any) => {
+  const FRESH_ENDPOINT = 'https://fcm.googleapis.com/send/fresh';
+
+  /** subscribe() 依次吐出 endpoints 里的端点；用尽后一直吐最后一个。 */
+  const stubPushEnv = (existing: any, endpoints: string[] = [FRESH_ENDPOINT]) => {
+    const queue = [...endpoints];
+    const subscribe = vi.fn().mockImplementation(async () => {
+      const endpoint = queue.length > 1 ? queue.shift()! : queue[0];
+      return {
+        endpoint,
+        options: { applicationServerKey: Uint8Array.from([1, 2, 3]).buffer },
+        unsubscribe: vi.fn().mockResolvedValue(true),
+        toJSON: () => ({ endpoint, keys: { p256dh: 'p2', auth: 'a2' } }),
+      };
+    });
     vi.stubGlobal('navigator', {
       serviceWorker: {
         ready: Promise.resolve({
-          pushManager: { getSubscription: vi.fn().mockResolvedValue(existing) },
+          pushManager: { getSubscription: vi.fn().mockResolvedValue(existing), subscribe },
         }),
       },
     });
     vi.stubGlobal('window', { PushManager: class {} });
     vi.stubGlobal('Notification', { permission: 'granted' });
+    return subscribe;
   };
 
   beforeEach(() => {
     reiClient.getVapidPublicKey.mockReset().mockResolvedValue(VAPID_AQID);
-    reiClient.subscribePush.mockReset().mockResolvedValue({
-      toJSON: () => ({ endpoint: 'https://fcm.googleapis.com/send/fresh', keys: { p256dh: 'p2', auth: 'a2' } }),
-    });
+    reiClient.subscribePush.mockReset();
   });
   afterEach(() => { vi.unstubAllGlobals(); });
 
   it('已有订阅是死端点 → 退订后重订，返回新订阅', async () => {
     const dead = makeSub('https://permanently-removed.invalid/x', [1, 2, 3]);
-    stubPushEnv(dead);
+    const subscribe = stubPushEnv(dead);
 
     const result = await runWithTimers(ActiveMsgClient.ensurePushSubscription());
 
     expect(dead.unsubscribe).toHaveBeenCalledTimes(1);
-    expect(reiClient.subscribePush).toHaveBeenCalledTimes(1);
-    expect((result as any).endpoint).toBe('https://fcm.googleapis.com/send/fresh');
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect((result as any).endpoint).toBe(FRESH_ENDPOINT);
   });
 
   it('已有订阅绑着旧 VAPID 公钥 → 退订后按 worker 当前公钥重订', async () => {
     const stale = makeSub('https://fcm.googleapis.com/send/x', [9, 9, 9]);
-    stubPushEnv(stale);
+    const subscribe = stubPushEnv(stale);
 
     const result = await runWithTimers(ActiveMsgClient.ensurePushSubscription());
 
     expect(stale.unsubscribe).toHaveBeenCalledTimes(1);
-    expect(reiClient.subscribePush).toHaveBeenCalledWith(VAPID_AQID, expect.anything());
-    expect((result as any).endpoint).toBe('https://fcm.googleapis.com/send/fresh');
+    expect(subscribe).toHaveBeenCalledWith(expect.objectContaining({ userVisibleOnly: true }));
+    expect((result as any).endpoint).toBe(FRESH_ENDPOINT);
+  });
+
+  it('订阅一律不经 ReiClient.subscribePush（它不做僵尸重试）', async () => {
+    stubPushEnv(null);
+
+    await runWithTimers(ActiveMsgClient.ensurePushSubscription());
+
+    expect(reiClient.subscribePush).not.toHaveBeenCalled();
+  });
+
+  it('重订第一次拿到僵尸哨兵、重试拿到活端点 → 返回活的那个', async () => {
+    const subscribe = stubPushEnv(null, ['https://permanently-removed.invalid/x', FRESH_ENDPOINT]);
+
+    const result = await runWithTimers(ActiveMsgClient.ensurePushSubscription());
+
+    expect(subscribe).toHaveBeenCalledTimes(2);
+    expect((result as any).endpoint).toBe(FRESH_ENDPOINT);
+  });
+
+  it('重试到底还是僵尸 → 抛 端点僵尸，绝不把死端点交出去', async () => {
+    stubPushEnv(null, ['https://permanently-removed.invalid/x']);
+
+    const failure = await runWithTimers(ActiveMsgClient.ensurePushSubscription().catch((e) => e));
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(readAmsgFailKind(failure)).toBe('端点僵尸');
   });
 
   it('已有订阅健康且公钥一致 → 原样复用，不重订', async () => {

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -791,14 +791,12 @@ const unsubscribeCurrentPush = async (): Promise<void> => {
 };
 
 /**
- * 重置的公共尾段：拿 worker 的 VAPID → 重新订阅 → 覆盖登记回 worker。
+ * 问 worker 要它自己签推送用的 VAPID 公钥。
  *
- * 订阅走共用的 subscribeWithRetry 而不是 `ReiClient.subscribePush`：后者是裸的
- * `pushManager.subscribe()`，拿到僵尸哨兵会原样交出来，登记上去就是往 worker 里
- * 写一个死端点——用户看到「重置成功」，照样一条消息都收不到。重试仍拿不到活端点
- * 的话挂 '端点僵尸' 代号，设置页据此把按钮升级成「深度重置」。
+ * 各用户自部署 worker、各有各的 VAPID，运行时拉、不编译进前端。拿别人的公钥订阅，
+ * worker 推的时候会 403。
  */
-const resubscribeAndRegister = async (client: ReiClient): Promise<void> => {
+const fetchWorkerVapidKey = async (client: ReiClient): Promise<string> => {
   let vapidPublicKey: string;
   try {
     vapidPublicKey = await client.getVapidPublicKey();
@@ -808,14 +806,35 @@ const resubscribeAndRegister = async (client: ReiClient): Promise<void> => {
   if (!vapidPublicKey) {
     throw withFailKind(new Error('Worker 没返回 VAPID 公钥，请确认已配置 VAPID 并部署了最新 worker。'), 'worker没配VAPID');
   }
+  return vapidPublicKey;
+};
 
-  const registration = await navigator.serviceWorker.ready;
+/**
+ * 建一条新的浏览器推送订阅，拿不到活端点就抛。
+ *
+ * 走共用的 subscribeWithRetry 而不是 `ReiClient.subscribePush`：后者是裸的
+ * `pushManager.subscribe()`，刚退订完的窗口期里浏览器会吐 permanently-removed.invalid
+ * 哨兵，它照单收下——那个死端点一旦被登记进 worker，用户看到「订阅成功」，到点却一条
+ * 都收不到，两边都没有任何报错。重试到底仍是僵尸的话挂 '端点僵尸' 代号，设置页据此
+ * 把「重置订阅」升级成「深度重置」。
+ */
+const subscribeOrThrow = async (
+  registration: ServiceWorkerRegistration,
+  vapidPublicKey: string,
+): Promise<PushSubscription> => {
   const { sub, reason } = await subscribeWithRetry(registration, vapidPublicKey, ACTIVE_MSG_RUNTIME_HEADER);
-  if (!sub) {
-    const message = reason || '订阅创建失败';
-    // 谓词在源码里写死，挂上去的是下面两个字面量之一；reason 原文只留在 toast 里。
-    throw withFailKind(new Error(message), isDeadPushEndpoint(message) ? '端点僵尸' : '订阅失败');
-  }
+  if (sub) return sub;
+  // 提示原文（浏览器能力、重试了几次）留在 toast 和 console 里。谓词写死在源码里，
+  // 挂上去的永远是下面两个字面量之一。
+  const message = reason || '订阅创建失败';
+  throw withFailKind(new Error(message), isDeadPushEndpoint(message) ? '端点僵尸' : '订阅失败');
+};
+
+/** 重置的公共尾段：拿 worker 的 VAPID → 重新订阅 → 覆盖登记回 worker。 */
+const resubscribeAndRegister = async (client: ReiClient): Promise<void> => {
+  const vapidPublicKey = await fetchWorkerVapidKey(client);
+  const registration = await navigator.serviceWorker.ready;
+  const sub = await subscribeOrThrow(registration, vapidPublicKey);
 
   try {
     await client.putPushSubscription(sub);
@@ -928,34 +947,17 @@ export const ActiveMsgClient = {
     await KeepAlive.init();
     const registration = await navigator.serviceWorker.ready;
 
-    // VAPID 公钥必须来自「这个 worker 自己」签推送用的那对密钥，否则 worker 推不动会 403。
-    // 各用户自部署 worker、各有各的 VAPID，运行时从 worker 拉、不编译进前端。
-    // **有旧订阅也要拉**：换过 VAPID 后旧订阅绑的还是老公钥，无条件复用等于把一个
-    // 必 403 的订阅继续写进新任务——自检就是拿目标公钥跟旧订阅比对（还有浏览器
-    // 僵尸化的死端点），不合格先退订再重订（见 dropStaleSubscription）。
+    // **有旧订阅也要拉公钥**：换过 VAPID 后旧订阅绑的还是老公钥，无条件复用等于把一个
+    // 必 403 的订阅继续写进新任务——自检就是拿目标公钥跟旧订阅比对（还有浏览器僵尸化
+    // 的死端点），不合格先退订再重订（见 dropStaleSubscription）。
     const client = createClient(config);
-    let vapidPublicKey: string;
-    try {
-      vapidPublicKey = await client.getVapidPublicKey();
-    } catch (error) {
-      throw normalizeActiveMsgApiError(error, '获取 Worker VAPID 公钥');
-    }
-    if (!vapidPublicKey) {
-      throw withFailKind(new Error('Worker 没返回 VAPID 公钥，请确认已配置 VAPID 并部署了最新 worker。'), 'worker没配VAPID');
-    }
+    const vapidPublicKey = await fetchWorkerVapidKey(client);
 
     const existing = await registration.pushManager.getSubscription();
     const reusable = await dropStaleSubscription(existing, vapidPublicKey);
     if (reusable) return reusable.toJSON();
 
-    try {
-      const subscription = await client.subscribePush(vapidPublicKey, registration);
-      return subscription.toJSON();
-    } catch (error) {
-      // 浏览器侧的订阅失败（没装 Google 服务的安卓、WebView 壳、FCM 连不上）。
-      // 提示原文由 pushSubscribeShared 翻译好后留在 toast 里，这里只留代号。
-      throw withFailKind(error instanceof Error ? error : new Error(String(error)), '订阅失败');
-    }
+    return (await subscribeOrThrow(registration, vapidPublicKey)).toJSON();
   },
 
   /**


### PR DESCRIPTION
浏览器刚退订完的那段窗口期里，紧接着的 subscribe() 不会去推送服务要新地址，而是
回一个 endpoint 形如 permanently-removed.invalid 的假订阅。这个域名是 RFC 保留的、 全球永不解析，推送发过去必然失败，但订阅对象本身看着完全正常。

「开启通知与推送」此前用的是库里那个不做检查的订阅方法，拿到什么登记什么。于是
死地址被写进 Worker，用户看到「通知权限和推送订阅已准备完成」，到点却一条消息都
收不到，两边都没有任何报错。重装 PWA、清过站点数据、换过 VAPID 之后都会走到这条
「退订完马上重订」的路上。

现在建订阅统一走带重试的共用实现（跟 Instant Push、重置订阅同一份）：拿到哨兵先
退掉、隔一会儿重试，最多三次；到底还是拿不到活地址就报错，绝不把死地址交出去。
设置页的「推送订阅状态」据此把「重置订阅」升级成「深度重置」。

顺手把「问 Worker 要 VAPID 公钥」和「建订阅」抽成两个小函数，开启推送与重置订阅
两条路共用，不再各写一遍。

Claude-Session: https://claude.ai/code/session_01T6Z3bzeKPu6jHyVuM3SuyW