### PR TITLE
fix(amsg2): 修掉重复排程，补上 Deno 门面与推送订阅失败的交代

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ dist-ssr
 # committed copy lives at worker/instant-push/worker.bundle.js
 public/instant-worker.bundle.js
 
+# build artifact — `pnpm run build:workers` 原样复制过来的，与源文件逐字节相同；
+# 提交的那份在 worker/amsg/deno-proxy.ts
+public/amsg-deno-proxy.ts
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/components/settings/ActiveMsgGlobalSettingsModal.tsx
+++ b/components/settings/ActiveMsgGlobalSettingsModal.tsx
@@ -100,6 +100,8 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
   const [deployOpen, setDeployOpen] = useState(false);
   // 手动粘贴部署：给没有 GitHub 账号的人留的退路，默认收着不干扰主流程。
   const [pasteFallbackOpen, setPasteFallbackOpen] = useState(false);
+  // Deno 门面：workers.dev 在国内连不上时才需要，默认收着。
+  const [denoProxyOpen, setDenoProxyOpen] = useState(false);
   const [pushStatus, setPushStatus] = useState<ActiveMsg2PushStatus | null>(null);
   // 「生成 Master Key」只在本次打开期间展示，前端不落盘——它是 worker 侧密钥，粘进 CF env 即可。
   const [generatedMasterKey, setGeneratedMasterKey] = useState('');
@@ -280,6 +282,19 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
       addToast(`复制失败（${error?.message || error}）。也可以从仓库 worker/amsg/worker.bundle.js 获取。`, 'error');
       // 剪贴板 API 在非 HTTPS / 部分 WebView 里会直接抛，这条就是那批人的规模。
       trackEvent('复制 2.0 Worker 代码', { result: 'failed' });
+    }
+  };
+
+  // workers.dev 在国内连不上时的门面脚本。跟上面那份不一样：这份不打包、原样发布，
+  // 用户要照着里面的注释改 UPSTREAM 那一行，所以注释必须留着。
+  const handleCopyDenoProxy = async () => {
+    try {
+      await ActiveMsgClient.copyDenoProxyToClipboard();
+      addToast('代理代码已复制，贴进 Deno Playground 后记得改 UPSTREAM 那一行。', 'success');
+      trackEvent('复制 2.0 Deno 代理代码', { result: 'ok' });
+    } catch (error: any) {
+      addToast(`复制失败（${error?.message || error}）。也可以从仓库 worker/amsg/deno-proxy.ts 获取。`, 'error');
+      trackEvent('复制 2.0 Deno 代理代码', { result: 'failed' });
     }
   };
 
@@ -610,6 +625,71 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
               placeholder="https://amsg.你的账号.workers.dev"
               className="w-full bg-white/70 border border-slate-200 rounded-2xl px-4 py-3 text-xs font-mono"
             />
+
+            <div className="mt-2">
+              <button
+                type="button"
+                onClick={() => setDenoProxyOpen((prev) => {
+                  if (!prev) trackEvent('展开 2.0 部署指引', { mode: 'Deno 代理' });
+                  return !prev;
+                })}
+                className="w-full flex items-center justify-between text-left text-[11px] font-bold text-slate-400"
+              >
+                <span>这个地址连不上？在外面套一层 Deno</span>
+                <span>{denoProxyOpen ? '收起' : '展开'}</span>
+              </button>
+
+              {denoProxyOpen ? (
+                <div className="mt-2 space-y-2">
+                  <p className="text-[11px] leading-relaxed text-slate-500">
+                    <code className="font-mono">workers.dev</code> 这个域名在国内连不上。
+                    办法是给它套一个门面：Worker 和数据全都留在 Cloudflare 不动，
+                    只在外面加一层只管转发的 Deno，然后把地址换成 Deno 那个。
+                  </p>
+
+                  <ol className="text-[11px] leading-relaxed text-slate-500 space-y-1.5 list-decimal list-outside pl-4">
+                    <li>
+                      去 Deno 控制台点右上角 <strong>New Playground</strong>。
+                    </li>
+                    <li>
+                      点下面「复制 Deno 代理代码」，在 Playground 里全选粘贴覆盖，
+                      把开头 <code className="font-mono">UPSTREAM</code> 那一行改成你上面填的
+                      Cloudflare 地址，然后 Deploy。
+                    </li>
+                    <li>
+                      把 Deploy 后拿到的 <code className="font-mono">https://xxx.deno.net</code> 地址
+                      填回上面的输入框，替换掉原来那个。
+                    </li>
+                  </ol>
+
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void handleCopyDenoProxy()}
+                      className="flex-1 py-2.5 rounded-xl text-xs font-bold bg-white border border-slate-200 text-slate-600 active:scale-95 transition-transform"
+                    >
+                      复制 Deno 代理代码
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        trackEvent('打开 Deno 控制台');
+                        window.open('https://console.deno.com', '_blank');
+                      }}
+                      className="shrink-0 px-3 py-2.5 rounded-xl text-xs font-bold bg-white border border-slate-200 text-slate-600 active:scale-95 transition-transform"
+                    >
+                      去 Deno
+                    </button>
+                  </div>
+
+                  <p className="text-[11px] leading-relaxed text-slate-400">
+                    收消息不走这一层——推送是 Cloudflare 直接发给手机的，
+                    所以这层就算挂了也只影响你打开这个面板改配置。
+                    部署好后打开 <code className="font-mono">/__proxy-health</code> 能看它活着没。
+                  </p>
+                </div>
+              ) : null}
+            </div>
           </div>
 
           <div>

--- a/components/settings/PushSubscriptionPanel.tsx
+++ b/components/settings/PushSubscriptionPanel.tsx
@@ -18,6 +18,16 @@ import {
   type AmsgRemotePushSubscription,
 } from '../../utils/activeMsgClient';
 import { readBrowserPushState, type BrowserPushState } from '../../utils/pushSubscribeShared';
+import {
+  describeElapsed,
+  describePermission,
+  describeServiceWorker,
+  describeSubscription,
+  describeSupport,
+  hasLiveFailure,
+  isSupportBad,
+  liveFailureKind,
+} from '../../utils/pushDiagnosticsView';
 import { bucketRetryCount, trackEvent } from '../../utils/analytics';
 
 interface PushSubscriptionPanelProps {
@@ -34,23 +44,6 @@ const Row: React.FC<{ label: string; value: string; bad?: boolean }> = ({ label,
   </div>
 );
 
-const describePermission = (permission: BrowserPushState['permission']) => {
-  if (permission === 'granted') return '已授权';
-  if (permission === 'denied') return '已拒绝（要去浏览器的站点设置里手动打开）';
-  if (permission === 'default') return '还没决定';
-  return '不可用';
-};
-
-const describeServiceWorker = (state: BrowserPushState) => {
-  if (state.swState === 'none') return '未注册';
-  const scope = state.swScope || '?';
-  return state.swState === 'activated' ? `已激活（scope: ${scope}）` : `${state.swState}（scope: ${scope}）`;
-};
-
-const describeSubscription = (state: BrowserPushState) => {
-  if (!state.endpoint) return '不存在';
-  return state.endpointDead ? '已被浏览器吊销' : '已建立';
-};
 
 const REGISTRATION_TEXT: Record<AmsgPushRegistrationState, { value: string; bad: boolean }> = {
   'worker-unset': { value: '还没填 Worker 地址', bad: true },
@@ -149,6 +142,9 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
                 swState: browser.swState === 'activated' ? 'activated' : browser.swState === 'none' ? 'none' : 'other',
                 platform: browser.capacitorNative ? 'capacitor_native' : browser.iosNeedsPwa ? 'ios_needs_pwa' : 'normal',
                 registration,
+                // 「接口全在但这台设备就是建不出订阅」的唯一可见出口。取的是共用层那个
+                // 固定枚举，不含报错原文。
+                lastFailure: liveFailureKind(browser) ?? 'none',
               } : undefined);
               void refresh();
             }}
@@ -161,15 +157,7 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
 
         {browser ? (
           <div className="space-y-1.5 text-[11px]">
-            <Row
-              label="浏览器支持"
-              value={
-                browser.capacitorNative ? '否（现在跑在 App 里）'
-                  : browser.supported ? '是'
-                  : '否（浏览器缺少推送相关接口）'
-              }
-              bad={!browser.supported || browser.capacitorNative}
-            />
+            <Row label="浏览器支持" value={describeSupport(browser)} bad={isSupportBad(browser)} />
             <Row label="通知权限" value={describePermission(browser.permission)} bad={browser.permission !== 'granted'} />
             <Row label="Service Worker" value={describeServiceWorker(browser)} bad={browser.swState !== 'activated'} />
             <Row
@@ -194,6 +182,24 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
                 {browser.capabilityGap}。
               </div>
             )}
+            {/* 失败原文以前只走 toast，一闪而过就没了——而这类失败恰恰最需要照着原文
+                排查。这里把它固定显示出来，直到订阅真的建起来为止。 */}
+            {hasLiveFailure(browser) && browser.lastSubscribeFailure && (() => {
+              const failure = browser.lastSubscribeFailure!;
+              const elapsed = describeElapsed(failure.at);
+              return (
+                <div className="mt-2 p-2 bg-rose-50 border border-rose-200 rounded-lg text-[10px] text-rose-700 leading-relaxed">
+                  <p className="font-semibold mb-1">上次建订阅失败{elapsed && `（${elapsed}）`}</p>
+                  <p>{failure.text}。</p>
+                  {failure.kind === 'channel-unreachable' && (
+                    <p className="mt-1.5 pt-1.5 border-t border-rose-200">
+                      这一类<b>重试多少次都是一样的结果</b>，问题不在这个站点、也不在权限，
+                      换一个浏览器或换台设备才有用。
+                    </p>
+                  )}
+                </div>
+              );
+            })()}
             {browser.endpointDead && (
               <div className="mt-2 p-2 bg-rose-50 border border-rose-200 rounded-lg text-[10px] text-rose-700 leading-relaxed">
                 订阅地址变成了 <code className="font-mono">permanently-removed.invalid</code>，
@@ -208,7 +214,9 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
                 点「重置订阅」把它改成这台。
               </div>
             )}
-            {registration === 'missing' && (
+            {/* 通道不通 / 内核不支持的时候不提「点重置订阅」：那一步必挂在建订阅上，
+                登记根本轮不到，上面那个失败框才是这台设备真正的结论。 */}
+            {registration === 'missing' && !isSupportBad(browser) && (
               <div className="mt-2 p-2 bg-rose-50 border border-rose-200 rounded-lg text-[10px] text-rose-700 leading-relaxed">
                 Worker 上一份订阅都没有，到点没地方推。点「重置订阅」登记一下这台设备。
               </div>

--- a/docs/amsg2-setup-walkthrough.md
+++ b/docs/amsg2-setup-walkthrough.md
@@ -201,6 +201,7 @@ env.DB (sullyos-amsg)   D1 Database
 - 地址是不是抄全了（要带 `https://`，末尾不要多斜杠）
 - 「共享密钥」和 Cloudflare 里的 `AMSG_SERVER_TOKEN` 是不是一模一样
 - 直接在浏览器打开 `你的地址/config-check`：后端会自己列出配置齐不齐。`"ok": true` 就是钥匙都填对了，问题在地址或密钥没对上；`"ok": false` 时后面的 `message` 会写明缺哪一样、去哪儿补。什么都打不开才是后端没起来，去看第三步的构建日志。
+- 上面这个地址挂梯子能打开、不挂就打不开：那是 `workers.dev` 在国内连不上，不是后端的问题，见下面「国内连不上 workers.dev 怎么办」。
 
 **连上了，但 `config-check` 的 `warnings` 里有东西**
 
@@ -219,6 +220,38 @@ env.DB (sullyos-amsg)   D1 Database
 **构建失败，日志里写 `D1_DATABASE_ID 是空的`**
 
 那个变量没设，或者设的时候点了 Encrypt。回到 Worker → **Settings** → 往下找 **Build** → **Variables**，加一个 `D1_DATABASE_ID`（普通变量，不加密），值是第二步的 Database ID，然后重新部署。
+
+---
+
+## 国内连不上 workers.dev 怎么办
+
+`https://xxx.workers.dev` 这个域名在国内的网络环境下打不开。表现是第五步点「连接」一直失败，但把地址挂梯子打开又是正常的。
+
+办法是给它加一个门面：Worker、数据库、定时任务全都留在 Cloudflare 不动，只在外面套一层 Deno——它什么都不做，只把请求原样转给你的 Worker，再把回复原样送回来。Deno 给的是 `xxx.deno.net` 域名，国内能直连。
+
+**先知道两件事**
+
+- **收消息不走这一层。** 推送是 Cloudflare 直接发给手机的，跟你用什么地址打开设置面板是两条独立的路。所以这层就算挂了也收得到消息，只是改不了配置。
+- **不用绑卡。** 没验证过的 Deno 账号只有免费额度的 1%（每月一万次请求），但 SullyOS 只在你点「连接」、打开设置面板、开推送这几下才会请求 Worker，一万次够用很久。
+
+**动手**
+
+1. 打开 [console.deno.com](https://console.deno.com)，用 GitHub 账号登录，点右上角 **New Playground**
+2. 回 SullyOS：**系统设置** → **主动消息 2.0** → **配置**，在「WORKER 地址」下面点开 **这个地址连不上？在外面套一层 Deno**，点 **复制 Deno 代理代码**
+3. 回 Playground，编辑器里全选、粘贴覆盖
+4. 找到开头 `UPSTREAM` 那一行，把引号里的地址换成你自己的 `https://xxx.workers.dev`
+5. 点右上角 **Deploy**，等构建跑完，标题旁边会出现 `https://xxx.deno.net`
+6. 把这个 `deno.net` 地址填回 SullyOS 的「WORKER 地址」，替换掉原来的，重新点一次 **连接并启用**
+
+> 不想把 Worker 地址写在代码里的话，第 4 步可以不改，改成在 Playground 的 **Env Variables** 里加一个 `AMSG_UPSTREAM`，值填你的 Worker 地址。两种都行，环境变量优先。
+
+**怎么确认这层是活的**
+
+浏览器打开 `你的deno.net地址/__proxy-health`。看到 `"ok": true` 和你填的上游地址就对了；`"ok": false` 说明 `UPSTREAM` 那行还是原来的占位符，没改成自己的地址。
+
+**一个会变的地方**
+
+设置面板里「去 Cloudflare 控制台」那个链接原本能直接跳到你那个 Worker 的页面，靠的是从 `workers.dev` 域名反推 Worker 名字。换成 `deno.net` 之后推不出来了，会跳到 Worker 列表页，自己再点一下。
 
 ---
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -533,6 +533,7 @@ Performance 标签页看：
 **设置 · 配置弹窗**
 
 - 发送 Instant Push 测试推送
+- 复制 2.0 Deno 代理代码
 - 复制 2.0 Worker 代码
 - 复制 Deno Loader
 - 复制 Instant Push Worker 代码

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -565,11 +565,14 @@ Performance 标签页看：
 这几条报的不是成败两态，而是卡在哪一类：
 `ok` / `success` / `地址没填` / `打到网页了` / `鉴权失败` / `端点不存在` / `建表失败` /
 `配置缺失` / `网络失败` / `权限被拒` / `不支持推送` / `worker没配VAPID` / `订阅失败` /
-`端点僵尸` / `其他`。
+`推送通道不通` / `端点僵尸` / `其他`。
 其中 `配置缺失` 来自连接前那次 `GET /config-check`（worker 自己报缺 D1 绑定或 master key），
 比 `建表失败` 精确——后者是按 HTTP 状态归的类，三种原因混在一格里。
 `端点僵尸` 是重试到底浏览器还是只给 `permanently-removed.invalid`，设置页据此把
 「重置订阅」升级成「深度重置」。
+`推送通道不通` 是浏览器接口齐全、权限也给了，但 `subscribe()` 连不上推送服务商——
+Chromium 系安卓版的网页推送要转交系统里的谷歌服务（GMS），没装 GMS 的国行安卓机全落这一格。
+这一格跟 `订阅失败` 分开是因为要修的事完全不同：前者只能换浏览器 / 换设备，重试无用。
 这些代号在**抛错那一刻**按 HTTP 状态和源码里的谓词挂上，报错原文（可能带 Worker 地址、
 push endpoint）留在 toast 和 console 里，一个字都不进上报。
 
@@ -579,9 +582,15 @@ push endpoint）留在 toast 和 console 里，一个字都不进上报。
 「刷新 Web Push 诊断」报的是设置页「推送订阅状态」面板当时的读数，全是固定枚举：
 `permission`、`subscription`（`none` / `dead` / `active`）、`swState`（`activated` /
 `none` / `other`）、`platform`（`normal` / `ios_needs_pwa` / `capacitor_native`）、
-`registration`（`worker-unset` / `unreachable` / `missing` / `other-endpoint` / `matched`）。
+`registration`（`worker-unset` / `unreachable` / `missing` / `other-endpoint` / `matched`）、
+`lastFailure`（`none` / `channel-unreachable` / `unsupported` / `permission` / `state` /
+`zombie` / `unknown`）。
 `registration` 是「worker 上登记的订阅是不是这台设备」，中间那两档对应的是任务建得成、
-到点却一条都不来的静默失联。端点地址、Worker 地址一概不带。
+到点却一条都不来的静默失联。
+`lastFailure` 是最近一次建订阅失败卡在哪类，手上已有活订阅时报 `none`。
+`channel-unreachable` 那一格量大就说明有一批设备（多半是没装谷歌服务的国行安卓机）
+从系统层面就用不了网页推送——这是它唯一能被看见的地方。
+端点地址、Worker 地址、报错原文一概不带。
 
 「探测 2.0 Worker 能力」每次会话最多一次，报 `ok` / `版本过旧` / `缺特性` / `端点不存在` /
 `探测失败`。跑着旧 worker 的表现是静默错（自述回写不落盘、任务重复推），用户不会来报，

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -1,6 +1,6 @@
 
 import { useState, useRef, useEffect, MutableRefObject } from 'react';
-import { CharacterProfile, UserProfile, Message, Emoji, EmojiCategory, GroupProfile, RealtimeConfig, CharacterBuff } from '../types';
+import { CharacterProfile, UserProfile, Message, Emoji, EmojiCategory, GroupProfile, RealtimeConfig, CharacterBuff, Amsg2ExpiredNoticeRecord } from '../types';
 import { DB } from '../utils/db';
 import { ChatPrompts } from '../utils/chatPrompts';
 import { safeFetchJson, safeResponseJson } from '../utils/safeApi';
@@ -42,8 +42,9 @@ import {
 import { ActiveMsgStore } from '../utils/activeMsgStore';
 import { markAmsgStateDirty, startAmsgChatPresence, stopAmsgChatPresence } from '../utils/amsgStateSync';
 import { getLastRealUserMessageAt } from '../utils/amsg2ExpireGuard';
-import { hasActiveAiTask, isAmsg2EnabledForChar } from '../utils/amsg2Tasks';
-import { collectAmsg2TaskContext } from '../utils/amsg2TaskContext';
+import { getPendingTasks, hasActiveAiTask, isAmsg2EnabledForChar } from '../utils/amsg2Tasks';
+import { buildAmsg2TaskContextText, collectAmsg2TaskContext } from '../utils/amsg2TaskContext';
+import { resolveCharTimeZone } from '../utils/timezone';
 import { AMSG2_SUPPRESSED_TRACE } from '../utils/amsg2InstantConflict';
 import { appendInstantTraceEntry } from '../utils/instantTraceLog';
 import { AMSG2_TOOLS, AMSG2_TOOL_NAMES, createAmsg2ToolSession, executeAmsg2Tool, isAmsg2GlobalReady } from '../utils/amsg2ToolBridge';
@@ -724,12 +725,24 @@ export const useChatAI = ({
         const amsg2Session = createAmsg2ToolSession({
             char, userProfile, groups, realtimeConfig, apiConfig, updateCharacter,
         });
+        // 本轮里角色自己新排出来的任务。排程现状块每轮现算时靠它把这些点名标出来——不标
+        // 的话角色分不清清单上哪条是自己刚排的，回头又排一条一模一样的。
+        const amsg2CreatedThisTurn = new Set<string>();
         // amsg2 工具在三个工具循环（麦当劳 / 瑞幸 / 通用）里都可能出现，执行方式完全一样，
         // 只有各自的 loopMessages 不同。
         const runAmsg2ToolCall = async (tc: any, fname: string, args: any, loopMessages: any[]) => {
             setSearchStatus(`正在执行：${fname}...`);
+            const taskUuidsBefore = new Set(
+                (amsg2Session.getConfig()?.tasks ?? []).map((t) => t.taskUuid),
+            );
             const result = await executeAmsg2Tool(fname, args, amsg2Session);
-            loopMessages.push({ role: 'tool', tool_call_id: tc.id, content: result } as any);
+            // 新增了哪几条不看工具回话（那是给模型读的散文），直接比对清单前后差异——
+            // schedule 与 renew 都走这里，补发/替换出来的新任务一并算进去。
+            for (const task of amsg2Session.getConfig()?.tasks ?? []) {
+                if (!taskUuidsBefore.has(task.taskUuid)) amsg2CreatedThisTurn.add(task.taskUuid);
+            }
+            // 带上 name：Gemini 兼容层要求工具结果的 name 非空，缺了会被判 INVALID_ARGUMENT。
+            loopMessages.push(buildToolResultMessage(tc, result) as any);
             setSearchStatus('');
         };
 
@@ -1013,22 +1026,43 @@ export const useChatAI = ({
             // 是否注入在上面 thinking 门那里就算好了（amsg2ToolsInjected）。
             // amsg2 和 instant push 互斥，不需要额外判断。
             let amsg2ExpiredIds: string[] = [];
+            let amsg2Notices: Amsg2ExpiredNoticeRecord[] = [];
             if (amsg2ToolsInjected) {
                 baseReqBody.tools = [...(baseReqBody.tools || []), ...AMSG2_TOOLS];
                 if (!baseReqBody.tool_choice) baseReqBody.tool_choice = 'auto';
                 try {
+                    // 回执这半边是「检出 + 落台账」的结果，带副作用，一轮只算一次；
+                    // 进行中任务那半边每次发请求现取（见下面的 withAmsg2TaskContext）。
                     const taskContext = await collectAmsg2TaskContext(char);
-                    if (taskContext.text) {
-                        amsg2ExpiredIds = taskContext.expiredIds;
-                        baseReqBody.messages = [
-                            ...baseReqBody.messages,
-                            { role: 'system', content: taskContext.text },
-                        ];
-                    }
+                    amsg2ExpiredIds = taskContext.expiredIds;
+                    amsg2Notices = taskContext.notices;
                 } catch (e) {
-                    console.warn('[amsg2] 排程现状块构建失败，本轮跳过', e);
+                    // 挂掉的只是作废回执这半边（它要读历史消息和台账）。进行中清单在内存里，
+                    // 照常渲染——角色至少知道自己名下有哪些任务，不至于一问三不知再排一条。
+                    console.warn('[amsg2] 作废回执检出失败，本轮只带进行中清单', e);
                 }
             }
+
+            /**
+             * 把排程现状块贴到 messages 末尾，每次发请求都按「此刻」的任务清单现算。
+             *
+             * 不写死进 baseReqBody.messages、也不进 loopMessages，是因为工具循环里角色会
+             * 边聊边排：写死的话第二轮起看到的是**排程前**那份空清单，跟工具刚回的「已创建」
+             * 打架，角色于是把同一条再排一遍；攒进历史的话则是好几份互相矛盾的旧清单叠着。
+             * 现算 + 只留一份，角色每轮读到的都是自己名下真实的任务，本轮刚排的还会被点名。
+             */
+            const withAmsg2TaskContext = (messages: any[]): any[] => {
+                if (!amsg2ToolsInjected) return messages;
+                const now = Date.now();
+                const text = buildAmsg2TaskContextText(
+                    getPendingTasks(amsg2Session.getConfig(), now),
+                    amsg2Notices,
+                    now,
+                    resolveCharTimeZone(char),
+                    amsg2CreatedThisTurn,
+                );
+                return text ? [...messages, { role: 'system', content: text }] : messages;
+            };
 
             // ─── Instant Push 分支 ───
             // 与本地 fetch 对称：sendInstantPushAndAwaitReply 内部完成 sub 获取 / push 监听 /
@@ -1157,7 +1191,7 @@ export const useChatAI = ({
             try {
                 data = await safeFetchJson(`${baseUrl}/chat/completions`, {
                     method: 'POST', headers,
-                    body: JSON.stringify(baseReqBody)
+                    body: JSON.stringify({ ...baseReqBody, messages: withAmsg2TaskContext(baseReqBody.messages) })
                 }, 2, 0, { appName: '消息', charId: char.id, charName: char.name, purpose: '聊天回复' }, streamHooks);
             } catch (e) {
                 // 仅通用 MCP、且没有和其他工具模式混用时降级。部分 OpenAI 兼容中转
@@ -1167,7 +1201,12 @@ export const useChatAI = ({
                     && !payload.flags.luckinChatActive && !payload.flags.mcdActive && !payload.flags.luckinActive;
                 if (!mcpOnly || !baseReqBody.tools?.length || !shouldRetryMcpWithoutTools(e)) throw e;
                 console.warn('🔌 [MCP] 当前中转拒绝 tools 请求，降级为正文工具调用兼容模式');
-                const fallbackBody = buildMcpRejectedToolsFallbackBody(baseReqBody);
+                // 这条路把 tools 全删了，角色排不了新任务；排程现状照样要带——它得知道
+                // 自己名下已经有哪些承诺，否则又会在正文里许一遍。
+                const fallbackBody = buildMcpRejectedToolsFallbackBody({
+                    ...baseReqBody,
+                    messages: withAmsg2TaskContext(baseReqBody.messages),
+                });
                 data = await safeFetchJson(`${baseUrl}/chat/completions`, {
                     method: 'POST', headers,
                     body: JSON.stringify(fallbackBody)
@@ -1204,7 +1243,7 @@ export const useChatAI = ({
             //     成"+加进购物车"卡片。返回 ack 给模型继续走它的文字 reply。
             if (payload.flags.mcdActive && data.choices?.[0]?.message?.tool_calls?.length) {
                 const MAX_PROPOSE_LOOPS = 3;
-                let loopMessages = [...fullMessages];
+                let loopMessages = [...baseReqBody.messages];
                 for (let it = 0; it < MAX_PROPOSE_LOOPS; it++) {
                     const toolCalls = data.choices?.[0]?.message?.tool_calls;
                     if (!toolCalls || !toolCalls.length) break;
@@ -1314,7 +1353,7 @@ export const useChatAI = ({
             // 3.5 瑞幸小程序 propose_cart_items UI 钩子工具循环 (与麦当劳同构)
             if (payload.flags.luckinActive && data.choices?.[0]?.message?.tool_calls?.length) {
                 const MAX_PROPOSE_LOOPS = 3;
-                let loopMessages = [...fullMessages];
+                let loopMessages = [...baseReqBody.messages];
                 for (let it = 0; it < MAX_PROPOSE_LOOPS; it++) {
                     const toolCalls = data.choices?.[0]?.message?.tool_calls;
                     if (!toolCalls || !toolCalls.length) break;
@@ -1421,7 +1460,7 @@ export const useChatAI = ({
             //       结果只回填循环不落卡片。两类工具可同时在场, 按名字各走各的。
             if ((payload.flags.luckinChatActive || mcpToolResolve || amsg2ToolsInjected) && data.choices?.[0]?.message?.tool_calls?.length) {
                 const MAX_LOOPS = 6;
-                let loopMessages = [...fullMessages];
+                let loopMessages = [...baseReqBody.messages];
                 const loc = luckinChatRef?.current;
                 for (let it = 0; it < MAX_LOOPS; it++) {
                     const toolCalls = normalizeToolCallsForCompat(
@@ -1514,7 +1553,9 @@ export const useChatAI = ({
                     }
                     // 继续让角色多步推进 (保留 tools, 允许 query→search→preview 连续走)
                     if (mcpToolResolve) setSearchStatus('正在整理 MCP 工具结果...');
-                    const followBody = { ...baseReqBody, messages: loopMessages };
+                    // 排程现状现算一次贴上：本轮刚排的任务这时才进得了清单，角色下一轮
+                    // 看到的是自己名下真实的排程，不会对着排程前的空清单再排一条。
+                    const followBody = { ...baseReqBody, messages: withAmsg2TaskContext(loopMessages) };
                     data = await safeFetchJson(`${baseUrl}/chat/completions`, {
                         method: 'POST', headers,
                         body: JSON.stringify(followBody)
@@ -1552,7 +1593,7 @@ export const useChatAI = ({
                             ? `工具 ${call.exposedName} 执行成功, 结果: ${formatMcpToolResult(r.data)}`
                             : `工具 ${call.exposedName} 执行失败: ${r.error}`);
                     }
-                    if (!textLoopMessages) textLoopMessages = [...fullMessages];
+                    if (!textLoopMessages) textLoopMessages = [...baseReqBody.messages];
                     textLoopMessages.push({ role: 'assistant', content: contentNow });
                     textLoopMessages.push({
                         role: 'user',

--- a/scripts/build-workers.mjs
+++ b/scripts/build-workers.mjs
@@ -17,7 +17,7 @@
 // through this pipeline.
 
 import { build } from 'esbuild';
-import { existsSync, statSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, statSync, readFileSync, writeFileSync, copyFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -116,6 +116,28 @@ for (const w of WORKERS) {
     outPublic && (w.outPublic || `public/${w.outName}`),
   ].filter(Boolean).join(' + ');
   console.log(`✓ ${w.name.padEnd(16)} ${sizeKb} KB  → ${dest}`);
+}
+
+// 原样复制到 public/ 的单文件脚本（不过 esbuild）。
+//
+// 为什么不打包：这些文件没有 import，是自包含单文件，而 Deno Playground 原生吃
+// TypeScript。过一遍 esbuild 只会剥掉类型、还可能顺手把注释吃了 —— 而这类脚本
+// 恰恰要用户读着注释改配置（比如 amsg 代理里的 UPSTREAM 那一行），注释没了就废了。
+const VERBATIM_COPIES = [
+  // amsg 的 Deno 门面：给 Cloudflare worker 换一个国内能直连的地址。
+  // 设置页「复制 Deno 代理代码」按钮 fetch 这份。
+  { from: 'worker/amsg/deno-proxy.ts', to: 'public/amsg-deno-proxy.ts' },
+];
+
+for (const { from, to } of VERBATIM_COPIES) {
+  const src = resolve(root, from);
+  if (!existsSync(src)) {
+    console.error(`ERROR: verbatim copy source not found: ${from}`);
+    process.exit(1);
+  }
+  copyFileSync(src, resolve(root, to));
+  const sizeKb = (statSync(src).size / 1024).toFixed(1);
+  console.log(`✓ ${from.split('/').pop().padEnd(16)} ${sizeKb} KB  → ${to} (原样复制)`);
 }
 
 // instant-worker.version.txt — Deno loader 冷启动时拉这个文件决定 bundle 版本号

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -911,6 +911,13 @@ export const ActiveMsgClient = {
     return copyWorkerBundleToClipboard('amsg-worker.bundle.js');
   },
 
+  // 复制 public/amsg-deno-proxy.ts —— 贴进 Deno Playground 当 worker 的门面用。
+  // 走的是同一套「fetch 站点静态文件 → 剪贴板」，只是这份不打包、原样发布，
+  // 因为用户要照着里面的注释改 UPSTREAM 那一行。
+  copyDenoProxyToClipboard(): Promise<void> {
+    return copyWorkerBundleToClipboard('amsg-deno-proxy.ts');
+  },
+
   async getPushStatus(): Promise<ActiveMsg2PushStatus> {
     const config = await ensureGlobalReady();
     const workerConfigured = Boolean(config.workerUrl.trim());

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -67,6 +67,7 @@ import {
   isDeadPushEndpoint,
   subscribeWithRetry,
   SUBSCRIBE_SETTLE_MS,
+  type SubscribeFailureKind,
 } from './pushSubscribeShared';
 
 export interface ActiveMsg2PushStatus {
@@ -196,6 +197,7 @@ export type AmsgFailKind =
   | '不支持推送'
   | 'worker没配VAPID'
   | '订阅失败'
+  | '推送通道不通'
   | '端点僵尸'
   | '其他';
 
@@ -818,16 +820,26 @@ const fetchWorkerVapidKey = async (client: ReiClient): Promise<string> => {
  * 都收不到，两边都没有任何报错。重试到底仍是僵尸的话挂 '端点僵尸' 代号，设置页据此
  * 把「重置订阅」升级成「深度重置」。
  */
+/** 共用层的失败分类 → 上报用的失败代号。两边都是源码里写死的枚举。 */
+const SUBSCRIBE_FAIL_KIND: Record<SubscribeFailureKind, AmsgFailKind> = {
+  'channel-unreachable': '推送通道不通',
+  unsupported: '不支持推送',
+  permission: '权限被拒',
+  state: '订阅失败',
+  zombie: '端点僵尸',
+  unknown: '订阅失败',
+};
+
 const subscribeOrThrow = async (
   registration: ServiceWorkerRegistration,
   vapidPublicKey: string,
 ): Promise<PushSubscription> => {
-  const { sub, reason } = await subscribeWithRetry(registration, vapidPublicKey, ACTIVE_MSG_RUNTIME_HEADER);
+  const { sub, failure } = await subscribeWithRetry(registration, vapidPublicKey, ACTIVE_MSG_RUNTIME_HEADER);
   if (sub) return sub;
-  // 提示原文（浏览器能力、重试了几次）留在 toast 和 console 里。谓词写死在源码里，
-  // 挂上去的永远是下面两个字面量之一。
-  const message = reason || '订阅创建失败';
-  throw withFailKind(new Error(message), isDeadPushEndpoint(message) ? '端点僵尸' : '订阅失败');
+  // 提示原文（浏览器能力、重试了几次）留在 toast 和 console 里。挂上去的代号来自
+  // 上面那张写死的表，不是从异常对象上读出来的任何东西。
+  const message = failure?.text || '订阅创建失败';
+  throw withFailKind(new Error(message), failure ? SUBSCRIBE_FAIL_KIND[failure.kind] : '订阅失败');
 };
 
 /** 重置的公共尾段：拿 worker 的 VAPID → 重新订阅 → 覆盖登记回 worker。 */

--- a/utils/agenticToolFeedback.test.ts
+++ b/utils/agenticToolFeedback.test.ts
@@ -206,7 +206,7 @@ describe('buildDuplicateToolMessage', () => {
   it('说清这次没真去查，结果在上面', () => {
     const msg = buildDuplicateToolMessage('recall');
     expect(msg).toContain('调取某个月的记忆');
-    expect(msg).toContain('没有再去查');
+    expect(msg).toContain('没有再执行');
   });
 
   // 同上：被打回之后让它「把要发的消息写出来」，模型很容易连前面说过的话带标记一起重写，

--- a/utils/agenticToolFeedback.ts
+++ b/utils/agenticToolFeedback.ts
@@ -62,6 +62,11 @@ const TOOL_LABELS: Record<string, string> = {
   // 漏在表外的话，回喂会拼出「你schedule_active_message，拿回了…」——内部工具名直接
   // 进了模型能看见的散文里。
   schedule_active_message: '给自己排下一条消息',
+  // 前台聊天里角色还能取消 / 改期 / 查清单（见 utils/amsg2ToolBridge.ts）。同样是漏在
+  // 表外就会把内部工具名拼进散文，所以三个一起登记。
+  cancel_active_message: '取消一条排好的消息',
+  renew_active_message: '把排好的消息改到别的时间',
+  list_active_messages: '查自己排了哪些消息',
 };
 
 /**
@@ -180,6 +185,8 @@ export const buildToolResultMessage = (opts: {
  */
 export const buildDuplicateToolMessage = (name: string): string => [
   `[系统: 你刚刚已经${describeTool(name)}过一次了，参数完全相同，结果就在上面。]`,
-  '[系统: 这一次没有再去查。别再重复同样的调用了——现在把要发的消息写出来，',
+  // 说「没有再执行」而不是「没有再去查」：这段话现在也管排程/取消/改期这类不是查询的
+  // 工具，说成「查」的话，角色收到的交代跟它刚做的事对不上。
+  '[系统: 这一次没有再执行。别再重复同样的调用了——现在把要发的消息写出来，',
   '或者换一个还没用过的工具。前面已经说出去的内容和标签不要重写，接着往下写就行。]',
 ].join('\n');

--- a/utils/amsg2ChatLoop.wiring.test.ts
+++ b/utils/amsg2ChatLoop.wiring.test.ts
@@ -1,0 +1,56 @@
+// 聊天工具循环里「角色看得到什么排程」的接线守卫。
+//
+// 仓库的 vitest 是纯 Node 环境（没装 jsdom），useChatAI 是个绑死 React 的大 hook，
+// 跑不起来测行为，所以沿用 activeMsgClient.wiring.test.ts 的做法做**源码级**断言。
+// 它验证不了运行时时序，只防「接线被误删/改回去」这一种回归。
+//
+// 钉的是同一件事的两半：
+//   1. 工具循环的第二轮起，请求体不能从「加排程块之前」的那份消息重新起步；
+//   2. 排程块要每轮现算贴末尾，而不是把首轮那份旧快照一路带下去。
+// 两半都塌的时候，角色刚排完任务、下一轮看到的清单却是空的，于是把同一条再排一遍
+// ——现场表现就是一句「等会找我」排出 5 条一模一样的任务。
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const src = readFileSync(
+  fileURLToPath(new URL('../hooks/useChatAI.ts', import.meta.url)),
+  'utf8',
+);
+
+describe('排程现状块每轮现算', () => {
+  it('有一个统一的贴块入口，而不是散在各处手拼', () => {
+    expect(src).toContain('const withAmsg2TaskContext =');
+  });
+
+  it('首轮请求也走这个入口（不再把块写死进 baseReqBody.messages）', () => {
+    // 写死进 baseReqBody.messages 的话，工具循环里那份就永远是排程前的旧清单。
+    expect(src).not.toMatch(/baseReqBody\.messages\s*=\s*\[\s*\n?\s*\.\.\.baseReqBody\.messages,\s*\n?\s*\{\s*role:\s*'system',\s*content:\s*taskContext\.text/);
+    expect(src).toMatch(/messages:\s*withAmsg2TaskContext\(baseReqBody\.messages\)/);
+  });
+
+  it('工具循环的后续请求也现算一次（本轮刚排的任务立刻进清单）', () => {
+    expect(src).toMatch(/messages:\s*withAmsg2TaskContext\(loopMessages\)/);
+  });
+
+  it('本轮新建的任务会被点名，传进渲染函数', () => {
+    expect(src).toContain('amsg2CreatedThisTurn');
+    expect(src).toMatch(/buildAmsg2TaskContextText\([\s\S]{0,200}amsg2CreatedThisTurn/);
+  });
+});
+
+describe('工具循环的消息起点', () => {
+  // 三个循环（麦当劳 / 瑞幸 / 通用）都可能执行主动消息 2.0 的排程工具——代码注释里
+  // 明写了「排程工具与点单工具会在同一批 tool_calls 里出现」，所以三处得一致。
+  it('三处 loopMessages 都从 baseReqBody.messages 起步', () => {
+    const starts = src.match(/let loopMessages = \[\.\.\.[A-Za-z.]+\]/g) ?? [];
+    expect(starts.length).toBe(3);
+    for (const line of starts) {
+      expect(line).toContain('baseReqBody.messages');
+    }
+  });
+
+  it('MCP 正文兜底那条也一样', () => {
+    expect(src).toMatch(/textLoopMessages = \[\.\.\.baseReqBody\.messages\]/);
+  });
+});

--- a/utils/amsg2TaskContext.test.ts
+++ b/utils/amsg2TaskContext.test.ts
@@ -86,6 +86,40 @@ describe('buildAmsg2TaskContextText', () => {
     expect(text).toContain('已作废（到点时对话正在进行');
     expect(text).toContain('已被手动取消');
   });
+
+  // 回归守卫：工具循环的第二轮起，这份清单是现算的，里面会有角色本轮刚排好的任务。
+  // 不点名的话，角色分不清「这条是我刚排的」还是「这条本来就有」，回头又排一条一样的
+  // ——现场那次「一句『等会找我』排出 5 条」就是这么来的。
+  const otherTask: ActiveMsg2TaskRecord = {
+    ...pendingTask, taskUuid: 'eeff0011-0000-0000-0000-000000000000', clientTaskId: 'cid-eeff',
+    promptHint: '提醒喝水',
+  };
+
+  it('本轮刚排的那条点名标出来，别的任务不受影响', () => {
+    const text = buildAmsg2TaskContextText(
+      [pendingTask, otherTask], [], Date.now(), undefined,
+      new Set([otherTask.taskUuid]),
+    )!;
+    const lines = text.split('\n');
+    expect(lines.find((l) => l.includes('[aabbccdd]'))).not.toContain('本轮');
+    expect(lines.find((l) => l.includes('[eeff0011]'))).toContain('本轮刚排的');
+  });
+
+  it('有本轮新排的 → 末尾多一句别再排一样的', () => {
+    const text = buildAmsg2TaskContextText(
+      [pendingTask], [], Date.now(), undefined, new Set([pendingTask.taskUuid]),
+    )!;
+    expect(text).toContain('别再排一条一样的');
+  });
+
+  it('没传本轮清单 → 一个字都不多（首轮那份不该凭空长出提醒）', () => {
+    const plain = buildAmsg2TaskContextText([pendingTask], [], 1_800_000_000_000, undefined)!;
+    const empty = buildAmsg2TaskContextText(
+      [pendingTask], [], 1_800_000_000_000, undefined, new Set(),
+    )!;
+    expect(plain).not.toContain('本轮');
+    expect(empty).toBe(plain);
+  });
 });
 
 describe('buildUserCancelledNotices', () => {

--- a/utils/amsg2TaskContext.ts
+++ b/utils/amsg2TaskContext.ts
@@ -103,8 +103,18 @@ export function buildAmsg2TaskContextText(
    * 位置参数不设默认值：这一段是给角色看的，调用方必须显式想过时间该按谁的钟写。
    */
   charTz: string | undefined,
+  /**
+   * 本轮工具循环里刚排出来的任务 uuid。
+   *
+   * 工具循环第二轮起这份清单是现算的，里面混着「本来就有的」和「角色刚排的」。不点名
+   * 的话角色分不清，容易当成别人排的、再排一条一样的——现场那次「一句『等会找我』排出
+   * 5 条」就有这一份。空集合等于没传：首轮那份是排程前的快照，不该凭空长出提醒。
+   */
+  createdThisTurn?: ReadonlySet<string>,
 ): string | null {
   if (!pending.length && !expired.length) return null;
+  const isNewThisTurn = (taskUuid: string) => !!createdThisTurn?.has(taskUuid);
+  const hasNewThisTurn = pending.some((t) => isNewThisTurn(t.taskUuid));
   const parts: string[] = ['【你的主动消息排程·仅你可见】'];
   // 闸自动作废 / 用户手动取消，两种回执给角色的交代完全不同（前者可以续期补上，
   // 后者是用户不要了），分成两段说。没有 kind 的老记录按自动作废处理。
@@ -118,9 +128,12 @@ export function buildAmsg2TaskContextText(
       // 是个好几天前的时刻，它会当成已经过去的排程，然后在对话里说漏嘴或重复排一条。
       const occurrenceMs = currentOccurrenceMs(t, nowMs);
       parts.push(`- [${shortTaskId(t.taskUuid)}] ${formatTaskTime(occurrenceMs ?? t.firstSendTime, charTz)} ${describeRecurrence(t.recurrenceType)}`
-        + ` · ${describeTaskMode(t)} · ${describeExpirePolicy(t.expirePolicy)}`);
+        + ` · ${describeTaskMode(t)} · ${describeExpirePolicy(t.expirePolicy)}`
+        + (isNewThisTurn(t.taskUuid) ? ' · 本轮刚排的' : ''));
     }
-    parts.push('（想调整就用 schedule/cancel/renew 工具；内容方向变了用 cancel + schedule 重建。）');
+    parts.push('（想调整就用 schedule/cancel/renew 工具；内容方向变了用 cancel + schedule 重建。'
+      + (hasNewThisTurn ? '标着「本轮刚排的」是你这次回复里已经排好的，别再排一条一样的。' : '')
+      + '）');
   }
 
   if (autoExpired.length) {
@@ -155,6 +168,14 @@ export interface Amsg2TaskContextResult {
   text: string | null;
   /** 本轮注入的回执 id（闸作废的 + 用户手动取消的），发送成功后 markExpiredNoticesNotified。 */
   expiredIds: string[];
+  /**
+   * 本轮要告知的回执原始记录。
+   *
+   * 工具循环里每发一次请求都要按最新任务清单重渲染这一块，但回执这半边是「检出 + 落台账」
+   * 的结果、带副作用，一轮只该算一次。把记录交出去，后续轮次直接拿它配上新的 pending 调
+   * buildAmsg2TaskContextText 就行，不用再碰 DB 和台账。
+   */
+  notices: Amsg2ExpiredNoticeRecord[];
 }
 
 export async function collectAmsg2TaskContext(char: CharacterProfile): Promise<Amsg2TaskContextResult> {
@@ -194,5 +215,6 @@ export async function collectAmsg2TaskContext(char: CharacterProfile): Promise<A
     // 两边对不上的话，纽约角色会在同一轮里读到差一个时差的两个「同一条任务」。
     text: buildAmsg2TaskContextText(pending, unnotified, now, resolveCharTimeZone(char)),
     expiredIds: unnotified.map((r) => r.id),
+    notices: unnotified,
   };
 }

--- a/utils/amsg2ToolBridge.test.ts
+++ b/utils/amsg2ToolBridge.test.ts
@@ -44,7 +44,9 @@ const makeSession = (charOver: Record<string, unknown> = {}) => {
   return { deps, char, persisted };
 };
 
-const future = () => new Date(Date.now() + 3600_000).toISOString();
+// 默认往后一小时；要在同一轮里排两条**不同**的任务就错开小时数——同名同参的调用
+// 现在会被指纹拦下（见文件末尾那组用例），两条都写同一个时刻测不出「累加」。
+const future = (hours = 1) => new Date(Date.now() + hours * 3600_000).toISOString();
 const lastTasks = (persisted: any[]) => persisted[persisted.length - 1]?.tasks ?? [];
 
 describe('amsg2ToolBridge 同一轮多次调用累加', () => {
@@ -65,8 +67,8 @@ describe('amsg2ToolBridge 同一轮多次调用累加', () => {
 
   it('一轮内两次 schedule → 本地保留两条（回归：陈旧快照覆盖）', async () => {
     const { deps, persisted } = makeSession();
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(2) }, deps);
 
     const tasks = lastTasks(persisted);
     expect(tasks).toHaveLength(2);
@@ -75,8 +77,8 @@ describe('amsg2ToolBridge 同一轮多次调用累加', () => {
 
   it('一轮内 schedule×2 后按短 id 取消其一 → 剩下的是另一条', async () => {
     const { deps, persisted } = makeSession();
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(2) }, deps);
     await executeAmsg2Tool('cancel_active_message', { task_id: shortOf(UUIDS[1]) }, deps);
 
     const tasks = lastTasks(persisted);
@@ -163,8 +165,8 @@ describe('amsg2ToolBridge 同一轮多次调用累加', () => {
 
   it('累加不靠就地改 char：React state 里的角色对象不被写脏', async () => {
     const { deps, char } = makeSession();
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
-    await executeAmsg2Tool('schedule_active_message', { send_at: future() }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(2) }, deps);
 
     // 落盘走 updateCharacter，char 快照本身保持原样（它是 React state 里的对象）。
     expect(char.activeMsg2Config.tasks).toEqual([]);
@@ -252,5 +254,101 @@ describe('角色排程的时间统一存绝对时刻', () => {
     expect(reply).toContain('09:00');
     // 折两次（先按设备解析原串、再换算到纽约）会落在别的钟点上
     expect(reply).not.toContain('21:00');
+  });
+});
+
+// ─── 打转防护 ───
+// 现场：用户说一句「等会找我」，角色一口气排出 5 条一模一样的任务（同时间、同提示词）。
+// 5 不是巧合——它是每个角色的待触发上限，也就是模型一路重复调用直到撞上限才停。前台的
+// 工具循环最多转 6 轮，每一轮执行一次 schedule 就是远端实打实 5 条任务。
+//
+// 两层防护，跟 worker 的 fire 循环同一套（见 utils/agenticToolFeedback.ts）：
+//   软的 —— 回话末尾明说「这一步做完了，别再调同一个」；
+//   硬的 —— 同名同参第二次直接打回，一次网络请求都不发。
+describe('同名同参的调用不重复执行', () => {
+  beforeEach(() => {
+    let n = 0;
+    (ActiveMsgClient.scheduleCharacterTask as any).mockReset();
+    (ActiveMsgClient.scheduleCharacterTask as any).mockImplementation(async () => ({
+      uuid: UUIDS[n++], clientTaskId: 'cid', anchorMs: 0, replacedCancelFailed: false,
+      firstSendAt: RESOLVED_ISO,
+    }));
+    (ActiveMsgClient.cancelTask as any).mockReset();
+    (ActiveMsgClient.cancelTask as any).mockResolvedValue({});
+  });
+
+  it('第二次完全相同的 schedule → 不建任务、不发请求，只回一句打回', async () => {
+    const { deps, persisted } = makeSession();
+    const args = { send_at: future(1), mode: 'prompted', prompt_hint: '等会来找你' };
+    await executeAmsg2Tool('schedule_active_message', args, deps);
+    const second = await executeAmsg2Tool('schedule_active_message', { ...args }, deps);
+
+    expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(1);
+    expect(lastTasks(persisted)).toHaveLength(1);
+    expect(second).not.toContain('已创建');
+    expect(second).toContain('不要');
+  });
+
+  it('参数写法变了但内容一样（键序不同）照样算同一次', async () => {
+    const { deps } = makeSession();
+    const send_at = future(1);
+    await executeAmsg2Tool('schedule_active_message', { send_at, mode: 'auto' }, deps);
+    await executeAmsg2Tool('schedule_active_message', { mode: 'auto', send_at }, deps);
+
+    expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('换个时间就照常放行（只拦完全一样的，多轮能力不减）', async () => {
+    const { deps, persisted } = makeSession();
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(3) }, deps);
+
+    expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(2);
+    expect(lastTasks(persisted)).toHaveLength(2);
+  });
+
+  it('renew 同参第二次也拦（它内部走的还是建新任务那条路）', async () => {
+    const { deps, persisted } = makeSession();
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    const renewArgs = { send_at: future(2), task_id: shortOf(UUIDS[0]) };
+    await executeAmsg2Tool('renew_active_message', renewArgs, deps);
+    const second = await executeAmsg2Tool('renew_active_message', { ...renewArgs }, deps);
+
+    // 首次 schedule + 首次 renew = 2 次；第二次 renew 不该再打一发
+    expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(2);
+    expect(lastTasks(persisted)).toHaveLength(1);
+    expect(second).toContain('不要');
+  });
+
+  it('list 不拦：同一轮里排完再查，清单本来就该变', async () => {
+    const { deps } = makeSession();
+    const empty = await executeAmsg2Tool('list_active_messages', {}, deps);
+    await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    const afterSchedule = await executeAmsg2Tool('list_active_messages', {}, deps);
+
+    expect(empty).toContain('没有任何定时主动消息任务');
+    expect(afterSchedule).toContain(shortOf(UUIDS[0]));
+  });
+
+  it('排程成功的回话末尾带收尾引导（软的那层）', async () => {
+    const { deps } = makeSession();
+    const reply = await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+
+    // 事实照说
+    expect(reply).toContain('已创建');
+    // 再明说这一步结束了，别接着调同一个
+    expect(reply).toContain('同样的调用不要再来一遍');
+  });
+
+  it('远端失败的那次不记账：改不了参数的重试仍放行一次', async () => {
+    const { deps } = makeSession();
+    (ActiveMsgClient.scheduleCharacterTask as any).mockRejectedValueOnce(new Error('worker 503'));
+    const args = { send_at: future(1) };
+    const failed = await executeAmsg2Tool('schedule_active_message', args, deps);
+    const retried = await executeAmsg2Tool('schedule_active_message', { ...args }, deps);
+
+    expect(failed).toContain('失败');
+    expect(retried).toContain('已创建');
+    expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(2);
   });
 });

--- a/utils/amsg2ToolBridge.ts
+++ b/utils/amsg2ToolBridge.ts
@@ -4,6 +4,10 @@
  *
  * 工具定义注入 useChatAI 的 tools 数组；执行器在工具循环里分发。
  * 多任务：一个角色可同时挂多个任务，用短 id（taskUuid 前 8 位）定位。
+ *
+ * 防打转是这份文件的一部分职责：工具循环最多转 6 轮，模型一旦每轮都重复同一个 schedule，
+ * 每一轮都会在远端实打实建一条任务。所以执行器自带软硬两层——回话末尾明说这一步做完了，
+ * 同名同参的第二次直接打回。口径与 worker 的 fire 循环共用，见 utils/agenticToolFeedback.ts。
  */
 
 import {
@@ -17,6 +21,7 @@ import {
 } from '../types';
 import { ActiveMsgClient } from './activeMsgClient';
 import { ActiveMsgStore } from './activeMsgStore';
+import { buildDuplicateToolMessage, toolCallFingerprint, type ToolCallRecord } from './agenticToolFeedback';
 import { trackEvent } from './analytics';
 import {
   applyScheduledTask, currentOccurrenceMs, describeExpirePolicy, describeRecurrence,
@@ -137,6 +142,8 @@ export interface Amsg2ToolDeps {
   getConfig: () => ActiveMsg2CharacterConfig | undefined;
   /** 写回任务清单：刷新 getConfig 的来源，同时落 React state / DB。 */
   setConfig: (config: ActiveMsg2CharacterConfig) => void;
+  /** 本轮已经真跑过的调用（同名同参）。executeAmsg2Tool 自己维护，调用方只管传下去。 */
+  seenCalls: ToolCallRecord[];
 }
 
 /**
@@ -163,6 +170,7 @@ export const createAmsg2ToolSession = (base: {
     groups: base.groups,
     realtimeConfig: base.realtimeConfig,
     apiConfig: base.apiConfig,
+    seenCalls: [],
     getConfig: () => liveConfig,
     setConfig: (config) => {
       liveConfig = config;
@@ -171,24 +179,64 @@ export const createAmsg2ToolSession = (base: {
   };
 };
 
+/**
+ * 会改动任务清单的那几个工具：跑一次就是远端多一条 / 少一条任务，所以要防打转。
+ *
+ * list 不在里面——同一轮里排完再查，清单本来就该变，拦掉的话角色拿到的是「结果就在
+ * 上面」但上面那份已经过时了。
+ */
+const MUTATING_TOOLS = new Set([
+  'schedule_active_message',
+  'cancel_active_message',
+  'renew_active_message',
+]);
+
+/**
+ * 每次工具跑完都补的收尾话（软的那层，硬的那层是下面的指纹拦截）。
+ *
+ * 只回一句「已创建 [xxx]」的话，模型看不出这一步已经结束了：工具循环最多转 6 轮，
+ * 常驻提示词里但凡有一句「需要时直接调工具」，它每轮都会照做，一路把同一条任务排到
+ * 撞上限为止（现场：一句「等会找我」排出 5 条一模一样的）。措辞跟 worker 的 fire
+ * 循环共用一套口径，见 utils/agenticToolFeedback.ts。
+ */
+const TOOL_FOLLOW_UP = [
+  '[系统: 这一次调用已经处理完了，结果就在上面。同样的调用不要再来一遍——',
+  '现在把要对用户说的话写出来，或者用一个还没用过的工具。',
+  '前面已经说出去的内容不要重写，接着往下写就行。]',
+].join('\n');
+
 export const executeAmsg2Tool = async (
   toolName: string,
   args: Record<string, any>,
   deps: Amsg2ToolDeps,
 ): Promise<string> => {
+  const mutating = MUTATING_TOOLS.has(toolName);
+  // 同名同参第二次直接打回，一次网络请求都不发。上面那段软提示挡不住时靠它兜底，
+  // 与 worker 的 fire 循环同一道闸。只拦**完全一样**的调用——换时间、换方向照常放行，
+  // 多轮能力一点不减。
+  const fingerprint = mutating ? toolCallFingerprint(toolName, args) : '';
+  if (mutating && deps.seenCalls.some((r) => r.fingerprint === fingerprint)) {
+    return buildDuplicateToolMessage(toolName);
+  }
   try {
-    switch (toolName) {
-      case 'schedule_active_message':
-        return await handleSchedule(args, deps);
-      case 'cancel_active_message':
-        return await handleCancel(args, deps);
-      case 'renew_active_message':
-        return await handleRenew(args, deps);
-      case 'list_active_messages':
-        return await handleList(deps);
-      default:
-        return `未知工具 ${toolName}。`;
-    }
+    const result = await (() => {
+      switch (toolName) {
+        case 'schedule_active_message':
+          return handleSchedule(args, deps);
+        case 'cancel_active_message':
+          return handleCancel(args, deps);
+        case 'renew_active_message':
+          return handleRenew(args, deps);
+        case 'list_active_messages':
+          return handleList(deps);
+        default:
+          return Promise.resolve(`未知工具 ${toolName}。`);
+      }
+    })();
+    // 记账放在跑完之后：抛错的那次等于没跑成（远端没建出东西），把它记下来的话，
+    // 角色连一次原样重试的机会都没有。
+    if (mutating) deps.seenCalls.push({ name: toolName, fingerprint });
+    return mutating ? `${result}\n${TOOL_FOLLOW_UP}` : result;
   } catch (e: any) {
     return `操作失败：${e?.message || String(e)}`;
   }

--- a/utils/instantPushClient.ts
+++ b/utils/instantPushClient.ts
@@ -609,7 +609,7 @@ export async function getOrCreateInstantSubscription(
       return { sub: null, reason: '通知权限已被拒绝（请到浏览器站点设置里手动开启）' };
     }
     const fresh = await subscribeWithRetry(reg, pub, '[InstantPush]');
-    if (!fresh.sub) return { sub: null, reason: fresh.reason };
+    if (!fresh.sub) return { sub: null, reason: fresh.failure?.text };
     sub = fresh.sub;
   }
 

--- a/utils/proactivePushConfig.ts
+++ b/utils/proactivePushConfig.ts
@@ -160,7 +160,7 @@ export async function getOrCreateSubscription(vapidPublicKey: string): Promise<S
       return { sub: null, reason: '通知权限已被拒绝（请到浏览器站点设置里手动开启）' };
     }
     const fresh = await subscribeWithRetry(reg, vapidPublicKey, '[ProactivePush]');
-    if (!fresh.sub) return { sub: null, reason: fresh.reason };
+    if (!fresh.sub) return { sub: null, reason: fresh.failure?.text };
     sub = fresh.sub;
   }
 

--- a/utils/pushDiagnosticsView.test.ts
+++ b/utils/pushDiagnosticsView.test.ts
@@ -1,0 +1,112 @@
+// 设置页「链路状态」面板文案的回归守卫。
+//
+// 要钉住的核心行为：**能力检测说「支持」不等于这台设备真能推**。华为 Mate 60 这类不带
+// 谷歌服务的国行安卓机上，Chromium 把 PushManager 编译进去了，所以接口检测全绿，但
+// subscribe() 必挂。以前面板对着这种机器写「浏览器支持：是」，用户完全无从下手。
+
+import { describe, expect, it } from 'vitest';
+import {
+  describeElapsed,
+  describeSupport,
+  hasLiveFailure,
+  isSupportBad,
+  liveFailureKind,
+} from './pushDiagnosticsView';
+import type { BrowserPushState } from './pushSubscribeShared';
+
+const baseState = (patch: Partial<BrowserPushState> = {}): BrowserPushState => ({
+  supported: true,
+  capabilityGap: null,
+  permission: 'granted',
+  swScope: 'https://example.test/',
+  swState: 'activated',
+  endpoint: null,
+  endpointDead: false,
+  channel: '未知',
+  iosNeedsPwa: false,
+  capacitorNative: false,
+  lastSubscribeFailure: null,
+  ...patch,
+});
+
+describe('「浏览器支持」这一行', () => {
+  it('接口齐全但连不上推送服务器时，不再简单说「是」', () => {
+    // 正是 Mate 60 的读数：接口全在、权限已授权、SW 已激活、订阅建不出来。
+    const state = baseState({
+      lastSubscribeFailure: { kind: 'channel-unreachable', text: '连不上推送服务器……', at: Date.now() },
+    });
+
+    expect(describeSupport(state)).toBe('接口齐全，但连不上推送服务器');
+    expect(isSupportBad(state)).toBe(true);
+  });
+
+  it('浏览器自称支持但实际建不出订阅时判「否」', () => {
+    const state = baseState({
+      lastSubscribeFailure: { kind: 'unsupported', text: '当前浏览器不支持网页推送……', at: Date.now() },
+    });
+
+    expect(describeSupport(state)).toBe('否（浏览器自称支持，实际建不出订阅）');
+    expect(isSupportBad(state)).toBe(true);
+  });
+
+  it('权限被拒、状态冲突这类不赖设备，「浏览器支持」照旧是「是」', () => {
+    // 这两类换设备没用、重试有用，标红只会把用户往错的方向引。
+    for (const kind of ['permission', 'state', 'zombie', 'unknown'] as const) {
+      const state = baseState({ lastSubscribeFailure: { kind, text: '...', at: Date.now() } });
+      expect(describeSupport(state)).toBe('是');
+      expect(isSupportBad(state)).toBe(false);
+    }
+  });
+
+  it('接口本身就缺、或跑在 App 里的老判定不变', () => {
+    expect(describeSupport(baseState({ supported: false }))).toBe('否（浏览器缺少推送相关接口）');
+    expect(describeSupport(baseState({ capacitorNative: true }))).toBe('否（现在跑在 App 里）');
+    expect(isSupportBad(baseState({ supported: false }))).toBe(true);
+    expect(isSupportBad(baseState({ capacitorNative: true }))).toBe(true);
+  });
+
+  it('什么都没失败过时是「是」，不标红', () => {
+    expect(describeSupport(baseState())).toBe('是');
+    expect(isSupportBad(baseState())).toBe(false);
+  });
+});
+
+describe('失败记录的时效', () => {
+  it('已经有活订阅了就当没失败过', () => {
+    // 换了浏览器 / SW 自愈重订之后，旧记录还在盘上但显然过期了，再显示就是误导。
+    const state = baseState({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/ok',
+      lastSubscribeFailure: { kind: 'channel-unreachable', text: '陈年旧账', at: 1 },
+    });
+
+    expect(hasLiveFailure(state)).toBe(false);
+    expect(liveFailureKind(state)).toBeNull();
+    expect(describeSupport(state)).toBe('是');
+  });
+
+  it('端点是僵尸哨兵时失败记录仍然算数', () => {
+    const state = baseState({
+      endpoint: 'https://permanently-removed.invalid/x',
+      endpointDead: true,
+      lastSubscribeFailure: { kind: 'channel-unreachable', text: '...', at: Date.now() },
+    });
+
+    expect(hasLiveFailure(state)).toBe(true);
+    expect(liveFailureKind(state)).toBe('channel-unreachable');
+  });
+});
+
+describe('describeElapsed', () => {
+  const now = 1_700_000_000_000;
+
+  it('按分钟 / 小时 / 天说人话', () => {
+    expect(describeElapsed(now - 10_000, now)).toBe('刚刚');
+    expect(describeElapsed(now - 5 * 60_000, now)).toBe('5 分钟前');
+    expect(describeElapsed(now - 3 * 3600_000, now)).toBe('3 小时前');
+    expect(describeElapsed(now - 2 * 86_400_000, now)).toBe('2 天前');
+  });
+
+  it('没有时间戳就不说', () => {
+    expect(describeElapsed(0, now)).toBe('');
+  });
+});

--- a/utils/pushDiagnosticsView.ts
+++ b/utils/pushDiagnosticsView.ts
@@ -1,0 +1,76 @@
+/**
+ * 设置页「推送订阅状态」面板的文案层：把 BrowserPushState 这份读数翻译成用户能看懂
+ * 的一行行字。纯函数、不碰 DOM，好让判定逻辑能被单测钉住——面板本身是 .tsx，跑不进
+ * 这个仓库的 node 测试环境。
+ */
+
+import type { BrowserPushState, SubscribeFailureKind } from './pushSubscribeShared';
+
+/** 这几类失败换多少次重试都是同一个结果，问题在设备/浏览器本身。 */
+const DEVICE_LEVEL_FAILURES: SubscribeFailureKind[] = ['channel-unreachable', 'unsupported'];
+
+/**
+ * 失败记录还算不算数：手上已经有一条活订阅，说明后来建成了，旧记录留着只会误导。
+ * subscribeWithRetry 成功时本来就会清盘，这里是防守——万一订阅是别的路径建起来的
+ * （换了浏览器、SW 自愈重订），记录不会被清，但它显然已经过期了。
+ */
+export const hasLiveFailure = (state: BrowserPushState): boolean =>
+  Boolean(state.lastSubscribeFailure) && (!state.endpoint || state.endpointDead);
+
+/** 当前生效的失败分类，没有（或已过期）是 null。 */
+export const liveFailureKind = (state: BrowserPushState): SubscribeFailureKind | null =>
+  hasLiveFailure(state) ? state.lastSubscribeFailure!.kind : null;
+
+export const describePermission = (permission: BrowserPushState['permission']): string => {
+  if (permission === 'granted') return '已授权';
+  if (permission === 'denied') return '已拒绝（要去浏览器的站点设置里手动打开）';
+  if (permission === 'default') return '还没决定';
+  return '不可用';
+};
+
+export const describeServiceWorker = (state: BrowserPushState): string => {
+  if (state.swState === 'none') return '未注册';
+  const scope = state.swScope || '?';
+  return state.swState === 'activated' ? `已激活（scope: ${scope}）` : `${state.swState}（scope: ${scope}）`;
+};
+
+export const describeSubscription = (state: BrowserPushState): string => {
+  if (!state.endpoint) return '不存在';
+  return state.endpointDead ? '已被浏览器吊销' : '已建立';
+};
+
+/**
+ * 「浏览器支持」这一行。
+ *
+ * 这行以前只答「接口齐不齐」，于是没装谷歌服务的国行安卓机上会显示「是」——接口确实
+ * 齐（Chromium 把 PushManager 编译进去了），但底下根本没有推送通道，用户看到的就是
+ * 「支持=是、权限=已授权、SW=已激活，订阅就是建不出来」，完全无从下手。能力检测查不
+ * 出这种情况（查的是 JS 接口在不在），实际试过一次才知道，所以这里把订阅失败的结论
+ * 也算进来。
+ */
+export const describeSupport = (state: BrowserPushState): string => {
+  if (state.capacitorNative) return '否（现在跑在 App 里）';
+  if (!state.supported) return '否（浏览器缺少推送相关接口）';
+  const failure = liveFailureKind(state);
+  if (failure === 'channel-unreachable') return '接口齐全，但连不上推送服务器';
+  if (failure === 'unsupported') return '否（浏览器自称支持，实际建不出订阅）';
+  return '是';
+};
+
+/** 「浏览器支持」这行要不要标红。 */
+export const isSupportBad = (state: BrowserPushState): boolean => {
+  if (!state.supported || state.capacitorNative) return true;
+  const failure = liveFailureKind(state);
+  return failure !== null && DEVICE_LEVEL_FAILURES.includes(failure);
+};
+
+/** 「3 分钟前」这种。刚发生的失败和上周留下的记录，排查价值差很远。 */
+export const describeElapsed = (at: number, now: number = Date.now()): string => {
+  if (!at) return '';
+  const minutes = Math.floor((now - at) / 60000);
+  if (minutes < 1) return '刚刚';
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  return `${Math.floor(hours / 24)} 天前`;
+};

--- a/utils/pushSubscribeShared.test.ts
+++ b/utils/pushSubscribeShared.test.ts
@@ -1,0 +1,116 @@
+// 「订阅建不出来时，用户能不能看懂为什么」这条链路的回归守卫。
+//
+// 背景：华为 Mate 60（国行安卓机，出厂不带谷歌服务）上的实测——面板显示浏览器支持=是、
+// 权限=已授权、SW=已激活，浏览器订阅就是「不存在」，点多少次重置都没变化。根因是
+// Chromium 系的网页推送要转交系统里的谷歌服务（GMS）去注册，没 GMS 就必挂；而失败原文
+// 只走 toast，一闪而过，用户回头什么都看不到。
+//
+// 这里钉住三件事：失败要分得出「换设备才有救」这一类、失败要落盘、修好之后记录要清掉。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearSubscribeFailure,
+  explainSubscribeError,
+  readSubscribeFailure,
+  rememberSubscribeFailure,
+  subscribeWithRetry,
+  SUBSCRIBE_ATTEMPTS_MAX,
+} from './pushSubscribeShared';
+
+/** 合法的 base64url，只为让 b64uToBytes 别在 atob 上炸。 */
+const FAKE_VAPID = 'AAAA';
+
+const makeRegistration = (subscribe: () => Promise<unknown>) =>
+  ({ pushManager: { subscribe } }) as unknown as ServiceWorkerRegistration;
+
+const makeSubscription = (endpoint: string) => ({
+  endpoint,
+  unsubscribe: async () => true,
+});
+
+const namedError = (name: string, message = '') => {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+};
+
+beforeEach(() => {
+  clearSubscribeFailure();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+describe('explainSubscribeError 的失败分类', () => {
+  it('把「连不上推送服务器」单独归成 channel-unreachable', () => {
+    // 没装谷歌服务的安卓机上，Chromium 就是这么抛的。这一类跟「订阅失败」必须分开：
+    // 前者重试无用、只能换浏览器/换设备，后者才值得让用户再点一次。
+    expect(explainSubscribeError(namedError('AbortError')).kind).toBe('channel-unreachable');
+    expect(
+      explainSubscribeError(namedError('Error', 'Registration failed - push service error')).kind,
+    ).toBe('channel-unreachable');
+  });
+
+  it('给出的建议里带上「换 Firefox」这条同机可走的路', () => {
+    // 只说「换台设备 / 用电脑」的话，手上只有这一台手机的用户就走到头了。
+    // Firefox 的推送走 Mozilla 自己的服务器，不经过谷歌，是同一台机器上唯一的希望。
+    expect(explainSubscribeError(namedError('AbortError')).text).toContain('Firefox');
+  });
+
+  it('权限、内核不支持、状态冲突各归各的', () => {
+    expect(explainSubscribeError(namedError('NotAllowedError')).kind).toBe('permission');
+    expect(explainSubscribeError(namedError('NotSupportedError')).kind).toBe('unsupported');
+    expect(explainSubscribeError(namedError('InvalidStateError')).kind).toBe('state');
+    expect(explainSubscribeError(namedError('WeirdError', '没见过')).kind).toBe('unknown');
+  });
+});
+
+describe('subscribeWithRetry 的失败落盘', () => {
+  it('subscribe 抛错时把原因记下来，面板才有得显示', async () => {
+    const registration = makeRegistration(async () => { throw namedError('AbortError'); });
+
+    const result = await subscribeWithRetry(registration, FAKE_VAPID, '[test]');
+
+    expect(result.sub).toBeNull();
+    expect(result.failure?.kind).toBe('channel-unreachable');
+    // 关键：落了盘。以前只有 toast，用户点完重置一眨眼就没了，回头再看面板还是干巴巴
+    // 一行「不存在」。
+    const stored = readSubscribeFailure();
+    expect(stored?.kind).toBe('channel-unreachable');
+    expect(stored?.text).toBe(result.failure?.text);
+    expect(stored?.at).toBeGreaterThan(0);
+  });
+
+  it('订阅建成时把上一次的失败记录清掉', async () => {
+    rememberSubscribeFailure({ kind: 'channel-unreachable', text: '陈年旧账', at: 1 });
+    const registration = makeRegistration(async () => makeSubscription('https://fcm.googleapis.com/fcm/send/ok'));
+
+    const result = await subscribeWithRetry(registration, FAKE_VAPID, '[test]');
+
+    expect(result.sub).not.toBeNull();
+    // 不清的话，用户换了浏览器修好了，面板还挂着一条早就过期的红色失败，比不显示更糟。
+    expect(readSubscribeFailure()).toBeNull();
+  });
+
+  it('重试到底还是僵尸端点时归成 zombie 并落盘', async () => {
+    vi.useFakeTimers();
+    const subscribe = vi.fn(async () => makeSubscription('https://permanently-removed.invalid/x'));
+    const pending = subscribeWithRetry(makeRegistration(subscribe), FAKE_VAPID, '[test]');
+    await vi.runAllTimersAsync();
+    const result = await pending;
+    vi.useRealTimers();
+
+    expect(subscribe).toHaveBeenCalledTimes(SUBSCRIBE_ATTEMPTS_MAX);
+    expect(result.sub).toBeNull();
+    expect(result.failure?.kind).toBe('zombie');
+    expect(readSubscribeFailure()?.kind).toBe('zombie');
+  });
+});
+
+describe('readSubscribeFailure 的容错', () => {
+  it('存的东西坏了就当没有，不抛', () => {
+    localStorage.setItem('push_last_subscribe_failure_v1', '{不是 JSON');
+    expect(readSubscribeFailure()).toBeNull();
+
+    localStorage.setItem('push_last_subscribe_failure_v1', JSON.stringify({ kind: 'x' }));
+    expect(readSubscribeFailure()).toBeNull();
+  });
+});

--- a/utils/pushSubscribeShared.ts
+++ b/utils/pushSubscribeShared.ts
@@ -76,6 +76,72 @@ export function describePushCapabilityGap(): string | null {
 }
 
 /**
+ * 订阅建不出来时，是卡在哪一类。面板据此决定「浏览器支持」那行怎么写，
+ * 各推送层据此挂自己的失败代号。
+ *
+ * 'channel-unreachable' 是最难自己看出来的一类：浏览器接口全在、权限也给了，
+ * 但底下那条通往推送服务商的路不通。Chromium 系（Chrome / Edge）安卓版的网页
+ * 推送是转交系统里的谷歌服务（GMS）去注册的，国行安卓机默认不装 GMS，于是
+ * 能力检测全绿、subscribe() 必挂。
+ */
+export type SubscribeFailureKind =
+  | 'channel-unreachable'
+  | 'unsupported'
+  | 'permission'
+  | 'state'
+  | 'zombie'
+  | 'unknown';
+
+export interface SubscribeFailure {
+  kind: SubscribeFailureKind;
+  /** 可直接展示给用户的整句。 */
+  text: string;
+  /** 失败发生的时刻（epoch ms）。面板拿它说「多久之前试的」，避免展示陈年旧账。 */
+  at: number;
+}
+
+const LAST_SUBSCRIBE_FAILURE_KEY = 'push_last_subscribe_failure_v1';
+
+/**
+ * 记下 / 读出 / 清掉「最近一次订阅失败」。
+ *
+ * 为什么要落盘：失败原文以前只走 toast，一闪而过，用户回头想看就没了——而这类
+ * 失败恰恰是最需要照着原文排查的。落盘之后设置页的面板能把它固定显示出来。
+ *
+ * 三条推送链路（主动消息 2.0 / Instant Push / Proactive Push）共用这一份记录，
+ * 因为底下调的是同一个 `pushManager.subscribe()`，失败原因是设备级的、不分链路。
+ *
+ * 写在 subscribeWithRetry 里面而不是各调用方：调用方漏写一处，那条路径的失败就
+ * 又变回一闪而过。localStorage 在 Service Worker 里不存在，所以带 typeof 守卫。
+ */
+export function rememberSubscribeFailure(failure: SubscribeFailure): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(LAST_SUBSCRIBE_FAILURE_KEY, JSON.stringify(failure));
+  } catch { /* 存不下就算了，诊断信息没到丢了要拦流程的地步 */ }
+}
+
+export function readSubscribeFailure(): SubscribeFailure | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(LAST_SUBSCRIBE_FAILURE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed.text !== 'string' || typeof parsed.kind !== 'string') return null;
+    return { kind: parsed.kind, text: parsed.text, at: typeof parsed.at === 'number' ? parsed.at : 0 };
+  } catch {
+    return null;
+  }
+}
+
+export function clearSubscribeFailure(): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(LAST_SUBSCRIBE_FAILURE_KEY);
+  } catch { /* 同上 */ }
+}
+
+/**
  * 从订阅端点认出推送厂商。端点域名是各厂商写死的，认不出就说「未识别厂商」，
  * 不猜。设置页拿它显示「推送通道」那一行——用户排障时第一句话往往是「我用的
  * Chrome」，能直接对上 Google FCM 就省一轮来回。
@@ -140,6 +206,14 @@ export interface BrowserPushState {
   channel: string;
   iosNeedsPwa: boolean;
   capacitorNative: boolean;
+  /**
+   * 最近一次订阅失败的记录，没失败过是 null。
+   *
+   * 这是判断「接口都在但这台设备实际推不了」的**唯一**可靠依据：能力检测查的是
+   * JS 接口在不在，而 Chromium 的 PushManager 是编译进去的，跟底下有没有推送通道
+   * 无关，所以没 GMS 的安卓机能力检测照样全绿。只有真的试过一次才知道。
+   */
+  lastSubscribeFailure: SubscribeFailure | null;
 }
 
 /**
@@ -183,6 +257,7 @@ export async function readBrowserPushState(): Promise<BrowserPushState> {
     channel: detectPushChannel(endpoint),
     iosNeedsPwa: detectIosNeedsPwa(),
     capacitorNative: detectCapacitorNative(),
+    lastSubscribeFailure: readSubscribeFailure(),
   };
 }
 
@@ -195,23 +270,35 @@ export async function readBrowserPushState(): Promise<BrowserPushState> {
  * reached.  We surface those distinctly so the user knows it's not a
  * permission issue.
  */
-export function explainSubscribeError(e: unknown): string {
+export function explainSubscribeError(e: unknown): Omit<SubscribeFailure, 'at'> {
   const err = e as { name?: string; message?: string } | null;
   const name = err?.name || '';
   const msg = err?.message || String(e || '未知错误');
   if (name === 'NotAllowedError') {
-    return '浏览器拒绝创建订阅（NotAllowedError）——通常是站点权限被拦截或处于隐身模式';
+    return {
+      kind: 'permission',
+      text: '浏览器拒绝创建订阅（NotAllowedError）——通常是站点权限被拦截或处于隐身模式',
+    };
   }
   if (name === 'NotSupportedError') {
-    return '当前浏览器不支持网页推送——常见于没装谷歌服务的国行安卓手机（小米/华为/OPPO/vivo 大多默认就没有），或者手机自带的精简浏览器。换 Chrome / Edge / Firefox 桌面版试试';
+    return {
+      kind: 'unsupported',
+      text: '当前浏览器不支持网页推送——常见于手机自带的精简浏览器，或没装谷歌服务的国行安卓机上的 Chrome / Edge。同一台手机上可以换 Firefox 试试（它的推送不经过谷歌），或者用电脑',
+    };
   }
   if (name === 'AbortError' || /push service|FCM|network/i.test(msg)) {
-    return '连不上推送服务器——这台设备的网页推送链路走不通。最常见两种情况：1) 国行安卓手机没装谷歌服务（小米/华为/OPPO/vivo 默认就没有），系统层面就推不了；2) 当前网络挡住了谷歌的推送服务器。建议：换台装了谷歌服务的设备，或者用电脑上的 Chrome / Edge / Firefox 试试';
+    return {
+      kind: 'channel-unreachable',
+      text: '连不上推送服务器——浏览器接口都在，但底下那条通往推送服务商的路走不通。Chrome / Edge 的网页推送要转交系统里的谷歌服务（GMS）去注册，国行安卓机（华为 / 小米 / OPPO / vivo）出厂就不带 GMS，装了也还得连得上谷歌的服务器。同一台手机上换 Firefox 最有希望（它走 Mozilla 自己的推送服务器，完全不碰谷歌），或者换电脑',
+    };
   }
   if (name === 'InvalidStateError') {
-    return '订阅状态冲突（InvalidStateError）——可能旧订阅没清干净，刷新页面或再点一次"重置订阅"';
+    return {
+      kind: 'state',
+      text: '订阅状态冲突（InvalidStateError）——可能旧订阅没清干净，刷新页面或再点一次「重置订阅」',
+    };
   }
-  return `订阅创建失败（${name || 'Error'}：${msg}）`;
+  return { kind: 'unknown', text: `订阅创建失败（${name || 'Error'}：${msg}）` };
 }
 
 /**
@@ -224,7 +311,15 @@ export async function subscribeWithRetry(
   reg: ServiceWorkerRegistration,
   vapidPublicKey: string,
   logPrefix: string,
-): Promise<{ sub: PushSubscription | null; reason?: string }> {
+): Promise<{ sub: PushSubscription | null; failure?: SubscribeFailure }> {
+  // 成败都要落一次盘：失败留原因给面板显示，成功清掉上一次的，否则修好之后面板
+  // 还挂着一条陈年失败，比不显示更误导。
+  const fail = (partial: Omit<SubscribeFailure, 'at'>) => {
+    const failure: SubscribeFailure = { ...partial, at: Date.now() };
+    rememberSubscribeFailure(failure);
+    return { sub: null, failure };
+  };
+
   for (let attempt = 0; attempt < SUBSCRIBE_ATTEMPTS_MAX; attempt++) {
     let sub: PushSubscription;
     try {
@@ -234,9 +329,12 @@ export async function subscribeWithRetry(
       });
     } catch (e) {
       console.warn(`${logPrefix} pushManager.subscribe failed`, e);
-      return { sub: null, reason: explainSubscribeError(e) };
+      return fail(explainSubscribeError(e));
     }
-    if (!isDeadPushEndpoint(sub.endpoint)) return { sub };
+    if (!isDeadPushEndpoint(sub.endpoint)) {
+      clearSubscribeFailure();
+      return { sub };
+    }
     try { await sub.unsubscribe(); } catch (e) {
       // 如果连 unsubscribe 都抛, 下一次 subscribe() 大概率还是同一个 zombie,
       // 但仍然兜底重试 (重试上限挡着不会死循环).
@@ -249,8 +347,8 @@ export async function subscribeWithRetry(
       await new Promise(r => setTimeout(r, wait));
     }
   }
-  return {
-    sub: null,
-    reason: `浏览器持续返回 permanently-removed.invalid（已尝试 ${SUBSCRIBE_ATTEMPTS_MAX} 次）— 可能是由于站点参与度 (Site Engagement) 过低或浏览器内部数据残留导致。请尝试清理站点数据后重试，或更换设备/浏览器`,
-  };
+  return fail({
+    kind: 'zombie',
+    text: `浏览器持续返回 permanently-removed.invalid（已尝试 ${SUBSCRIBE_ATTEMPTS_MAX} 次）— 可能是由于站点参与度 (Site Engagement) 过低或浏览器内部数据残留导致。请尝试清理站点数据后重试，或更换设备/浏览器`,
+  });
 }

--- a/worker/amsg/deno-proxy.test.ts
+++ b/worker/amsg/deno-proxy.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Deno 代理层的回归守卫。
+ *
+ * 这两组断言各自钉住一个「改坏了不会当场报错、但线上会出怪事」的行为：
+ *   - 响应头清洗：留着 content-encoding 的话，浏览器会拿已经解压过的 body 再解一次，
+ *     报的错跟真实原因八竿子打不着。
+ *   - 请求改写：host 没换掉的话上游收到的是 deno.net 的 host；路径前缀吃掉的话
+ *     上游地址带子路径的人会 404。
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+// deno-proxy.ts 顶层就调 Deno.serve()，import 之前得先把 Deno 垫上，
+// 否则模块一加载就 ReferenceError。serve 垫成空实现，不真起服务。
+vi.stubGlobal('Deno', {
+  env: { get: (): string | undefined => undefined },
+  serve: (): void => undefined,
+});
+
+const { buildUpstreamRequest, relayResponse, isConfigured } = await import('./deno-proxy');
+
+describe('relayResponse - 响应头清洗', () => {
+  /** 造一个「上游回了压缩响应」的场景：fetch 已经替我们解压，但头还留着压缩前的描述。 */
+  const upstreamResponse = () =>
+    new Response('{"success":true}', {
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Content-Encoding': 'gzip',
+        'Content-Length': '1234',
+        'Transfer-Encoding': 'chunked',
+        'Access-Control-Allow-Origin': '*',
+        'X-Amsg-Server-Version': '2.6.0',
+      },
+    });
+
+  it('摘掉 content-encoding：留着的话浏览器会对已解压的 body 再解一次压', () => {
+    expect(relayResponse(upstreamResponse()).headers.get('content-encoding')).toBeNull();
+  });
+
+  it('摘掉 content-length：解压后长度已经对不上了', () => {
+    expect(relayResponse(upstreamResponse()).headers.get('content-length')).toBeNull();
+  });
+
+  it('摘掉 transfer-encoding：逐跳头，跨代理带过去没有意义', () => {
+    expect(relayResponse(upstreamResponse()).headers.get('transfer-encoding')).toBeNull();
+  });
+
+  it('业务头原样留着 —— 别把 CORS 和版本号一起清掉了', () => {
+    const relayed = relayResponse(upstreamResponse());
+    expect(relayed.headers.get('access-control-allow-origin')).toBe('*');
+    expect(relayed.headers.get('x-amsg-server-version')).toBe('2.6.0');
+    expect(relayed.headers.get('content-type')).toBe('application/json; charset=utf-8');
+  });
+
+  it('状态码和 body 原样透传', async () => {
+    const relayed = relayResponse(
+      new Response('nope', { status: 401, statusText: 'Unauthorized' }),
+    );
+    expect(relayed.status).toBe(401);
+    expect(await relayed.text()).toBe('nope');
+  });
+});
+
+describe('buildUpstreamRequest - 请求改写', () => {
+  const incoming = (url: string, init?: RequestInit) => new Request(url, init);
+
+  it('路径和查询串原样接到上游域名后面', () => {
+    const rewritten = buildUpstreamRequest(
+      incoming('https://proxy.deno.net/init-tenant?foo=bar'),
+      'https://amsg.example.workers.dev',
+    );
+    expect(rewritten.url).toBe('https://amsg.example.workers.dev/init-tenant?foo=bar');
+  });
+
+  it('上游地址带子路径时不能把前缀吃掉', () => {
+    const rewritten = buildUpstreamRequest(
+      incoming('https://proxy.deno.net/capabilities'),
+      'https://example.com/amsg',
+    );
+    expect(rewritten.url).toBe('https://example.com/amsg/capabilities');
+  });
+
+  it('删掉 host：不删的话上游收到的是 deno.net 的 host', () => {
+    const request = incoming('https://proxy.deno.net/config-check', {
+      headers: { Host: 'proxy.deno.net' },
+    });
+    expect(buildUpstreamRequest(request, 'https://amsg.example.workers.dev').headers.get('host'))
+      .toBeNull();
+  });
+
+  it('鉴权头和自定义头必须原样带过去，否则 amsg 一律 401', () => {
+    const request = incoming('https://proxy.deno.net/init-tenant', {
+      method: 'POST',
+      headers: {
+        'X-Client-Token': 'shared-secret',
+        'X-User-Id': 'u-1',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    });
+    const rewritten = buildUpstreamRequest(request, 'https://amsg.example.workers.dev');
+    expect(rewritten.headers.get('x-client-token')).toBe('shared-secret');
+    expect(rewritten.headers.get('x-user-id')).toBe('u-1');
+    expect(rewritten.headers.get('content-type')).toBe('application/json');
+  });
+
+  it('方法原样保留，POST 的 body 跟着走', async () => {
+    const request = incoming('https://proxy.deno.net/init-tenant', {
+      method: 'POST',
+      body: '{"probe":true}',
+    });
+    const rewritten = buildUpstreamRequest(request, 'https://amsg.example.workers.dev');
+    expect(rewritten.method).toBe('POST');
+    expect(await rewritten.text()).toBe('{"probe":true}');
+  });
+
+  it('GET 不能带 body', () => {
+    const rewritten = buildUpstreamRequest(
+      incoming('https://proxy.deno.net/capabilities'),
+      'https://amsg.example.workers.dev',
+    );
+    expect(rewritten.body).toBeNull();
+  });
+});
+
+describe('isConfigured - 上游地址有没有填', () => {
+  it('占位符没改 → 判定为没配，好让自检端点直说而不是闷头转发', () => {
+    expect(isConfigured('https://sullyos-amsg.你的账号.workers.dev')).toBe(false);
+  });
+
+  it('填了真实地址 → 通过', () => {
+    expect(isConfigured('https://amsg.example.workers.dev')).toBe(true);
+  });
+
+  it('不是 http(s) 开头 → 不通过', () => {
+    expect(isConfigured('amsg.example.workers.dev')).toBe(false);
+    expect(isConfigured('')).toBe(false);
+  });
+});

--- a/worker/amsg/deno-proxy.ts
+++ b/worker/amsg/deno-proxy.ts
@@ -1,0 +1,153 @@
+/**
+ * amsg 的 Deno 门面 —— 给 Cloudflare worker 换一个国内能直连的地址。
+ *
+ * 主动消息的 worker 跑在 Cloudflare 上，默认地址是 `*.workers.dev`，这个域名
+ * 在国内连不上。这份脚本部署到 Deno Deploy 之后会拿到一个 `*.deno.net` 地址，
+ * 它只做一件事：把收到的请求原样转给你自己的 Cloudflare worker，再把响应原样
+ * 送回来。业务逻辑、D1 数据库、Cron 定时任务全都还留在 Cloudflare，这一层不存
+ * 任何数据、不认任何业务端点。
+ *
+ * 怎么用：
+ *   1. 打开 console.deno.com，点右上角「New Playground」
+ *   2. 把这份文件整个贴进去
+ *   3. 改下面 `UPSTREAM` 那一行，填你自己的 Cloudflare worker 地址
+ *   4. 部署后拿到的 `https://xxx.deno.net` 地址，填进 SullyOS
+ *      「设置 → 主动消息 → Worker 地址」，替换原来的 workers.dev 地址
+ *
+ * 两件值得先知道的事：
+ *   - 推送不走这条路。Cloudflare worker 是直接把消息发给 FCM / APNs 的，
+ *     跟浏览器怎么访问 worker 是两条独立的路。所以这层挂了不影响收消息，
+ *     只影响你打开设置面板改配置。
+ *   - 设置页里「去 Cloudflare 控制台」那个链接靠 workers.dev 域名反推 worker
+ *     名字，换成 deno.net 之后会退化成跳 worker 列表页，得自己再点一下。
+ */
+
+/**
+ * 你自己的 Cloudflare amsg worker 地址（就是原来填在 SullyOS 设置里的那个）。
+ * 不想把地址写在代码里的话，可以留空不动，改在 Deno 的 Settings → Environment
+ * Variables 里加一个 `AMSG_UPSTREAM`，那边的值优先。
+ */
+const UPSTREAM = 'https://sullyos-amsg.你的账号.workers.dev';
+
+/**
+ * 代理自己的自检端点，跟上游无关。部署完直接在浏览器打开它，能看到 JSON 就说明
+ * 这一层活着、上游地址也填对了。amsg 的端点都是 `/init-tenant` 这种单词形式，
+ * 不会跟双下划线开头的路径撞车。
+ */
+const HEALTH_PATH = '/__proxy-health';
+
+/** 改完记得在下面自检端点的输出里核对一眼，确认 Playground 跑的确实是新版。 */
+const PROXY_REVISION = 'amsg-deno-proxy-v1';
+
+declare const Deno: {
+  env: { get(name: string): string | undefined };
+  serve(handler: (request: Request) => Response | Promise<Response>): unknown;
+};
+
+/**
+ * 转发响应时必须摘掉的头。
+ *
+ * 前四个是逐跳（hop-by-hop）头：只描述「这一段 TCP 连接」，跨代理带过去没有意义。
+ * `content-encoding` / `content-length` 是更要命的一对 —— fetch 拿到 gzip 响应时
+ * 会自动解压，但这两个头描述的还是压缩前的状态。原样带回浏览器的话，浏览器会拿
+ * 已经解开的 body 再解一次压，直接读失败。摘掉之后 Deno Deploy 出口会按浏览器的
+ * accept-encoding 重新压一遍，端到端的压缩收益不会丢。
+ */
+const STRIPPED_RESPONSE_HEADERS = [
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+  'upgrade',
+];
+
+/** 上游地址：环境变量优先，都没有就用文件顶上那个常量。统一去掉尾斜杠。 */
+const resolveUpstream = (): string =>
+  (Deno.env.get('AMSG_UPSTREAM') || UPSTREAM).trim().replace(/\/+$/, '');
+
+/** 占位符没改就算没配 —— 与其闷头往一个不存在的域名转发，不如直接说清楚。 */
+export const isConfigured = (upstream: string): boolean =>
+  /^https?:\/\//i.test(upstream) && !upstream.includes('你的账号');
+
+/** 把进来的请求改写成打给上游的请求：换掉 host，路径和查询串原样保留。 */
+export const buildUpstreamRequest = (request: Request, upstream: string): Request => {
+  const incoming = new URL(request.url);
+  const target = new URL(upstream);
+  // 上游地址允许带路径前缀（少见但合法），拼接时不要把它吃掉。
+  target.pathname = `${target.pathname.replace(/\/+$/, '')}${incoming.pathname}`;
+  target.search = incoming.search;
+
+  const headers = new Headers(request.headers);
+  // host 交给 fetch 按目标地址自己填，否则上游会收到 deno.net 的 host。
+  headers.delete('host');
+
+  const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
+  const init: RequestInit = {
+    method: request.method,
+    headers,
+    body: hasBody ? request.body : undefined,
+    // 上游返回 3xx 时不要自动跟过去，原样交给浏览器判断。
+    redirect: 'manual',
+  };
+  // 流式转发请求体（配置上云可能不小）时，fetch 标准要求显式声明 duplex。
+  // TS 的 RequestInit 还没收录这个字段，所以在这里单独挂上去。
+  if (hasBody) (init as { duplex?: string }).duplex = 'half';
+
+  return new Request(target.toString(), init);
+};
+
+/** 原样回传上游响应，只摘掉那些跨代理会出问题的头。 */
+export const relayResponse = (upstreamResponse: Response): Response => {
+  const headers = new Headers(upstreamResponse.headers);
+  for (const name of STRIPPED_RESPONSE_HEADERS) headers.delete(name);
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers,
+  });
+};
+
+const json = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  });
+
+Deno.serve(async (request: Request): Promise<Response> => {
+  const upstream = resolveUpstream();
+  const pathname = new URL(request.url).pathname;
+
+  if (pathname === HEALTH_PATH) {
+    return json(
+      {
+        ok: isConfigured(upstream),
+        revision: PROXY_REVISION,
+        upstream: isConfigured(upstream) ? upstream : null,
+        hint: isConfigured(upstream)
+          ? '这一层活着。把当前 deno.net 地址填进 SullyOS 的主动消息设置即可。'
+          : '还没填上游地址：改脚本里的 UPSTREAM 常量，或加一个 AMSG_UPSTREAM 环境变量。',
+      },
+      isConfigured(upstream) ? 200 : 503,
+    );
+  }
+
+  if (!isConfigured(upstream)) {
+    return json({ error: `代理没配上游地址，打开 ${HEALTH_PATH} 看说明。` }, 503);
+  }
+
+  try {
+    return relayResponse(await fetch(buildUpstreamRequest(request, upstream)));
+  } catch (error) {
+    // 上游连不上（地址填错、Cloudflare 那边挂了）时给个能看懂的回执，
+    // 别让前端只拿到一个没有上下文的 500。
+    return json(
+      {
+        error: '连不上 Cloudflare worker',
+        upstream,
+        detail: error instanceof Error ? error.message : String(error),
+      },
+      502,
+    );
+  }
+});

--- a/worker/amsg/src/index.test.ts
+++ b/worker/amsg/src/index.test.ts
@@ -694,7 +694,7 @@ describe('executeToolCalls 的工具编排', () => {
       [{ ...call, id: 'c2' }],
       session,
     );
-    expect(second.content).toContain('没有再去查');
+    expect(second.content).toContain('没有再执行');
   });
 
   // 闸只拦「完全一样」的调用。换个月份是正当的多轮使用，拦了就是把能力砍了。
@@ -708,7 +708,7 @@ describe('executeToolCalls 的工具编排', () => {
       [toolCall('c2', 'recall', { year: '2026', month: '07' })],
       session,
     );
-    expect(other.content).not.toContain('没有再去查');
+    expect(other.content).not.toContain('没有再执行');
   });
 
   it('参数字段顺序变了仍算同一次调用', async () => {
@@ -721,7 +721,7 @@ describe('executeToolCalls 的工具编排', () => {
       [toolCall('c2', 'recall', { month: '06', year: '2026' })],
       session,
     );
-    expect(reordered.content).toContain('没有再去查');
+    expect(reordered.content).toContain('没有再执行');
   });
 
   // 轮次快用完了还在请求工具，上游会抛 AGENTIC_LOOP_EXCEEDED：这次攒的旁白全丢、任务


### PR DESCRIPTION
主动消息 2.0 的三件事，都是用户实际撞上的。

## 角色一次回复排出 5 条一样的定时消息

用户说一句「等会找我」，角色一口气排出 5 条同时间、同提示词的任务；开着 MCP 工具时必现，关掉就正常。

5 不是巧合——它是每个角色的待触发上限，也就是模型在这一次回复里反复调排程工具，一路撞到上限才停。工具越多、提示词里关于工具的常驻说明越长，模型越容易每轮都再调一次；而这一侧原本什么都没拦，重复一次就是远端实打实多一条任务。

改后：同一次回复里参数完全相同的排程 / 取消 / 改期第二次直接打回，一次请求都不发（换时间、换方向照常放行）；工具跑完会明说这一步做完了别再调同一个；「排程现状」清单改成每次发请求现算，本轮刚排好的那几条会被点名标出来——以前这份清单只跟着第一次请求走，角色一开始调工具，第二轮起整块就没了，看不到自己名下有什么，于是又排了一条。

## workers.dev 在国内连不上

后端建起来了、设置页却怎么都连不上，也分不清是自己填错还是网络问题。

Worker 地址下面多了一段展开区：新建 Deno Playground、复制代理代码贴进去改一行上游地址、把拿到的 deno.net 地址填回来。Worker、D1 数据、Cron 全留在 Cloudflare 不动，Deno 那层只转发。收消息不走这层（推送是 Cloudflare 直接发给手机的），所以它挂了只影响打开面板改配置。

## 推送订阅建不出来却看不出为什么

没装谷歌服务的国行安卓机上，面板会显示「浏览器支持：是、通知权限：已授权、Service Worker：已激活」，唯独订阅建不出来，点多少次「重置订阅」都没反应——失败原文只走 toast，一闪而过。

改后失败原因会落盘并固定显示到订阅真的建起来为止，「连不上推送服务器」这类会单独标红并给出同一台手机上可走的 Firefox。

## 验证

`pnpm vitest run` 全绿（184 文件 / 2399 用例），其中新增的回归守卫覆盖：同名同参只执行一次与收尾话、排程清单里的本轮标记、四处工具循环的消息起点、Deno 代理的转发行为、推送失败的面板文案判定。

## 部署

worker 不用手动动。`utils/**` 变更会在合并到 master 后由 Sync worker bundles 自动重打并同步到部署仓库；这次 worker 侧只有回话措辞变化，不涉及契约，晚一步同步也不会坏。前端站点的构建已经串上 `build:workers`，Deno 代理脚本会跟着发布上去。

https://claude.ai/code/session_01CF3SApaLzJTyPTH2ujbQ8a