### PR TITLE
feat(amsg2): 「清空云端数据」一次清掉任务、角色上下文和推送订阅

### DIFF
--- a/components/settings/ActiveMsgGlobalSettingsModal.tsx
+++ b/components/settings/ActiveMsgGlobalSettingsModal.tsx
@@ -3,7 +3,7 @@ import Modal from '../os/Modal';
 import { ActiveMsg2GlobalConfig, RealtimeConfig } from '../../types';
 import { ActiveMsgClient, ActiveMsg2PushStatus, readAmsgFailKind } from '../../utils/activeMsgClient';
 import { ActiveMsgStore, maskActiveMsgUserId } from '../../utils/activeMsgStore';
-import { cancelAllRemoteAmsgTasks, isWorkerUrlCleared } from '../../utils/amsgStateSync';
+import { cancelAllRemoteAmsgTasks, isWorkerUrlCleared, wipeAmsgCloudData } from '../../utils/amsgStateSync';
 import {
   buildCloudflareDashboardUrl,
   isInstantConfigReady,
@@ -81,7 +81,7 @@ interface ActiveMsgGlobalSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   addToast: (message: string, type?: 'success' | 'error' | 'info') => void;
-  /** 「清除云端状态」清完要立刻把工具凭据补传回去，所以这里需要当前这份配置。 */
+  /** 「清空云端数据」清完要立刻把工具凭据补传回去，所以这里需要当前这份配置。 */
   realtimeConfig: RealtimeConfig;
   /** 由 Settings 注入：点「去推送凭据面板」时打开顶层 PushVapidSettingsModal */
   onOpenVapid?: () => void;
@@ -325,23 +325,49 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
     return revealAndCopy(ActiveMsgClient.generateMasterKey(), setGeneratedMasterKey, 'AMSG_MASTER_KEY');
   };
 
-  const handleClearClientState = async () => {
-    if (!confirm('确定清空云端状态？Worker D1 里同步的角色上下文（fire_pack）会全部删除。在下一次聊天重新同步之前，已排程的 AI 任务到点会失败；固定消息任务不受影响。')) return;
+  const handleWipeCloudData = async () => {
+    if (!confirm(
+      '确定清空云端数据？Worker D1 里属于你的这几样会一起删掉：\n\n'
+      + '· 已排程的主动消息任务（含角色自己排的）\n'
+      + '· 同步上去的角色上下文与工具凭据\n'
+      + '· 推送订阅登记\n\n'
+      + '任务删了要重新排。角色上下文下次聊天会自动传回去，工具凭据和推送订阅当场就补登记。'
+    )) return;
     setLoading(true);
     try {
-      // 工具凭据在清空的同一步就补回去了（见 clearClientState）：它不像角色上下文那样
-      // 每轮聊天重传，不当场补的话之后没人会补，AI 任务会一直失败。
-      const { deleted, toolConfigRestored } = await ActiveMsgClient.clearClientState(realtimeConfig);
-      addToast(
-        toolConfigRestored
-          ? `已清空云端状态（${deleted} 条）。`
-          : `已清空云端状态（${deleted} 条），但工具凭据没能补传回去——请到「实时感知」里重新保存一次配置，否则已排程的 AI 任务会一直失败。`,
-        toolConfigRestored ? 'success' : 'error',
-      );
+      const result = await wipeAmsgCloudData(realtimeConfig, {
+        pushRegistered: Boolean(pushStatus?.hasSubscription),
+      });
+
+      // 没清干净的地方逐条说明白：这个按钮多半是在「云端数据已经出问题」时点的，
+      // 含糊一句「部分失败」会让人不知道下一步该干嘛。
+      const problems: string[] = [];
+      if (!result.tasks.listed) {
+        problems.push('任务清单读不出来（换过 AMSG_MASTER_KEY 的话旧任务解不开就会这样），这些任务到点会失败，Worker 会在 7 天后自动清掉它们');
+      } else if (result.tasks.failed > 0) {
+        problems.push(`${result.tasks.failed} 个任务没取消成功，建议到角色的主动消息面板里逐个处理`);
+      }
+      if (result.stateDeleted === null) {
+        problems.push('角色上下文没能删掉');
+      } else if (!result.toolConfigRestored) {
+        problems.push('工具凭据没能补传回去，请到「实时感知」里重新保存一次配置，否则已排程的 AI 任务会一直失败');
+      }
+      if (result.push === 'failed') {
+        problems.push('推送订阅没能收拾干净，建议到上面的推送区域重新订阅一次');
+      }
+
+      if (problems.length > 0) {
+        addToast(`云端数据没能全部清干净：${problems.join('；')}。`, 'error');
+      } else {
+        const done = [`任务 ${result.tasks.total} 个`, `状态 ${result.stateDeleted} 条`];
+        if (result.push === 'reregistered') done.push('推送订阅已重新登记');
+        addToast(`已清空云端数据（${done.join('、')}）。`, 'success');
+      }
     } catch (error: any) {
-      addToast(error?.message || '清除云端状态失败。', 'error');
+      addToast(error?.message || '清空云端数据失败。', 'error');
     } finally {
       setLoading(false);
+      void refresh();
     }
   };
 
@@ -786,17 +812,21 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
                 （<code className="font-mono">origin: '*'</code>），想收紧就把它改成自己站点的域名再部署。
               </p>
               <div className="bg-rose-50 border border-rose-100 rounded-2xl p-3 space-y-2">
-                <div className="font-semibold text-rose-700">清除云端状态</div>
+                <div className="font-semibold text-rose-700">清空云端数据</div>
                 <p className="text-[11px] leading-relaxed text-rose-600">
-                  删除 Worker D1 里同步的角色上下文（角色卡、最近聊天窗口等）。角色靠它到点现场组消息，
-                  所以在下次聊天自动重新同步之前，已排程的 AI 任务到点会失败；固定消息任务不受影响。
+                  把 Worker D1 里属于你的数据全部删掉：已排程的主动消息任务（含角色自己排的）、
+                  同步上去的角色上下文（角色卡、最近聊天窗口等）与工具凭据、推送订阅登记。
+                </p>
+                <p className="text-[11px] leading-relaxed text-rose-600">
+                  清完角色上下文下次聊天会自动传回去，工具凭据和推送订阅当场补登记，任务要自己重新排。
+                  换过 <code className="font-mono">AMSG_MASTER_KEY</code> 之后旧数据解不开，也从这里清干净。
                 </p>
                 <button
-                  onClick={() => void handleClearClientState()}
+                  onClick={() => void handleWipeCloudData()}
                   disabled={loading}
                   className="w-full py-2.5 bg-rose-500 text-white font-bold rounded-2xl active:scale-95 transition-transform disabled:opacity-50"
                 >
-                  {loading ? '处理中...' : '清除云端状态'}
+                  {loading ? '处理中...' : '清空云端数据'}
                 </button>
               </div>
             </div>

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -1032,6 +1032,23 @@ export const ActiveMsgClient = {
   },
 
   /**
+   * 只删掉 worker 上登记的那行订阅，浏览器这边的订阅原样不动。
+   *
+   * 跟 resetPushSubscription 的分工：那个是「收不到推送了」的修复动作，删完要重建
+   * 浏览器订阅再登记回去；这里是清空云端数据时的收尾，本机压根没开推送的话不该顺手
+   * 去申请通知权限，把云端那行删干净、留白就是对的。
+   */
+  async deleteRemotePushSubscription(): Promise<void> {
+    const config = await ensureWorkerReady();
+    const client = await initializeClient(config);
+    try {
+      await client.deletePushSubscription();
+    } catch (error) {
+      throw normalizeActiveMsgApiError(error, '删除推送订阅登记');
+    }
+  },
+
+  /**
    * 重置订阅：清掉现在这条，重新建一条，再覆盖登记回 worker。
    *
    * 三步缺一不可。只在浏览器重订不登记的话，worker 的 push_subscriptions 里还是
@@ -1734,7 +1751,7 @@ export const ActiveMsgClient = {
    * 清掉某个角色在云端 client_state 里的全部条目（fire_pack / tool_pack /
    * 活跃会话租约 / 旁路存的小红书会话），删角色时用。
    *
-   * 为什么单独有这么一个：设置页的「清除云端状态」是全局的、要用户主动去点，
+   * 为什么单独有这么一个：设置页的「清空云端数据」是全局的、要用户主动去点，
    * 删一个角色时该走的是只清这一个角色的路。返回被清掉的键名供调用方记账。
    */
   async clearCharClientState(charId: string): Promise<string[]> {
@@ -1744,8 +1761,8 @@ export const ActiveMsgClient = {
   },
 
   /**
-   * 清空该用户在 worker D1 里的全部 client_state（设置页「清除云端状态」按钮），
-   * 清完立刻把全局工具凭据补回去。
+   * 清空该用户在 worker D1 里的全部 client_state，清完立刻把全局工具凭据补回去。
+   * 设置页「清空云端数据」把它当其中一步用（见 amsgStateSync 的 wipeAmsgCloudData）。
    *
    * 为什么补传这一步是必须的：云端有三份数据，角色上下文与角色工具数据每轮聊完都会
    * 重新同步（见 syncCharFirePacks），只有全局的 tool_config 是「改的时候才传」——
@@ -1753,8 +1770,8 @@ export const ActiveMsgClient = {
    * 的 fireStateError），于是清空之后已排程的 AI 任务会一直失败，聊多少轮天都不会好。
    *
    * 清空这个动作本身就是一次「云端凭据变没了」的变更，所以在这里就地补回来，
-   * 不必让每轮同步都白传一遍。任务表跟 client_state 不在一起、不受清空影响，
-   * 所以这也是「任务还活着、凭据却没了」的唯一入口，堵住这里就够。
+   * 不必让每轮同步都白传一遍。这个方法只碰 client_state、不动任务表，所以它就是
+   * 「任务还活着、凭据却没了」的唯一入口，堵住这里就够。
    *
    * 补传失败不算清空失败（清空确实成功了），返回值把结果交给调用方去提示。
    */

--- a/utils/amsgStateSync.test.ts
+++ b/utils/amsgStateSync.test.ts
@@ -12,6 +12,9 @@ vi.mock('./activeMsgClient', () => ({
     syncToolConfig: vi.fn().mockResolvedValue(undefined),
     listAllTasks: vi.fn().mockResolvedValue([]),
     cancelTask: vi.fn().mockResolvedValue({ uuid: '', alreadyGone: false }),
+    clearClientState: vi.fn().mockResolvedValue({ deleted: 0, toolConfigRestored: true }),
+    registerPushSubscription: vi.fn().mockResolvedValue(undefined),
+    deleteRemotePushSubscription: vi.fn().mockResolvedValue(undefined),
   },
 }));
 vi.mock('./activeMsgStore', () => ({
@@ -22,6 +25,7 @@ import {
   AMSG2_PENDING_SYNC_LS_KEY,
   AMSG2_PENDING_TOOL_CONFIG_LS_KEY,
   cancelAllRemoteAmsgTasks,
+  wipeAmsgCloudData,
   flushAmsgState,
   isWorkerUrlCleared,
   markAmsgStateDirty,
@@ -71,6 +75,12 @@ beforeEach(() => {
   (ActiveMsgClient.listAllTasks as any).mockResolvedValue([]);
   (ActiveMsgClient.cancelTask as any).mockReset();
   (ActiveMsgClient.cancelTask as any).mockResolvedValue({ uuid: '', alreadyGone: false });
+  (ActiveMsgClient.clearClientState as any).mockReset();
+  (ActiveMsgClient.clearClientState as any).mockResolvedValue({ deleted: 0, toolConfigRestored: true });
+  (ActiveMsgClient.registerPushSubscription as any).mockReset();
+  (ActiveMsgClient.registerPushSubscription as any).mockResolvedValue(undefined);
+  (ActiveMsgClient.deleteRemotePushSubscription as any).mockReset();
+  (ActiveMsgClient.deleteRemotePushSubscription as any).mockResolvedValue(undefined);
   (ActiveMsgStore.getGlobalConfig as any).mockReset();
   (ActiveMsgStore.getGlobalConfig as any).mockResolvedValue({ workerUrl: 'https://amsg.example.dev' });
 });
@@ -409,6 +419,59 @@ describe('清空 Worker 地址前的收尾', () => {
 
     expect(result.listed).toBe(false);
     expect(ActiveMsgClient.cancelTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('清空云端数据', () => {
+  // 这一组守的是同一条：三样各清各的，谁失败都不许短路后面两样。
+  // 换过 AMSG_MASTER_KEY 之后旧密文全解不开，而「列任务」要逐条解密、必然最先炸，
+  // 偏偏这时候最需要被清掉的是 client_state —— 串行短路的话用户一样都清不成。
+  it('任务清单读不出来时，角色上下文和推送订阅照样收拾干净', async () => {
+    (ActiveMsgClient.listAllTasks as any).mockRejectedValue(new Error('decryption failed'));
+    (ActiveMsgClient.clearClientState as any).mockResolvedValue({ deleted: 7, toolConfigRestored: true });
+
+    const result = await wipeAmsgCloudData(undefined, { pushRegistered: true });
+
+    expect(result.tasks.listed).toBe(false);
+    expect(ActiveMsgClient.clearClientState).toHaveBeenCalledTimes(1);
+    expect(result.stateDeleted).toBe(7);
+    expect(ActiveMsgClient.registerPushSubscription).toHaveBeenCalledTimes(1);
+    expect(result.push).toBe('reregistered');
+  });
+
+  it('角色上下文清不掉时，任务照样取消、推送订阅照样收拾', async () => {
+    (ActiveMsgClient.listAllTasks as any).mockResolvedValue([{ uuid: 'u-1' }, { uuid: 'u-2' }]);
+    (ActiveMsgClient.clearClientState as any).mockRejectedValue(new Error('boom'));
+
+    const result = await wipeAmsgCloudData(undefined, { pushRegistered: true });
+
+    expect(ActiveMsgClient.cancelTask).toHaveBeenCalledTimes(2);
+    expect(result.tasks).toEqual({ total: 2, failed: 0, listed: true });
+    expect(result.stateDeleted).toBeNull();
+    expect(result.toolConfigRestored).toBe(false);
+    expect(result.push).toBe('reregistered');
+  });
+
+  it('推送订阅收拾不了也不影响前两样的结果', async () => {
+    (ActiveMsgClient.listAllTasks as any).mockResolvedValue([{ uuid: 'u-1' }]);
+    (ActiveMsgClient.clearClientState as any).mockResolvedValue({ deleted: 3, toolConfigRestored: true });
+    (ActiveMsgClient.registerPushSubscription as any).mockRejectedValue(new Error('no permission'));
+
+    const result = await wipeAmsgCloudData(undefined, { pushRegistered: true });
+
+    expect(result.tasks).toEqual({ total: 1, failed: 0, listed: true });
+    expect(result.stateDeleted).toBe(3);
+    expect(result.push).toBe('failed');
+  });
+
+  // 本机没订阅还去 registerPushSubscription 的话，会当场向用户要通知权限——
+  // 「清空数据」不该顺手弹权限框，删掉云端那行留白就是对的。
+  it('本机没有推送订阅时只删云端那行，不去重新登记', async () => {
+    const result = await wipeAmsgCloudData(undefined, { pushRegistered: false });
+
+    expect(ActiveMsgClient.deleteRemotePushSubscription).toHaveBeenCalledTimes(1);
+    expect(ActiveMsgClient.registerPushSubscription).not.toHaveBeenCalled();
+    expect(result.push).toBe('deleted');
   });
 });
 

--- a/utils/amsgStateSync.ts
+++ b/utils/amsgStateSync.ts
@@ -403,6 +403,67 @@ export const cancelAllRemoteAmsgTasks = async (): Promise<{
   return { total: uuids.length, failed, listed: true };
 };
 
+/** 「清空云端数据」逐项的结果，界面照着它说清楚哪几样清干净了、哪几样没有。 */
+export interface AmsgCloudWipeResult {
+  /** 任务表：读到清单才有数，listed:false 表示清单压根读不出来。 */
+  tasks: { total: number; failed: number; listed: boolean };
+  /** 角色上下文清掉的条目数；这一步失败时是 null。 */
+  stateDeleted: number | null;
+  /** 工具凭据有没有当场补传回去（它没有别的补写时机）。 */
+  toolConfigRestored: boolean;
+  /** 推送订阅的去向：重新登记了 / 删掉了不再登记 / 没弄成。 */
+  push: 'reregistered' | 'deleted' | 'failed';
+}
+
+/**
+ * 清空这个用户在 worker D1 里的全部数据：已排程的任务、同步上去的角色上下文与
+ * 工具凭据、推送订阅登记。设置页「清空云端数据」按钮走的就是这里。
+ *
+ * 三样各清各的，**一步失败不短路后面两步**。这一条是这个函数存在的意义：换过
+ * AMSG_MASTER_KEY 之后，旧密文全解不开，而「列任务」恰恰要逐条解密（GET /messages），
+ * 于是它必然是最先炸的那一步；偏偏这时候最需要被清掉的是 client_state（不清的话
+ * 读它的接口一直报错）。串行短路的话用户会一样都清不成，正好卡在最需要它的场景里。
+ *
+ * 任务清单读不出来时不用另想办法：解不开的任务到点会失败，worker 每轮 cron 都会删掉
+ * 7 天前的失败任务，它们会自己消失。
+ *
+ * @param options.pushRegistered 本机当前有没有推送订阅。有就覆盖登记一份新的
+ *   （worker 上按 user_id 存单行，PUT 一次就顶掉旧行，不用先删、也就没有「删完没
+ *   登记上」的裸奔窗口）；没有就只把云端那行删掉，不去申请通知权限。
+ */
+export const wipeAmsgCloudData = async (
+  realtimeConfig: RealtimeConfig | undefined,
+  options: { pushRegistered: boolean },
+): Promise<AmsgCloudWipeResult> => {
+  // 先收任务：清空过程中就不会再有任务到点触发，跑到一半的状态不至于被现场读走。
+  const tasks = await cancelAllRemoteAmsgTasks();
+
+  let stateDeleted: number | null = null;
+  let toolConfigRestored = false;
+  try {
+    const cleared = await ActiveMsgClient.clearClientState(realtimeConfig);
+    stateDeleted = cleared.deleted;
+    toolConfigRestored = cleared.toolConfigRestored;
+  } catch (error) {
+    console.warn(`${HEADER} 清空云端状态失败`, error);
+  }
+
+  let push: AmsgCloudWipeResult['push'] = 'failed';
+  try {
+    if (options.pushRegistered) {
+      await ActiveMsgClient.registerPushSubscription();
+      push = 'reregistered';
+    } else {
+      await ActiveMsgClient.deleteRemotePushSubscription();
+      push = 'deleted';
+    }
+  } catch (error) {
+    console.warn(`${HEADER} 推送订阅收尾失败`, error);
+  }
+
+  return { tasks, stateDeleted, toolConfigRestored, push };
+};
+
 const writeChatPresence = (charId: string, lastUserMessageAt: number | null) => {
   const presence: AmsgChatPresence = {
     v: 1,


### PR DESCRIPTION
## 改了什么

设置页「主动消息 2.0 → 高级信息」里的那个红色按钮，从「清除云端状态」扩成「清空云端数据」。

| | 改之前 | 改之后 |
|---|---|---|
| 角色上下文与工具凭据 | 清 | 清 |
| 已排程的主动消息任务 | 不动 | 清（含角色自己排的） |
| 推送订阅登记 | 不动 | 清 |

按钮原来的范围是云端只有 `client_state` 一张表时定下的，后来任务表和推送订阅表陆续加进来，
「清空」却还停在一张表上。现在三样一起收拾。

清完能自己回来的会自己回来：工具凭据和推送订阅当场补登记，角色上下文下次聊天自动传回去。
任务需要用户重新排。

## 为什么三样要各清各的

这个按钮最常被点到的场景，是用户换过 `AMSG_MASTER_KEY` 之后旧数据全部解不开。而恰恰在这个场景里，
「列任务」是必然最先失败的一步（列表接口要逐条解密旧密文），偏偏这时候最需要被清掉的是角色上下文
——不清的话读它的接口会一直报错。

所以三步之间不能串行短路，否则用户会一样都清不成，正好卡在最需要它的场景。这条行为由
`amsgStateSync.test.ts` 里新增的一组回归测试钉住（任一步失败，另外两步都要照常完成）。

任务清单读不出来时界面会直接说清原因，并说明那些任务到点会失败、Worker 七天后自动清理，
不用再做别的处理。

## 一个小心思

本机没有推送订阅时只删云端那行，不去重新登记——不然「清空数据」会顺手弹出通知权限申请框。

## 验证

- `pnpm vitest run utils/amsgStateSync.test.ts` — 31 passed（含新增 4 条）
- `pnpm vitest run` 相邻四个 amsg 测试文件 — 134 passed
- `npx tsc --noEmit` — 触及的文件零错误，仓库既有错误数改动前后同为 221

## 已知遗留

全清只动远端，角色本地配置里的任务条目还留着，面板上会看到已经不存在的任务。不致命：
取消接口对「远端已不存在」回 `alreadyGone`，之后再取消不会报错。要一并清掉得动角色记录，
不在这次范围内。

https://claude.ai/code/session_01EH42LDLUSWc4qdhTpqQ61d
