### PR TITLE
ci: claude/ 与 codex/ 分支合进 master 后自动删掉远端分支

### DIFF
--- a/.github/workflows/on-merge-branch-cleanup.yml
+++ b/.github/workflows/on-merge-branch-cleanup.yml
@@ -1,0 +1,35 @@
+name: 合并后清理机器人分支
+
+# claude/ 或 codex/ 开头的分支，PR 合进 master 之后就把远端分支删掉，
+# 分支列表里不会一直堆着已经合完的临时分支。
+# 只管本仓库自己的分支，fork 过来的 PR 不碰。
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-head-branch:
+    name: 删除已合并的 head 分支
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.event.pull_request.head.ref, 'claude/')
+      || startsWith(github.event.pull_request.head.ref, 'codex/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: 删除远端分支
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh api -X DELETE "repos/$REPO/git/refs/heads/$BRANCH" --silent; then
+            echo "已删除分支：$BRANCH"
+          else
+            # 分支可能已被手动删掉，或者受保护规则拦着，这里不算失败
+            echo "没能删掉 $BRANCH（可能已经不存在，或者有分支保护），跳过"
+          fi


### PR DESCRIPTION
## 这是什么

Claude Code 和 Codex 干活时会临时开 `claude/xxx`、`codex/xxx` 分支，合完就没用了，但一直留在远端，分支列表越堆越长。

这份工作流让它们在 PR 合进 master 之后自动消失。

## 行为边界

| 情况 | 会不会删 |
|------|---------|
| `claude/` 或 `codex/` 开头，PR 合进 master | 删 |
| 其他前缀的分支（`feat/`、`fix/` 等） | 不删 |
| PR 关掉了但没合 | 不删 |
| 来自 fork 仓库的 PR | 不删（分支不在本仓库） |
| 分支已被手动删掉，或受分支保护拦着 | 日志记一笔，工作流不报红 |

## 需要留意

工作流用的是 `pull_request_target`，GitHub 执行的是 **base 分支（master）上那一份**定义。所以这份文件合进 master 之后才会开始生效，对本 PR 自身不起作用。

仓库当前的 `delete_branch_on_merge` 是关闭状态，不会和 GitHub 内置的自动删除功能重复触发。

远端已经堆着的一批历史 `claude/` `codex/` 分支属于存量，本工作流不负责清理。

https://claude.ai/code/session_01A45wTeey8NMgnKeRXnLn1L