### PR TITLE
fix(types): 清掉 44 个 tsc 报错（挑活跃分支没动的文件）

### DIFF
--- a/apps/BankApp.tsx
+++ b/apps/BankApp.tsx
@@ -798,7 +798,7 @@ ${previousGuestbook}
                     <BankDollhouse
                         shopState={state.shop}
                         dollhouseState={dollhouseState}
-                        onDollhouseChange={persistDollhouseUpdate}
+                        onDollhouseChange={async (updater) => { await persistDollhouseUpdate(updater); }}
                         characters={characters}
                         userProfile={userProfile}
                         apiConfig={apiConfig}

--- a/apps/GuidebookApp.tsx
+++ b/apps/GuidebookApp.tsx
@@ -1623,7 +1623,8 @@ const GuidebookApp: React.FC = () => {
                 )}
 
                 {error && (
-                    <Card className="p-3" style={{ border: '1px solid rgba(200,160,160,0.3)', background: 'rgba(250,240,240,0.6)' }}>
+                    // Card 只用自己那套卡片样式，不转发 style，这里原来传的红框/浅红底从来没生效过，就别传了
+                    <Card className="p-3">
                         <div className="text-red-500 text-xs">{error}</div>
                     </Card>
                 )}

--- a/apps/SongwritingApp.tsx
+++ b/apps/SongwritingApp.tsx
@@ -98,6 +98,24 @@ type LyricSlot = {
     lineInSection: number;
 };
 
+// SECTION_LABELS 声明成了 Record<string, …>，从它身上取出来的 key 只剩 string，
+// 这里把段落 key 收窄回 SongLine['section']。实际用到的 key 就是这七个，
+// 兜底沿用段落选择器的初始值 'verse'。
+const toSectionKind = (value: string): SongLine['section'] => {
+    switch (value) {
+        case 'intro':
+        case 'verse':
+        case 'pre-chorus':
+        case 'chorus':
+        case 'bridge':
+        case 'outro':
+        case 'free':
+            return value;
+        default:
+            return 'verse';
+    }
+};
+
 type PaperTheme = {
     background: string;
     ink: string;
@@ -188,7 +206,7 @@ const SongwritingApp: React.FC = () => {
 
     // Write View State
     const [inputText, setInputText] = useState('');
-    const [currentSection, setCurrentSection] = useState<string>('verse');
+    const [currentSection, setCurrentSection] = useState<SongLine['section']>('verse');
     const [isTyping, setIsTyping] = useState(false);
     const [lastTokenUsage, setLastTokenUsage] = useState<number | null>(null);
     const [showStructureGuide, setShowStructureGuide] = useState(false);
@@ -455,7 +473,7 @@ const SongwritingApp: React.FC = () => {
                 content: m.content
             }));
 
-            await injectMemoryPalace(collaborator, undefined, `${updatedSong.title || ''} ${updatedSong.theme || ''} ${userMessage}`.trim() || undefined);
+            await injectMemoryPalace(collaborator, undefined, `${updatedSong.title || ''} ${userMessage}`.trim() || undefined);
             const systemPrompt = SongPrompts.buildMentorSystemPrompt(collaborator, userProfile, updatedSong, msgContext);
             let userPrompt = SongPrompts.buildUserMessage(updatedSong, userMessage, currentSection);
             if (requestedType) {
@@ -803,7 +821,7 @@ const SongwritingApp: React.FC = () => {
                 if (!content) return;
                 const existing = lineAtSlot({ ...activeSong, lines: snapshotLines }, index);
                 const targetSlot = buildLyricSlots(activeSong)[index]
-                    || { index, section: currentSection as SongLine['section'], chars: '不限', sectionOccurrence: 0, lineInSection: index };
+                    || { index, section: currentSection, chars: '不限', sectionOccurrence: 0, lineInSection: index };
                 if (existing) {
                     snapshotLines = snapshotLines.map(line => line.id === existing.id
                         ? { ...line, content, section: targetSlot.section, slotIndex: index }
@@ -902,7 +920,7 @@ const SongwritingApp: React.FC = () => {
             await injectMemoryPalace(
                 collaborator,
                 undefined,
-                `${activeSong.title} ${activeSong.theme || ''} ${activeSong.lines.map(line => line.content).join(' ')}`.trim(),
+                `${activeSong.title} ${activeSong.lines.map(line => line.content).join(' ')}`.trim(),
                 userProfile.name,
             );
             const systemPrompt = SongPrompts.buildCompletionSystemPrompt(collaborator, userProfile);
@@ -2301,11 +2319,11 @@ const SongwritingApp: React.FC = () => {
                         </div>
                         <div className="rounded-2xl p-4 shizuku-glass" style={{ border: `1px solid ${MusicC.faint}40` }}>
                             <div className="grid grid-cols-3 gap-3">
-                                {[
+                                {([
                                     { label: '起点色', color: customCoverFrom, position: 'from' },
                                     { label: '中间色', color: customCoverVia, position: 'via' },
                                     { label: '终点色', color: customCoverTo,  position: 'to'   }
-                                ].map(item => (
+                                ] as const).map(item => (
                                     <label key={item.label} className="space-y-1.5">
                                         <span className="block text-[10px]" style={{ color: MusicC.muted }}>{item.label}</span>
                                         <div className="rounded-lg overflow-hidden" style={{ height: 28, background: item.color, border: `1px solid ${MusicC.faint}40`, boxShadow: `inset 0 1px 0 rgba(255,255,255,0.2)` }}>
@@ -3171,7 +3189,7 @@ const SongwritingApp: React.FC = () => {
                 })),
                 {
                     index: nextFreeIndex,
-                    section: currentSection as SongLine['section'],
+                    section: currentSection,
                     chars: '不限',
                     sectionOccurrence: 0,
                     lineInSection: nextFreeIndex,
@@ -3398,7 +3416,7 @@ const SongwritingApp: React.FC = () => {
                                 {Object.entries(SECTION_LABELS).map(([key, info]) => (
                                     <button
                                         key={key}
-                                        onClick={() => setCurrentSection(key)}
+                                        onClick={() => setCurrentSection(toSectionKind(key))}
                                         className="shrink-0 px-2.5 py-1 rounded-full text-[9px] transition-all"
                                         style={currentSection === key
                                             ? { color: '#fff', background: paper.accent }

--- a/components/ValentineEvent.tsx
+++ b/components/ValentineEvent.tsx
@@ -663,7 +663,7 @@ export const ValentineSession: React.FC<ValentineSessionProps> = ({ charId, onCl
         if (!recordRef.current || isExporting) return;
         setIsExporting(true);
         try {
-            const mod: any = await import('https://esm.sh/html2canvas@1.4.1');
+            const mod = await import('https://esm.sh/html2canvas@1.4.1');
             const html2canvas = mod.default;
             const canvas = await html2canvas(recordRef.current, {
                 backgroundColor: '#faf6f1',

--- a/components/WhiteDayEvent.tsx
+++ b/components/WhiteDayEvent.tsx
@@ -905,7 +905,7 @@ ${answerSummary}
         if (!char || !apiConfig || !canvasRef.current) return;
         try {
             // 截图必须在 setPhase 之前完成，否则元素会被卸载导致 html2canvas 报错
-            const mod: any = await import('https://esm.sh/html2canvas@1.4.1');
+            const mod = await import('https://esm.sh/html2canvas@1.4.1');
             const html2canvas = mod.default;
             const canvas = await html2canvas(canvasRef.current, {
                 backgroundColor: null,

--- a/components/bank/BankDollhouse.tsx
+++ b/components/bank/BankDollhouse.tsx
@@ -12,6 +12,7 @@ import { useOS } from '../../context/OSContext';
 import { DB } from '../../utils/db';
 import { processImage } from '../../utils/file';
 import { Armchair, PaintBucket, SquaresFour, Image as ImageIcon, HouseSimple, PencilSimple } from '@phosphor-icons/react';
+import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 
 const ROOM_UNLOCK_COSTS: Record<string, number> = {
     'room-1f-left': 0,
@@ -27,7 +28,7 @@ const CUSTOM_FURNITURE_ASSET_KEY = 'bank_custom_furniture_assets_v1';
 
 type DecorTab = 'layout' | 'rename' | 'wallpaper' | 'furniture' | 'floor' | 'roomTexture';
 
-const DECOR_TAB_ICONS: Record<DecorTab, React.FC<{ size?: number; weight?: string; className?: string }>> = {
+const DECOR_TAB_ICONS: Record<DecorTab, PhosphorIcon> = {
     furniture: Armchair,
     wallpaper: PaintBucket,
     floor: SquaresFour,

--- a/components/mcd/McdMiniApp.tsx
+++ b/components/mcd/McdMiniApp.tsx
@@ -1169,7 +1169,7 @@ const McdMiniApp: React.FC<McdMiniAppProps> = ({ open, onClose, char, userProfil
                 }
             }
             if (activeCodes.size > 0) {
-                const filtered: Record<string, { name?: string; currentPrice?: string }> = {};
+                const filtered: NonNullable<MealsData['meals']> = {};
                 for (const code of activeCodes) {
                     if (fullMeals[code]) filtered[code] = fullMeals[code];
                 }
@@ -1236,9 +1236,10 @@ const McdMiniApp: React.FC<McdMiniAppProps> = ({ open, onClose, char, userProfil
         if (!meal) {
             // 服务端没修上 / propose 直接漏了 code 校准: 在这儿按 name 兜底
             const { fixed, fixes } = autoFixProposalCodesByName([it], menuData.meals);
-            if (fixes.length && fixed[0]?.code && menuData.meals[fixed[0].code]) {
-                realCode = fixed[0].code;
-                meal = menuData.meals[realCode];
+            const fixedCode = fixed[0]?.code;
+            if (fixes.length && fixedCode && menuData.meals[fixedCode]) {
+                realCode = fixedCode;
+                meal = menuData.meals[fixedCode];
                 console.log(`🍔 [MCD-MiniApp] 客户端兜底修 code: '${it.code}' → '${realCode}' (${fixes[0].name})`);
             }
         }

--- a/components/schedule/ScheduleCard.tsx
+++ b/components/schedule/ScheduleCard.tsx
@@ -149,7 +149,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
 
     const palette = resolveScheduleCardPalette(
         theme.scheduleCardAppearance,
-        character?.themeColor || theme.hue || 260,
+        theme.hue || 260,
         inheritedContentColor,
     );
     const contentColor = palette.text;

--- a/components/schedule/ScheduleHomeWidget.tsx
+++ b/components/schedule/ScheduleHomeWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CharacterProfile, DailySchedule, ScheduleSlot } from '../../types';
 import ScheduleCard from './ScheduleCard';
 import { getCurrentScheduleSlotIndex, getScheduleWallClock } from '../../utils/scheduleTime';
@@ -28,7 +28,7 @@ export const ScheduleSquareWidget: React.FC<ScheduleSquareWidgetProps> = ({
 
     const palette = resolveScheduleCardPalette(
         theme.scheduleCardAppearance,
-        character?.themeColor ?? theme.hue ?? 260,
+        theme.hue ?? 260,
         inheritedContentColor,
     );
     const contentColor = palette.text;
@@ -178,7 +178,7 @@ export const ScheduleHomeWidget: React.FC<ScheduleHomeWidgetProps> = ({
 
     const palette = resolveScheduleCardPalette(
         theme.scheduleCardAppearance,
-        character?.themeColor ?? theme.hue ?? 260,
+        theme.hue ?? 260,
         inheritedContentColor,
     );
     const effectivePaper = paper && palette.isOriginal;
@@ -497,10 +497,8 @@ export const ScheduleFullscreenViewer: React.FC<ScheduleFullscreenViewerProps> =
         return () => window.removeEventListener('keydown', onKey);
     }, [open, onClose]);
 
-    const accentHsl = useMemo(
-        () => `hsl(${activeCharacter?.themeColor ?? 260}, 70%, 65%)`,
-        [activeCharacter?.themeColor]
-    );
+    // 这层全屏查看器不跟随卡片配色，固定用默认色相做强调色
+    const accentHsl = 'hsl(260, 70%, 65%)';
 
     if (!open) return null;
 
@@ -564,7 +562,7 @@ export const ScheduleFullscreenViewer: React.FC<ScheduleFullscreenViewerProps> =
                                                 ? `2px solid ${accentHsl}`
                                                 : '2px solid rgba(255,255,255,0.12)',
                                             boxShadow: isActive
-                                                ? `0 6px 18px hsla(${c.themeColor ?? 260}, 70%, 55%, 0.45)`
+                                                ? '0 6px 18px hsla(260, 70%, 55%, 0.45)'
                                                 : 'none',
                                         }}
                                     >

--- a/esm-sh.d.ts
+++ b/esm-sh.d.ts
@@ -1,0 +1,17 @@
+// esm.sh 上的运行时 CDN 依赖：Vite 会原样保留这类 URL 动态 import，
+// 但 tsc 解析不到，所以在这里按实际用法补一份环境声明（别把它们改成 npm 依赖）。
+
+declare module 'https://esm.sh/html2canvas@1.4.1' {
+    /** 只声明调用点用到的选项，需要别的再往上加 */
+    export interface Html2CanvasOptions {
+        backgroundColor: string | null;
+        scale: number;
+        useCORS: boolean;
+        logging: boolean;
+    }
+
+    export default function html2canvas(
+        element: HTMLElement,
+        options?: Partial<Html2CanvasOptions>
+    ): Promise<HTMLCanvasElement>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/utils/charMusicPersona.ts
+++ b/utils/charMusicPersona.ts
@@ -238,16 +238,14 @@ export const CharMusicPersona = {
 
         // 解析：结构化 parse 优先；不行就 scavenge（逐字段正则抠）
         // 两条线结果合并 — 任何字段单项 OK 都先收下
-        const structured = extractJson<PersonaDraft>(rawText) || {};
+        // LLM 吐的 JSON 缺字段是常态，所以按 Partial 收，字段级兜底在下面
+        const structured: Partial<PersonaDraft> = extractJson<Partial<PersonaDraft>>(rawText) || {};
         const scavenged = scavengeFields(rawText);
         const draft: Partial<PersonaDraft> = {
             bio: sanitizeStr(structured.bio) || sanitizeStr(scavenged.bio),
             genreTags: firstArray(structured.genreTags, scavenged.genreTags),
-            signatureArtists: firstArray(
-                structured.signatureArtists,
-                scavenged.signatureArtists as PersonaDraft['signatureArtists'],
-            ),
-            playlists: firstArray(structured.playlists, scavenged.playlists as PersonaDraft['playlists']),
+            signatureArtists: firstArray(structured.signatureArtists, scavenged.signatureArtists),
+            playlists: firstArray(structured.playlists, scavenged.playlists),
         };
 
         // 艺人字段：兼容三种形态 — [{name:"..."}] / ["..."] / 混合

--- a/utils/mcdToolBridge.ts
+++ b/utils/mcdToolBridge.ts
@@ -201,7 +201,8 @@ export const isMcdActivatedInMessages = (messages: MsgLike[]): boolean => {
 
 export interface McdMiniAppSnapshot {
     open: boolean;
-    step?: 'mode' | 'pick' | 'menu' | 'review';
+    /** 跟 McdMiniApp 里的 Step 一一对应 (下单成功后会停在 success) */
+    step?: 'mode' | 'pick' | 'menu' | 'review' | 'success';
     orderType?: 1 | 2;
     storeCode?: string;
     storeName?: string;
@@ -249,6 +250,14 @@ export const MCD_PROPOSE_TOOL = {
     }
 };
 
+/** propose_cart_items 里的一项 (模型现编的, 字段都可能缺, 所以全是可选) */
+export interface McdProposalItemLike {
+    code?: string;
+    name?: string;
+    qty?: number;
+    reason?: string;
+}
+
 /**
  * 把 char 在 propose_cart_items 里塞的 items 里所有 productCode 校准:
  * - 如果 code 已经在菜单字典里, 原样保留
@@ -259,9 +268,9 @@ export const MCD_PROPOSE_TOOL = {
  * 返回 { fixed: 修正后的 items, fixes: 修了哪些 (用于 log) }
  */
 export const autoFixProposalCodesByName = (
-    items: any[],
+    items: McdProposalItemLike[],
     menuMeals: Record<string, { name?: string; currentPrice?: string }> | undefined
-): { fixed: any[]; fixes: Array<{ from: string; to: string; name: string }> } => {
+): { fixed: McdProposalItemLike[]; fixes: Array<{ from: string; to: string; name: string }> } => {
     const fixes: Array<{ from: string; to: string; name: string }> = [];
     if (!items?.length || !menuMeals || !Object.keys(menuMeals).length) {
         return { fixed: items || [], fixes };
@@ -334,18 +343,18 @@ export const buildMcdMiniAppContextBlock = (snap?: McdMiniAppSnapshot, userName:
     }
     lines.push('');
 
-    const menuLoaded = !!(snap.menuMeals && Object.keys(snap.menuMeals).length);
-    if (!menuLoaded) {
+    const loadedMenuMeals = snap.menuMeals && Object.keys(snap.menuMeals).length ? snap.menuMeals : null;
+    if (!loadedMenuMeals) {
         lines.push(`# 当前菜单: ❌ 还没加载 (用户还在选模式 / 选地址门店阶段)`);
         lines.push(`**这一阶段不要调 propose_cart_items**: 没有菜单字典, 你 propose 出去的任何 code 都会被服务端拒 (会回一条 tool error)。陪用户选地址 / 门店就好, 文字回应即可; 等小程序进入菜单页, system prompt 里出现"当前门店在售"清单后再说推荐。`);
         lines.push('');
     }
-    if (menuLoaded) {
+    if (loadedMenuMeals) {
         // 把套餐排前面 (人气热卖里的套餐 char 看着最先, 下意识更倾向推套餐)
         const COMBO_RE = /(套餐|单人餐|双人餐|全家桶|三件套|四件套|五件套|超值组合|节省组合)/;
-        const allEntries = Object.entries(snap.menuMeals).filter(([, m]: any) => m?.name);
-        const combos = allEntries.filter(([, m]: any) => COMBO_RE.test(String(m.name)));
-        const singles = allEntries.filter(([, m]: any) => !COMBO_RE.test(String(m.name)));
+        const allEntries = Object.entries(loadedMenuMeals).filter(([, m]) => m?.name);
+        const combos = allEntries.filter(([, m]) => COMBO_RE.test(String(m.name)));
+        const singles = allEntries.filter(([, m]) => !COMBO_RE.test(String(m.name)));
         const ordered = [...combos, ...singles].slice(0, 100);
         lines.push(`# 当前门店在售 (前 ${ordered.length} 项, 推荐时从这里挑; **套餐已排在前面, 优先看这些**)`);
         lines.push('格式: \`code=商品名 ¥价格\` ← propose_cart_items 的 code 字段必须用这里的 code (= 号左边那串), 不要用商品名');

--- a/utils/memoryPalace/groupPipeline.ts
+++ b/utils/memoryPalace/groupPipeline.ts
@@ -19,7 +19,7 @@ import type { Message, CharacterProfile, GroupProfile } from '../../types';
 import type { EmbeddingConfig, MemoryNode, RemoteVectorConfig, MemoryVector } from './types';
 import type { LightLLMConfig } from './pipeline';
 import { DB } from '../db';
-import { MemoryNodeDB, MemoryVectorDB } from './db';
+import { MemoryNodeDB, MemoryVectorDB, ensureFloat32 } from './db';
 import { getEmbeddings, cosineSimilarity } from './embedding';
 import { extractGroupMemoriesFromBuffer } from './groupExtraction';
 import { isMessageSemanticallyRelevant } from '../messageFormat';
@@ -272,7 +272,10 @@ export async function processGroupNewMessages(
                     const vector = vectors[i];
 
                     // 与该成员已有记忆去重（同样的群记忆草稿可能跟以前的群记忆撞）
-                    const isDup = existingVectors.some(ev => cosineSimilarity(vector, ev.vector) > DEDUP_THRESHOLD);
+                    // ev.vector 声明上有 number[] / Float32Array / Uint8Array 三态，
+                    // ensureFloat32 统一（DB 层已经转好，这里是恒等返回），别让
+                    // cosineSimilarity 把 Uint8Array 的原始字节当成分量读。
+                    const isDup = existingVectors.some(ev => cosineSimilarity(vector, ensureFloat32(ev.vector)) > DEDUP_THRESHOLD);
                     if (isDup) {
                         console.log(`♻️ [GroupPalace] ${member.name}：重复群记忆跳过 "${draft.content.slice(0, 30)}..."`);
                         continue;

--- a/utils/novelUtils.ts
+++ b/utils/novelUtils.ts
@@ -651,10 +651,12 @@ export const parsePersonaMarkdown = (rawPersona: string) => {
     const sections: {title: string, content: string[], icon: string}[] = [];
     let currentSection: {title: string, content: string[], icon: string} | null = null;
 
-    lines.forEach(line => {
+    // 用 for...of 而不是 forEach：回调里的赋值不进 TS 的控制流分析，
+    // 循环结束后 currentSection 会被当成还是初始的 null。
+    for (const line of lines) {
         const trimmed = line.trim();
-        if (!trimmed) return;
-        
+        if (!trimmed) continue;
+
         const headerMatch = trimmed.match(/^###\s*(.+)/) || 
                            trimmed.match(/^\*\*([^*]+)\*\*\s*[:：]\s*(.*)/) ||
                            trimmed.match(/^([^-•\d][^:：]{1,15})[:：]\s*(.*)/);
@@ -679,8 +681,8 @@ export const parsePersonaMarkdown = (rawPersona: string) => {
                 currentSection.content.push(cleanLine);
             }
         }
-    });
-    
+    }
+
     if (currentSection && currentSection.content.length > 0) {
         sections.push(currentSection);
     }

--- a/worker/proactive-push/src/index.ts
+++ b/worker/proactive-push/src/index.ts
@@ -22,6 +22,26 @@ interface Env {
   HEARTBEAT_WINDOW_MS: string;
 }
 
+// 最小 Worker 运行时类型（跟 post-office / instant-push 一样，只声明本文件真正用到的
+// 那几个成员，不引 @cloudflare/workers-types）。
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run(): Promise<unknown>;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results: T[] }>;
+}
+/** cron 触发时 CF 传进来的事件；本 Worker 不读它的字段，只按签名占位。 */
+interface ScheduledEvent {
+  scheduledTime: number;
+  cron: string;
+}
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
 interface ScheduleRow {
   endpoint: string;
   char_id: string;

--- a/worker/proactive-push/src/webpush.ts
+++ b/worker/proactive-push/src/webpush.ts
@@ -32,7 +32,10 @@ export function b64uEncode(buf: ArrayBuffer | Uint8Array): string {
   return out;
 }
 
-export function b64uDecode(s: string): Uint8Array {
+// 注：下面凡是要交给 Web Crypto / fetch 的字节都写成 Uint8Array<ArrayBuffer>。
+// TS 5.7 起 Uint8Array 默认是 Uint8Array<ArrayBufferLike>，而 BufferSource / BodyInit
+// 只收 ArrayBuffer 撑的视图；这些数组本来就是 new Uint8Array(...) 现造的，如实标注即可。
+export function b64uDecode(s: string): Uint8Array<ArrayBuffer> {
   const clean = s.replace(/-/g, '+').replace(/_/g, '/');
   const padded = clean + '='.repeat((4 - (clean.length % 4)) % 4);
   const bin = atob(padded);
@@ -41,7 +44,7 @@ export function b64uDecode(s: string): Uint8Array {
   return out;
 }
 
-function concatBytes(...parts: Uint8Array[]): Uint8Array {
+function concatBytes(...parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
   const len = parts.reduce((n, p) => n + p.length, 0);
   const out = new Uint8Array(len);
   let off = 0;
@@ -97,7 +100,12 @@ async function buildVapidJwt(audience: string, vapid: VapidContext): Promise<str
 }
 
 // ---------- HKDF ----------
-async function hkdf(ikm: Uint8Array, salt: Uint8Array, info: Uint8Array, lengthBytes: number): Promise<Uint8Array> {
+async function hkdf(
+  ikm: Uint8Array<ArrayBuffer>,
+  salt: Uint8Array<ArrayBuffer>,
+  info: Uint8Array<ArrayBuffer>,
+  lengthBytes: number,
+): Promise<Uint8Array<ArrayBuffer>> {
   const key = await crypto.subtle.importKey('raw', ikm, { name: 'HKDF' }, false, ['deriveBits']);
   const bits = await crypto.subtle.deriveBits(
     { name: 'HKDF', hash: 'SHA-256', salt, info },
@@ -108,7 +116,11 @@ async function hkdf(ikm: Uint8Array, salt: Uint8Array, info: Uint8Array, lengthB
 }
 
 // ---------- aes128gcm content encoding (RFC 8188 + RFC 8291) ----------
-async function encryptAes128Gcm(payload: Uint8Array, clientP256dh: Uint8Array, clientAuth: Uint8Array): Promise<Uint8Array> {
+async function encryptAes128Gcm(
+  payload: Uint8Array<ArrayBuffer>,
+  clientP256dh: Uint8Array<ArrayBuffer>,
+  clientAuth: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
   // 1. Ephemeral ECDH key pair on Worker side
   const ephemeral = await crypto.subtle.generateKey(
     { name: 'ECDH', namedCurve: 'P-256' },
@@ -184,7 +196,7 @@ export interface PushResult {
   responseText?: string;
 }
 
-export async function sendPush(vapid: VapidContext, sub: PushSubscription, payload: Uint8Array | string): Promise<PushResult> {
+export async function sendPush(vapid: VapidContext, sub: PushSubscription, payload: Uint8Array<ArrayBuffer> | string): Promise<PushResult> {
   const bytes = typeof payload === 'string' ? new TextEncoder().encode(payload) : payload;
   const url = new URL(sub.endpoint);
   const audience = url.origin;


### PR DESCRIPTION
`tsc --noEmit` 原来 73 个错，这轮修掉 44 个，只剩 29 个（全在 dev/amsg2 正在改的热文件里，故意没碰，见下）。全部是类型层修正：没有 `as any`、
没有 `@ts-ignore`，运行时行为保持不变。

- worker/proactive-push: 补本文件用到的最小 Worker 运行时类型 （D1Database / ScheduledEvent / ExecutionContext，跟 post-office、 instant-push 一样的做法，不引 workers-types）；webpush 里交给 Web Crypto / fetch 的字节如实标成 Uint8Array<ArrayBuffer> （TS 5.7 起默认是 ArrayBufferLike，BufferSource/BodyInit 不收）
- schedule: `character?.themeColor` 从来不存在于 CharacterProfile， 也没人写过它，读出来永远 undefined、兜底永远生效 —— 删掉这些死读， 保留各处 `||` / `??` 原本算出来的值
- BankDollhouse: 图标表用 @phosphor-icons/react 自己导出的 Icon 类型， 别手搓不兼容的 FC 签名
- SongwritingApp: currentSection 收窄成 SongLine['section']，段落 key 过一层 toSectionKind 收窄；`song.theme` 这个字段同样从不存在，删掉
- mcd: 菜单字典的 name 必填/可选对不上，改用 MealsData['meals'] 本身； step 联合补上实际会出现的 'success'
- charMusicPersona: `extractJson<PersonaDraft>(...) || {}` 推成了 `PersonaDraft | {}`，按 Partial<PersonaDraft> 收
- novelUtils: forEach 回调里的赋值不进 TS 控制流分析，改 for...of
- groupPipeline: 去重时把 ev.vector 过一遍 ensureFloat32（DB 层已转好， 这里是恒等返回），别让 Uint8Array 的原始字节被当成分量读
- esm.sh 上 html2canvas 的 URL 动态 import 补一份环境声明，顺手去掉 两处 `const mod: any`
- tsconfig: lib ES2020 → ES2022，让 4 个测试里的 Array.prototype.at 有声明（target 不动，noEmit + vite build 不受影响）

没碰（活跃分支正在改，留给对应分支）：MemoryPalaceApp.tsx 19 个、
vite.config.ts 6 个、apiCallLog.ts 2 个、MessageItem.tsx 与 ThemeMaker.tsx 各 1 个。

测试与改动前一致：2461 通过，12 失败且全在 utils/amsg2ToolBridge.test.ts （改动前就红，属 amsg2 在改的范围）。pnpm build:workers 产物字节不变。


Claude-Session: https://claude.ai/code/session_01L215gJAmyhT6Qde7mpPUKi