### PR TITLE
Consolidate emotion eval logic & fix message deduplication

### DIFF
--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -45,7 +45,7 @@ import { getLastRealUserMessageAt } from '../utils/amsg2ExpireGuard';
 import { getPendingTasks, hasActiveAiTask, isAmsg2EnabledForChar } from '../utils/amsg2Tasks';
 import { buildAmsg2NoticesText, buildAmsg2TaskContextText, collectAmsg2TaskContext } from '../utils/amsg2TaskContext';
 import { resolveCharTimeZone } from '../utils/timezone';
-import { isInstantChatReady, sendInstantChatTurn } from '../utils/amsgInstantChat';
+import { getInstantChatPending, isInstantChatReady, sendInstantChatTurn } from '../utils/amsgInstantChat';
 // worker 模块的常量叶子（零运行时依赖，前端引它不带进 worker 环境）：
 // 云端 fire 的总时长上限，安全网超时从它推导，worker 调预算时前端自动跟上。
 import { INSTANT_TOTAL_TIMEOUT_MS } from '../worker/amsg/src/instantChat';
@@ -62,6 +62,28 @@ import {
     getMemoryPalaceHighWaterMarkForContext,
     loadCharacterContextRange,
 } from '../utils/chatContextRange';
+
+// ─── 云端情绪评估的安全网定时器（模块级，按角色）───
+// 为什么不放 hook 里：结论（emotionDone）是全局事件，用户切了角色、离开聊天页之后
+// 照样会到，而 hook 里的监听是跟着当前挂载角色走的——单个 ref 存定时器的话，切走再回来
+// 结论到了也没人清，安全网到点就弹「worker 可能是旧版，请重新部署」的假告警；给 B 布防
+// 还会静默吞掉 A 的真告警。按 charId 记、模块级监听清，两个都治。
+const cloudEmotionTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const clearCloudEmotionTimer = (charId: unknown): void => {
+    if (typeof charId !== 'string') return;
+    const timer = cloudEmotionTimers.get(charId);
+    if (timer != null) {
+        clearTimeout(timer);
+        cloudEmotionTimers.delete(charId);
+    }
+};
+if (typeof window !== 'undefined') {
+    // emotionDone 是「这一轮评估有结论了」（成败都发）：flush 落结果、收尾判失败两条路
+    // 都会广播。不论哪个角色、Chat 挂没挂载，结论一到就撤掉对应的安全网。
+    window.addEventListener(CHAT_GEN_EVENTS.emotionDone, (e) => {
+        clearCloudEmotionTimer((e as CustomEvent).detail?.charId);
+    });
+}
 
 // ─── 情绪评估（副API，fire & forget）───
 
@@ -502,8 +524,10 @@ export const useChatAI = ({
     // 下一轮 system prompt 会把它作为角色的内心状态注入
     const [evolvedNarrative, setEvolvedNarrative] = useState<string>('');
 
-    // instant 情绪评估的 "情绪更新中" 徽章安全超时句柄 (worker 推回 emotion_update 前别一直转).
-    const instantEmotionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // 云端情绪评估安全网到点时判断「用户现在看的还是不是布防那个角色」用（防止过期
+    // 定时器把当前角色的徽章错熄）。定时器本体在模块级 cloudEmotionTimers（按角色记）。
+    const currentCharIdRef = useRef<string | null>(null);
+    currentCharIdRef.current = char?.id ?? null;
 
     // 切换角色时重置
     useEffect(() => {
@@ -642,11 +666,8 @@ export const useChatAI = ({
         const emotionDoneHandler = (e: Event) => {
             const detail = (e as CustomEvent).detail;
             if (detail?.charId !== charIdAtMount) return;
+            // 安全网定时器由模块级监听按 charId 清（切走了也清得到），这里只管当前页的徽章。
             setEmotionStatus('');
-            if (instantEmotionTimerRef.current) {
-                clearTimeout(instantEmotionTimerRef.current);
-                instantEmotionTimerRef.current = null;
-            }
         };
         window.addEventListener(CHAT_GEN_EVENTS.emotionDone, emotionDoneHandler);
 
@@ -974,10 +995,7 @@ export const useChatAI = ({
              * 「worker 可能是旧版」的提示，而真实原因是这条消息压根没发出去。
              */
             const extinguishCloudEmotionBadge = () => {
-                if (instantEmotionTimerRef.current) {
-                    clearTimeout(instantEmotionTimerRef.current);
-                    instantEmotionTimerRef.current = null;
-                }
+                clearCloudEmotionTimer(char.id);
                 setEmotionStatus('');
                 announceChatGen(CHAT_GEN_EVENTS.emotionEnd, { charId: char.id, charName: char.name });
             };
@@ -988,20 +1006,36 @@ export const useChatAI = ({
                 announceChatGen(CHAT_GEN_EVENTS.emotionStart, {
                     charId: char.id, charName: char.name, ttlMs: cloudEvalTimeoutMs,
                 });
-                if (instantEmotionTimerRef.current) clearTimeout(instantEmotionTimerRef.current);
-                instantEmotionTimerRef.current = setTimeout(() => {
-                    setEmotionStatus('');
-                    instantEmotionTimerRef.current = null;
-                    // 超时无回音最常见的原因是用户部署的 worker 版本过旧（不支持情绪评估、
-                    // 压根不会推结果回来），其次是 worker 被杀/推送丢失。过去这里
-                    // 静默熄灯, 用户只看到「情绪永远不更新」—— 给一条可操作的提示。
-                    announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
-                        charId: char.id, charName: char.name,
-                        reason: instantChatRoute
-                            ? '云端情绪评估超时无回音——worker 可能是旧版（不支持情绪评估），请到 设置→主动消息 2.0 重新部署 worker 后重试'
-                            : '云端情绪评估超时无回音——worker 可能是旧版（不支持情绪评估），请到 设置→Instant 消息设置 更新 worker 后重试',
-                    });
-                }, cloudEvalTimeoutMs);
+                // 布防按 charId 记进模块级 map。到点先看这一轮死没死透：即时对话的待收
+                // 记录还在 = 云端还没给结论（worker 的 2/4/6 分钟重试梯子完全可能把合法
+                // 回复拖过这个点）——这不是「无回音」，安静续期一小段再看，别抢在状态机
+                // 前面宣判、把一个好端端的 worker 说成旧版让用户白重部署。待收记录没了
+                // 而结论（emotionDone）一直没来，才是真的「跑完了但没人回音」。
+                const charIdAtArm = char.id;
+                const charNameAtArm = char.name;
+                const armCloudEmotionSafetyNet = (delayMs: number) => {
+                    clearCloudEmotionTimer(charIdAtArm);
+                    cloudEmotionTimers.set(charIdAtArm, setTimeout(() => {
+                        cloudEmotionTimers.delete(charIdAtArm);
+                        if (instantChatRoute && getInstantChatPending(charIdAtArm)) {
+                            armCloudEmotionSafetyNet(60_000);
+                            return;
+                        }
+                        // 徽章只熄「布防那个角色」的：用户已切到别的角色时，这个 setter
+                        // 管的是人家的徽章，不能碰。
+                        if (currentCharIdRef.current === charIdAtArm) setEmotionStatus('');
+                        // 超时无回音最常见的原因是用户部署的 worker 版本过旧（不支持情绪评估、
+                        // 压根不会推结果回来），其次是 worker 被杀/推送丢失。过去这里
+                        // 静默熄灯, 用户只看到「情绪永远不更新」—— 给一条可操作的提示。
+                        announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
+                            charId: charIdAtArm, charName: charNameAtArm,
+                            reason: instantChatRoute
+                                ? '云端情绪评估超时无回音——worker 可能是旧版（不支持情绪评估），请到 设置→主动消息 2.0 重新部署 worker 后重试'
+                                : '云端情绪评估超时无回音——worker 可能是旧版（不支持情绪评估），请到 设置→Instant 消息设置 更新 worker 后重试',
+                        });
+                    }, delayMs));
+                };
+                armCloudEmotionSafetyNet(cloudEvalTimeoutMs);
             }
 
             // 发送前汇总计时

--- a/plans/amsg2-instant-chat-contract.md
+++ b/plans/amsg2-instant-chat-contract.md
@@ -42,6 +42,9 @@
 
 - 处理步骤（严格顺序，两个 await 失败即向客户端返回明确错误，不落任务）：
   1. 内部 `upstream.fetch` 转发 `PUT /client-state`（statePayload）→ 必须成功。
+     HTTP ok 还不够：上游按 updatedAt 条件写（旧不盖新），成功体 `data.skippedEntries`
+     里点名了 `fire_pack` 条目（典型成因：设备时钟被回拨过）时同样打回——
+     `409 INSTANT_CHAT_STATE_STALE`，绝不落任务（否则 fire 拿旧 chat 段答话）。
   2. 内部转发 `POST /schedule-message`（taskPayload）→ 必须成功，拿到 uuid
      （顶替在上游事务内完成）。
   3. 返回 `202 { status: 'accepted', uuid }`。
@@ -122,8 +125,16 @@
 
 - 客户端「正在输入」的主判定是**云端任务状态**：还欠着回复时每 60s 查一次
   `GET /message?id=<uuid>`，`pending` 就继续等，行已失败 / 行没了才收尾；
-  查询本身失败（网络、鉴权）不下任何结论，等下一跳。下结论前先拉一次 outbox。
+  查询本身失败不立刻下结论，等下一跳。下结论前先拉一次 outbox。
   **只在前台查**：页面不可见时既不查也不排下一跳，回前台立刻点一次名把周期接上。
+  **失联判死线**：联网状态（`navigator.onLine !== false`）下同一轮连续 5 次查询
+  失败 → worker 多半已不在（被删 / 密钥换了），明确收尾并提示去设置页重新连接
+  验证；离线时的失败不计数。「不按时长宣判」只对云端还答得上话的等待成立。
+- worker 留痕 `chat_fail`（char namespace 的 client_state，认 uuid）：fire 收尾
+  失败、过期跳过（reason `stale`）、以及 skip-push（reason `empty-generation` /
+  `side-effects-only`——即时对话的一次性行会被上游当成功消费删掉，客户端只能看到
+  gone）三处都写。客户端 completed 与 gone 两个分支都点名读回翻成人话，别把
+  「没生成出来」说成「回复没能取回」。
 - worker 侧若现有 hook（如 `onFireSettled`）拿得到失败结局且拿得到 push 发送
   能力 → 尽力补发一条 `messageKind: 'error'`（SW 已有该分轨）。拿不到就算了，
   别为此改上游。

--- a/public/instant-worker.deno.bundle.js
+++ b/public/instant-worker.deno.bundle.js
@@ -2969,6 +2969,88 @@ function classifyLLMOutput(text) {
 // utils/instantWorkerVersion.ts
 var INSTANT_WORKER_VERSION = "2026-07-17";
 
+// utils/emotionEvalCore.ts
+var EMOTION_EVAL_SYSTEM_SLOT = "__EMOTION_EVAL_SYSTEM_PROMPT__";
+var EMOTION_EVAL_HISTORY_SLOT = "__EMOTION_EVAL_HISTORY__";
+var EMOTION_EVAL_TIMEOUT_MS = 12e4;
+var flattenEvalContent = (content) => {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => part?.type === "text" ? part.text || "" : part?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
+  }
+  return "";
+};
+var restoreEvalPrompt = (template, chatMessages, charName) => {
+  const messages = Array.isArray(chatMessages) ? chatMessages : [];
+  let systemPromptText = "";
+  let conversation = messages;
+  if (messages.length > 0 && messages[0]?.role === "system") {
+    systemPromptText = flattenEvalContent(messages[0].content);
+    conversation = messages.slice(1);
+  }
+  const recentLines = conversation.map((m) => {
+    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? charName : "\u7CFB\u7EDF";
+    return `[${role}]: ${flattenEvalContent(m.content)}`;
+  }).join("\n");
+  return String(template).replace(EMOTION_EVAL_SYSTEM_SLOT, () => systemPromptText).replace(EMOTION_EVAL_HISTORY_SLOT, () => recentLines);
+};
+var ERROR_SNIPPET_MAX = 120;
+var maskAndSnip = (text, apiKey) => {
+  let snippet = text.replace(/\s+/g, " ").trim();
+  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join("***");
+  return snippet.slice(0, ERROR_SNIPPET_MAX);
+};
+var requestEmotionEval = async (api, promptContent, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseUrl = String(api.baseUrl).replace(/\/+$/, "");
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api.apiKey || "sk-none"}`
+      },
+      body: JSON.stringify({
+        model: api.model,
+        messages: [{ role: "user", content: promptContent }],
+        temperature: 0.85,
+        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
+        // 会被截成半截 JSON。
+        max_tokens: 8e3,
+        stream: false
+      }),
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      let body = "";
+      try {
+        body = await res.text();
+      } catch {
+      }
+      console.warn("[emotion-eval] \u526F API \u62D2\u4E86\u8FD9\u6B21\u8BC4\u4F30\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", res.status);
+      const snippet = maskAndSnip(body, api.apiKey);
+      return { raw: null, error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
+    }
+    const data = await res.json();
+    const message = data?.choices?.[0]?.message;
+    const raw = flattenEvalContent(message?.content) || (typeof message?.reasoning_content === "string" ? message.reasoning_content : "");
+    if (!raw.trim()) {
+      return {
+        raw: null,
+        error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9\uFF08finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"}\uFF09`
+      };
+    }
+    return { raw, error: null };
+  } catch (error) {
+    console.warn("[emotion-eval] \u8BC4\u4F30\u5931\u8D25\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", error);
+    const reason = controller.signal.aborted ? `\u8BC4\u4F30\u8D85\u65F6\uFF08${Math.round(timeoutMs / 1e3)} \u79D2\u6CA1\u56DE\u6765\uFF09` : `\u8BC4\u4F30\u8BF7\u6C42\u6CA1\u53D1\u51FA\u53BB\uFF1A${maskAndSnip(error instanceof Error ? error.message : String(error), api.apiKey)}`;
+    return { raw: null, error: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 // worker/instant-push/src/index.ts
 var MULTIPART_TRANSPORT = { enabled: true };
 var UTILITY_CORS_HEADERS = {
@@ -3315,65 +3397,13 @@ async function runEmotionEval(body) {
   if (!ee?.prompt || !ee?.api?.baseUrl || !ee?.api?.apiKey || !ee?.api?.model) {
     return { raw: "", error: "\u8BC4\u4F30\u914D\u7F6E\u4E0D\u5B8C\u6574\uFF08\u7F3A prompt / baseUrl / apiKey / model\uFF09" };
   }
-  const charId = body?.metadata && typeof body.metadata === "object" ? body.metadata.charId : "";
   const priorMessages = Array.isArray(body?.messages) ? body.messages : [];
   const contactName = body?.contactName || "\u89D2\u8272";
-  const flattenContent = (content) => {
-    if (typeof content === "string") return content;
-    if (Array.isArray(content)) {
-      return content.map((p) => p?.type === "text" ? p.text || "" : p?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
-    }
-    return "";
-  };
-  let systemPromptText = "";
-  let conversation = priorMessages;
-  if (priorMessages.length > 0 && priorMessages[0]?.role === "system") {
-    systemPromptText = flattenContent(priorMessages[0].content);
-    conversation = priorMessages.slice(1);
-  }
-  const recentLines = conversation.map((m) => {
-    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? contactName : "\u7CFB\u7EDF";
-    return `[${role}]: ${flattenContent(m.content)}`;
-  }).join("\n");
-  const evalContent = String(ee.prompt).replace("__EMOTION_EVAL_SYSTEM_PROMPT__", () => systemPromptText).replace("__EMOTION_EVAL_HISTORY__", () => recentLines);
-  const evalMessages = [{ role: "user", content: evalContent }];
-  try {
-    const baseUrl = String(ee.api.baseUrl).replace(/\/+$/, "");
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${ee.api.apiKey || "sk-none"}`
-      },
-      body: JSON.stringify({
-        model: ee.api.model,
-        messages: evalMessages,
-        temperature: 0.85,
-        // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小, eval 输出很长, 会被截断成半截 JSON
-        max_tokens: 8e3,
-        stream: false
-      })
-    });
-    if (!res.ok) {
-      let snippet = "";
-      try {
-        snippet = (await res.text()).replace(/\s+/g, " ").slice(0, 120);
-      } catch {
-      }
-      console.error("[emotion-eval] LLM call failed", res.status);
-      return { raw: "", error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
-    }
-    const data = await res.json();
-    const msg = data?.choices?.[0]?.message;
-    const raw = flattenContent(msg?.content) || (typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "");
-    if (!raw) {
-      return { raw: "", error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9 (finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"})` };
-    }
-    return { raw };
-  } catch (e) {
-    console.error("[emotion-eval] failed", e);
-    return { raw: "", error: `\u8BC4\u4F30\u8BF7\u6C42\u5F02\u5E38\uFF1A${e?.message || String(e)}` };
-  }
+  const outcome = await requestEmotionEval(
+    ee.api,
+    restoreEvalPrompt(String(ee.prompt), priorMessages, contactName)
+  );
+  return outcome.raw != null ? { raw: outcome.raw } : { raw: "", error: outcome.error ?? void 0 };
 }
 function withSseAntiBufferingHeaders(resp) {
   const contentType = resp.headers.get("content-type") || "";

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -22,6 +22,7 @@ import {
   resolveExpirePolicy, toDatetimeLocalValue,
 } from './amsg2Tasks';
 import { AMSG_CHAT_PRESENCE_KEY, AmsgChatPresence } from './amsgChatPresence';
+import { flattenContentPartsToText } from './promptMessageCleanup';
 import {
   AMSG_FIRE_PACK_KEY,
   FIRE_PACK_VERSION,
@@ -298,7 +299,13 @@ const ensureWorkerReady = async () => {
   return config;
 };
 
-const initializeClient = async (config: ActiveMsg2GlobalConfig) => {
+// 握手结果按配置记忆化：init()（get-user-key）是一次真网络往返，而用户密钥不变——
+// 即时对话把它放上了发送热路径（拿到 202 之前的串行延迟）和 60s 状态点名（一跳最多
+// 两次），逐次重新握手纯属白付 RTT。键取会影响握手的三个字段；配置一变（换 worker /
+// 换密钥 / 清空重连）键就换，旧缓存自然作废。失败的握手不缓存，下一次重新来过。
+let cachedClientEntry: { key: string; promise: ReturnType<typeof createAndInitClient> } | null = null;
+
+const createAndInitClient = async (config: ActiveMsg2GlobalConfig) => {
   const client = createClient(config);
   try {
     await client.init();
@@ -306,6 +313,17 @@ const initializeClient = async (config: ActiveMsg2GlobalConfig) => {
     throw normalizeActiveMsgApiError(error, '获取用户密钥');
   }
   return client;
+};
+
+const initializeClient = (config: ActiveMsg2GlobalConfig) => {
+  const key = `${config.workerUrl}|${config.userId}|${config.serverToken ?? ''}`;
+  if (cachedClientEntry?.key === key) return cachedClientEntry.promise;
+  const promise = createAndInitClient(config);
+  cachedClientEntry = { key, promise };
+  promise.catch(() => {
+    if (cachedClientEntry?.promise === promise) cachedClientEntry = null;
+  });
+  return promise;
 };
 
 const resolveApiConfig = (char: CharacterProfile, config: ActiveMsg2CharacterConfig, apiConfig: APIConfig) => {
@@ -404,16 +422,40 @@ const readEmojiLibrary = async (): Promise<EmojiLibrary> => {
 };
 
 // export 只为单测（activeMsgClient.test.ts 钉 tzId 取值与模板不烤时间）。
+/**
+ * 即时对话轻量包的模板占位（角色 2.0 关着且没有任何任务时用）：定时任务那条路才渲染
+ * 模板，这类角色的包永远没人渲染，每次发送重建一整份系统提示词 + 近史转写纯属白付
+ * （主线程二次构建 + 手机上行几十 KB，都发生在拿到 202 之前）。写成一眼能认出来的
+ * 标记：它要是出现在推送正文里，说明有本不该渲染模板的 fire 在渲染它。
+ */
+const AMSG2_INSTANT_STUB_TEMPLATE =
+  'AMSG2_INSTANT_STUB_TEMPLATE（即时对话轻量包：该角色无定时任务，模板未随发送重建；看到这条正文说明有本不该渲染模板的 fire 在渲染它）';
+
 export const buildFirePack = async (
   char: CharacterProfile,
   userProfile: UserProfile,
   groups: GroupProfile[],
   realtimeConfig: RealtimeConfig | undefined,
   emojiLibrary?: EmojiLibrary,
+  opts?: {
+    /**
+     * 用占位模板替代真模板（跳过系统提示词 + 近史转写 + 表情全库读取这三样大头）。
+     * 只许在「这份包的模板确定无人渲染」时传：即时对话发送路径上，角色 2.0 关着
+     * （selfScheduleEnabled=false，云端 fire 不给排程能力）且本地任务清单为空。
+     * 其余字段（scene / lastUserMessageAt / pendingTasks / tzId…）照常构建——
+     * 即时 fire 自己要读它们（sceneSong、锚点、任务清单块）。
+     */
+    templateStub?: boolean;
+  },
 ): Promise<AmsgFirePack> => {
+  const templateStub = opts?.templateStub === true;
   const [{ recentMessages, lastUserMessageAt }, library, schedule] = await Promise.all([
     buildTimeGapHint(char.id),
-    emojiLibrary ? Promise.resolve(emojiLibrary) : readEmojiLibrary(),
+    // 表情库只喂系统提示词/近史渲染：占位模板路径整库都不用读（表情记录带图片数据，
+    // 全表 getAll 不便宜）。
+    templateStub
+      ? Promise.resolve({ all: [], categories: [] } as unknown as EmojiLibrary)
+      : (emojiLibrary ? Promise.resolve(emojiLibrary) : readEmojiLibrary()),
     // 日程随包带原始表（不是渲染好的文字），worker 到点自己挑时段。总开关关掉的角色没有表。
     isScheduleFeatureOn(char)
       ? getDailyScheduleForChar(char).catch((e) => {
@@ -468,7 +510,7 @@ export const buildFirePack = async (
     library.categories,
     char.id,
   );
-  const systemPrompt = await ChatPrompts.buildSystemPrompt(
+  const systemPrompt = templateStub ? '' : await ChatPrompts.buildSystemPrompt(
     char,
     userProfile,
     groups,
@@ -484,15 +526,13 @@ export const buildFirePack = async (
     // 具体拿掉哪些块、到点由谁补，见 ChatPrompts.PromptBuildOptions 上的表。
     { forFirePack: true },
   );
-  const { apiMessages } = ChatPrompts.buildMessageHistory(
+  const recentTranscript = templateStub ? '' : ChatPrompts.buildMessageHistory(
     recentMessages,
     Math.min(char.contextLimit || 120, 120),
     char,
     userProfile,
     emojis,
-  );
-
-  const recentTranscript = apiMessages
+  ).apiMessages
     .slice(-30)
     .map((message) => formatHistoryLine(message.role, message.content, char, userProfile))
     .join('\n\n');
@@ -505,7 +545,7 @@ export const buildFirePack = async (
     ? `- 你的记忆库里存着这些月份的经历：${recallableMonths.join('、')}。想聊起其中某段时，先输出 [[RECALL: 年-月]] 把细节取回来再写，别凭印象编。`
     : null;
 
-  const template = [
+  const template = templateStub ? AMSG2_INSTANT_STUB_TEMPLATE : [
     '你将代表下面这个角色，生成一条“主动发给用户”的私聊消息。',
     '',
     '【重要规则】',
@@ -647,14 +687,9 @@ const utf8ByteLength = (text: string): number => new TextEncoder().encode(text).
 const hasNonTextPart = (content: unknown): boolean =>
   Array.isArray(content) && content.some((part: any) => part?.type !== 'text');
 
-/** 结构化分段 → 只剩文字的那一句（丢掉图片本体时的替代内容）。 */
-const flattenToText = (content: unknown[]): string => {
-  const text = content
-    .map((part: any) => (part?.type === 'text' ? String(part.text ?? '') : ''))
-    .filter(Boolean)
-    .join('\n');
-  return text || '[图片]';
-};
+// 「图片消息 → 文字占位」的拍平内核与本地 stripImages 路径共用同一份
+// （promptMessageCleanup.flattenContentPartsToText）：超预算降级产物必须与
+// 本地拍平产物严格同源，否则同一条历史消息在两条生成路上渲染成两种样子。
 
 /**
  * 本地那串 fullMessages → fire_pack 的 `chat.messages`。
@@ -703,7 +738,7 @@ export const toFirePackChatMessages = (
   for (let i = 0; i < result.length && totalBytes > CHAT_CONTENT_BUDGET_BYTES; i += 1) {
     if (i === protectedIdx || !hasNonTextPart(result[i].content)) continue;
     const bytesBefore = entryBytes(result[i]);
-    result[i] = { role: result[i].role, content: flattenToText(result[i].content as unknown[]) };
+    result[i] = { role: result[i].role, content: flattenContentPartsToText(result[i].content as unknown[]) };
     totalBytes -= bytesBefore - entryBytes(result[i]);
     console.warn(`${ACTIVE_MSG_RUNTIME_HEADER} 即时对话这轮体积超标，第 ${i + 1} 条消息的图片本体没带上云（文字段保留）`);
   }
@@ -1747,8 +1782,13 @@ export const ActiveMsgClient = {
 
     const now = Date.now();
     const tzId = resolveCharTimeZone(char) ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // 模板只有定时任务那条路才渲染：角色 2.0 关着（云端 fire 不注入排程工具，排不出
+    // 会消费模板的新任务）且本地任务清单为空时，用占位模板省掉每次发送的二次全量
+    // 构建与上传。2.0 开着 / 还挂着任务（含取消失败的幽灵行）就老老实实带真模板。
+    const templateStub = !isAmsg2EnabledForChar(char)
+      && (char.activeMsg2Config?.tasks?.length ?? 0) === 0;
     const firePack: AmsgFirePack = {
-      ...(await buildFirePack(char, userProfile, groups, realtimeConfig)),
+      ...(await buildFirePack(char, userProfile, groups, realtimeConfig, undefined, { templateStub })),
       chat: { messages: toFirePackChatMessages(chatMessages), builtAt: now },
     };
 
@@ -2183,6 +2223,8 @@ export const ActiveMsgClient = {
     realtimeConfig: RealtimeConfig | undefined,
   ): Promise<{ deleted: number; toolConfigRestored: boolean }> {
     const config = await ensureWorkerReady();
+    // 清云端状态可能连用户密钥一起换代：握手缓存作废，之后的第一次调用重新 init。
+    cachedClientEntry = null;
     const client = createClient(config);
     const response = await client.clearClientState();
     if (!response?.success) {

--- a/utils/activeMsgRuntime.test.ts
+++ b/utils/activeMsgRuntime.test.ts
@@ -596,6 +596,34 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
     expect(staleMs, '补收该跳过打字延迟').toBeLessThan(400);
   }, 20000);
 
+  // 同一条推送的「第二次到达」（outbox 补收先落库、被推送服务延迟的原始 push 几分钟后
+  // 才送达；或补收销账时 cancelTask 没拦住、worker 重试重跑复用同 messageId）不该再上
+  // 屏一遍：落库前按聊天近史里的 activeMsg2.messageId 去重。
+  it('聊天记录里已有同 messageId → 第二次到达整条丢弃，不重复上屏', async () => {
+    const charId = 'char-dedup-redelivery';
+    await DB.saveCharacter({ id: charId, name: '去重角色' } as any);
+    await ActiveMsgStore.saveInboxMessage(inboxMsg({
+      messageId: 'msg_task_9@1700000000000_hook_0',
+      charId,
+      messageType: 'text',
+      sentAt: Date.now() - 8 * 60_000, // 走补收口径，跳过拟人慢放
+    }));
+    await flushInboxToChat();
+    const first = await assistantMsgs(charId);
+    expect(first.length).toBeGreaterThan(0);
+
+    // 同一条（同 messageId）再次入库 = 迟到的原始推送终于送达
+    await ActiveMsgStore.saveInboxMessage(inboxMsg({
+      messageId: 'msg_task_9@1700000000000_hook_0',
+      charId,
+      messageType: 'text',
+      sentAt: Date.now() - 8 * 60_000,
+    }));
+    await flushInboxToChat();
+
+    expect((await assistantMsgs(charId)).length, '第二次到达不能再上屏').toBe(first.length);
+  }, 20000);
+
   // 即时对话的情绪评估在 worker 里跟主回复并行跑，结果挂在最后一条推送的 metadata 上。
   // 收侧得走 Instant Push 那条 emotion_update 同一条链：同一个 applyEmotionEvalRaw 落 buff、
   // 同一个 'instant-emotion-done' 熄灯。漏了这一段，用户看到的是「回复来了、情绪永远不更新、

--- a/utils/activeMsgRuntime.test.ts
+++ b/utils/activeMsgRuntime.test.ts
@@ -725,6 +725,44 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       readSpy.mockRestore();
       clearSpy.mockRestore();
     }, 20000);
+
+    // 降级存原稿（post-processing 失败到头 / 白名单外类型）也要消费情绪附赠：全仓库
+    // 唯一的消费点在主路径里面，降级只把 metadata 原样抄进聊天记录的话，结果永远无人
+    // 再读——徽章亮满十来分钟的安全网，然后弹「worker 可能是旧版」的假告警，其实结论
+    // 早就到了本地。
+    it('降级存原稿路径 → 照样落 buff + 熄灯（结果不能躺在 metadata 里烂掉）', async () => {
+      const charId = 'char-emotion-degraded';
+      await DB.saveCharacter({ id: charId, name: '降级角色' } as any);
+      await ActiveMsgStore.saveInboxMessage(inboxMsg({
+        messageId: 'msg-emotion-degraded',
+        charId,
+        charName: '降级角色',
+        messageType: 'forum', // 白名单外 → 不走 post-processing，直接原稿落库（routed=false）
+        metadata: {
+          charId,
+          amsgEmotionDone: true,
+          amsgEmotionUpdate: JSON.stringify({
+            changed: true,
+            buffs: [{ label: '释然', emoji: '🌿', intensity: 2 }],
+            injection: '你此刻很释然。',
+          }),
+        },
+      }));
+
+      const { seen, restore } = captureEvents();
+      try {
+        await flushInboxToChat();
+      } finally {
+        restore();
+      }
+
+      const updated = (await DB.getAllCharacters()).find((c) => c.id === charId)!;
+      expect(updated.activeBuffs?.map((b: any) => b.label), '降级路径也要落 buff').toContain('释然');
+      expect(seen.some((e) => e.type === 'instant-emotion-done' && e.detail?.charId === charId),
+        '降级路径也要熄灯，别把安全网的假告警等出来').toBe(true);
+      // 原稿本体照常上屏
+      expect((await assistantMsgs(charId)).length).toBeGreaterThan(0);
+    }, 20000);
   });
 
   // 聊天走即时对话时，思考是在 worker 里生成的，客户端手上没有那份 reasoning。
@@ -1746,6 +1784,80 @@ describe('即时对话的待收记录（走真库）', () => {
     const systemMsgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter((m) => m.role === 'system');
     expect(systemMsgs).toHaveLength(1);
     expect(systemMsgs[0].content).toContain('回复没能取回');
+  }, 20000);
+
+  // gone 不都是「发成功后行被删」：模型空输出 / 纯拒答被 worker 判 skip-push 时，一次性
+  // 行同样被上游当成功消费删掉，worker 在那一刻写过 chat_fail。gone 分支不读它的话，
+  // 给用户的解释是「云端已处理但回复没能取回」——把「没生成出来」说成了「取不回」，
+  // 用户以为是投递故障白重发，其实该知道的是模型这轮没说话。
+  it('行没了 + outbox 为空 + chat_fail 说是 skip → 照实说「模型这轮没有生成内容」', async () => {
+    const charId = 'char-instant-skip';
+    await DB.saveCharacter({ id: charId, name: '即时角色' } as any);
+    setInstantChatPending(charId, 'uuid-skip', Date.now());
+    vi.spyOn(ActiveMsgClient, 'readClientStateValue').mockImplementation(async (_ns, key) => (
+      key === 'chat_fail'
+        ? JSON.stringify({ v: 1, uuid: 'uuid-skip', reason: 'empty-generation', retryCount: 0, at: Date.now() })
+        : null
+    ));
+    vi.spyOn(ActiveMsgClient, 'getRemoteTaskStatus').mockResolvedValue({ state: 'gone' });
+
+    await runInstantChatStatusCheck();
+
+    expect(getInstantChatPending(charId)).toBeNull();
+    const systemMsgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter((m) => m.role === 'system');
+    expect(systemMsgs).toHaveLength(1);
+    expect(systemMsgs[0].content).toContain('模型这轮没有生成内容');
+    expect(systemMsgs[0].content, '不许把「没生成」说成「取不回」').not.toContain('回复没能取回');
+  }, 20000);
+
+  // 「不按时长宣判」只对云端还答得上话的等待成立。worker 被删（未知路由回 HTML 页）、
+  // 共享密钥被换（401）这类用户自己动过环境的场景，状态查询永远抛错——不设线的话
+  // 「正在输入…」跨重启常亮、每 60s 空转、该角色 fire_pack 同步被无限期挂起。
+  it('联网状态下状态查询连续失败到第 5 次 → 明确判失联收场，不再无限等', async () => {
+    const charId = 'char-instant-unreachable';
+    await DB.saveCharacter({ id: charId, name: '即时角色' } as any);
+    setInstantChatPending(charId, 'uuid-unreachable', Date.now());
+    vi.spyOn(ActiveMsgClient, 'readClientStateValue').mockResolvedValue(null);
+    vi.spyOn(ActiveMsgClient, 'getRemoteTaskStatus').mockRejectedValue(new Error('Unexpected token < in JSON'));
+
+    const timers = captureStatusPollTimers();
+    try {
+      for (let i = 0; i < 4; i += 1) {
+        await runInstantChatStatusCheck();
+        expect(getInstantChatPending(charId)?.uuid, `第 ${i + 1} 次失败还不够判死`).toBe('uuid-unreachable');
+      }
+      await runInstantChatStatusCheck();
+    } finally {
+      timers.restore();
+    }
+
+    expect(getInstantChatPending(charId), '连续 5 次问不出话就该收场').toBeNull();
+    const systemMsgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter((m) => m.role === 'system');
+    expect(systemMsgs).toHaveLength(1);
+    expect(systemMsgs[0].content).toContain('联系不上云端 worker');
+    expect(systemMsgs[0].content, '要给用户指条能走的路').toContain('重新连接并验证');
+  }, 20000);
+
+  // 断网的失败是这台设备的问题，攒不出「worker 失联」的结论——恢复网络后从头计。
+  it('设备离线时的查询失败不计入失联判定', async () => {
+    const charId = 'char-instant-airplane';
+    await DB.saveCharacter({ id: charId, name: '即时角色' } as any);
+    setInstantChatPending(charId, 'uuid-airplane', Date.now());
+    vi.spyOn(ActiveMsgClient, 'readClientStateValue').mockResolvedValue(null);
+    vi.spyOn(ActiveMsgClient, 'getRemoteTaskStatus').mockRejectedValue(new Error('Failed to fetch'));
+    vi.stubGlobal('navigator', { onLine: false });
+
+    const timers = captureStatusPollTimers();
+    try {
+      for (let i = 0; i < 6; i += 1) await runInstantChatStatusCheck();
+    } finally {
+      timers.restore();
+      vi.unstubAllGlobals();
+    }
+
+    expect(getInstantChatPending(charId)?.uuid, '离线失败次数再多也不许判死').toBe('uuid-airplane');
+    const msgs = await DB.getRecentMessagesByCharId(charId, 50);
+    expect(msgs.some((m) => m.role === 'system')).toBe(false);
   }, 20000);
 
   // 「取不回」的结论 = 行没了 **且 outbox 读到了、里面确实没有**。outbox 那一步读失败

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -12,7 +12,7 @@ import {
 import { runPendingToolCalls } from './instantToolRunner';
 import { drainPendingDiaries } from './pendingDiary';
 import { applyEmotionEvalRaw } from './emotionApply';
-import { CHAT_GEN_EVENTS, announceEmotionDone } from './chatGenEvents';
+import { CHAT_GEN_EVENTS, announceChatGen, announceEmotionDone } from './chatGenEvents';
 import { processNewMessages } from './memoryPalace/pipeline';
 import { loadMusicHooks } from '../context/MusicContext';
 import type { XhsNote } from './realtimeContext';
@@ -607,16 +607,13 @@ const processInboxMessageWithPostProcessing = async (
     // 情绪没变、没有任何解释。worker 捎回来的那句原因（副 API 的状态码 / 模型没输出）
     // 直接给用户看：他自己部署的 worker，「可查日志」对多数人等于没说。
     const workerReason = (message.metadata as any)?.amsgEmotionError;
-    try {
-      window.dispatchEvent(new CustomEvent(CHAT_GEN_EVENTS.emotionFailed, {
-        detail: {
-          charId: message.charId, charName: message.charName || '',
-          reason: typeof workerReason === 'string' && workerReason
-            ? `云端情绪评估失败——${workerReason}`
-            : '云端情绪评估无输出（副 API 报错或模型没返回内容，可查 worker 日志）',
-        },
-      }));
-    } catch { /* SSR-safe */ }
+    // 统一走 announceChatGen（chatGenEvents 的唯一派发出口），别再手写 dispatchEvent。
+    announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
+      charId: message.charId, charName: message.charName || '',
+      reason: typeof workerReason === 'string' && workerReason
+        ? `云端情绪评估失败——${workerReason}`
+        : '云端情绪评估无输出（副 API 报错或模型没返回内容，可查 worker 日志）',
+    });
   }
   if (emotionDone || emotionUpdateRaw) {
     announceEmotionDone(message.charId);
@@ -1259,6 +1256,29 @@ const flushInboxToChatImpl = async () => {
   // finally 里撤掉：落库成功的那时聊天记录已经查得到；requeue 回收件箱的那几条
   // 也重新出现在 listInboxMessages 里，两条腿都接上了才撤。
   trackInFlightInboxMessageIds(pendingMessages.map((m) => m.messageId));
+  // ─── 落库前的 messageId 去重 ───
+  // 同一条推送有两条可达的「第二次到达」路径：① outbox 补收先落了库，被推送服务
+  // 延迟的原始 Web Push 几分钟后才送达（补收绕过 SW，delivery-dedupe 里没有记录）；
+  // ② 补收销账时 best-effort cancelTask 没拦住重试，worker 重跑整个 fire——重叠段号
+  // 复用相同 messageId（`msg_task_{行id}@{occurrenceMs}_hook_{i}` 是确定性规则）。
+  // 聊天近史里已经有这个 activeMsg2.messageId 的，直接丢弃：不落库、不弹 toast、
+  // 不重放 directives。只对首次处理（processAttempts=0）做——重试那几条的半成品
+  // 气泡刚被 prepareInboxRetry 清场，近史里查到的正是「该重跑」的证据，不能误杀。
+  const persistedIdsByChar = new Map<string, Set<string>>();
+  const isAlreadyPersisted = async (charId: string, messageId: string): Promise<boolean> => {
+    if (!messageId) return false;
+    let ids = persistedIdsByChar.get(charId);
+    if (!ids) {
+      const recent = await DB.getRecentMessagesByCharId(charId, 200);
+      ids = new Set(
+        recent
+          .map((m: any) => m?.metadata?.activeMsg2?.messageId)
+          .filter((id: unknown): id is string => typeof id === 'string' && !!id),
+      );
+      persistedIdsByChar.set(charId, ids);
+    }
+    return ids.has(messageId);
+  };
   try {
   // consumeInboxMessages 是 "先 ack 后处理" 语义 —— inbox 已经原子地清空。
   // 这里 per-message try/catch: 单条处理抛错 (quota / DB 故障 / postprocess 异常) 不连累
@@ -1278,6 +1298,15 @@ const flushInboxToChatImpl = async () => {
       bodyChars: typeof message.body === 'string' ? message.body.length : undefined,
     });
 
+    // 见上面 isAlreadyPersisted 的注释：这条已经在聊天记录里了（补收先到、真推送迟到，
+    // 或重试重跑的重叠段），第二份原样丢弃。
+    if (!(message.processAttempts && message.processAttempts > 0)
+      && await isAlreadyPersisted(message.charId, message.messageId)) {
+      log.warn('这条消息已在聊天记录里（补收先到/重试重跑的第二份），丢弃', { messageId: message.messageId, charId: message.charId });
+      activeMsgTrace('runtime-inbox-duplicate-dropped', { messageId: message.messageId, charId: message.charId });
+      continue;
+    }
+
     // emotion_update: worker 跑完副 API 情绪评估后推回的 buff 结果. 不渲染成聊天消息, 直接落 buff +
     // 广播 innerState (useChatAI 监听 'emotion-innerstate-updated' → setEvolvedNarrative 喂下一轮).
     // 识别条件用 messageType==='emotion_update' 或 metadata.emotionRaw 存在 —— 后者兜底旧 SW
@@ -1293,16 +1322,12 @@ const flushInboxToChatImpl = async () => {
         // 派发失败事件让 OSContext 弹 toast。2026-07-17+ 的 worker 会把具体原因带在
         // metadata.emotionError（副 API HTTP 状态等）；旧 worker 没这字段就给通用文案。
         const workerReason = (message.metadata as any)?.emotionError;
-        try {
-          window.dispatchEvent(new CustomEvent(CHAT_GEN_EVENTS.emotionFailed, {
-            detail: {
-              charId: message.charId, charName: '',
-              reason: typeof workerReason === 'string' && workerReason
-                ? `云端评估失败——${workerReason}`
-                : '云端情绪评估无输出（副 API 报错或模型没返回内容，可查 worker 日志）',
-            },
-          }));
-        } catch { /* SSR-safe */ }
+        announceChatGen(CHAT_GEN_EVENTS.emotionFailed, {
+          charId: message.charId, charName: '',
+          reason: typeof workerReason === 'string' && workerReason
+            ? `云端评估失败——${workerReason}`
+            : '云端情绪评估无输出（副 API 报错或模型没返回内容，可查 worker 日志）',
+        });
       }
       // 无论成功与否都通知 useChatAI 熄灭 "情绪更新中" 徽章 (buff 已落 / 或这轮没结果).
       announceEmotionDone(message.charId);
@@ -1544,7 +1569,11 @@ const flushInboxToChatImpl = async () => {
         // 2/4/6 分钟的重试队列里，跑起来就是同一轮的第二份回复。尽力取消；
         // 正常送达的路不带这个标记（行发完即删，也无从取消），一个多余请求都不发。
         if ((message.metadata as any)?.amsgOutboxBackfill) {
-          ActiveMsgClient.cancelTask(pendingForChar.uuid).catch(() => {});
+          // 取消失败别静默吞：重试跑起来就是同一轮的第二份回复（重叠段有上面的
+          // messageId 去重兜着，多出的段拦不住），至少留下一条可查的痕。
+          ActiveMsgClient.cancelTask(pendingForChar.uuid).catch((e) => {
+            log.warn('补收销账后取消重试任务失败（若重试已在跑，重复段会被落库去重拦下）', { uuid: pendingForChar.uuid, error: e });
+          });
         }
         // 末段先到、中段还丢在路上的乱序场景：销账后 pending 没了，常规兜底不会再看
         // 这一轮——离场前按这轮的 uuid 补扫一次 outbox，把缺的段捡回来。

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -1487,6 +1487,22 @@ const flushInboxToChatImpl = async () => {
         // requeue 后跳过这条消息的 dispatchEvent —— UI 不该误以为收到了
         continue;
       }
+      // 情绪附赠也要在这里消费：结果就挂在这条 push 的 metadata 上，而全仓库唯一的
+      // 消费点在 post-processing 内部——走到降级这条路说明那边失败到头了，光把 metadata
+      // 原样抄进聊天记录的话结果永远无人再读：「情绪更新中」徽章亮满十来分钟的安全网，
+      // 然后弹「worker 可能是旧版」的假告警，其实结论早就到了本地。best-effort：情绪是
+      // 附赠，消费失败不能连累「原稿已落库」这个事实（与上面销账块同一口径）。
+      try {
+        const degradedEmotionDone = (message.metadata as any)?.amsgEmotionDone === true;
+        const degradedInline = (message.metadata as any)?.amsgEmotionUpdate;
+        const degradedUpdateRaw = typeof degradedInline === 'string' && degradedInline
+          ? degradedInline
+          : await fetchOffloadedEmotionUpdate(message);
+        if (degradedUpdateRaw) await landCloudEmotionResult(message.charId, degradedUpdateRaw);
+        if (degradedEmotionDone || degradedUpdateRaw) announceEmotionDone(message.charId);
+      } catch (e) {
+        log.warn('降级存原稿路径消费情绪结果失败（原稿已落库，不受影响）', { messageId: message.messageId, error: e });
+      }
     }
 
     // 不管走 post-processing 还是 raw fallback, 单条 inbox message 触发一次 'active-msg-received',
@@ -1645,6 +1661,17 @@ const drainInstantChatOutboxAndFlush = async (charId?: string): Promise<number |
 
 let instantChatStatusPollTimer: ReturnType<typeof setTimeout> | null = null;
 
+// ─── 状态查询连续失败的判死线 ───
+// 「不按时长宣判」只对**云端还答得上话**的等待成立（pending 是云端亲口说的，等多久都对）。
+// 但 worker 被删（未知路由回 HTML 页）、共享密钥被换（401）这类用户自己动过环境的场景，
+// 查询这一步会永远抛错——云端的结论永远问不出来，待收记录就永远销不了账：「正在输入…」
+// 跨重启常亮、每 60s 空转一跳、该角色的 fire_pack 同步被无限期挂起。联网状态下连续
+// 多次问不出话，就把这一轮明确判死并告诉用户去检查 worker 配置，不再无限等。
+// 计数按任务 uuid 记，查询成功或换了轮次就清零；断网（navigator.onLine=false）不计数
+// ——那是这台设备暂时没网，不是 worker 的错。
+const instantStatusCheckFailures = new Map<string, number>();
+const INSTANT_STATUS_CHECK_MAX_FAILURES = 5;
+
 /**
  * 还欠着回复时，把下一跳点名排到 60s 后；一条都不欠就直接撤掉定时器。
  *
@@ -1682,7 +1709,13 @@ const scheduleNextInstantChatStatusCheck = () => {
  */
 export const runInstantChatStatusCheck = async (): Promise<void> => {
   if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
-  for (const pending of listInstantChatPendings()) {
+  const pendings = listInstantChatPendings();
+  // 计数器只留还在等的轮次（销账走别的路时这里顺手清，别攒垃圾）。
+  const activeUuids = new Set(pendings.map((p) => p.uuid));
+  for (const uuid of [...instantStatusCheckFailures.keys()]) {
+    if (!activeUuids.has(uuid)) instantStatusCheckFailures.delete(uuid);
+  }
+  for (const pending of pendings) {
     await drainInstantChatOutboxAndFlush(pending.charId);
     // 补收那一步如果把回复放进来了，flush 里已经销账了——这一轮就此结束。
     if (getInstantChatPending(pending.charId)?.uuid !== pending.uuid) continue;
@@ -1691,9 +1724,28 @@ export const runInstantChatStatusCheck = async (): Promise<void> => {
     try {
       status = await ActiveMsgClient.getRemoteTaskStatus(pending.uuid);
     } catch (e) {
-      log.warn('即时对话状态查询失败（等下一跳）', { uuid: pending.uuid, error: e });
+      // 设备自己没网不算 worker 的失败——这种失败攒不出「worker 失联」的结论。
+      if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        log.warn('即时对话状态查询失败（设备离线，等下一跳）', { uuid: pending.uuid, error: e });
+        continue;
+      }
+      const count = (instantStatusCheckFailures.get(pending.uuid) ?? 0) + 1;
+      if (count < INSTANT_STATUS_CHECK_MAX_FAILURES) {
+        instantStatusCheckFailures.set(pending.uuid, count);
+        log.warn('即时对话状态查询失败（等下一跳）', { uuid: pending.uuid, count, error: e });
+        continue;
+      }
+      // 联网状态下连问 N 次都问不出话：worker 多半已经不在了（被删 / 密钥换了 / 路由变了）。
+      // 明确判死这一轮，别让「正在输入」永亮、fire_pack 同步无限期挂起。
+      instantStatusCheckFailures.delete(pending.uuid);
+      const lastError = e instanceof Error ? e.message : String(e);
+      log.warn('即时对话状态查询连续失败，按云端失联收场', { uuid: pending.uuid, count, error: e });
+      await failInstantChatPending(pending.charId, pending.uuid,
+        `联系不上云端 worker（连续 ${count} 次状态查询失败：${lastError.slice(0, 120)}）。`
+        + 'worker 可能已被删除或共享密钥已变，去「设置 → 主动消息 2.0」重新连接并验证');
       continue;
     }
+    instantStatusCheckFailures.delete(pending.uuid);
 
     if (status.state === 'pending') {
       if (status.retryCount) log.warn('即时对话云端在重试', { uuid: pending.uuid, retryCount: status.retryCount });
@@ -1707,25 +1759,7 @@ export const runInstantChatStatusCheck = async (): Promise<void> => {
     // 上游的 completed = 行还在、但已经出了 pending 队列（sent / failed 都算这个码）。
     // 而一次性任务发成功会把行删掉、查出来是 gone——所以还查得到的 completed 行只可能是 failed。
     if (status.state === 'completed') {
-      let reason: string | undefined;
-      try {
-        // 失败原因从 chat_fail 一次点名读回：worker 在 fire 收尾 / 过期跳过时留的痕
-        // （见 amsgFirePack 的 AMSG_CHAT_FAIL_KEY），不用按角色扫全量任务列表逐条解密。
-        // 记录认 uuid：读到的是别轮的（比如上一轮失败的陈痕）就当没有，报笼统原因。
-        // 收尾那一步照旧认 uuid——网络读再快也有空档，迟到的结论不许碰新那一轮。
-        const raw = await ActiveMsgClient.readClientStateValue(
-          amsgStateNamespace(pending.charId), AMSG_CHAT_FAIL_KEY,
-        );
-        const record = parseChatFailRecord(raw);
-        if (record?.uuid === pending.uuid) {
-          reason = describeInstantChatFailure(
-            { at: new Date(record.at).toISOString(), reason: record.reason },
-            record.retryCount,
-          ) ?? undefined;
-        }
-      } catch (e) {
-        log.warn('即时对话失败原因取不到（报个笼统的）', { uuid: pending.uuid, error: e });
-      }
+      let reason = await readInstantChatFailReason(pending.charId, pending.uuid);
       // chat_fail 没留下（isolate 连人带痕一起没了那种）时退回 409 捎来的行级
       // lastError（amsg-server 2.6.0-next.15 起；查询按 uuid 点名，必然是这一行的）。
       if (!reason && status.lastError) {
@@ -1741,11 +1775,38 @@ export const runInstantChatStatusCheck = async (): Promise<void> => {
         log.warn('即时对话云端那行已经没了，但 outbox 没读成——这一跳不下结论', { charId: pending.charId, uuid: pending.uuid });
         continue;
       }
-      log.warn('即时对话云端那行已经没了，回复也取不回', { charId: pending.charId, uuid: pending.uuid });
-      await failInstantChatPending(pending.charId, pending.uuid);
+      // gone 不都是「发成功后行被删」：skip-push（模型空输出 / 纯拒答 / 只做副作用）的
+      // 一次性行同样被上游当成功消费删掉，worker 在那一刻写过 chat_fail。不读的话给
+      // 用户的解释是「云端已处理但回复没能取回」——把「没生成出来」说成了「取不回」。
+      const reason = await readInstantChatFailReason(pending.charId, pending.uuid);
+      log.warn('即时对话云端那行已经没了，回复也取不回', { charId: pending.charId, uuid: pending.uuid, reason });
+      await failInstantChatPending(pending.charId, pending.uuid, reason);
     }
   }
   scheduleNextInstantChatStatusCheck();
+};
+
+/**
+ * 云端 chat_fail 留痕的一次点名读，翻成给用户看的人话；读不到 / uuid 对不上 / 网络
+ * 失败都返回 undefined（这是提示通道，绝不硬失败）。completed 和 gone 两个分支共用：
+ * worker 在 fire 收尾失败、过期跳过、以及 skip-push（空输出）三处都会留痕。
+ * 记录认 uuid：读到的是别轮的（比如上一轮失败的陈痕）就当没有，报笼统原因。
+ */
+const readInstantChatFailReason = async (charId: string, uuid: string): Promise<string | undefined> => {
+  try {
+    const raw = await ActiveMsgClient.readClientStateValue(
+      amsgStateNamespace(charId), AMSG_CHAT_FAIL_KEY,
+    );
+    const record = parseChatFailRecord(raw);
+    if (record?.uuid !== uuid) return undefined;
+    return describeInstantChatFailure(
+      { at: new Date(record.at).toISOString(), reason: record.reason },
+      record.retryCount,
+    ) ?? undefined;
+  } catch (e) {
+    log.warn('即时对话失败原因取不到（报个笼统的）', { uuid, error: e });
+    return undefined;
+  }
 };
 
 // ─── 订阅变化标记（SW 写，这里读/清）────────────────────────────────────────

--- a/utils/amsg2Tasks.test.ts
+++ b/utils/amsg2Tasks.test.ts
@@ -361,6 +361,15 @@ describe('describeInstantChatFailure', () => {
     expect(describeInstantChatFailure({ reason: 'stale' }, 2)).toBe('云端排队太久没轮到这一轮（重试 2 次后放弃）');
   });
 
+  // skip-push 的两种机器码（worker 在 chat_fail 里留的）：这一轮不是失败、是没产出。
+  // 掉进「生成失败」句式的话，用户以为出了故障，其实是模型拒答/只做了动作。
+  it("reason 'empty-generation' / 'side-effects-only' 照实说没产出，不说成失败", () => {
+    expect(describeInstantChatFailure({ reason: 'empty-generation' }))
+      .toBe('模型这轮没有生成内容（空输出或拒答）');
+    expect(describeInstantChatFailure({ reason: 'side-effects-only' }))
+      .toBe('角色这轮只做了动作，没有文字回复');
+  });
+
   it('一长串原始报错照样截断；没有 lastError → null', () => {
     expect(describeInstantChatFailure({ reason: 'x'.repeat(500) })!.length).toBeLessThan(120);
     expect(describeInstantChatFailure(null)).toBeNull();

--- a/utils/amsg2Tasks.ts
+++ b/utils/amsg2Tasks.ts
@@ -312,6 +312,10 @@ export const describeInstantChatFailure = (
   const retried = retryCount && retryCount > 0 ? `（重试 ${retryCount} 次后放弃）` : '';
   // 'stale' 是「排队太久没轮到就被跳过」，没有底层报错可以引。
   if (lastError.reason === 'stale') return `云端排队太久没轮到这一轮${retried}`;
+  // skip-push 的两种（worker 在 chat_fail 里留的机器码）：这一轮云端跑完了，但没有
+  // 能推给用户的正文。照实说，别掉进下面「生成失败」的口径——生成没失败，是没产出。
+  if (lastError.reason === 'empty-generation') return '模型这轮没有生成内容（空输出或拒答）';
+  if (lastError.reason === 'side-effects-only') return '角色这轮只做了动作，没有文字回复';
   const detail = (lastError.reason || '').slice(0, REMOTE_ERROR_REASON_MAX);
   return `生成失败${retried}${detail ? `：${detail}` : ''}`;
 };

--- a/utils/amsg2Timezone.test.ts
+++ b/utils/amsg2Timezone.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { formatTaskTime, fromDatetimeLocalValue, toDatetimeLocalValue } from './amsg2Tasks';
 import { buildAmsg2TaskContextText } from './amsg2TaskContext';
 import {
-    AMSG_SLOT_CURRENT_TIME, AMSG_SLOT_USER_CLOCK,
+    AMSG_SLOT_CURRENT_TIME, AMSG_SLOT_USER_CLOCK, FIRE_PACK_VERSION,
     formatFireTimeShort, renderFirePack, type AmsgFirePack,
 } from './amsgFirePack';
 import { buildFireScheduleBlock, buildFireScheduleTool, resolveSendAtMs } from './amsgFireSchedule';
@@ -58,7 +58,7 @@ describe('给角色看的时间跟 fire 侧同一个钟', () => {
 // 手里就是排到上海用户的凌晨三点，而且它没有任何线索能察觉这件事。
 describe('角色知道对方那边现在几点', () => {
     const pack: AmsgFirePack = {
-        v: 6, builtAt: 1, pendingTasks: [], scene: null, lastUserMessageAt: null,
+        v: FIRE_PACK_VERSION, builtAt: 1, pendingTasks: [], scene: null, selfScheduleEnabled: true, lastUserMessageAt: null,
         template: `当前本地时间（你所在地）：${AMSG_SLOT_CURRENT_TIME}${AMSG_SLOT_USER_CLOCK}`,
         tzId: CHAR_TZ,
         userTzId: DEVICE_TZ,

--- a/utils/amsg2ToolBridge.test.ts
+++ b/utils/amsg2ToolBridge.test.ts
@@ -370,3 +370,48 @@ describe('同名同参的调用不重复执行', () => {
     expect(ActiveMsgClient.scheduleCharacterTask).toHaveBeenCalledTimes(2);
   });
 });
+
+// 连发上限的本地排程闸（与 worker fire 侧 unanswered_limit 对齐）：本地排到超限的
+// 那几条会被到点兜底闸静默 skip——角色在正文里承诺了「等下再来找你」，到点却凭空
+// 蒸发。这里钉住：超限时带回喂打回、一次远端请求都不发；面板任务不占额度。
+describe('连发上限·本地排程闸', () => {
+  beforeEach(() => {
+    (ActiveMsgClient.scheduleCharacterTask as any).mockReset();
+    (ActiveMsgClient.scheduleCharacterTask as any).mockImplementation(async () => ({
+      uuid: UUIDS[0], clientTaskId: 'ct-limit', firstSendAt: RESOLVED_ISO, anchorMs: null,
+    }));
+  });
+
+  const selfTask = (uuid: string) => ({
+    taskUuid: uuid, clientTaskId: `${uuid}-c`, mode: 'auto', recurrenceType: 'none',
+    expirePolicy: 'expire', source: 'character', status: 'scheduled',
+    firstSendTime: new Date(Date.now() + 3600_000).toISOString(), createdAt: Date.now(),
+  });
+
+  it('挂满自排任务（默认上限 3）再排 → 打回，不发远端请求', async () => {
+    const { deps } = makeSession({
+      activeMsg2Config: { enabled: true, tasks: [selfTask('u1'), selfTask('u2'), selfTask('u3')] },
+    });
+    const reply = await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    expect(reply).toContain('连发上限');
+    expect(ActiveMsgClient.scheduleCharacterTask).not.toHaveBeenCalled();
+  });
+
+  it('面板里用户亲手排的任务不占连发额度', async () => {
+    const userTask = (uuid: string) => ({ ...selfTask(uuid), source: 'user' });
+    const { deps } = makeSession({
+      activeMsg2Config: { enabled: true, tasks: [userTask('u1'), userTask('u2'), userTask('u3')] },
+    });
+    const reply = await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    expect(reply).toContain('已创建');
+  });
+
+  it('用户把上限设成 1 → 第一条自排就打回第二条', async () => {
+    const { deps } = makeSession({
+      activeMsg2Config: { enabled: true, maxUnansweredSends: 1, tasks: [selfTask('u1')] },
+    });
+    const reply = await executeAmsg2Tool('schedule_active_message', { send_at: future(1) }, deps);
+    expect(reply).toContain('连发上限是 1 条');
+    expect(ActiveMsgClient.scheduleCharacterTask).not.toHaveBeenCalled();
+  });
+});

--- a/utils/amsg2ToolBridge.ts
+++ b/utils/amsg2ToolBridge.ts
@@ -26,8 +26,9 @@ import { trackEvent } from './analytics';
 import {
   applyScheduledTask, currentOccurrenceMs, describeExpirePolicy, describeRecurrence,
   describeTaskMode, describeTaskProgress, findTaskByShortId, formatTaskTime,
-  getPendingTasks, pruneStaleTasks, resolveExpirePolicy, shortTaskId,
+  getPendingTasks, isPendingTask, pruneStaleTasks, resolveExpirePolicy, shortTaskId,
 } from './amsg2Tasks';
+import { resolveMaxUnansweredSends } from './amsgFirePack';
 import { EXPIRE_POLICY_DESCRIPTION } from './amsgFireSchedule';
 import { resolveCharTimeZone } from './timezone';
 
@@ -270,6 +271,21 @@ const persistTasks = (
 async function handleSchedule(args: Record<string, any>, deps: Amsg2ToolDeps): Promise<string> {
   const { char, userProfile, groups, realtimeConfig, apiConfig } = deps;
   const config = readConfig(deps);
+  // 连发上限·本地排程闸（与 worker fire 侧 runFireScheduleTool 的 unanswered_limit
+  // 对齐）：挂着的自排任务到点各消耗一条连发额度，本地排到超限的那几条会被到点兜底闸
+  // 静默 skip——角色在正文里承诺了「等下再来找你」，到点却凭空蒸发。在这里带回喂打回，
+  // 让模型当场改口。本地轮次用户刚开口（连发计数已清零），所以只数还没响的自排任务；
+  // 面板里用户亲手排的（source!=='character'）不占额度，与 worker 侧同一口径。
+  // 改期/补当次（__replaceTaskUuid / __makeupForTaskUuid）不新占额度，放行。
+  if (!args.__replaceTaskUuid && !args.__makeupForTaskUuid) {
+    const unansweredLimit = resolveMaxUnansweredSends(char.activeMsg2Config?.maxUnansweredSends);
+    const plannedSelfSends = config.tasks
+      .filter((t) => t.source === 'character' && isPendingTask(t, Date.now()))
+      .length;
+    if (plannedSelfSends + 1 > unansweredLimit) {
+      return `对方还没回复，这期间你已经排了 ${plannedSelfSends} 条后续，用户设置的连发上限是 ${unansweredLimit} 条——这次别排了，等 ta 回复再说。`;
+    }
+  }
   // 回话里的时间按角色的钟写：到点 worker 渲染排程清单用的也是角色时区，两边对不上的话
   // 纽约角色刚排的那条，在下一轮的排程现状里会显示成差一个时差的另一个时刻。
   const charTz = resolveCharTimeZone(char);

--- a/utils/amsgFirePack.test.ts
+++ b/utils/amsgFirePack.test.ts
@@ -120,7 +120,7 @@ describe('formatFireTimeFull / formatFireTimeShort（角色参照系的自然中
 
 describe('renderFirePack', () => {
   const basePack: AmsgFirePack = {
-    v: FIRE_PACK_VERSION, builtAt: 1_700_000_000_000, pendingTasks: [], scene: null,
+    v: FIRE_PACK_VERSION, builtAt: 1_700_000_000_000, pendingTasks: [], scene: null, selfScheduleEnabled: true,
     template: [
       `当前本地时间：${AMSG_SLOT_CURRENT_TIME}`,
       AMSG_SLOT_TIME_SINCE_USER,
@@ -176,7 +176,7 @@ describe('对方那边现在几点（AMSG_SLOT_USER_CLOCK）', () => {
   // 纽约角色 / 上海用户：2026-08-02T13:00Z = 纽约 09:00、上海 21:00。
   const AT = Date.UTC(2026, 7, 2, 13, 0);
   const nyChar: AmsgFirePack = {
-    v: FIRE_PACK_VERSION, builtAt: 1, pendingTasks: [], scene: null, lastUserMessageAt: null,
+    v: FIRE_PACK_VERSION, builtAt: 1, pendingTasks: [], scene: null, selfScheduleEnabled: true, lastUserMessageAt: null,
     template: `当前本地时间（你所在地）：${AMSG_SLOT_CURRENT_TIME}${AMSG_SLOT_USER_CLOCK}`,
     tzId: 'America/New_York',
     userTzId: 'Asia/Shanghai',
@@ -211,7 +211,7 @@ describe('对方那边现在几点（AMSG_SLOT_USER_CLOCK）', () => {
 describe('parseFirePack', () => {
   const valid: AmsgFirePack = {
     v: FIRE_PACK_VERSION, template: 'x', lastUserMessageAt: null, tzId: 'Asia/Shanghai', userTzId: 'Asia/Shanghai', targetName: 'A',
-    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null,
+    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null, selfScheduleEnabled: true,
   };
 
   it('合法 JSON 原样返回', () => {
@@ -269,7 +269,7 @@ describe('self_log', () => {
   const packAt = 1_700_000_000_000;
   const pack: AmsgFirePack = {
     v: FIRE_PACK_VERSION, template: 'x', lastUserMessageAt: null, tzId: 'UTC', userTzId: 'UTC', targetName: '小明同学',
-    builtAt: packAt, pendingTasks: [], scene: null,
+    builtAt: packAt, pendingTasks: [], scene: null, selfScheduleEnabled: true,
   };
   const entry = (id: string, text: string, at = packAt) => ({ id, at, text });
 
@@ -482,7 +482,7 @@ describe('连发提醒（自述块内的计数与上限）', () => {
   const packAt = 1_700_000_000_000;
   const slotted: AmsgFirePack = {
     v: FIRE_PACK_VERSION, lastUserMessageAt: null, tzId: 'UTC', userTzId: 'UTC', targetName: '小明同学',
-    builtAt: packAt, pendingTasks: [], scene: null,
+    builtAt: packAt, pendingTasks: [], scene: null, selfScheduleEnabled: true,
     template: `【最近对话上下文】\n用户：在吗${AMSG_SLOT_SELF_LOG}\n\n【本次任务】\n${AMSG_SLOT_TASK_INSTRUCTION}`,
   };
   const entry = (id: string, text: string) => ({ id, at: packAt, text });
@@ -562,7 +562,7 @@ describe('fire_pack 任务指令槽', () => {
     v: FIRE_PACK_VERSION,
     template: `头部\n${AMSG_SLOT_TASK_INSTRUCTION}\n尾部 ${AMSG_SLOT_CURRENT_TIME}`,
     lastUserMessageAt: null, tzId: 'Asia/Shanghai', userTzId: 'Asia/Shanghai', targetName: '小明同学',
-    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null,
+    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null, selfScheduleEnabled: true,
   };
 
   it('renderFirePack 用传入的任务指令填槽', () => {
@@ -590,6 +590,7 @@ describe('client_state 值压缩', () => {
     builtAt: 1_700_000_000_000,
     pendingTasks: [],
     scene: null,
+    selfScheduleEnabled: true,
   });
 
   it('压完再解回来，一个字都不差', async () => {
@@ -653,7 +654,7 @@ describe('client_state 值压缩', () => {
 describe('fire_pack 版本对不上时说清该做什么', () => {
   const pack = (v: unknown) => JSON.stringify({
     v, template: 'x', lastUserMessageAt: null, tzId: 'UTC', userTzId: 'UTC', targetName: 'A',
-    builtAt: 1, pendingTasks: [], scene: null,
+    builtAt: 1, pendingTasks: [], scene: null, selfScheduleEnabled: true,
   });
 
   it('旧包（worker 新、前端旧）→ 让用户打开一次网页重传', () => {
@@ -687,7 +688,7 @@ describe('fire_pack v7 的 chat 段', () => {
   const base: AmsgFirePack = {
     v: FIRE_PACK_VERSION, template: 'x', lastUserMessageAt: null,
     tzId: 'Asia/Shanghai', userTzId: 'Asia/Shanghai', targetName: '小明',
-    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null,
+    builtAt: 1_700_000_000_000, pendingTasks: [], scene: null, selfScheduleEnabled: true,
   };
   const chat = { messages: [{ role: 'user', content: '在吗' }], builtAt: 1_700_000_000_000 };
 

--- a/utils/amsgFirePack.ts
+++ b/utils/amsgFirePack.ts
@@ -455,9 +455,10 @@ export interface AmsgFirePack {
    * amsg2ToolsInjected（角色级开关关掉的不注入，否则被用户显式关掉的功能会被角色
    * 一次工具调用重新打开），云端不看这个字段的话正好把那道闸绕穿：全局即时对话开着、
    * 角色 2.0 关着，角色照样能在云端聊天轮里排出真会触发的任务。
-   * 缺省当 true：定时任务路径的包只会来自开着 2.0 的角色，旧包缺字段不该被拦。
+   * 必填：v7 的唯一生产者（buildFirePack）无条件写它。这是一道用户主权闸，缺省放行
+   * 的容错方向是 fail-open（字段一丢开关就被静默重新打开），宁可整包打回。
    */
-  selfScheduleEnabled?: boolean;
+  selfScheduleEnabled: boolean;
 }
 
 // ─── 按角色参照系渲染时间（②：worker 给角色看的一切时间只此一份） ───
@@ -899,7 +900,7 @@ export const parseFirePack = (value: string): AmsgFirePack | null => {
         || (typeof parsed.maxUnansweredSends === 'number'
           && Number.isFinite(parsed.maxUnansweredSends)
           && parsed.maxUnansweredSends >= 0)) &&
-      (parsed.selfScheduleEnabled === undefined || typeof parsed.selfScheduleEnabled === 'boolean')
+      typeof parsed.selfScheduleEnabled === 'boolean'
     ) {
       return parsed as AmsgFirePack;
     }

--- a/utils/amsgFireSchedule.ts
+++ b/utils/amsgFireSchedule.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ActiveMsg2ExpirePolicy, ActiveMsg2Mode, ActiveMsg2Recurrence, ActiveMsg2TaskRecord } from '../types';
-import { findTaskByShortId } from './amsg2Tasks';
+import { findTaskByShortId, isPendingTask } from './amsg2Tasks';
 import { type AmsgTzRef, formatFireTimeShort, wallClockPartsInZone } from './amsgFirePack';
 import { wallClockToTimestamp } from './timezone';
 
@@ -317,13 +317,17 @@ export const parseFireScheduleArgs = (
 // ─── 取消 / 改期的目标解析（fire 侧） ───
 
 /**
- * 按 task_id（或「只有一个就选它」）从 fire 时刻的活任务清单里解出目标。
- * 语义与前台 resolveTargetTask 对齐：短 id / 全 uuid 都认；不带 task_id 时
- * 只有清单恰好一条才敢动。找不到就回一句能照做的话（不抛错，见 parseFireScheduleArgs）。
+ * 按 task_id（或「唯一即选」）从 fire 时刻的活任务清单里解出目标。
+ * 语义与前台 resolveTargetTask 对齐：短 id / 全 uuid 都认；不带 task_id 时先按
+ * fire 时刻复筛 pending（快照里可能混着已过点变陈旧的一次性任务——pack 只在打包
+ * 那一刻筛过一次），唯一 pending 就选它，没有 pending 而清单恰好一条也选它。
+ * 不对齐的话，同一句 cancel_active_message 本地能成、云端却被打回 ambiguous_task。
+ * 找不到就回一句能照做的话（不抛错，见 parseFireScheduleArgs）。
  */
 export const resolveFireTargetTask = (
   tasks: ActiveMsg2TaskRecord[],
   taskIdArg: unknown,
+  nowMs: number,
 ): { task: ActiveMsg2TaskRecord } | FireScheduleReject => {
   if (tasks.length === 0) {
     return { ok: false, reason: 'no_tasks', message: '你现在没有挂着任何排程任务。' };
@@ -334,7 +338,9 @@ export const resolveFireTargetTask = (
       ? { task }
       : { ok: false, reason: 'task_not_found', message: `没有找到短 id 为 ${taskIdArg.trim()} 的任务——短 id 在排程清单里，照着那里的写。` };
   }
-  if (tasks.length === 1) return { task: tasks[0] };
+  const pending = tasks.filter((t) => isPendingTask(t, nowMs));
+  if (pending.length === 1) return { task: pending[0] };
+  if (pending.length === 0 && tasks.length === 1) return { task: tasks[0] };
   return { ok: false, reason: 'ambiguous_task', message: '你挂着不止一个任务，带 task_id（排程清单里的短 id）指定要动哪一个。' };
 };
 

--- a/utils/amsgInstantChat.test.ts
+++ b/utils/amsgInstantChat.test.ts
@@ -232,6 +232,37 @@ describe('POST /instant-chat 的形状', () => {
     expect(keys).toContain('tool_config');
   });
 
+  // ── 轻量包：模板只有定时任务那条路才渲染 ──
+  // 角色 2.0 关着（云端 fire 不注入排程工具）且没有任务时，每次发送重建一整份系统
+  // 提示词 + 近史转写纯属白付——主线程二次构建 + 上行几十 KB 都发生在拿到 202 之前。
+  it('角色 2.0 关着且无任务 → 模板用占位标记，系统提示词一次都不构建', async () => {
+    const { state } = await postOnce([{ role: 'user', content: '在吗' }]);
+    const entry = state.entries.find((e: any) => e.key === 'fire_pack');
+    const pack = JSON.parse(await unpackStateValue(entry.value));
+    expect(pack.template).toContain('AMSG2_INSTANT_STUB_TEMPLATE');
+    expect(pack.selfScheduleEnabled).toBe(false);
+    // chat 段照常带全——即时 fire 吃的是它，不是模板
+    expect(pack.chat.messages).toHaveLength(1);
+    expect(ChatPrompts.buildSystemPrompt).not.toHaveBeenCalled();
+  });
+
+  it('角色 2.0 开着 → 照旧带真模板（云端 fire 可能当场排出会消费它的任务）', async () => {
+    stubFirePackDeps();
+    const calls = mockInstantChatFetch(202, { status: 'accepted', uuid: 'uuid-real-template' });
+    const charOn = { ...CHAR, activeMsg2Config: { enabled: true, tasks: [] } } as any;
+    await ActiveMsgClient.sendInstantChat({
+      char: charOn, chatMessages: [{ role: 'user', content: '在吗' }], api: API,
+      userProfile: USER, groups: [], realtimeConfig: {} as any,
+    });
+    const body = JSON.parse(String(calls[0].init.body));
+    const state = JSON.parse(body.statePayload.encryptedData);
+    const entry = state.entries.find((e: any) => e.key === 'fire_pack');
+    const pack = JSON.parse(await unpackStateValue(entry.value));
+    expect(pack.template).toContain('SYS_PROMPT_MARKER');
+    expect(pack.template).not.toContain('AMSG2_INSTANT_STUB_TEMPLATE');
+    expect(pack.selfScheduleEnabled).toBe(true);
+  });
+
   // ── 图片：云端这条路必须跟本地跑出来的一模一样 ──
   //
   // 拍平图片曾经是这里的做法，代价是模型看不到用户刚发的那张图，只能对着
@@ -378,7 +409,7 @@ describe('待收记录（「正在输入…」那盏灯的唯一依据）', () =
   it('落在 localStorage 里，重启后还在', () => {
     setInstantChatPending('char-a', 'uuid-a', 1_000);
     // 模块状态每次都从存储读，等价于重开一次应用。
-    expect(getInstantChatPending('char-a')).toEqual({ charId: 'char-a', uuid: 'uuid-a', acceptedAt: 1_000 });
+    expect(getInstantChatPending('char-a')).toEqual({ charId: 'char-a', uuid: 'uuid-a', acceptedAt: 1_000, charName: '' });
     expect(localStorage.getItem(AMSG_INSTANT_CHAT_PENDING_LS_KEY)).toContain('uuid-a');
   });
 
@@ -567,5 +598,28 @@ describe('推送丢了的补收对账', () => {
 
   it('推送载荷少了 charId → 没有落点，丢掉而不是造一条无主消息', () => {
     expect(chatOutboxPayloadToInbox({ message: '孤儿' }, 1)).toBeNull();
+  });
+
+  // 契约测试：push→inbox 的字段映射有两份手工同步的副本（SW 的 saveContentToInbox 与
+  // 这里的补收路径），销账检查只读 metadata.messageIndex/totalMessages、缺失当末段——
+  // 任一副本漏抄这两个字段，多段回复的首段就会被当成末段销账，后续段永久丢失且无报错。
+  // 这里钉住补收侧必须把顶层段号抄进 metadata（与 sw-keep-alive.ts 的映射同一条规则；
+  // 那份是 SW 代码没法直接 import，改动 SW 映射时这条测试就是要一起过的清单）。
+  it('顶层 messageIndex/totalMessages 必须抄进 metadata（销账检查只认 metadata 里的）', () => {
+    const inbox = chatOutboxPayloadToInbox({
+      charId: CHAR.id,
+      charName: '小满',
+      message: '第一段',
+      messageId: 'msg_task_7@1700000000000_hook_0',
+      sessionId: 'sess_task_7@1700000000000',
+      taskUuid: 'uuid-round-1',
+      messageIndex: 1,
+      totalMessages: 3,
+      metadata: { charId: CHAR.id },
+    }, Date.now())!;
+    expect(inbox).toBeTruthy();
+    expect((inbox.metadata as any).messageIndex).toBe(1);
+    expect((inbox.metadata as any).totalMessages).toBe(3);
+    expect((inbox.metadata as any).sessionId).toBe('sess_task_7@1700000000000');
   });
 });

--- a/utils/amsgInstantChat.ts
+++ b/utils/amsgInstantChat.ts
@@ -43,8 +43,8 @@ export interface AmsgInstantChatPending {
   uuid: string;
   /** 受理时刻（epoch ms），排查时看「这一轮等了多久」用。 */
   acceptedAt: number;
-  /** 角色名快照（全局横幅显示用；旧记录可能没有，缺省显示空）。 */
-  charName?: string;
+  /** 角色名快照（全局横幅显示用）。必填：唯一写入方恒定带上（角色名为空就是空串）。 */
+  charName: string;
 }
 
 type PendingMap = Record<string, AmsgInstantChatPending>;
@@ -57,11 +57,13 @@ const readPendingMap = (): PendingMap => {
     for (const [charId, value] of Object.entries(parsed as Record<string, unknown>)) {
       const record = value as Partial<AmsgInstantChatPending> | null;
       if (record && typeof record.uuid === 'string' && typeof record.acceptedAt === 'number') {
+        // charName 的形状防御是「防 localStorage 损坏/手改」，不是兼容什么旧记录——
+        // 这个 key 与写入方同一次发布上线，缺名就按空串补齐。
         result[charId] = {
           charId,
           uuid: record.uuid,
           acceptedAt: record.acceptedAt,
-          ...(typeof record.charName === 'string' && record.charName ? { charName: record.charName } : {}),
+          charName: typeof record.charName === 'string' ? record.charName : '',
         };
       }
     }
@@ -96,10 +98,10 @@ export const setInstantChatPending = (
   charId: string,
   uuid: string,
   acceptedAt = Date.now(),
-  charName?: string,
+  charName = '',
 ): void => {
   const map = readPendingMap();
-  map[charId] = { charId, uuid, acceptedAt, ...(charName ? { charName } : {}) };
+  map[charId] = { charId, uuid, acceptedAt, charName };
   writePendingMap(map);
   announcePendingChanged(charId);
 };

--- a/utils/amsgStateSync.test.ts
+++ b/utils/amsgStateSync.test.ts
@@ -22,6 +22,7 @@ vi.mock('./activeMsgStore', () => ({
 }));
 
 import {
+  FLUSH_DEBOUNCE_MS,
   AMSG2_PENDING_SYNC_LS_KEY,
   AMSG2_PENDING_TOOL_CONFIG_LS_KEY,
   cancelAllRemoteAmsgTasks,
@@ -152,7 +153,7 @@ describe('markAmsgStateDirty 同步门', () => {
     (ActiveMsgStore.getGlobalConfig as any).mockResolvedValue({ workerUrl: '' });
     const char = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).not.toHaveBeenCalled();
     // 没有去处不算「欠着」：底账也一起清，别让下次启动为它白跑一趟补传。
     expect(JSON.parse(localStorage.getItem(AMSG2_PENDING_SYNC_LS_KEY) || '[]')).not.toContain(char.id);
@@ -162,7 +163,7 @@ describe('markAmsgStateDirty 同步门', () => {
     (ActiveMsgClient.syncCharFirePacks as any).mockRejectedValueOnce(new Error('worker down'));
     const char = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
 
     await flushAmsgState('test-retry');
@@ -175,7 +176,7 @@ describe('markAmsgStateDirty 同步门', () => {
     (ActiveMsgClient.syncCharFirePacks as any).mockRejectedValueOnce(new Error('worker down'));
     const char = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(30_000);
@@ -188,7 +189,7 @@ describe('markAmsgStateDirty 同步门', () => {
     const stale = charWithAiTask(id);
     stale.name = '旧快照';
     markAmsgStateDirty(snapshotOf(stale));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
 
     const fresh = charWithAiTask(id);
     fresh.name = '新快照';
@@ -204,7 +205,7 @@ describe('markAmsgStateDirty 同步门', () => {
     (ActiveMsgClient.syncCharFirePacks as any).mockRejectedValue(new Error('offline'));
     const char = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
 
     // 30s → 60s → 120s 三次重排后放手（快照仍留在队列里等下一轮打脏）
@@ -216,24 +217,30 @@ describe('markAmsgStateDirty 同步门', () => {
   });
 });
 
-// 即时冲刷回归守卫：打脏后不再有去抖窗口，微任务内就冲刷。
-// 旧的 10s 去抖行为下第一条会挂（0ms 时还没冲刷）。
-describe('即时冲刷', () => {
-  it('打脏后立即冲刷，不等任何窗口', async () => {
+// 打脏合并窗口回归守卫：一轮聊天的多次打脏（收尾 / 情绪落库 / 记忆写入）不在同一个
+// tick，各自触发完整冲刷太贵（重读近史 + 重建提示词 + 加密 + PUT ~40KB）。第一次打脏起
+// FLUSH_DEBOUNCE_MS 内的合并成一次上传；固定窗口不顺延，持续打脏也保证窗口到点必冲。
+// 数据丢失窗口没有回退：底账在打脏那一刻就写、切后台立即冲刷、启动有补传。
+describe('打脏合并窗口', () => {
+  it('窗口内不发请求，窗口到点冲刷一次', async () => {
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS - 1);
+    expect(ActiveMsgClient.syncCharFirePacks).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
   });
 
-  it('同一个事件循环里连环打脏只合并成一次上传', async () => {
+  it('窗口内的连环打脏（隔几个 tick 也算）只合并成一次上传', async () => {
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));
+    // 情绪 buff 落库这类晚半秒才来的打脏，也该并进同一次上传
+    await vi.advanceTimersByTimeAsync(500);
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
     expect((ActiveMsgClient.syncCharFirePacks as any).mock.calls[0][0]).toHaveLength(2);
   });
 
-  it('同一个角色同 tick 打两次脏只传最新那份', async () => {
+  it('同一个角色窗口内打两次脏只传最新那份', async () => {
     const id = nextCharId();
     const stale = charWithAiTask(id);
     stale.name = '旧快照';
@@ -242,7 +249,7 @@ describe('即时冲刷', () => {
 
     markAmsgStateDirty(snapshotOf(stale));
     markAmsgStateDirty(snapshotOf(fresh));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
 
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
     const batch = (ActiveMsgClient.syncCharFirePacks as any).mock.calls[0][0];
@@ -258,11 +265,11 @@ describe('即时冲刷', () => {
       () => new Promise<void>((resolve) => { release = resolve; }),
     );
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));
-    await vi.advanceTimersByTimeAsync(0);           // 第一次冲刷挂起中
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);   // 第一次冲刷挂起中
 
     const later = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(later));
-    await vi.advanceTimersByTimeAsync(0);           // 撞上 flushing
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);   // 撞上 flushing
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
 
     release();
@@ -278,10 +285,10 @@ describe('即时冲刷', () => {
       () => new Promise<void>((_, reject) => { fail = () => reject(new Error('worker down')); }),
     );
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
 
     markAmsgStateDirty(snapshotOf(charWithAiTask(nextCharId())));  // 在飞期间又打脏
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
 
     fail();
     await vi.advanceTimersByTimeAsync(0);
@@ -308,13 +315,13 @@ describe('即时冲刷', () => {
 
     const doomed = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(doomed));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     await vi.advanceTimersByTimeAsync(30_000 + 60_000 + 120_000 + 1_000);
     expect(mock).toHaveBeenCalledTimes(4);           // 第四次挂在半空
 
     const later = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(later));
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(mock).toHaveBeenCalledTimes(4);           // 撞上 flushing，先记账
 
     failLast();
@@ -342,7 +349,7 @@ describe('即时对话挂起（chat 段不许被常规冲刷覆盖）', () => {
     const char = charWithAiTask(nextCharId());
     setInstantChatPending(char.id, 'uuid-instant-defer');
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks, '等回复期间一个包都不许传').not.toHaveBeenCalled();
 
     clearInstantChatPending(char.id);
@@ -358,7 +365,7 @@ describe('即时对话挂起（chat 段不许被常规冲刷覆盖）', () => {
     setInstantChatPending(owing.id, 'uuid-instant-owing');
     markAmsgStateDirty(snapshotOf(owing));
     markAmsgStateDirty(snapshotOf(free));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
 
     const mock = ActiveMsgClient.syncCharFirePacks as any;
     expect(mock).toHaveBeenCalledTimes(1);
@@ -383,7 +390,7 @@ describe('脏标记持久化与启动补传', () => {
     markAmsgStateDirty(snapshotOf(char));
     expect(readMarks()).toContain(char.id);
 
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
     expect(readMarks()).not.toContain(char.id);
   });
@@ -398,7 +405,7 @@ describe('脏标记持久化与启动补传', () => {
     (ActiveMsgClient.syncCharFirePacks as any).mockRejectedValueOnce(new Error('worker down'));
     const char = charWithAiTask(nextCharId());
     markAmsgStateDirty(snapshotOf(char));
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(FLUSH_DEBOUNCE_MS);
     expect(ActiveMsgClient.syncCharFirePacks).toHaveBeenCalledTimes(1);
     expect(readMarks()).toContain(char.id);
   });

--- a/utils/amsgStateSync.ts
+++ b/utils/amsgStateSync.ts
@@ -64,22 +64,25 @@ let retryCount = 0;
 /** 「退避打光了还是没传上去」每次会话只上报一次。 */
 let staleStateReported = false;
 
-// ─── 打脏即传的两个合并开关 ───
-// 一轮聊天不止打一次脏（收尾一次、情绪 buff 落库又一次），中间还有群聊逐个成员打脏这种
-// 连环调用。这两个开关负责收口：同一个事件循环里的连环打脏合并成一次上传；上传途中
-// 来的打脏等这次传完再补跑一次（丢弃的话那份快照就永远躺在队列里了）。
-/** 已经排了一个微任务等着冲刷，别重复排。 */
-let flushQueued = false;
-/** 冲刷进行中又有人打脏，这次传完得再跑一轮。 */
+// ─── 打脏后的合并窗口 ───
+// 一轮聊天不止打一次脏，而且**不在同一个 tick**：收尾在 finally 里、情绪 buff 落库在
+// 副 API 回来后的事件回调里、记忆写入又是一拨；用户连删几条消息更是一次操作一个 tick。
+// 微任务合并只能收拢同 tick 的连环调用，上面这些各自触发一次「重读 200 条近史 + 重建
+// 系统提示词 + gzip + 加密 + PUT ~40KB」的完整冲刷。这里给一个短的固定合并窗口：
+// 第一次打脏起 1.5s 内的都并进同一次上传。数据丢失窗口不回退——底账（persistDirtyMark）
+// 在打脏那一刻就写了，切后台有 visibilitychange 的立即冲刷，杀进程有启动补传。
+/** 打脏合并窗口（固定窗口不顺延：持续打脏也保证 1.5s 内必冲一次）。 */
+export const FLUSH_DEBOUNCE_MS = 1_500;
+let flushDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+/** 冲刷进行中又有人打脏，这次传完得再跑一轮（丢弃的话那份快照就永远躺在队列里了）。 */
 let reflushRequested = false;
 
 const queueFlush = () => {
-  if (flushQueued) return;
-  flushQueued = true;
-  queueMicrotask(() => {
-    flushQueued = false;
+  if (flushDebounceTimer != null) return;
+  flushDebounceTimer = setTimeout(() => {
+    flushDebounceTimer = null;
     void flushAmsgState('dirty');
-  });
+  }, FLUSH_DEBOUNCE_MS);
 };
 
 // ─── 脏标记轻量持久化 ───
@@ -177,6 +180,10 @@ const requeue = (batch: AmsgSyncSnapshot[]) => {
 
 /** 把所有脏角色的 fire_pack 批量上传。失败退避重排，快照留在队列里等下次。 */
 export const flushAmsgState = async (reason: string): Promise<void> => {
+  // 这次冲刷把队列带走了，还挂着的合并窗口就不用再响一次（响了也只是空跑一趟）。
+  // 顺手把句柄归零：不归零的话，外部触发的冲刷（hidden / resume / 测试清理）之后
+  // 队列里再打的脏会以为已有窗口在等，实际那个 timer 早没了。
+  if (flushDebounceTimer != null) { clearTimeout(flushDebounceTimer); flushDebounceTimer = null; }
   // 工具凭据欠着的话顺手一起补：它和 fire_pack 一样是「云端那份过时了」，
   // 而且冲刷时机（切后台 / 聊完一轮）正是网络多半又通了的时候。
   void runToolConfigSync(`flush:${reason}`);

--- a/utils/emotionEvalCore.ts
+++ b/utils/emotionEvalCore.ts
@@ -1,0 +1,155 @@
+/**
+ * 云端情绪评估的共用内核：占位符还原 + 副 API 请求 + 失败文案（先打码后截断）。
+ *
+ * 两个 worker（amsg 的即时对话路径、instant-push 的 Instant 路径）吃的是前端同一个
+ * `buildEmotionEvalPrompt(..., includeContext=false, ...)` 模板，还原与请求逻辑必须
+ * **逐字同款**——过去是两份手工同步的副本，d92231a 给报错加 apiKey 打码时只落了一份，
+ * 另一份就把副 API key 随 push 带出去了。收敛到这一份叶子后，改哪条规则两边一起动。
+ *
+ * 零浏览器 / 零 worker 运行时依赖（两个 worker bundle 都会把这份代码打进去）。
+ */
+
+/** 副 API 凭据（没单独配就是主 API 那一份）。 */
+export interface EmotionEvalApi { baseUrl: string; apiKey: string; model: string }
+
+export const EMOTION_EVAL_SYSTEM_SLOT = '__EMOTION_EVAL_SYSTEM_PROMPT__';
+export const EMOTION_EVAL_HISTORY_SLOT = '__EMOTION_EVAL_HISTORY__';
+
+/** 单次评估请求的上限；副 API 卡住的话，主流程不该跟着一起被扣在这儿。 */
+export const EMOTION_EVAL_TIMEOUT_MS = 120_000;
+
+/**
+ * 消息 content → 一行文本。结构化分段（带图片的消息）拍平成「文字 [图片]」。
+ * 与本地 buildEmotionEvalPrompt 的 recentLines 同款：用空格连接、空段丢掉。
+ */
+export const flattenEvalContent = (content: unknown): string => {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part: any) => (part?.type === 'text'
+        ? (part.text || '')
+        : (part?.type === 'image_url' ? '[图片]' : '')))
+      .filter(Boolean)
+      .join(' ');
+  }
+  return '';
+};
+
+/**
+ * 把模板里的两个占位符用本次请求的消息还原掉。
+ *
+ * - `messages[0]`（role=system）= 本地的 mainSystemPrompt
+ * - `messages[1..]` = 本地的 cleanedApiMessages，拼成 `[用户]: …` / `[角色名]: …` / `[系统]: …`
+ *
+ * 用函数式 replacer：system prompt 和对话里出现 `$&`、`$1` 这类字符时，
+ * String.replace 会把它们当成替换模式解析，评估看到的就不是原话了。
+ */
+export const restoreEvalPrompt = (
+  template: string,
+  chatMessages: Array<{ role: string; content: unknown }>,
+  charName: string,
+): string => {
+  const messages = Array.isArray(chatMessages) ? chatMessages : [];
+  let systemPromptText = '';
+  let conversation = messages;
+  if (messages.length > 0 && messages[0]?.role === 'system') {
+    systemPromptText = flattenEvalContent(messages[0].content);
+    conversation = messages.slice(1);
+  }
+  const recentLines = conversation
+    .map((m) => {
+      const role = m.role === 'user' ? '用户' : (m.role === 'assistant' ? charName : '系统');
+      return `[${role}]: ${flattenEvalContent(m.content)}`;
+    })
+    .join('\n');
+  return String(template)
+    .replace(EMOTION_EVAL_SYSTEM_SLOT, () => systemPromptText)
+    .replace(EMOTION_EVAL_HISTORY_SLOT, () => recentLines);
+};
+
+/** 报错正文最多带回这么长——够定位是限流还是鉴权就行，不是日志转发通道。 */
+export const ERROR_SNIPPET_MAX = 120;
+
+/**
+ * 「先打码、后截断」的唯一出口：所有会随 push 出门的失败文案（HTTP 分支、catch 分支）
+ * 都要过这里。打码在截断之前——先截的话，切口正好落在 key 中间时整串就查不到 key，
+ * 半截凭据原样带出去。个别中转会把整个请求（含 Authorization 头）回显在错误页里。
+ */
+export const maskAndSnip = (text: string, apiKey: string): string => {
+  let snippet = text.replace(/\s+/g, ' ').trim();
+  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join('***');
+  return snippet.slice(0, ERROR_SNIPPET_MAX);
+};
+
+/** 一次评估的结局：拿到原文，或者一句能给用户看的短失败原因。 */
+export interface EmotionEvalOutcome {
+  /** 评估模型的输出原文；没跑出来时为 null。 */
+  raw: string | null;
+  /** 没跑出来的原因（人话、一句话）；成功时为 null。 */
+  error: string | null;
+}
+
+/**
+ * 发一次评估请求并解析输出。promptContent 传 restoreEvalPrompt 还原好的整段。
+ * 失败绝不抛：给一句已打码的短原因（它最终要走 push 出门，凭据绝不进 push 是红线）。
+ */
+export const requestEmotionEval = async (
+  api: EmotionEvalApi,
+  promptContent: string,
+  timeoutMs: number = EMOTION_EVAL_TIMEOUT_MS,
+): Promise<EmotionEvalOutcome> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseUrl = String(api.baseUrl).replace(/\/+$/, '');
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${api.apiKey || 'sk-none'}`,
+      },
+      body: JSON.stringify({
+        model: api.model,
+        messages: [{ role: 'user', content: promptContent }],
+        temperature: 0.85,
+        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
+        // 会被截成半截 JSON。
+        max_tokens: 8000,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      // 正文可能是 HTML 错误页，截一小段够定位即可。
+      let body = '';
+      try { body = await res.text(); } catch { /* 读不出正文就只报状态码 */ }
+      console.warn('[emotion-eval] 副 API 拒了这次评估（主流程不受影响）', res.status);
+      const snippet = maskAndSnip(body, api.apiKey);
+      return { raw: null, error: `副 API HTTP ${res.status}${snippet ? `：${snippet}` : ''}` };
+    }
+    const data = await res.json() as any;
+    // 个别中转把全部输出塞进 reasoning_content 而 content 留空——与客户端
+    // utils/emotionApply.ts 的 extractAssistantText 同一套兜底。
+    const message = data?.choices?.[0]?.message;
+    const raw = flattenEvalContent(message?.content)
+      || (typeof message?.reasoning_content === 'string' ? message.reasoning_content : '');
+    if (!raw.trim()) {
+      return {
+        raw: null,
+        error: `评估模型没有输出内容（finish_reason: ${data?.choices?.[0]?.finish_reason ?? '?'}）`,
+      };
+    }
+    return { raw, error: null };
+  } catch (error) {
+    console.warn('[emotion-eval] 评估失败（主流程不受影响）', error);
+    // 只带异常名/消息，不带栈：这句要走 push 出门，短一点、也别把内部路径抖出去。
+    // 异常消息同样过打码：fetch 异常一般不含请求头，但 URL 解析类错误会回显传入的
+    // 地址，用户把 key 拼在 baseUrl 里时不打码就漏了。
+    const reason = controller.signal.aborted
+      ? `评估超时（${Math.round(timeoutMs / 1000)} 秒没回来）`
+      : `评估请求没发出去：${maskAndSnip(error instanceof Error ? error.message : String(error), api.apiKey)}`;
+    return { raw: null, error: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/utils/promptMessageCleanup.ts
+++ b/utils/promptMessageCleanup.ts
@@ -20,6 +20,21 @@ export function cleanApiMessages(
 }
 
 /**
+ * 单条多模态 content 的拍平内核：保留 text 部分，丢弃 image_url/base64。
+ * 「图片消息 → 文字占位」这条规则全仓库只此一份——本地 stripImages 路径
+ * （flattenImageContentParts）和即时对话超预算降级路径（activeMsgClient 的
+ * toFirePackChatMessages）都从这里出，两条路的产物永远同源。
+ */
+export function flattenContentPartsToText(parts: any[]): string {
+    const text = parts
+        .filter((part: any) => part?.type === 'text')
+        .map((part: any) => part.text || '')
+        .join('\n')
+        .trim();
+    return text || '[图片]';
+}
+
+/**
  * 把多模态图片消息压平成纯文本：保留 text 部分，丢弃 image_url/base64。
  */
 export function flattenImageContentParts(
@@ -27,11 +42,6 @@ export function flattenImageContentParts(
 ): Array<{ role: string; content: any }> {
     return apiMessages.map((msg) => {
         if (!Array.isArray(msg.content)) return msg;
-        const text = msg.content
-            .filter((part: any) => part?.type === 'text')
-            .map((part: any) => part.text || '')
-            .join('\n')
-            .trim();
-        return { ...msg, content: text || '[图片]' };
+        return { ...msg, content: flattenContentPartsToText(msg.content) };
     });
 }

--- a/worker/amsg/src/emotionEval.ts
+++ b/worker/amsg/src/emotionEval.ts
@@ -10,15 +10,22 @@
  * 还原回原位。这样上下文不必在请求体里重复发一份，输出又与本地逐字对齐。
  *
  * 还原规则与 instant push worker 的 `runEmotionEval`（worker/instant-push/src/index.ts）
- * **逐字同款**——两边吃的是同一个模板，格式一漂输出就变味。之所以复制一份而不是共享：
- * 两个 worker 是各自打包部署的 bundle，共享只能走 utils/ 叶子，而这段逻辑贴着 amsg 的
- * chat 段形状，放在 amsg 侧更贴。
+ * **逐字同款**——两边吃的是同一个模板，格式一漂输出就变味。所以内核收敛在
+ * utils/emotionEvalCore.ts 这份零依赖叶子里，两个 worker bundle 共用；这里只留
+ * amsg 侧特有的部分（评估配置的摘取与红线处理、旁路存储键）。
  *
  * 失败绝不连累主回复——用户等的是那句话，情绪只是附赠；跑挂了就带一句短原因回去，
  * 让客户端能照实说明白，而不是丢一句「可查 worker 日志」。
  *
  * 零浏览器依赖（这份代码会被打进 worker bundle）。
  */
+
+import {
+  EMOTION_EVAL_TIMEOUT_MS,
+  requestEmotionEval,
+  restoreEvalPrompt as coreRestoreEvalPrompt,
+  type EmotionEvalOutcome,
+} from '../../../utils/emotionEvalCore';
 
 /** 前端塞进任务 metadata.amsgEmotionEval 的那份评估配置。 */
 export interface AmsgEmotionEvalSpec {
@@ -28,11 +35,6 @@ export interface AmsgEmotionEvalSpec {
   api: { baseUrl: string; apiKey: string; model: string };
 }
 
-const SYSTEM_SLOT = '__EMOTION_EVAL_SYSTEM_PROMPT__';
-const HISTORY_SLOT = '__EMOTION_EVAL_HISTORY__';
-
-/** 单次评估请求的上限；副 API 卡住的话，主回复不该跟着一起被扣在这儿。 */
-const EMOTION_EVAL_TIMEOUT_MS = 120_000;
 
 /**
  * 评估结果太大、一条 push 装不下时的旁路存储键（同 XHS 那套，见 amsgXhsSessionKey）。
@@ -100,87 +102,12 @@ export const takeEmotionEvalSpec = (
   return isUsableEvalSpec(spec) ? spec : null;
 };
 
-/**
- * 消息 content → 一行文本。结构化分段（带图片的消息）拍平成「文字 [图片]」。
- * 与本地 buildEmotionEvalPrompt 的 recentLines 同款：用空格连接、空段丢掉。
- */
-const flattenContent = (content: unknown): string => {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((part: any) => (part?.type === 'text'
-        ? (part.text || '')
-        : (part?.type === 'image_url' ? '[图片]' : '')))
-      .filter(Boolean)
-      .join(' ');
-  }
-  return '';
-};
-
-/**
- * 把模板里的两个占位符用本次请求的消息还原掉。
- *
- * - `messages[0]`（role=system）= 本地的 mainSystemPrompt
- * - `messages[1..]` = 本地的 cleanedApiMessages，拼成 `[用户]: …` / `[角色名]: …` / `[系统]: …`
- *
- * 用函数式 replacer：system prompt 和对话里出现 `$&`、`$1` 这类字符时，
- * String.replace 会把它们当成替换模式解析，评估看到的就不是原话了。
- */
-export const restoreEvalPrompt = (
-  template: string,
-  chatMessages: Array<{ role: string; content: unknown }>,
-  charName: string,
-): string => {
-  const messages = Array.isArray(chatMessages) ? chatMessages : [];
-  let systemPromptText = '';
-  let conversation = messages;
-  if (messages.length > 0 && messages[0]?.role === 'system') {
-    systemPromptText = flattenContent(messages[0].content);
-    conversation = messages.slice(1);
-  }
-  const recentLines = conversation
-    .map((m) => {
-      const role = m.role === 'user' ? '用户' : (m.role === 'assistant' ? charName : '系统');
-      return `[${role}]: ${flattenContent(m.content)}`;
-    })
-    .join('\n');
-  return String(template)
-    .replace(SYSTEM_SLOT, () => systemPromptText)
-    .replace(HISTORY_SLOT, () => recentLines);
-};
+// 占位符还原 / 打码 / 请求内核在 utils/emotionEvalCore.ts（与 instant-push 共用）。
+// re-export 保住既有导入点（本文件历史上就是它们的家）。
+export { restoreEvalPrompt } from '../../../utils/emotionEvalCore';
 
 /** 一次评估的结局：拿到原文，或者一句能给用户看的短失败原因。 */
-export interface AmsgEmotionEvalOutcome {
-  /** 评估模型的输出原文；没跑出来时为 null。 */
-  raw: string | null;
-  /** 没跑出来的原因（人话、一句话）；成功时为 null。 */
-  error: string | null;
-}
-
-/** 报错正文最多带回这么长——够定位是限流还是鉴权就行，不是日志转发通道。 */
-const ERROR_SNIPPET_MAX = 120;
-
-/**
- * 「先打码、后截断」的唯一出口：所有会随 push 出门的失败文案（HTTP 分支、catch 分支）
- * 都要过这里。打码在截断之前——先截的话，切口正好落在 key 中间时整串就查不到 key，
- * 半截凭据原样带出去。
- */
-const maskAndSnip = (text: string, apiKey: string): string => {
-  let snippet = text.replace(/\s+/g, ' ').trim();
-  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join('***');
-  return snippet.slice(0, ERROR_SNIPPET_MAX);
-};
-
-/**
- * 从失败响应里摘一句能给用户看的原因。
- *
- * **绝不能带出 apiKey**：个别中转会把整个请求（含 Authorization 头）回显在错误页里，
- * 而这句话最终要走 push 出门。摘之前先按 key 本身过一遍，命中就打码。
- */
-const describeEvalFailure = (status: number, body: string, apiKey: string): string => {
-  const snippet = maskAndSnip(body, apiKey);
-  return `副 API HTTP ${status}${snippet ? `：${snippet}` : ''}`;
-};
+export type AmsgEmotionEvalOutcome = EmotionEvalOutcome;
 
 /**
  * 跑一次评估。成功给原文（解析交给客户端的 applyEmotionEvalRaw，与本地路径共用同一套
@@ -195,59 +122,5 @@ export const runAmsgEmotionEval = async (
   chatMessages: Array<{ role: string; content: unknown }>,
   charName: string,
   timeoutMs: number = EMOTION_EVAL_TIMEOUT_MS,
-): Promise<AmsgEmotionEvalOutcome> => {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const baseUrl = String(spec.api.baseUrl).replace(/\/+$/, '');
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${spec.api.apiKey || 'sk-none'}`,
-      },
-      body: JSON.stringify({
-        model: spec.api.model,
-        messages: [{ role: 'user', content: restoreEvalPrompt(spec.prompt, chatMessages, charName) }],
-        temperature: 0.85,
-        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
-        // 会被截成半截 JSON（与 instant push worker 同一个数）。
-        max_tokens: 8000,
-        stream: false,
-      }),
-      signal: controller.signal,
-    });
-    if (!res.ok) {
-      // 正文可能是 HTML 错误页，截一小段够定位即可（与 instant push worker 同一套）。
-      let body = '';
-      try { body = await res.text(); } catch { /* 读不出正文就只报状态码 */ }
-      console.warn('[amsg:emotion] 副 API 拒了这次评估（主回复不受影响）', res.status);
-      return { raw: null, error: describeEvalFailure(res.status, body, spec.api.apiKey) };
-    }
-    const data = await res.json() as any;
-    // 个别中转把全部输出塞进 reasoning_content 而 content 留空——与客户端
-    // utils/emotionApply.ts 的 extractAssistantText 同一套兜底。
-    const message = data?.choices?.[0]?.message;
-    const raw = flattenContent(message?.content)
-      || (typeof message?.reasoning_content === 'string' ? message.reasoning_content : '');
-    if (!raw.trim()) {
-      return {
-        raw: null,
-        error: `评估模型没有输出内容（finish_reason: ${data?.choices?.[0]?.finish_reason ?? '?'}）`,
-      };
-    }
-    return { raw, error: null };
-  } catch (error) {
-    console.warn('[amsg:emotion] 评估失败（主回复不受影响）', error);
-    // 只带异常名/消息，不带栈：这句要走 push 出门，短一点、也别把内部路径抖出去。
-    // 异常消息同样过打码（凭据绝不进 push 的红线不分分支）：fetch 异常一般不含
-    // 请求头，但 URL 解析类错误会回显传入的地址，用户把 key 拼在 baseUrl 里时
-    // 不打码就漏了。
-    const reason = controller.signal.aborted
-      ? `评估超时（${Math.round(timeoutMs / 1000)} 秒没回来）`
-      : `评估请求没发出去：${maskAndSnip(error instanceof Error ? error.message : String(error), spec.api.apiKey)}`;
-    return { raw: null, error: reason };
-  } finally {
-    clearTimeout(timer);
-  }
-};
+): Promise<AmsgEmotionEvalOutcome> =>
+  requestEmotionEval(spec.api, coreRestoreEvalPrompt(spec.prompt, chatMessages, charName), timeoutMs);

--- a/worker/amsg/src/index.test.ts
+++ b/worker/amsg/src/index.test.ts
@@ -16,6 +16,7 @@ import { MAX_PUSH_PAYLOAD_BYTES } from '@rei-standard/amsg-server/cloudflare';
 import { amsgEmotionUpdateKey } from './emotionEval';
 import { INSTANT_TOTAL_TIMEOUT_MS } from './instantChat';
 import {
+  AMSG_CHAT_FAIL_KEY,
   AMSG_CHAT_OUTBOX_KEY,
   AMSG_FIRE_PACK_KEY,
   AMSG_LAST_SKIP_KEY,
@@ -2378,6 +2379,44 @@ describe('没发出去时写 last_skip', () => {
   it('留痕写失败不影响 skip 本身（best-effort）', async () => {
     const { decision } = await runEmptyFire({ writeStateFails: true });
     expect(decision.decision).toBe('skip-push');
+  });
+
+  // 即时对话被 skip 时一次性行会被上游当成功消费删掉，客户端点名只能看到 gone + 空
+  // outbox——不写 chat_fail 的话，给用户的解释是「回复没能取回」，把「没生成出来」说成
+  // 了「取不回」。定时任务不用写：那条路没有人在等着销账，last_skip 就够面板解释了。
+  it('即时对话空输出 → 除 last_skip 外还写 chat_fail（认 uuid，客户端 gone 分支照实解释）', async () => {
+    const { ctx, scratch, writeState } = makeCtx({
+      metadata: { amsgInstantChat: true, amsgMode: 'instant', amsgTaskInstruction: undefined },
+      charRows: [
+        { key: AMSG_FIRE_PACK_KEY, value: firePackValue(null, { chat: { messages: [{ role: 'user', content: '在吗' }], builtAt: PACK_BUILT_AT } }) },
+        { key: AMSG_TOOL_PACK_KEY, value: toolPackValue },
+      ],
+    });
+    await amsgHooks.onBeforeFire(ctx);
+    const decision = await amsgHooks.onLLMOutput({
+      sessionId: 'sess_task_42',
+      llmResponse: {},
+      llmOutputText: '',
+      contactName: 'Nyah',
+      metadata: { charId: CHAR_ID, amsgClientTaskId: 'client-task-1', amsgMode: 'instant', amsgInstantChat: true },
+      scratch,
+      writeState,
+    } as any);
+    expect((decision as any).decision).toBe('skip-push');
+
+    const call = writeState.mock.calls.find(([, entries]) =>
+      entries.some((e: { key: string }) => e.key === AMSG_CHAT_FAIL_KEY));
+    expect(call, '应该写过 chat_fail').toBeTruthy();
+    const fail = JSON.parse(String(call![1].find((e: { key: string }) => e.key === AMSG_CHAT_FAIL_KEY)!.value));
+    expect(fail.uuid).toBe(TASK_UUID);
+    expect(fail.reason).toBe('empty-generation');
+  });
+
+  it('定时任务空输出 → 只写 last_skip，不写 chat_fail', async () => {
+    const { writeState } = await runEmptyFire();
+    const call = writeState.mock.calls.find(([, entries]) =>
+      entries.some((e: { key: string }) => e.key === AMSG_CHAT_FAIL_KEY));
+    expect(call).toBeFalsy();
   });
 
   it('正常出正文的 fire 不写 empty-generation', async () => {

--- a/worker/amsg/src/index.test.ts
+++ b/worker/amsg/src/index.test.ts
@@ -58,6 +58,7 @@ const firePackValue = (
   builtAt: PACK_BUILT_AT,
   pendingTasks: [],
   scene: null,
+  selfScheduleEnabled: true,
   ...extra,
 });
 
@@ -1530,6 +1531,7 @@ describe('self_log — 角色自述回写', () => {
     builtAt,
     pendingTasks: [],
     scene: null,
+    selfScheduleEnabled: true,
   });
 
   /** 会真的记住写入的假 client_state：第二次 fire 靠它读回第一次写下的自述。 */
@@ -2189,7 +2191,7 @@ describe('fire 侧取消 / 改期任务', () => {
   it('短 id 找目标、全 uuid 传给 ctx.cancelTask，账记进 cancelledTasks', async () => {
     const cancel = okCancel();
     const stash = makeStash({ pendingTasks: [taskRec('11112222-aaaa-4bbb-8ccc-000000000001')] });
-    const out = await runFireCancelTool(stash, cancel, { task_id: '11112222' });
+    const out = await runFireCancelTool(stash, cancel, { task_id: '11112222' }, NOW_MS);
     expect(out.ok).toBe(true);
     expect(cancel).toHaveBeenCalledWith('11112222-aaaa-4bbb-8ccc-000000000001');
     expect(stash.cancelledTasks).toEqual(['11112222-aaaa-4bbb-8ccc-000000000001']);
@@ -2198,18 +2200,30 @@ describe('fire 侧取消 / 改期任务', () => {
   it('只有一条时可省略 task_id；多条时打回 ambiguous、一条都不动', async () => {
     const cancel = okCancel();
     const one = makeStash({ pendingTasks: [taskRec('u-only')] });
-    expect((await runFireCancelTool(one, cancel, {})).ok).toBe(true);
+    expect((await runFireCancelTool(one, cancel, {}, NOW_MS)).ok).toBe(true);
 
     const many = makeStash({ pendingTasks: [taskRec('u-a'), taskRec('u-b')] });
-    const out = await runFireCancelTool(many, cancel, {});
+    const out = await runFireCancelTool(many, cancel, {}, NOW_MS);
     expect(out.reason).toBe('ambiguous_task');
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  // 与前台 resolveTargetTask 对齐的回归守卫：清单快照里混着一条已过点变陈旧的一次性
+  // 任务（pack 只在打包那一刻筛过 pending）时，不带 task_id 也能锁定唯一还活着的那条。
+  // 不复筛的话，同一句 cancel_active_message 本地能成、云端却被打回 ambiguous_task。
+  it('快照里混着过点的陈旧任务 → 不带 task_id 仍锁定唯一 pending 那条', async () => {
+    const cancel = okCancel();
+    const stale = taskRec('u-stale', { firstSendTime: new Date(NOW_MS - 2 * 3600_000).toISOString() });
+    const stash = makeStash({ pendingTasks: [stale, taskRec('u-live')] });
+    const out = await runFireCancelTool(stash, cancel, {}, NOW_MS);
+    expect(out.ok).toBe(true);
+    expect(cancel).toHaveBeenCalledWith('u-live');
   });
 
   it('当前正在 fire 的这条不在可取消视图里（它的收尾归 run-tick 管）', async () => {
     const cancel = okCancel();
     const stash = makeStash({ pendingTasks: [taskRec(TASK_UUID)] });
-    const out = await runFireCancelTool(stash, cancel, { task_id: TASK_UUID.slice(0, 8) });
+    const out = await runFireCancelTool(stash, cancel, { task_id: TASK_UUID.slice(0, 8) }, NOW_MS);
     expect(out.ok).toBe(false);
     expect(cancel).not.toHaveBeenCalled();
   });
@@ -2220,7 +2234,7 @@ describe('fire 侧取消 / 改期任务', () => {
       pendingTasks: [rec],
       selfLog: { v: 3, basePackAt: 1, anchorUserMsgAt: null, entries: [], tasks: [rec] },
     });
-    await runFireCancelTool(stash, okCancel(), { task_id: 'u-selflog' });
+    await runFireCancelTool(stash, okCancel(), { task_id: 'u-selflog' }, NOW_MS);
     expect(stash.selfLog.tasks).toEqual([]);
     expect(stash.selfLogDirty).toBe(true);
   });
@@ -2228,7 +2242,7 @@ describe('fire 侧取消 / 改期任务', () => {
   it('本轮刚排的那条允许当场反悔：scheduledTasks 一并摘掉', async () => {
     const rec = taskRec('u-fresh', { source: 'character' });
     const stash = makeStash({ scheduledTasks: [rec] });
-    const out = await runFireCancelTool(stash, okCancel(), { task_id: 'u-fresh' });
+    const out = await runFireCancelTool(stash, okCancel(), { task_id: 'u-fresh' }, NOW_MS);
     expect(out.ok).toBe(true);
     expect(stash.scheduledTasks).toEqual([]);
   });
@@ -2236,14 +2250,14 @@ describe('fire 侧取消 / 改期任务', () => {
   it('行已经不在了（cancelled:false）→ 照实说、不记账', async () => {
     const cancel = vi.fn(async () => ({ cancelled: false }));
     const stash = makeStash({ pendingTasks: [taskRec('u-gone')] });
-    const out = await runFireCancelTool(stash, cancel, { task_id: 'u-gone' });
+    const out = await runFireCancelTool(stash, cancel, { task_id: 'u-gone' }, NOW_MS);
     expect(out.ok).toBe(true);
     expect(out.already_gone).toBe(true);
     expect(stash.cancelledTasks).toEqual([]);
   });
 
   it('老部署没有 ctx.cancelTask → not_supported，一句能照做的话', async () => {
-    const out = await runFireCancelTool(makeStash({ pendingTasks: [taskRec('u-x')] }), undefined, {});
+    const out = await runFireCancelTool(makeStash({ pendingTasks: [taskRec('u-x')] }), undefined, {}, NOW_MS);
     expect(out.reason).toBe('not_supported');
   });
 

--- a/worker/amsg/src/index.ts
+++ b/worker/amsg/src/index.ts
@@ -59,7 +59,7 @@ import {
 } from '../../../utils/amsgFirePack';
 import { resolveFireSceneSong } from '../../../utils/amsgFireScene';
 import { shouldExpireFire } from '../../../utils/amsg2ExpireGuard';
-import { buildFireTaskListBlock, isPendingTask, MAX_ACTIVE_TASKS_PER_CHAR } from '../../../utils/amsg2Tasks';
+import { buildFireTaskListBlock, isPendingTask, MAX_ACTIVE_TASKS_PER_CHAR, shortTaskId } from '../../../utils/amsg2Tasks';
 import {
   AMSG_FIRE_CANCEL_TOOL,
   AMSG_FIRE_RENEW_TOOL,
@@ -299,18 +299,18 @@ interface FireStash {
   pendingTaskCount: number;
   /**
    * fire 开场的活任务清单（客户端快照 + 自排未认领），取消 / 改期工具按短 id
-   * 在这里找目标。直造的旧 stash 可能没有这个字段，缺省当空清单。
+   * 在这里找目标。唯一生产者 onBeforeFire 恒定初始化，必填。
    */
-  pendingTasks?: ActiveMsg2TaskRecord[];
+  pendingTasks: ActiveMsg2TaskRecord[];
   /** 角色本次 fire 已经排成功的任务（也是要随 push 带回客户端认领的那些）。 */
   scheduledTasks: ActiveMsg2TaskRecord[];
   /**
    * 本次 fire 里取消 / 改期掉的既有任务（uuid / uuid+新时刻）。随最后一条 push 的
    * metadata.amsgTaskMutations 带回客户端消账——D1 行已经动了，本地清单不跟着动的话，
-   * 面板会一直列着一条永远不会响（或时间不对）的任务。
+   * 面板会一直列着一条永远不会响（或时间不对）的任务。唯一生产者恒定初始化，必填。
    */
-  cancelledTasks?: string[];
-  renewedTasks?: Array<{ taskUuid: string; sendAt: string }>;
+  cancelledTasks: string[];
+  renewedTasks: Array<{ taskUuid: string; sendAt: string }>;
   /**
    * 用户设的「未回复期间最多连发几条」（已解析：0 → Infinity、缺省 → 默认值）。
    * 排程工具用它打回超额的自排；到点兜底闸在 onBeforeFire 里直接用 pack 上的原始值。
@@ -868,10 +868,9 @@ export const runFireScheduleTool = async (
   }
   // 连发上限·排程闸（用户主权）：已发的 + 先前排了还没响的 + 这次已排的，加上这条会超
   // 就打回。到点兜底闸（onBeforeFire）是它的另一半——先排满再触发的在那边拦。
-  // 直造的旧 stash 可能没有这两个字段，缺省当不限，别让 undefined 比较把排程整个禁掉。
-  const unansweredLimit = stash.maxUnansweredSends ?? Infinity;
+  const unansweredLimit = stash.maxUnansweredSends;
   const committedSends = countUnansweredSends(stash.selfLog)
-    + (stash.plannedSelfSends ?? 0) + stash.scheduledTasks.length;
+    + stash.plannedSelfSends + stash.scheduledTasks.length;
   if (committedSends + 1 > unansweredLimit) {
     return {
       ok: false,
@@ -977,7 +976,7 @@ export const runFireScheduleTool = async (
 
   return {
     ok: true,
-    task_id: result.uuid.slice(0, 8),
+    task_id: shortTaskId(result.uuid),
     send_at: sendAt,
     message: '排好了。到点你会知道自己这次说了什么，接着说就行，现在不用剧透。',
   };
@@ -988,8 +987,8 @@ export const runFireScheduleTool = async (
  * 刨掉本轮已经取消的。不含当前正在 fire 的这条（它的收尾归 run-tick 管）。
  */
 const liveTaskView = (stash: FireStash): ActiveMsg2TaskRecord[] => {
-  const cancelled = new Set(stash.cancelledTasks ?? []);
-  return [...(stash.pendingTasks ?? []), ...stash.scheduledTasks]
+  const cancelled = new Set(stash.cancelledTasks);
+  return [...stash.pendingTasks, ...stash.scheduledTasks]
     .filter((t) => !cancelled.has(t.taskUuid) && t.taskUuid !== stash.taskUuid);
 };
 
@@ -1023,11 +1022,12 @@ export const runFireCancelTool = async (
   stash: FireStash,
   cancelTask: CancelTask | undefined,
   args: Record<string, unknown>,
+  nowMs: number,
 ): Promise<Record<string, unknown>> => {
   if (typeof cancelTask !== 'function') {
     return { ok: false, reason: 'not_supported', message: '当前后台版本还不支持取消任务，先当它会照常响，把要说的话说清楚。' };
   }
-  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id);
+  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id, nowMs);
   if ('ok' in resolved) return resolved as unknown as Record<string, unknown>;
   const target = resolved.task;
 
@@ -1039,14 +1039,14 @@ export const runFireCancelTool = async (
   }
   if (!result.cancelled) {
     // 行已经不在了（先前取消过 / 已经触发跑掉了）。对模型来说目的达成，照实说。
-    return { ok: true, already_gone: true, message: `任务 [${target.taskUuid.slice(0, 8)}] 已经不在排程里了，不用再管它。` };
+    return { ok: true, already_gone: true, message: `任务 [${shortTaskId(target.taskUuid)}] 已经不在排程里了，不用再管它。` };
   }
 
-  stash.cancelledTasks = [...(stash.cancelledTasks ?? []), target.taskUuid];
+  stash.cancelledTasks = [...stash.cancelledTasks, target.taskUuid];
   stash.scheduledTasks = stash.scheduledTasks.filter((t) => t.taskUuid !== target.taskUuid);
   patchSelfLogTask(stash, target.taskUuid, { remove: true });
   console.log('[amsg:self-cancel]', { uuid: target.taskUuid });
-  return { ok: true, task_id: target.taskUuid.slice(0, 8), message: `已取消 [${target.taskUuid.slice(0, 8)}]。` };
+  return { ok: true, task_id: shortTaskId(target.taskUuid), message: `已取消 [${shortTaskId(target.taskUuid)}]。` };
 };
 
 /**
@@ -1066,7 +1066,7 @@ export const runFireRenewTool = async (
   if (typeof fireCtx.renewTask !== 'function') {
     return { ok: false, reason: 'not_supported', message: '当前后台版本还不支持改期，要么取消重排，要么先当它会照常响。' };
   }
-  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id);
+  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id, nowMs);
   if ('ok' in resolved) return resolved as unknown as Record<string, unknown>;
   const target = resolved.task;
   if (target.mode === 'fixed') {
@@ -1086,7 +1086,7 @@ export const runFireRenewTool = async (
       expire_policy: target.expirePolicy,
     }, nowMs);
     if (result.ok === true) {
-      return { ...result, message: `已为 [${target.taskUuid.slice(0, 8)}] 的这一次补上一条一次性任务，原来的重复节奏不变。` };
+      return { ...result, message: `已为 [${shortTaskId(target.taskUuid)}] 的这一次补上一条一次性任务，原来的重复节奏不变。` };
     }
     return result;
   }
@@ -1099,17 +1099,17 @@ export const runFireRenewTool = async (
     return { ok: false, reason: 'renew_rejected', message: error instanceof Error ? error.message : String(error) };
   }
   if (!result.renewed) {
-    return { ok: false, reason: 'task_gone', message: `任务 [${target.taskUuid.slice(0, 8)}] 已经不在排程里了（可能刚触发过），要说的话用 schedule_active_message 重新排。` };
+    return { ok: false, reason: 'task_gone', message: `任务 [${shortTaskId(target.taskUuid)}] 已经不在排程里了（可能刚触发过），要说的话用 schedule_active_message 重新排。` };
   }
 
-  stash.renewedTasks = [...(stash.renewedTasks ?? []), { taskUuid: target.taskUuid, sendAt: result.nextSendAt }];
+  stash.renewedTasks = [...stash.renewedTasks, { taskUuid: target.taskUuid, sendAt: result.nextSendAt }];
   patchSelfLogTask(stash, target.taskUuid, { sendAt: result.nextSendAt });
   console.log('[amsg:self-renew]', { uuid: target.taskUuid, sendAt: result.nextSendAt });
   return {
     ok: true,
-    task_id: target.taskUuid.slice(0, 8),
+    task_id: shortTaskId(target.taskUuid),
     send_at: result.nextSendAt,
-    message: `已把 [${target.taskUuid.slice(0, 8)}] 改到新时间（编号不变）。`,
+    message: `已把 [${shortTaskId(target.taskUuid)}] 改到新时间（编号不变）。`,
   };
 };
 
@@ -1395,8 +1395,8 @@ export const amsgHooks = {
     // 角色级 2.0 开关（pack.selfScheduleEnabled，打包时取 isAmsg2EnabledForChar）。
     // 关着 = 排程说明块、排程工具、任务清单一概不注入：本地路径这道闸在 useChatAI 的
     // amsg2ToolsInjected——用户显式关掉的功能不能被云端聊天轮绕开重排任务。
-    // 缺省当 true（旧包 / 定时任务路径的包只会来自开着 2.0 的角色）。
-    const selfScheduleAllowed = pack.selfScheduleEnabled !== false;
+    // 必填字段（parseFirePack 把关），不做缺省——这道闸缺省放行就是 fail-open。
+    const selfScheduleAllowed = pack.selfScheduleEnabled;
 
     // 老 worker 部署（amsg-server < 2.6.0-next.9）没有这个口子。教了也排不成，
     // 只会让角色说「我等下再找你」然后没有下文——干脆不教。
@@ -1743,8 +1743,8 @@ export const amsgHooks = {
 
       // 本轮取消 / 改期掉的既有任务同样随最后一条回去消账（与排程认领对称：那边是
       // 「D1 多了一行，本地补上」，这边是「D1 那行没了 / 换时间了，本地跟上」）。
-      const cancelled = stash.cancelledTasks ?? [];
-      const renewed = stash.renewedTasks ?? [];
+      const cancelled = stash.cancelledTasks;
+      const renewed = stash.renewedTasks;
       if ((cancelled.length > 0 || renewed.length > 0) && payloads.length > 0) {
         payloads = attachMetaAt(payloads, payloads.length - 1, {
           amsgTaskMutations: {
@@ -1909,7 +1909,7 @@ export const amsgHooks = {
         const result = name === AMSG_FIRE_SCHEDULE_TOOL
           ? await runFireScheduleTool(stash, ctx.scheduleTask, args, Date.now())
           : name === AMSG_FIRE_CANCEL_TOOL
-            ? await runFireCancelTool(stash, ctx.cancelTask, args)
+            ? await runFireCancelTool(stash, ctx.cancelTask, args, Date.now())
             : name === AMSG_FIRE_RENEW_TOOL
               ? await runFireRenewTool(stash, ctx, args, Date.now())
               : name.startsWith(MCP_FIRE_NAME_PREFIX)

--- a/worker/amsg/src/index.ts
+++ b/worker/amsg/src/index.ts
@@ -1711,6 +1711,16 @@ export const amsgHooks = {
         reason: decision.reason,
         skippedAt: Date.now(),
       });
+      // 即时对话被 skip：一次性行会被上游当成功消费删掉，客户端点名只能看到「行没了、
+      // outbox 也空」，落下的说明是「回复没能取回」——把「没生成出来」说成了「取不回」。
+      // 也写一份 chat_fail（认 uuid），客户端 gone 分支读回后能照实说「模型这轮没说话」。
+      if (stash.instant && stash.taskUuid && ctx.writeState) {
+        await writeChatFail(ctx.writeState, stash.charId, {
+          uuid: stash.taskUuid,
+          reason: decision.reason,
+          retryCount: 0,
+        });
+      }
     }
 
     if (decision.decision === 'finish') {

--- a/worker/amsg/src/instantChat.test.ts
+++ b/worker/amsg/src/instantChat.test.ts
@@ -199,6 +199,40 @@ describe('POST /instant-chat — 严格顺序与失败传播', () => {
     expect(paths()).toEqual(['PUT /client-state']);
   });
 
+  // HTTP ok ≠ 都写进去了：上游按 updatedAt 条件写，被拦的条目在成功体 skippedEntries 里
+  // 点名。fire_pack 被拦（设备时钟回拨过）还落任务的话，fire 会拿旧 chat 段答话——用户
+  // 拿着 202 白等一轮甚至收到答非所问，且无任何报错。
+  it('client-state 200 但 fire_pack 被条件写拦下 → 409 INSTANT_CHAT_STATE_STALE，绝不建任务', async () => {
+    const { upstream, paths } = makeUpstream({
+      clientState: {
+        status: 200,
+        body: {
+          success: true,
+          data: { upserted: 2, skippedEntries: [{ namespace: 'amsg:char:c1', key: 'fire_pack' }] },
+        },
+      },
+    });
+    const response = await run({ request: post(validBody()), upstream });
+    expect(response.status).toBe(409);
+    const body = await response.json() as any;
+    expect(body.error.code).toBe('INSTANT_CHAT_STATE_STALE');
+    expect(body.error.step).toBe('client-state');
+    expect(paths()).toEqual(['PUT /client-state']);
+  });
+
+  it('client-state 200、被拦的只是别的条目（非 fire_pack）→ 照常受理', async () => {
+    const { upstream } = makeUpstream({
+      clientState: {
+        status: 200,
+        body: {
+          success: true,
+          data: { upserted: 2, skippedEntries: [{ namespace: 'amsg:char:c1', key: 'chat_presence' }] },
+        },
+      },
+    });
+    expect((await run({ request: post(validBody()), upstream })).status).toBe(202);
+  });
+
   it('建任务失败 → 报 schedule-message 那一步，不假装受理', async () => {
     const { upstream } = makeUpstream({
       scheduleMessage: { status: 409, body: { success: false, error: { code: 'PUSH_SUBSCRIPTION_MISSING' } } },

--- a/worker/amsg/src/instantChat.ts
+++ b/worker/amsg/src/instantChat.ts
@@ -20,6 +20,7 @@
 
 import {
   AMSG_CHAT_OUTBOX_KEY,
+  AMSG_FIRE_PACK_KEY,
   amsgStateNamespace,
   appendChatOutbox,
   buildUserClockHint,
@@ -338,6 +339,25 @@ export const handleInstantChat = async (args: {
         message: '云端状态没传上去，这条没发出去',
         step: 'client-state',
         upstream: await readBody(stateResponse),
+      },
+    });
+  }
+  // HTTP ok ≠ 都写进去了：上游按 updatedAt 做条件写（旧不盖新），被拦的条目在成功体的
+  // skippedEntries 里点名。fire_pack 被拦（典型成因：设备时钟在两次发送之间被回拨，
+  // 这次的 updatedAt 反而比云端存量旧）时绝不能落任务——到点的 fire 读到的是上一轮的
+  // chat 段，要么对旧消息答非所问、要么硬失败，用户却已经拿到 202 在等「正在输入」。
+  // 「状态没落地就不落任务」正是这条两步串行存在的意义，这里把它守完整。
+  const stateBody = await readBody(stateResponse);
+  const skippedEntries = (stateBody as {
+    data?: { skippedEntries?: Array<{ namespace?: unknown; key?: unknown }> };
+  } | null)?.data?.skippedEntries;
+  if (Array.isArray(skippedEntries) && skippedEntries.some((entry) => entry?.key === AMSG_FIRE_PACK_KEY)) {
+    return json(409, {
+      success: false,
+      error: {
+        code: 'INSTANT_CHAT_STATE_STALE',
+        message: '云端拒收了这轮的最新状态（云端已有更新的一份）——设备时钟可能被回拨过，检查系统时间后再发一次',
+        step: 'client-state',
       },
     });
   }

--- a/worker/amsg/worker.bundle.js
+++ b/worker/amsg/worker.bundle.js
@@ -9470,6 +9470,18 @@ var handleInstantChat = async (args) => {
       }
     });
   }
+  const stateBody = await readBody(stateResponse);
+  const skippedEntries = stateBody?.data?.skippedEntries;
+  if (Array.isArray(skippedEntries) && skippedEntries.some((entry) => entry?.key === AMSG_FIRE_PACK_KEY)) {
+    return json(409, {
+      success: false,
+      error: {
+        code: "INSTANT_CHAT_STATE_STALE",
+        message: "\u4E91\u7AEF\u62D2\u6536\u4E86\u8FD9\u8F6E\u7684\u6700\u65B0\u72B6\u6001\uFF08\u4E91\u7AEF\u5DF2\u6709\u66F4\u65B0\u7684\u4E00\u4EFD\uFF09\u2014\u2014\u8BBE\u5907\u65F6\u949F\u53EF\u80FD\u88AB\u56DE\u62E8\u8FC7\uFF0C\u68C0\u67E5\u7CFB\u7EDF\u65F6\u95F4\u540E\u518D\u53D1\u4E00\u6B21",
+        step: "client-state"
+      }
+    });
+  }
   const taskResponse = await upstream2.fetch(
     new Request(internalUrl("/schedule-message"), {
       method: "POST",
@@ -10379,6 +10391,13 @@ var amsgHooks = {
         reason: decision.reason,
         skippedAt: Date.now()
       });
+      if (stash.instant && stash.taskUuid && ctx.writeState) {
+        await writeChatFail(ctx.writeState, stash.charId, {
+          uuid: stash.taskUuid,
+          reason: decision.reason,
+          retryCount: 0
+        });
+      }
     }
     if (decision.decision === "finish") {
       stash.selfLogTexts = decision.pushPayloads.map(

--- a/worker/amsg/worker.bundle.js
+++ b/worker/amsg/worker.bundle.js
@@ -5263,7 +5263,7 @@ var chatFieldOk = (chat) => {
 var parseFirePack = (value) => {
   try {
     const parsed = JSON.parse(value);
-    if (parsed && typeof parsed === "object" && parsed.v === FIRE_PACK_VERSION && chatFieldOk(parsed.chat) && typeof parsed.template === "string" && parsed.template.length > 0 && (parsed.lastUserMessageAt === null || typeof parsed.lastUserMessageAt === "number") && typeof parsed.tzId === "string" && parsed.tzId.length > 0 && typeof parsed.userTzId === "string" && parsed.userTzId.length > 0 && typeof parsed.targetName === "string" && typeof parsed.builtAt === "number" && Array.isArray(parsed.pendingTasks) && (parsed.scene === null || typeof parsed.scene === "object") && (parsed.maxUnansweredSends === void 0 || typeof parsed.maxUnansweredSends === "number" && Number.isFinite(parsed.maxUnansweredSends) && parsed.maxUnansweredSends >= 0) && (parsed.selfScheduleEnabled === void 0 || typeof parsed.selfScheduleEnabled === "boolean")) {
+    if (parsed && typeof parsed === "object" && parsed.v === FIRE_PACK_VERSION && chatFieldOk(parsed.chat) && typeof parsed.template === "string" && parsed.template.length > 0 && (parsed.lastUserMessageAt === null || typeof parsed.lastUserMessageAt === "number") && typeof parsed.tzId === "string" && parsed.tzId.length > 0 && typeof parsed.userTzId === "string" && parsed.userTzId.length > 0 && typeof parsed.targetName === "string" && typeof parsed.builtAt === "number" && Array.isArray(parsed.pendingTasks) && (parsed.scene === null || typeof parsed.scene === "object") && (parsed.maxUnansweredSends === void 0 || typeof parsed.maxUnansweredSends === "number" && Number.isFinite(parsed.maxUnansweredSends) && parsed.maxUnansweredSends >= 0) && typeof parsed.selfScheduleEnabled === "boolean") {
       return parsed;
     }
   } catch {
@@ -5524,7 +5524,7 @@ var parseFireScheduleArgs = (args, nowMs, tz) => {
     expirePolicy
   };
 };
-var resolveFireTargetTask = (tasks, taskIdArg) => {
+var resolveFireTargetTask = (tasks, taskIdArg, nowMs) => {
   if (tasks.length === 0) {
     return { ok: false, reason: "no_tasks", message: "\u4F60\u73B0\u5728\u6CA1\u6709\u6302\u7740\u4EFB\u4F55\u6392\u7A0B\u4EFB\u52A1\u3002" };
   }
@@ -5532,7 +5532,9 @@ var resolveFireTargetTask = (tasks, taskIdArg) => {
     const task = findTaskByShortId(tasks, taskIdArg.trim());
     return task ? { task } : { ok: false, reason: "task_not_found", message: `\u6CA1\u6709\u627E\u5230\u77ED id \u4E3A ${taskIdArg.trim()} \u7684\u4EFB\u52A1\u2014\u2014\u77ED id \u5728\u6392\u7A0B\u6E05\u5355\u91CC\uFF0C\u7167\u7740\u90A3\u91CC\u7684\u5199\u3002` };
   }
-  if (tasks.length === 1) return { task: tasks[0] };
+  const pending = tasks.filter((t) => isPendingTask(t, nowMs));
+  if (pending.length === 1) return { task: pending[0] };
+  if (pending.length === 0 && tasks.length === 1) return { task: tasks[0] };
   return { ok: false, reason: "ambiguous_task", message: "\u4F60\u6302\u7740\u4E0D\u6B62\u4E00\u4E2A\u4EFB\u52A1\uFF0C\u5E26 task_id\uFF08\u6392\u7A0B\u6E05\u5355\u91CC\u7684\u77ED id\uFF09\u6307\u5B9A\u8981\u52A8\u54EA\u4E00\u4E2A\u3002" };
 };
 var parseFireRenewSendAt = (raw, nowMs, tz) => {
@@ -9221,10 +9223,89 @@ function buildScheduledPush(message, build, extraMeta, bannerBody) {
   };
 }
 
-// worker/amsg/src/emotionEval.ts
-var SYSTEM_SLOT = "__EMOTION_EVAL_SYSTEM_PROMPT__";
-var HISTORY_SLOT = "__EMOTION_EVAL_HISTORY__";
+// utils/emotionEvalCore.ts
+var EMOTION_EVAL_SYSTEM_SLOT = "__EMOTION_EVAL_SYSTEM_PROMPT__";
+var EMOTION_EVAL_HISTORY_SLOT = "__EMOTION_EVAL_HISTORY__";
 var EMOTION_EVAL_TIMEOUT_MS = 12e4;
+var flattenEvalContent = (content) => {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => part?.type === "text" ? part.text || "" : part?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
+  }
+  return "";
+};
+var restoreEvalPrompt = (template, chatMessages, charName) => {
+  const messages = Array.isArray(chatMessages) ? chatMessages : [];
+  let systemPromptText = "";
+  let conversation = messages;
+  if (messages.length > 0 && messages[0]?.role === "system") {
+    systemPromptText = flattenEvalContent(messages[0].content);
+    conversation = messages.slice(1);
+  }
+  const recentLines = conversation.map((m) => {
+    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? charName : "\u7CFB\u7EDF";
+    return `[${role}]: ${flattenEvalContent(m.content)}`;
+  }).join("\n");
+  return String(template).replace(EMOTION_EVAL_SYSTEM_SLOT, () => systemPromptText).replace(EMOTION_EVAL_HISTORY_SLOT, () => recentLines);
+};
+var ERROR_SNIPPET_MAX = 120;
+var maskAndSnip = (text, apiKey) => {
+  let snippet = text.replace(/\s+/g, " ").trim();
+  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join("***");
+  return snippet.slice(0, ERROR_SNIPPET_MAX);
+};
+var requestEmotionEval = async (api, promptContent, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseUrl = String(api.baseUrl).replace(/\/+$/, "");
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api.apiKey || "sk-none"}`
+      },
+      body: JSON.stringify({
+        model: api.model,
+        messages: [{ role: "user", content: promptContent }],
+        temperature: 0.85,
+        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
+        // 会被截成半截 JSON。
+        max_tokens: 8e3,
+        stream: false
+      }),
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      let body = "";
+      try {
+        body = await res.text();
+      } catch {
+      }
+      console.warn("[emotion-eval] \u526F API \u62D2\u4E86\u8FD9\u6B21\u8BC4\u4F30\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", res.status);
+      const snippet = maskAndSnip(body, api.apiKey);
+      return { raw: null, error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
+    }
+    const data = await res.json();
+    const message = data?.choices?.[0]?.message;
+    const raw = flattenEvalContent(message?.content) || (typeof message?.reasoning_content === "string" ? message.reasoning_content : "");
+    if (!raw.trim()) {
+      return {
+        raw: null,
+        error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9\uFF08finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"}\uFF09`
+      };
+    }
+    return { raw, error: null };
+  } catch (error) {
+    console.warn("[emotion-eval] \u8BC4\u4F30\u5931\u8D25\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", error);
+    const reason = controller.signal.aborted ? `\u8BC4\u4F30\u8D85\u65F6\uFF08${Math.round(timeoutMs / 1e3)} \u79D2\u6CA1\u56DE\u6765\uFF09` : `\u8BC4\u4F30\u8BF7\u6C42\u6CA1\u53D1\u51FA\u53BB\uFF1A${maskAndSnip(error instanceof Error ? error.message : String(error), api.apiKey)}`;
+    return { raw: null, error: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+// worker/amsg/src/emotionEval.ts
 var amsgEmotionUpdateKey = (clientTaskId) => `emotion_update:${clientTaskId}`;
 var isUsableEvalSpec = (spec) => {
   const s = spec;
@@ -9246,86 +9327,7 @@ var takeEmotionEvalSpec = (metadata) => {
   }
   return isUsableEvalSpec(spec) ? spec : null;
 };
-var flattenContent = (content) => {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content.map((part) => part?.type === "text" ? part.text || "" : part?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
-  }
-  return "";
-};
-var restoreEvalPrompt = (template, chatMessages, charName) => {
-  const messages = Array.isArray(chatMessages) ? chatMessages : [];
-  let systemPromptText = "";
-  let conversation = messages;
-  if (messages.length > 0 && messages[0]?.role === "system") {
-    systemPromptText = flattenContent(messages[0].content);
-    conversation = messages.slice(1);
-  }
-  const recentLines = conversation.map((m) => {
-    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? charName : "\u7CFB\u7EDF";
-    return `[${role}]: ${flattenContent(m.content)}`;
-  }).join("\n");
-  return String(template).replace(SYSTEM_SLOT, () => systemPromptText).replace(HISTORY_SLOT, () => recentLines);
-};
-var ERROR_SNIPPET_MAX = 120;
-var maskAndSnip = (text, apiKey) => {
-  let snippet = text.replace(/\s+/g, " ").trim();
-  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join("***");
-  return snippet.slice(0, ERROR_SNIPPET_MAX);
-};
-var describeEvalFailure = (status, body, apiKey) => {
-  const snippet = maskAndSnip(body, apiKey);
-  return `\u526F API HTTP ${status}${snippet ? `\uFF1A${snippet}` : ""}`;
-};
-var runAmsgEmotionEval = async (spec, chatMessages, charName, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const baseUrl = String(spec.api.baseUrl).replace(/\/+$/, "");
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${spec.api.apiKey || "sk-none"}`
-      },
-      body: JSON.stringify({
-        model: spec.api.model,
-        messages: [{ role: "user", content: restoreEvalPrompt(spec.prompt, chatMessages, charName) }],
-        temperature: 0.85,
-        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
-        // 会被截成半截 JSON（与 instant push worker 同一个数）。
-        max_tokens: 8e3,
-        stream: false
-      }),
-      signal: controller.signal
-    });
-    if (!res.ok) {
-      let body = "";
-      try {
-        body = await res.text();
-      } catch {
-      }
-      console.warn("[amsg:emotion] \u526F API \u62D2\u4E86\u8FD9\u6B21\u8BC4\u4F30\uFF08\u4E3B\u56DE\u590D\u4E0D\u53D7\u5F71\u54CD\uFF09", res.status);
-      return { raw: null, error: describeEvalFailure(res.status, body, spec.api.apiKey) };
-    }
-    const data = await res.json();
-    const message = data?.choices?.[0]?.message;
-    const raw = flattenContent(message?.content) || (typeof message?.reasoning_content === "string" ? message.reasoning_content : "");
-    if (!raw.trim()) {
-      return {
-        raw: null,
-        error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9\uFF08finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"}\uFF09`
-      };
-    }
-    return { raw, error: null };
-  } catch (error) {
-    console.warn("[amsg:emotion] \u8BC4\u4F30\u5931\u8D25\uFF08\u4E3B\u56DE\u590D\u4E0D\u53D7\u5F71\u54CD\uFF09", error);
-    const reason = controller.signal.aborted ? `\u8BC4\u4F30\u8D85\u65F6\uFF08${Math.round(timeoutMs / 1e3)} \u79D2\u6CA1\u56DE\u6765\uFF09` : `\u8BC4\u4F30\u8BF7\u6C42\u6CA1\u53D1\u51FA\u53BB\uFF1A${maskAndSnip(error instanceof Error ? error.message : String(error), spec.api.apiKey)}`;
-    return { raw: null, error: reason };
-  } finally {
-    clearTimeout(timer);
-  }
-};
+var runAmsgEmotionEval = async (spec, chatMessages, charName, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => requestEmotionEval(spec.api, restoreEvalPrompt(spec.prompt, chatMessages, charName), timeoutMs);
 
 // worker/amsg/src/instantChat.ts
 var INSTANT_TOTAL_TIMEOUT_MS = 6e5;
@@ -9872,8 +9874,8 @@ var runFireScheduleTool = async (stash, scheduleTask, args, nowMs) => {
   if (typeof scheduleTask !== "function") {
     return { ok: false, reason: "not_supported", message: "\u5F53\u524D\u540E\u53F0\u7248\u672C\u8FD8\u4E0D\u652F\u6301\u7ED9\u81EA\u5DF1\u6392\u540E\u7EED\uFF0C\u8FD9\u6B21\u5C31\u628A\u8BDD\u8BF4\u5B8C\u5427\u3002" };
   }
-  const unansweredLimit = stash.maxUnansweredSends ?? Infinity;
-  const committedSends = countUnansweredSends(stash.selfLog) + (stash.plannedSelfSends ?? 0) + stash.scheduledTasks.length;
+  const unansweredLimit = stash.maxUnansweredSends;
+  const committedSends = countUnansweredSends(stash.selfLog) + stash.plannedSelfSends + stash.scheduledTasks.length;
   if (committedSends + 1 > unansweredLimit) {
     return {
       ok: false,
@@ -9961,14 +9963,14 @@ var runFireScheduleTool = async (stash, scheduleTask, args, nowMs) => {
   }
   return {
     ok: true,
-    task_id: result.uuid.slice(0, 8),
+    task_id: shortTaskId(result.uuid),
     send_at: sendAt,
     message: "\u6392\u597D\u4E86\u3002\u5230\u70B9\u4F60\u4F1A\u77E5\u9053\u81EA\u5DF1\u8FD9\u6B21\u8BF4\u4E86\u4EC0\u4E48\uFF0C\u63A5\u7740\u8BF4\u5C31\u884C\uFF0C\u73B0\u5728\u4E0D\u7528\u5267\u900F\u3002"
   };
 };
 var liveTaskView = (stash) => {
-  const cancelled = new Set(stash.cancelledTasks ?? []);
-  return [...stash.pendingTasks ?? [], ...stash.scheduledTasks].filter((t) => !cancelled.has(t.taskUuid) && t.taskUuid !== stash.taskUuid);
+  const cancelled = new Set(stash.cancelledTasks);
+  return [...stash.pendingTasks, ...stash.scheduledTasks].filter((t) => !cancelled.has(t.taskUuid) && t.taskUuid !== stash.taskUuid);
 };
 var patchSelfLogTask = (stash, taskUuid, patch) => {
   const tasks = stash.selfLog.tasks;
@@ -9979,11 +9981,11 @@ var patchSelfLogTask = (stash, taskUuid, patch) => {
   };
   stash.selfLogDirty = true;
 };
-var runFireCancelTool = async (stash, cancelTask, args) => {
+var runFireCancelTool = async (stash, cancelTask, args, nowMs) => {
   if (typeof cancelTask !== "function") {
     return { ok: false, reason: "not_supported", message: "\u5F53\u524D\u540E\u53F0\u7248\u672C\u8FD8\u4E0D\u652F\u6301\u53D6\u6D88\u4EFB\u52A1\uFF0C\u5148\u5F53\u5B83\u4F1A\u7167\u5E38\u54CD\uFF0C\u628A\u8981\u8BF4\u7684\u8BDD\u8BF4\u6E05\u695A\u3002" };
   }
-  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id);
+  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id, nowMs);
   if ("ok" in resolved) return resolved;
   const target = resolved.task;
   let result;
@@ -9993,19 +9995,19 @@ var runFireCancelTool = async (stash, cancelTask, args) => {
     return { ok: false, reason: "cancel_failed", message: error instanceof Error ? error.message : String(error) };
   }
   if (!result.cancelled) {
-    return { ok: true, already_gone: true, message: `\u4EFB\u52A1 [${target.taskUuid.slice(0, 8)}] \u5DF2\u7ECF\u4E0D\u5728\u6392\u7A0B\u91CC\u4E86\uFF0C\u4E0D\u7528\u518D\u7BA1\u5B83\u3002` };
+    return { ok: true, already_gone: true, message: `\u4EFB\u52A1 [${shortTaskId(target.taskUuid)}] \u5DF2\u7ECF\u4E0D\u5728\u6392\u7A0B\u91CC\u4E86\uFF0C\u4E0D\u7528\u518D\u7BA1\u5B83\u3002` };
   }
-  stash.cancelledTasks = [...stash.cancelledTasks ?? [], target.taskUuid];
+  stash.cancelledTasks = [...stash.cancelledTasks, target.taskUuid];
   stash.scheduledTasks = stash.scheduledTasks.filter((t) => t.taskUuid !== target.taskUuid);
   patchSelfLogTask(stash, target.taskUuid, { remove: true });
   console.log("[amsg:self-cancel]", { uuid: target.taskUuid });
-  return { ok: true, task_id: target.taskUuid.slice(0, 8), message: `\u5DF2\u53D6\u6D88 [${target.taskUuid.slice(0, 8)}]\u3002` };
+  return { ok: true, task_id: shortTaskId(target.taskUuid), message: `\u5DF2\u53D6\u6D88 [${shortTaskId(target.taskUuid)}]\u3002` };
 };
 var runFireRenewTool = async (stash, fireCtx, args, nowMs) => {
   if (typeof fireCtx.renewTask !== "function") {
     return { ok: false, reason: "not_supported", message: "\u5F53\u524D\u540E\u53F0\u7248\u672C\u8FD8\u4E0D\u652F\u6301\u6539\u671F\uFF0C\u8981\u4E48\u53D6\u6D88\u91CD\u6392\uFF0C\u8981\u4E48\u5148\u5F53\u5B83\u4F1A\u7167\u5E38\u54CD\u3002" };
   }
-  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id);
+  const resolved = resolveFireTargetTask(liveTaskView(stash), args.task_id, nowMs);
   if ("ok" in resolved) return resolved;
   const target = resolved.task;
   if (target.mode === "fixed") {
@@ -10022,7 +10024,7 @@ var runFireRenewTool = async (stash, fireCtx, args, nowMs) => {
       expire_policy: target.expirePolicy
     }, nowMs);
     if (result2.ok === true) {
-      return { ...result2, message: `\u5DF2\u4E3A [${target.taskUuid.slice(0, 8)}] \u7684\u8FD9\u4E00\u6B21\u8865\u4E0A\u4E00\u6761\u4E00\u6B21\u6027\u4EFB\u52A1\uFF0C\u539F\u6765\u7684\u91CD\u590D\u8282\u594F\u4E0D\u53D8\u3002` };
+      return { ...result2, message: `\u5DF2\u4E3A [${shortTaskId(target.taskUuid)}] \u7684\u8FD9\u4E00\u6B21\u8865\u4E0A\u4E00\u6761\u4E00\u6B21\u6027\u4EFB\u52A1\uFF0C\u539F\u6765\u7684\u91CD\u590D\u8282\u594F\u4E0D\u53D8\u3002` };
     }
     return result2;
   }
@@ -10033,16 +10035,16 @@ var runFireRenewTool = async (stash, fireCtx, args, nowMs) => {
     return { ok: false, reason: "renew_rejected", message: error instanceof Error ? error.message : String(error) };
   }
   if (!result.renewed) {
-    return { ok: false, reason: "task_gone", message: `\u4EFB\u52A1 [${target.taskUuid.slice(0, 8)}] \u5DF2\u7ECF\u4E0D\u5728\u6392\u7A0B\u91CC\u4E86\uFF08\u53EF\u80FD\u521A\u89E6\u53D1\u8FC7\uFF09\uFF0C\u8981\u8BF4\u7684\u8BDD\u7528 schedule_active_message \u91CD\u65B0\u6392\u3002` };
+    return { ok: false, reason: "task_gone", message: `\u4EFB\u52A1 [${shortTaskId(target.taskUuid)}] \u5DF2\u7ECF\u4E0D\u5728\u6392\u7A0B\u91CC\u4E86\uFF08\u53EF\u80FD\u521A\u89E6\u53D1\u8FC7\uFF09\uFF0C\u8981\u8BF4\u7684\u8BDD\u7528 schedule_active_message \u91CD\u65B0\u6392\u3002` };
   }
-  stash.renewedTasks = [...stash.renewedTasks ?? [], { taskUuid: target.taskUuid, sendAt: result.nextSendAt }];
+  stash.renewedTasks = [...stash.renewedTasks, { taskUuid: target.taskUuid, sendAt: result.nextSendAt }];
   patchSelfLogTask(stash, target.taskUuid, { sendAt: result.nextSendAt });
   console.log("[amsg:self-renew]", { uuid: target.taskUuid, sendAt: result.nextSendAt });
   return {
     ok: true,
-    task_id: target.taskUuid.slice(0, 8),
+    task_id: shortTaskId(target.taskUuid),
     send_at: result.nextSendAt,
-    message: `\u5DF2\u628A [${target.taskUuid.slice(0, 8)}] \u6539\u5230\u65B0\u65F6\u95F4\uFF08\u7F16\u53F7\u4E0D\u53D8\uFF09\u3002`
+    message: `\u5DF2\u628A [${shortTaskId(target.taskUuid)}] \u6539\u5230\u65B0\u65F6\u95F4\uFF08\u7F16\u53F7\u4E0D\u53D8\uFF09\u3002`
   };
 };
 var FINAL_ROUND_NOTICE = "\uFF08\u63D0\u9192\uFF1A\u8FD9\u662F\u6700\u540E\u4E00\u8F6E\u4E86\uFF0C\u4E0D\u8981\u518D\u8C03\u7528\u4EFB\u4F55\u5DE5\u5177\uFF0C\u76F4\u63A5\u628A\u60F3\u8BF4\u7684\u8BDD\u5199\u5B8C\u3002\uFF09";
@@ -10186,7 +10188,7 @@ var amsgHooks = {
       return { skip: true };
     }
     const livePendingTasks = [...pack.pendingTasks, ...selfLog.tasks];
-    const selfScheduleAllowed = pack.selfScheduleEnabled !== false;
+    const selfScheduleAllowed = pack.selfScheduleEnabled;
     const canSelfSchedule = typeof ctx.scheduleTask === "function" && selfScheduleAllowed;
     const tz = { tzId: pack.tzId };
     const clientTaskId = typeof taskMeta.amsgClientTaskId === "string" ? taskMeta.amsgClientTaskId : "";
@@ -10405,8 +10407,8 @@ var amsgHooks = {
       );
       let payloads = attachScheduledTasks(decision.pushPayloads, stash.scheduledTasks);
       const attachMetaAt = (list, idx, extra) => list.map((payload, i) => i === idx ? { ...payload, metadata: { ...payload.metadata ?? {}, ...extra } } : payload);
-      const cancelled = stash.cancelledTasks ?? [];
-      const renewed = stash.renewedTasks ?? [];
+      const cancelled = stash.cancelledTasks;
+      const renewed = stash.renewedTasks;
       if ((cancelled.length > 0 || renewed.length > 0) && payloads.length > 0) {
         payloads = attachMetaAt(payloads, payloads.length - 1, {
           amsgTaskMutations: {
@@ -10510,7 +10512,7 @@ var amsgHooks = {
           });
           continue;
         }
-        const result = name === AMSG_FIRE_SCHEDULE_TOOL ? await runFireScheduleTool(stash, ctx.scheduleTask, args, Date.now()) : name === AMSG_FIRE_CANCEL_TOOL ? await runFireCancelTool(stash, ctx.cancelTask, args) : name === AMSG_FIRE_RENEW_TOOL ? await runFireRenewTool(stash, ctx, args, Date.now()) : name.startsWith(MCP_FIRE_NAME_PREFIX) ? await runMcpFireTool(stash, name, args) : await dispatchAgenticTool(name, args, stash.toolCtx);
+        const result = name === AMSG_FIRE_SCHEDULE_TOOL ? await runFireScheduleTool(stash, ctx.scheduleTask, args, Date.now()) : name === AMSG_FIRE_CANCEL_TOOL ? await runFireCancelTool(stash, ctx.cancelTask, args, Date.now()) : name === AMSG_FIRE_RENEW_TOOL ? await runFireRenewTool(stash, ctx, args, Date.now()) : name.startsWith(MCP_FIRE_NAME_PREFIX) ? await runMcpFireTool(stash, name, args) : await dispatchAgenticTool(name, args, stash.toolCtx);
         stash.session.toolCalls.push({ name, fingerprint, ran: !neverRan(result) });
         content = buildToolResultMessage({ name, result, history: stash.session.toolCalls });
         console.log("[amsg:agentic]", { type: "tool_done", sessionId: ctx.sessionId, tool: name });

--- a/worker/instant-push/src/index.ts
+++ b/worker/instant-push/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { classifyLLMOutput } from './classifier';
 import { sanitizeIntoSegments, type Segment } from '../../../utils/sanitize';
 import { INSTANT_WORKER_VERSION } from '../../../utils/instantWorkerVersion';
+import { requestEmotionEval, restoreEvalPrompt } from '../../../utils/emotionEvalCore';
 
 export interface Env {
   VAPID_PUBLIC_KEY: string;
@@ -469,80 +470,20 @@ async function runEmotionEval(body: any): Promise<{ raw: string; error?: string 
     return { raw: '', error: '评估配置不完整（缺 prompt / baseUrl / apiKey / model）' };
   }
 
-  const charId = (body?.metadata && typeof body.metadata === 'object') ? body.metadata.charId : '';
   // 情绪评估 = 单条 user 消息, 与本地 buildEmotionEvalPrompt 输出**逐字对齐**. 客户端把 prompt 里
-  // 两段大文本 (system prompt、对话历史) 留成占位符, 这里用本次请求已有的 messages 还原后替换回原位:
-  //   - body.messages[0] (role=system) = 本地的 mainSystemPrompt
-  //   - body.messages[1..]             = 本地的 cleanedApiMessages → 同格式拼成 recentLines
+  // 两段大文本 (system prompt、对话历史) 留成占位符, 用本次请求已有的 messages 还原后替换回原位,
   // 这样上下文不必在请求体里重复发 (keepalive 不被降级), 评估质量/顺序与本地完全一致.
+  // 还原 + 请求 + 失败文案（含 apiKey 打码红线）收敛在 utils/emotionEvalCore.ts,
+  // 与 amsg worker 的即时对话评估共用同一份——改格式两边一起动, 不再手工同步两份副本.
   const priorMessages = Array.isArray(body?.messages) ? body.messages : [];
   const contactName = body?.contactName || '角色';
-  const flattenContent = (content: any): string => {
-    if (typeof content === 'string') return content;
-    if (Array.isArray(content)) {
-      return content
-        .map((p: any) => (p?.type === 'text' ? (p.text || '') : (p?.type === 'image_url' ? '[图片]' : '')))
-        .filter(Boolean)
-        .join(' ');
-    }
-    return '';
-  };
-  let systemPromptText = '';
-  let conversation = priorMessages;
-  if (priorMessages.length > 0 && priorMessages[0]?.role === 'system') {
-    systemPromptText = flattenContent(priorMessages[0].content);
-    conversation = priorMessages.slice(1);
-  }
-  // 与本地 recentLines 完全同格式: `[用户]: ...` / `[角色名]: ...` / `[系统]: ...`, 用 \n 连接.
-  const recentLines = conversation
-    .map((m: any) => {
-      const role = m.role === 'user' ? '用户' : (m.role === 'assistant' ? contactName : '系统');
-      return `[${role}]: ${flattenContent(m.content)}`;
-    })
-    .join('\n');
-  // 用函数式 replacer: 避免 systemPrompt / 对话里出现 $&、$1 等被 String.replace 当成替换模式解析.
-  const evalContent = String(ee.prompt)
-    .replace('__EMOTION_EVAL_SYSTEM_PROMPT__', () => systemPromptText)
-    .replace('__EMOTION_EVAL_HISTORY__', () => recentLines);
-  const evalMessages = [{ role: 'user', content: evalContent }];
-  try {
-    const baseUrl = String(ee.api.baseUrl).replace(/\/+$/, '');
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${ee.api.apiKey || 'sk-none'}`,
-      },
-      body: JSON.stringify({
-        model: ee.api.model,
-        messages: evalMessages,
-        temperature: 0.85,
-        // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小, eval 输出很长, 会被截断成半截 JSON
-        max_tokens: 8000,
-        stream: false,
-      }),
-    });
-    if (!res.ok) {
-      // 失败原因带回客户端 toast。正文可能是 HTML 错误页, 截一小段够定位即可。
-      let snippet = '';
-      try { snippet = (await res.text()).replace(/\s+/g, ' ').slice(0, 120); } catch { /* ignore */ }
-      console.error('[emotion-eval] LLM call failed', res.status);
-      return { raw: '', error: `副 API HTTP ${res.status}${snippet ? `：${snippet}` : ''}` };
-    }
-    const data: any = await res.json();
-    // content 可能是分块数组; 个别代理把全部输出塞进 reasoning_content 而 content 留空 —
-    // 与客户端 utils/emotionApply.ts:extractAssistantText 同一套兜底 (解析容错在客户端 applyEmotionEvalRaw).
-    const msg = data?.choices?.[0]?.message;
-    const raw = flattenContent(msg?.content)
-      || (typeof msg?.reasoning_content === 'string' ? msg.reasoning_content : '');
-    if (!raw) {
-      return { raw: '', error: `评估模型没有输出内容 (finish_reason: ${data?.choices?.[0]?.finish_reason ?? '?'})` };
-    }
-    return { raw };
-  } catch (e: any) {
-    console.error('[emotion-eval] failed', e);
-    return { raw: '', error: `评估请求异常：${e?.message || String(e)}` };
-  }
+  const outcome = await requestEmotionEval(
+    ee.api,
+    restoreEvalPrompt(String(ee.prompt), priorMessages, contactName),
+  );
+  return outcome.raw != null
+    ? { raw: outcome.raw }
+    : { raw: '', error: outcome.error ?? undefined };
 }
 
 /**

--- a/worker/instant-push/worker.bundle.js
+++ b/worker/instant-push/worker.bundle.js
@@ -2969,6 +2969,88 @@ function classifyLLMOutput(text) {
 // utils/instantWorkerVersion.ts
 var INSTANT_WORKER_VERSION = "2026-07-17";
 
+// utils/emotionEvalCore.ts
+var EMOTION_EVAL_SYSTEM_SLOT = "__EMOTION_EVAL_SYSTEM_PROMPT__";
+var EMOTION_EVAL_HISTORY_SLOT = "__EMOTION_EVAL_HISTORY__";
+var EMOTION_EVAL_TIMEOUT_MS = 12e4;
+var flattenEvalContent = (content) => {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => part?.type === "text" ? part.text || "" : part?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
+  }
+  return "";
+};
+var restoreEvalPrompt = (template, chatMessages, charName) => {
+  const messages = Array.isArray(chatMessages) ? chatMessages : [];
+  let systemPromptText = "";
+  let conversation = messages;
+  if (messages.length > 0 && messages[0]?.role === "system") {
+    systemPromptText = flattenEvalContent(messages[0].content);
+    conversation = messages.slice(1);
+  }
+  const recentLines = conversation.map((m) => {
+    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? charName : "\u7CFB\u7EDF";
+    return `[${role}]: ${flattenEvalContent(m.content)}`;
+  }).join("\n");
+  return String(template).replace(EMOTION_EVAL_SYSTEM_SLOT, () => systemPromptText).replace(EMOTION_EVAL_HISTORY_SLOT, () => recentLines);
+};
+var ERROR_SNIPPET_MAX = 120;
+var maskAndSnip = (text, apiKey) => {
+  let snippet = text.replace(/\s+/g, " ").trim();
+  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join("***");
+  return snippet.slice(0, ERROR_SNIPPET_MAX);
+};
+var requestEmotionEval = async (api, promptContent, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseUrl = String(api.baseUrl).replace(/\/+$/, "");
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api.apiKey || "sk-none"}`
+      },
+      body: JSON.stringify({
+        model: api.model,
+        messages: [{ role: "user", content: promptContent }],
+        temperature: 0.85,
+        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
+        // 会被截成半截 JSON。
+        max_tokens: 8e3,
+        stream: false
+      }),
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      let body = "";
+      try {
+        body = await res.text();
+      } catch {
+      }
+      console.warn("[emotion-eval] \u526F API \u62D2\u4E86\u8FD9\u6B21\u8BC4\u4F30\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", res.status);
+      const snippet = maskAndSnip(body, api.apiKey);
+      return { raw: null, error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
+    }
+    const data = await res.json();
+    const message = data?.choices?.[0]?.message;
+    const raw = flattenEvalContent(message?.content) || (typeof message?.reasoning_content === "string" ? message.reasoning_content : "");
+    if (!raw.trim()) {
+      return {
+        raw: null,
+        error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9\uFF08finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"}\uFF09`
+      };
+    }
+    return { raw, error: null };
+  } catch (error) {
+    console.warn("[emotion-eval] \u8BC4\u4F30\u5931\u8D25\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", error);
+    const reason = controller.signal.aborted ? `\u8BC4\u4F30\u8D85\u65F6\uFF08${Math.round(timeoutMs / 1e3)} \u79D2\u6CA1\u56DE\u6765\uFF09` : `\u8BC4\u4F30\u8BF7\u6C42\u6CA1\u53D1\u51FA\u53BB\uFF1A${maskAndSnip(error instanceof Error ? error.message : String(error), api.apiKey)}`;
+    return { raw: null, error: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 // worker/instant-push/src/index.ts
 var MULTIPART_TRANSPORT = { enabled: true };
 var UTILITY_CORS_HEADERS = {
@@ -3315,65 +3397,13 @@ async function runEmotionEval(body) {
   if (!ee?.prompt || !ee?.api?.baseUrl || !ee?.api?.apiKey || !ee?.api?.model) {
     return { raw: "", error: "\u8BC4\u4F30\u914D\u7F6E\u4E0D\u5B8C\u6574\uFF08\u7F3A prompt / baseUrl / apiKey / model\uFF09" };
   }
-  const charId = body?.metadata && typeof body.metadata === "object" ? body.metadata.charId : "";
   const priorMessages = Array.isArray(body?.messages) ? body.messages : [];
   const contactName = body?.contactName || "\u89D2\u8272";
-  const flattenContent = (content) => {
-    if (typeof content === "string") return content;
-    if (Array.isArray(content)) {
-      return content.map((p) => p?.type === "text" ? p.text || "" : p?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
-    }
-    return "";
-  };
-  let systemPromptText = "";
-  let conversation = priorMessages;
-  if (priorMessages.length > 0 && priorMessages[0]?.role === "system") {
-    systemPromptText = flattenContent(priorMessages[0].content);
-    conversation = priorMessages.slice(1);
-  }
-  const recentLines = conversation.map((m) => {
-    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? contactName : "\u7CFB\u7EDF";
-    return `[${role}]: ${flattenContent(m.content)}`;
-  }).join("\n");
-  const evalContent = String(ee.prompt).replace("__EMOTION_EVAL_SYSTEM_PROMPT__", () => systemPromptText).replace("__EMOTION_EVAL_HISTORY__", () => recentLines);
-  const evalMessages = [{ role: "user", content: evalContent }];
-  try {
-    const baseUrl = String(ee.api.baseUrl).replace(/\/+$/, "");
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${ee.api.apiKey || "sk-none"}`
-      },
-      body: JSON.stringify({
-        model: ee.api.model,
-        messages: evalMessages,
-        temperature: 0.85,
-        // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小, eval 输出很长, 会被截断成半截 JSON
-        max_tokens: 8e3,
-        stream: false
-      })
-    });
-    if (!res.ok) {
-      let snippet = "";
-      try {
-        snippet = (await res.text()).replace(/\s+/g, " ").slice(0, 120);
-      } catch {
-      }
-      console.error("[emotion-eval] LLM call failed", res.status);
-      return { raw: "", error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
-    }
-    const data = await res.json();
-    const msg = data?.choices?.[0]?.message;
-    const raw = flattenContent(msg?.content) || (typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "");
-    if (!raw) {
-      return { raw: "", error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9 (finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"})` };
-    }
-    return { raw };
-  } catch (e) {
-    console.error("[emotion-eval] failed", e);
-    return { raw: "", error: `\u8BC4\u4F30\u8BF7\u6C42\u5F02\u5E38\uFF1A${e?.message || String(e)}` };
-  }
+  const outcome = await requestEmotionEval(
+    ee.api,
+    restoreEvalPrompt(String(ee.prompt), priorMessages, contactName)
+  );
+  return outcome.raw != null ? { raw: outcome.raw } : { raw: "", error: outcome.error ?? void 0 };
 }
 function withSseAntiBufferingHeaders(resp) {
   const contentType = resp.headers.get("content-type") || "";

--- a/worker/instant-push/worker.deno.bundle.js
+++ b/worker/instant-push/worker.deno.bundle.js
@@ -2969,6 +2969,88 @@ function classifyLLMOutput(text) {
 // utils/instantWorkerVersion.ts
 var INSTANT_WORKER_VERSION = "2026-07-17";
 
+// utils/emotionEvalCore.ts
+var EMOTION_EVAL_SYSTEM_SLOT = "__EMOTION_EVAL_SYSTEM_PROMPT__";
+var EMOTION_EVAL_HISTORY_SLOT = "__EMOTION_EVAL_HISTORY__";
+var EMOTION_EVAL_TIMEOUT_MS = 12e4;
+var flattenEvalContent = (content) => {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map((part) => part?.type === "text" ? part.text || "" : part?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
+  }
+  return "";
+};
+var restoreEvalPrompt = (template, chatMessages, charName) => {
+  const messages = Array.isArray(chatMessages) ? chatMessages : [];
+  let systemPromptText = "";
+  let conversation = messages;
+  if (messages.length > 0 && messages[0]?.role === "system") {
+    systemPromptText = flattenEvalContent(messages[0].content);
+    conversation = messages.slice(1);
+  }
+  const recentLines = conversation.map((m) => {
+    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? charName : "\u7CFB\u7EDF";
+    return `[${role}]: ${flattenEvalContent(m.content)}`;
+  }).join("\n");
+  return String(template).replace(EMOTION_EVAL_SYSTEM_SLOT, () => systemPromptText).replace(EMOTION_EVAL_HISTORY_SLOT, () => recentLines);
+};
+var ERROR_SNIPPET_MAX = 120;
+var maskAndSnip = (text, apiKey) => {
+  let snippet = text.replace(/\s+/g, " ").trim();
+  if (apiKey && snippet.includes(apiKey)) snippet = snippet.split(apiKey).join("***");
+  return snippet.slice(0, ERROR_SNIPPET_MAX);
+};
+var requestEmotionEval = async (api, promptContent, timeoutMs = EMOTION_EVAL_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const baseUrl = String(api.baseUrl).replace(/\/+$/, "");
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${api.apiKey || "sk-none"}`
+      },
+      body: JSON.stringify({
+        model: api.model,
+        messages: [{ role: "user", content: promptContent }],
+        temperature: 0.85,
+        // 显式给足输出额度：部分中转不传 max_tokens 时默认很小，评估输出很长，
+        // 会被截成半截 JSON。
+        max_tokens: 8e3,
+        stream: false
+      }),
+      signal: controller.signal
+    });
+    if (!res.ok) {
+      let body = "";
+      try {
+        body = await res.text();
+      } catch {
+      }
+      console.warn("[emotion-eval] \u526F API \u62D2\u4E86\u8FD9\u6B21\u8BC4\u4F30\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", res.status);
+      const snippet = maskAndSnip(body, api.apiKey);
+      return { raw: null, error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
+    }
+    const data = await res.json();
+    const message = data?.choices?.[0]?.message;
+    const raw = flattenEvalContent(message?.content) || (typeof message?.reasoning_content === "string" ? message.reasoning_content : "");
+    if (!raw.trim()) {
+      return {
+        raw: null,
+        error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9\uFF08finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"}\uFF09`
+      };
+    }
+    return { raw, error: null };
+  } catch (error) {
+    console.warn("[emotion-eval] \u8BC4\u4F30\u5931\u8D25\uFF08\u4E3B\u6D41\u7A0B\u4E0D\u53D7\u5F71\u54CD\uFF09", error);
+    const reason = controller.signal.aborted ? `\u8BC4\u4F30\u8D85\u65F6\uFF08${Math.round(timeoutMs / 1e3)} \u79D2\u6CA1\u56DE\u6765\uFF09` : `\u8BC4\u4F30\u8BF7\u6C42\u6CA1\u53D1\u51FA\u53BB\uFF1A${maskAndSnip(error instanceof Error ? error.message : String(error), api.apiKey)}`;
+    return { raw: null, error: reason };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
 // worker/instant-push/src/index.ts
 var MULTIPART_TRANSPORT = { enabled: true };
 var UTILITY_CORS_HEADERS = {
@@ -3315,65 +3397,13 @@ async function runEmotionEval(body) {
   if (!ee?.prompt || !ee?.api?.baseUrl || !ee?.api?.apiKey || !ee?.api?.model) {
     return { raw: "", error: "\u8BC4\u4F30\u914D\u7F6E\u4E0D\u5B8C\u6574\uFF08\u7F3A prompt / baseUrl / apiKey / model\uFF09" };
   }
-  const charId = body?.metadata && typeof body.metadata === "object" ? body.metadata.charId : "";
   const priorMessages = Array.isArray(body?.messages) ? body.messages : [];
   const contactName = body?.contactName || "\u89D2\u8272";
-  const flattenContent = (content) => {
-    if (typeof content === "string") return content;
-    if (Array.isArray(content)) {
-      return content.map((p) => p?.type === "text" ? p.text || "" : p?.type === "image_url" ? "[\u56FE\u7247]" : "").filter(Boolean).join(" ");
-    }
-    return "";
-  };
-  let systemPromptText = "";
-  let conversation = priorMessages;
-  if (priorMessages.length > 0 && priorMessages[0]?.role === "system") {
-    systemPromptText = flattenContent(priorMessages[0].content);
-    conversation = priorMessages.slice(1);
-  }
-  const recentLines = conversation.map((m) => {
-    const role = m.role === "user" ? "\u7528\u6237" : m.role === "assistant" ? contactName : "\u7CFB\u7EDF";
-    return `[${role}]: ${flattenContent(m.content)}`;
-  }).join("\n");
-  const evalContent = String(ee.prompt).replace("__EMOTION_EVAL_SYSTEM_PROMPT__", () => systemPromptText).replace("__EMOTION_EVAL_HISTORY__", () => recentLines);
-  const evalMessages = [{ role: "user", content: evalContent }];
-  try {
-    const baseUrl = String(ee.api.baseUrl).replace(/\/+$/, "");
-    const res = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${ee.api.apiKey || "sk-none"}`
-      },
-      body: JSON.stringify({
-        model: ee.api.model,
-        messages: evalMessages,
-        temperature: 0.85,
-        // 显式给足输出额度: 部分代理不传 max_tokens 时默认很小, eval 输出很长, 会被截断成半截 JSON
-        max_tokens: 8e3,
-        stream: false
-      })
-    });
-    if (!res.ok) {
-      let snippet = "";
-      try {
-        snippet = (await res.text()).replace(/\s+/g, " ").slice(0, 120);
-      } catch {
-      }
-      console.error("[emotion-eval] LLM call failed", res.status);
-      return { raw: "", error: `\u526F API HTTP ${res.status}${snippet ? `\uFF1A${snippet}` : ""}` };
-    }
-    const data = await res.json();
-    const msg = data?.choices?.[0]?.message;
-    const raw = flattenContent(msg?.content) || (typeof msg?.reasoning_content === "string" ? msg.reasoning_content : "");
-    if (!raw) {
-      return { raw: "", error: `\u8BC4\u4F30\u6A21\u578B\u6CA1\u6709\u8F93\u51FA\u5185\u5BB9 (finish_reason: ${data?.choices?.[0]?.finish_reason ?? "?"})` };
-    }
-    return { raw };
-  } catch (e) {
-    console.error("[emotion-eval] failed", e);
-    return { raw: "", error: `\u8BC4\u4F30\u8BF7\u6C42\u5F02\u5E38\uFF1A${e?.message || String(e)}` };
-  }
+  const outcome = await requestEmotionEval(
+    ee.api,
+    restoreEvalPrompt(String(ee.prompt), priorMessages, contactName)
+  );
+  return outcome.raw != null ? { raw: outcome.raw } : { raw: "", error: outcome.error ?? void 0 };
 }
 function withSseAntiBufferingHeaders(resp) {
   const contentType = resp.headers.get("content-type") || "";


### PR DESCRIPTION
## Summary

This PR consolidates cloud emotion evaluation logic into a shared core module (`utils/emotionEvalCore.ts`) used by both amsg and instant-push workers, fixes message deduplication to prevent duplicate delivery, and improves event dispatching consistency.

## Key Changes

### Emotion Evaluation Core Consolidation
- **New file**: `utils/emotionEvalCore.ts` - Zero-dependency leaf module containing:
  - `restoreEvalPrompt()` - Template placeholder restoration (system prompt + conversation history)
  - `requestEmotionEval()` - Unified API request logic with timeout handling
  - `maskAndSnip()` - API key masking before error reporting (security red line)
  - Constants: `EMOTION_EVAL_SYSTEM_SLOT`, `EMOTION_EVAL_HISTORY_SLOT`, `EMOTION_EVAL_TIMEOUT_MS`
  
- **Rationale**: Both amsg worker (instant chat path) and instant-push worker were maintaining duplicate copies of this logic. When d92231a added API key masking, only one copy was updated, causing the other to leak credentials in push payloads. Consolidation ensures format changes sync automatically across both workers.

- **Updated imports**: 
  - `worker/amsg/src/emotionEval.ts` now re-exports from core
  - `worker/instant-push/src/index.ts` imports from core
  - Both worker bundles include the consolidated code

### Message Deduplication
- **New deduplication logic** in `flushInboxToChatImpl()`:
  - Checks if `messageId` already exists in recent chat history (200 messages) before persisting
  - Prevents duplicate delivery from two paths:
    1. Outbox recovery arrives first, then delayed original Web Push arrives minutes later
    2. Retry rerun reuses same `messageId` (deterministic rule: `msg_task_{行id}@{occurrenceMs}_hook_{i}`)
  - Only applies to first-time processing (`processAttempts=0`); retries are exempt to avoid killing legitimate rerun evidence
  - Logs and traces dropped duplicates for debugging

### Event Dispatching Consistency
- **New function**: `announceChatGen()` in `chatGenEvents.ts` - Single dispatch point for all chat generation events
- **Updated calls**: Replace manual `window.dispatchEvent()` with `announceChatGen()` in:
  - `activeMsgRuntime.ts` emotion failure events (both emotion_update and post-processing paths)
  - Ensures consistent error handling and removes try/catch boilerplate

### Cloud Emotion Timer Management
- **Module-level timer tracking** in `useChatAI.ts`:
  - Moved from hook-level `instantEmotionTimerRef` to module-level `cloudEmotionTimers` Map
  - Keyed by `charId` to handle user navigation (switching characters, leaving chat page)
  - Listens to global `emotionDone` event to clear timers regardless of component mount state
  - Prevents false "worker may be outdated" warnings when emotion conclusion arrives after navigation

### Fire Pack & Task Handling
- **`selfScheduleEnabled` field**: Now required (non-optional) in `AmsgFirePack`
  - Indicates whether cloud fire can inject scheduling tools
  - Prevents cloud fire from scheduling tasks when character 2.0 is disabled
  
- **Task resolution improvements**:
  - `resolveFireTargetTask()` now accepts `nowMs` parameter
  - Filters to pending tasks first, then falls back to all tasks if none pending
  - Prevents ambiguous task selection when some are expired

- **Instant chat state validation**:
  - Detects when `fire_pack` is skipped in conditional write (device clock rollback)
  - Returns `409 INSTANT_CHAT_STATE_STALE` instead of `202` to prevent stale task creation

### Lightweight Template Optimization
- **Stub template for disabled character 2.0**:
  - When character 2.0 is off and no tasks exist, use `AMSG2_INSTANT_STUB_TEMPLATE` placeholder

https://claude.ai/code/session_01HgC4kRan9XErYkUw4adkQv