### PR TITLE
调试终端：把光秃秃的 Failed to fetch 变成能照着排查的日志

### DIFF
--- a/components/os/StatusBar.tsx
+++ b/components/os/StatusBar.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useOS } from '../../context/OSContext';
 import Modal from './Modal';
 import { resolveStatusBarMode } from '../../utils/iosStandalone';
+import { NETWORK_SELF_CHECK_STEPS } from '../../utils/networkFailureDiagnosis';
 
 // TypeScript definition for Web Battery API
 interface BatteryManager extends EventTarget {
@@ -64,6 +65,9 @@ const StatusBar: React.FC = () => {
     const text = `${log.message} ${log.detail || ''}`.toLowerCase();
     return text.includes('backing store') || text.includes('indexeddb.open');
   });
+  // 「连不上」这类错误光看日志没用，多半要用户自己在设备上试几刀才能定位，
+  // 所以顺手把自查顺序摆在终端里，省得每次都要去群里问。
+  const hasNetworkFailure = systemLogs.some(log => log.type === 'network' && log.source === 'Network');
 
   // 三档状态栏布局；旧版 hideStatusBar 存档仍可解析。错误指示器与本设置无关，始终独立渲染。
   const statusBarMode = resolveStatusBarMode(theme.statusBarMode, theme.hideStatusBar);
@@ -146,6 +150,15 @@ const StatusBar: React.FC = () => {
                   <div className="font-bold mb-1">检测到浏览器存储无法打开</div>
                   <div>请先不要清除浏览器数据、格式化或重置 SullyOS。彻底关闭浏览器后重启设备，并确认仍从原来的网址进入；若恢复打开，请立即完整导出备份。此错误通常来自浏览器/WebView 的站点存储，而不是应用主动删除数据。</div>
               </div>
+          )}
+          {hasNetworkFailure && (
+              <details className="mb-3 rounded-xl border border-sky-200 bg-sky-50 p-3 text-xs leading-relaxed text-sky-900">
+                  <summary className="font-bold cursor-pointer select-none">网络连接失败？按这个顺序自查</summary>
+                  <ol className="mt-2 list-decimal pl-4 space-y-1">
+                      {NETWORK_SELF_CHECK_STEPS.map(step => <li key={step}>{step}</li>)}
+                  </ol>
+                  <div className="mt-2 opacity-80">日志里的「初判」和「连通性复检」两行已经替你缩小了范围，先看那两行再动手。</div>
+              </details>
           )}
           <div className="h-64 bg-slate-900 rounded-xl p-3 overflow-y-auto font-mono text-[10px] space-y-2 no-scrollbar shadow-inner">
               {systemLogs.length === 0 ? (

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -23,6 +23,7 @@ import { safeFetchJson } from '../utils/safeApi';
 import { captureApiRequestOnce, getApiCallAmbientContext, recordApiCall, setApiCallAmbientContext, updateApiRequestCaptureUsage } from '../utils/apiCallLog';
 import { isGlobalStreamEnabled, upgradeChatBodyToStream, assembleUpgradedResponse } from '../utils/streamUpgrade';
 import { rewriteStaleWorkerUrl } from '../utils/proxyWorker';
+import { buildFetchFailureDetail, classifyFetchFailure, describeReachabilityProbe, parseTargetUrl, probeOriginReachability } from '../utils/networkFailureDiagnosis';
 import { INSTALLED_APPS, HIDDEN_APP_NAMES } from '../constants';
 import { isAnalyticsRequestUrl, trackEvent, trackDataScaleOnce, trackCurrentAppearanceOnce, trackCurrentCharSettingsOnce, trackCurrentFeaturesOnce } from '../utils/analytics';
 import { collectAppearance, collectCharSettings, collectDataScale, collectFeatureFlagsAsync } from '../utils/analyticsSnapshot';
@@ -1203,14 +1204,42 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   recordApiCall({ requestId: (config as any)?.__sullyApiCallId, url: urlStr, body: (sendArgs[1] as any)?.body, ok: false, meta: (config as any)?.__sullyMeta || ambientMetaAtStart, durationMs: Date.now() - fetchStartedAt });
               }
               if (!isAnalyticsRequestUrl(urlStr)) {
+                  // 光秃秃一句 "Failed to fetch" + 一个 URL 排查不了任何东西（社区里这条卡过好几个人）。
+                  // 这里把浏览器肯在 JS 侧交出来的旁证一次性补齐：方法、耗时、在线状态、是否跨域、
+                  // Resource Timing 里那条记录，再给一句初判；随后异步做一次 no-cors 连通性复检，
+                  // 结论回填到同一条日志上——「网络不通」和「网络通但响应被 CORS 拦」要走的排查路
+                  // 完全相反，不分开的话用户只能瞎试。详见 utils/networkFailureDiagnosis.ts。
+                  const logId = `log-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+                  const method = (typeof Request !== 'undefined' && resource instanceof Request)
+                      ? resource.method
+                      : ((config as RequestInit | undefined)?.method || 'GET');
+                  const baseDetail = buildFetchFailureDetail({
+                      url: urlStr,
+                      method,
+                      durationMs: Date.now() - fetchStartedAt,
+                      error: err,
+                  });
                   setSystemLogs(prev => [{
-                      id: `log-${Date.now()}`,
+                      id: logId,
                       timestamp: Date.now(),
                       type: 'network',
                       source: 'Network',
                       message: err.message || 'Fetch Failed',
-                      detail: `URL: ${urlStr}`
+                      detail: baseDetail,
                   }, ...prev.slice(0, 49)]);
+
+                  // 只对「拿不到响应」这一类做复检：主动取消 / 混合内容 / 地址非法已经有确定结论了，
+                  // 再打一次纯属浪费。复检走 originalFetch，否则它自己失败会再写一条日志滚雪球。
+                  if (classifyFetchFailure({ url: urlStr, error: err }) === 'blocked') {
+                      void (async () => {
+                          const verdict = await probeOriginReachability(urlStr, originalFetch);
+                          const line = describeReachabilityProbe(verdict, parseTargetUrl(urlStr).host);
+                          if (!line) return;
+                          setSystemLogs(prev => prev.map(log => (
+                              log.id === logId ? { ...log, detail: `${log.detail || ''}\n${line}` } : log
+                          )));
+                      })();
+                  }
               }
               throw err;
           }

--- a/docs/dev-debug.md
+++ b/docs/dev-debug.md
@@ -348,3 +348,61 @@ SW 跑在自己的 context，没法直接访问 page 的 `localStorage` / `appen
 | `public/sw-keep-alive.js` | 1308 | `[InstantTrace:SW]`（构建产物里也叫这名） |
 
 > **建议路径**：等真的有 SW 端 bug 需要远端排障时再做（开发本地 SW 在 DevTools 单独面板就能看，价值不大）。做的时候在 `utils/swVersion.ts` 旁边新增 `utils/swTrace.ts` 包通信协议。
+
+---
+
+## 十二、系统调试终端里的网络失败诊断（面向普通用户）
+
+> 注意：这一节讲的是**所有用户都看得到**的「系统调试终端」（状态栏下方的红色 `SYSTEM ERROR` 胶囊点开的那个），
+> 不是上面十一节那个只在开发分支出现的 devDebug 面板。两者是两套东西，别改串了。
+
+### 背景
+
+浏览器出于安全，把下面这些完全不同的事统统报成同一句 `TypeError: Failed to fetch`，不带任何细节：
+
+- 梯子 / 代理把这个域名的连接掐了
+- DNS 解析不到
+- 浏览器扩展（广告拦截、隐私盾、脚本管理器）在请求发出前就屏蔽了
+- 对方**回了响应，但没有 CORS 头**（Cloudflare 限流页、人机验证页、网关错误页都长这样）
+
+旧版日志只记 `URL: xxx` 一行，用户复制出来发到群里，信息量是零。
+
+### 现在记什么
+
+`utils/networkFailureDiagnosis.ts` 负责把能补的旁证一次性补齐，`context/OSContext.tsx` 的 fetch 拦截器
+在 `catch` 里调用它：
+
+```
+URL: https://sullymeow.ccwu.cc/api/health
+请求: GET · 失败于 43ms
+错误: TypeError: Failed to fetch
+目标域名: sullymeow.ccwu.cc（跨域请求，受 CORS 约束）
+本页来源: https://xxx.pages.dev
+浏览器联网状态: 在线
+Resource Timing: responseStatus=429, transferSize=0 → 对方其实回了 HTTP 429，是响应被 CORS 拦掉的，不是网络不通
+初判: 请求在拿到响应头之前就失败了——浏览器没告诉我们具体是哪一步断的。
+可能原因: 梯子/代理把这个域名的连接掐了 · DNS 解析不到 · ...
+连通性复检: no-cors 直连 sullymeow.ccwu.cc 成功 → 网络路径是通的，问题出在响应本身（...）
+```
+
+两个关键设计：
+
+1. **Resource Timing 的 `responseStatus`**：跨域也能读（不受 TAO 限制）。它 > 0 就说明**对方其实回了**，
+   那就是 CORS / 限流页的事，跟网络通不通无关——这一条直接把排查范围砍一半。
+2. **no-cors 连通性复检**：`mode: 'no-cors'` 不做 CORS 校验，只要网络路径通就会拿到 opaque 响应。
+   它成功而原请求失败 ⇒ 响应头的问题；它也失败 ⇒ 这台设备到这个域名是真的不通。结论异步回填到同一条日志。
+
+### 改这块时的坑
+
+- **复检必须用 `originalFetch`**（拦截器闭包里那个未打补丁的），用打过补丁的 `window.fetch` 会让探测自己
+  失败时再写一条日志，一条网络错误滚成一屏。
+- **复检打的是域名根路径，不是原地址**：原地址可能是有副作用的接口（发帖、下单），复检不该顺手触发它；
+  而 DNS / 梯子 / 防火墙 / 扩展拦的都是整个域名，打根路径一样测得出来。
+- **同域名 30s 冷却**：一串请求同时炸时不能对同一个域名连打探测。
+- **只对 `blocked` 这一类复检**：主动取消 / 混合内容 / 地址非法已经有确定结论，再打一次纯属浪费。
+- 判定全是纯函数，回归守卫在 `utils/networkFailureDiagnosis.test.ts`——改文案时先看那份测试想守的是什么。
+
+### 用户侧自查清单
+
+`NETWORK_SELF_CHECK_STEPS` 同时被调试终端（`components/os/StatusBar.tsx`，网络类错误时折叠展示）复用。
+改文案改那一处即可，两边不会不同步。

--- a/utils/networkFailureDiagnosis.test.ts
+++ b/utils/networkFailureDiagnosis.test.ts
@@ -1,0 +1,227 @@
+// utils/networkFailureDiagnosis.test.ts
+// 回归守卫：
+//   1. 调试终端里那条 network 日志不能再退回「Failed to fetch + 一个 URL」——方法、耗时、
+//      在线状态、跨域与否、初判、可能原因，少一样用户就又只能来问作者。
+//   2. 分类不能认错：主动取消 / 离线 / https 打 http / 地址非法 这四种都有确定结论，
+//      混进 blocked 会白白多打一次探测，还会给出跑偏的排查方向。
+//   3. no-cors 复检的两个结论必须泾渭分明：「通了」指向 CORS/限流，「没通」指向线路，
+//      两边要查的东西完全相反，说反了比不说更糟。
+//   4. 探测有 30s 冷却：一串请求同时炸时不能对同一个域名连打探测。
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    NETWORK_SELF_CHECK_STEPS,
+    buildFetchFailureDetail,
+    classifyFetchFailure,
+    describeReachabilityProbe,
+    parseTargetUrl,
+    probeOriginReachability,
+    readResourceTimingHint,
+    resetReachabilityProbeCooldown,
+} from './networkFailureDiagnosis';
+
+const failedToFetch = () => new TypeError('Failed to fetch');
+
+describe('classifyFetchFailure', () => {
+    it('Chrome / Safari / Firefox 三种说法都算「拿不到响应」', () => {
+        for (const msg of ['Failed to fetch', 'Load failed', 'NetworkError when attempting to fetch resource']) {
+            expect(classifyFetchFailure({
+                url: 'https://sullymeow.ccwu.cc/api/health',
+                error: new TypeError(msg),
+                online: true,
+                pageProtocol: 'https:',
+            })).toBe('blocked');
+        }
+    });
+
+    it('主动取消不算网络失败', () => {
+        const err = new Error('The operation was aborted.');
+        err.name = 'AbortError';
+        expect(classifyFetchFailure({ url: 'https://a.example.com/x', error: err })).toBe('aborted');
+    });
+
+    it('浏览器报离线时优先归到离线', () => {
+        expect(classifyFetchFailure({
+            url: 'https://a.example.com/x', error: failedToFetch(), online: false, pageProtocol: 'https:',
+        })).toBe('offline');
+    });
+
+    it('https 页面打 http 地址 → 混合内容，且优先级高于离线判定', () => {
+        expect(classifyFetchFailure({
+            url: 'http://a.example.com/x', error: failedToFetch(), online: false, pageProtocol: 'https:',
+        })).toBe('mixed-content');
+    });
+
+    it('http://localhost 不当混合内容拦（Chrome 视其为可信来源）', () => {
+        expect(classifyFetchFailure({
+            url: 'http://localhost:18060/api/health', error: failedToFetch(), online: true, pageProtocol: 'https:',
+        })).toBe('blocked');
+    });
+
+    it('地址本身不合法 → bad-url', () => {
+        expect(classifyFetchFailure({
+            url: 'sullymeow ccwu cc/api', error: failedToFetch(), online: true, pageProtocol: 'https:',
+        })).toBe('bad-url');
+    });
+});
+
+describe('buildFetchFailureDetail', () => {
+    const detail = () => buildFetchFailureDetail({
+        url: 'https://sullymeow.ccwu.cc/api/health',
+        method: 'get',
+        durationMs: 43,
+        error: failedToFetch(),
+        online: true,
+        pageOrigin: 'https://sullyos.example.com',
+        pageProtocol: 'https:',
+    }, { perf: { getEntriesByName: () => [] } });
+
+    it('把能补的旁证全补上', () => {
+        const text = detail();
+        expect(text).toContain('URL: https://sullymeow.ccwu.cc/api/health');
+        expect(text).toContain('GET');
+        expect(text).toContain('43ms');
+        expect(text).toContain('TypeError: Failed to fetch');
+        expect(text).toContain('sullymeow.ccwu.cc');
+        expect(text).toContain('跨域');
+        expect(text).toContain('在线');
+        expect(text).toContain('初判:');
+        expect(text).toContain('可能原因:');
+    });
+
+    it('同源请求不会被标成跨域', () => {
+        const text = buildFetchFailureDetail({
+            url: 'https://sullyos.example.com/api/x',
+            error: failedToFetch(),
+            online: true,
+            pageOrigin: 'https://sullyos.example.com',
+            pageProtocol: 'https:',
+        }, { perf: { getEntriesByName: () => [] } });
+        expect(text).toContain('同源');
+        expect(text).not.toContain('跨域请求');
+    });
+
+    it('混合内容给的是「改成 https」而不是「查梯子」', () => {
+        const text = buildFetchFailureDetail({
+            url: 'http://my-bridge.example.com/api/health',
+            error: failedToFetch(),
+            online: true,
+            pageOrigin: 'https://sullyos.example.com',
+            pageProtocol: 'https:',
+        }, { perf: { getEntriesByName: () => [] } });
+        expect(text).toContain('混合内容');
+        expect(text).not.toContain('DNS 解析不到');
+    });
+
+    it('Resource Timing 里有状态码时，直接点破「不是网络不通」', () => {
+        const text = buildFetchFailureDetail({
+            url: 'https://sullymeow.ccwu.cc/api/health',
+            error: failedToFetch(),
+            online: true,
+            pageOrigin: 'https://sullyos.example.com',
+            pageProtocol: 'https:',
+        }, {
+            perf: { getEntriesByName: () => [{ responseStatus: 429, transferSize: 0, duration: 120 }] },
+        });
+        expect(text).toContain('responseStatus=429');
+        expect(text).toContain('CORS');
+    });
+});
+
+describe('readResourceTimingHint', () => {
+    it('没有记录时说明「连接可能压根没建立」', () => {
+        expect(readResourceTimingHint('https://a.example.com/x', { getEntriesByName: () => [] }))
+            .toContain('没有这条请求的记录');
+    });
+
+    it('取最后一条记录（同一 URL 重试过多次）', () => {
+        const hint = readResourceTimingHint('https://a.example.com/x', {
+            getEntriesByName: () => [{ responseStatus: 200 }, { responseStatus: 503 }],
+        });
+        expect(hint).toContain('503');
+    });
+
+    it('performance 不可用时静默返回空串，不能抛', () => {
+        expect(readResourceTimingHint('https://a.example.com/x', {})).toBe('');
+        expect(readResourceTimingHint('https://a.example.com/x', {
+            getEntriesByName: () => { throw new Error('boom'); },
+        })).toBe('');
+    });
+});
+
+describe('probeOriginReachability', () => {
+    beforeEach(() => resetReachabilityProbeCooldown());
+
+    it('打的是域名根路径，不是原地址——原地址可能有副作用', async () => {
+        const seen: any[] = [];
+        const fakeFetch = ((url: any, init: any) => { seen.push([url, init]); return Promise.resolve(new Response('')); }) as any;
+        const verdict = await probeOriginReachability('https://sullymeow.ccwu.cc/api/publish', fakeFetch);
+        expect(verdict).toBe('reachable');
+        expect(seen[0][0]).toBe('https://sullymeow.ccwu.cc/');
+        expect(seen[0][1].mode).toBe('no-cors');
+        expect(seen[0][1].credentials).toBe('omit');
+    });
+
+    it('探测也失败 → unreachable', async () => {
+        const fakeFetch = (() => Promise.reject(failedToFetch())) as any;
+        expect(await probeOriginReachability('https://sullymeow.ccwu.cc/api/health', fakeFetch)).toBe('unreachable');
+    });
+
+    it('被超时控制器掐断 → timeout，不是 unreachable', async () => {
+        const fakeFetch = (() => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            return Promise.reject(err);
+        }) as any;
+        expect(await probeOriginReachability('https://sullymeow.ccwu.cc/api/health', fakeFetch)).toBe('timeout');
+    });
+
+    it('同一域名 30s 内只探一次', async () => {
+        let calls = 0;
+        const fakeFetch = (() => { calls += 1; return Promise.resolve(new Response('')); }) as any;
+        const now = () => 1_000_000;
+        expect(await probeOriginReachability('https://a.example.com/1', fakeFetch, { now })).toBe('reachable');
+        expect(await probeOriginReachability('https://a.example.com/2', fakeFetch, { now })).toBe('skipped');
+        expect(calls).toBe(1);
+        // 换个域名不受上一个的冷却影响
+        expect(await probeOriginReachability('https://b.example.com/1', fakeFetch, { now })).toBe('reachable');
+        expect(calls).toBe(2);
+    });
+
+    it('地址非法直接跳过，不浪费一次请求', async () => {
+        let calls = 0;
+        const fakeFetch = (() => { calls += 1; return Promise.resolve(new Response('')); }) as any;
+        expect(await probeOriginReachability('not a url', fakeFetch)).toBe('skipped');
+        expect(calls).toBe(0);
+    });
+});
+
+describe('describeReachabilityProbe', () => {
+    it('通了 → 指向 CORS/限流，明确说「网络路径是通的」', () => {
+        const text = describeReachabilityProbe('reachable', 'sullymeow.ccwu.cc');
+        expect(text).toContain('网络路径是通的');
+        expect(text).toContain('CORS');
+        expect(text).not.toContain('梯子的分流规则');
+    });
+
+    it('没通 → 指向线路，不能再提 CORS 把人带偏', () => {
+        const text = describeReachabilityProbe('unreachable', 'sullymeow.ccwu.cc');
+        expect(text).toContain('连不上');
+        expect(text).toContain('梯子');
+        expect(text).not.toContain('网络路径是通的');
+    });
+
+    it('skipped 不产出文案（不往日志里塞废话）', () => {
+        expect(describeReachabilityProbe('skipped', 'a.example.com')).toBe('');
+    });
+});
+
+describe('parseTargetUrl / 自查清单', () => {
+    it('相对地址按 base 解析', () => {
+        expect(parseTargetUrl('/api/health', 'https://sullyos.example.com/index.html').host).toBe('sullyos.example.com');
+    });
+
+    it('自查清单第一步就是「换节点 / 关梯子直连」', () => {
+        expect(NETWORK_SELF_CHECK_STEPS.length).toBeGreaterThanOrEqual(4);
+        expect(NETWORK_SELF_CHECK_STEPS[0]).toContain('梯子');
+    });
+});

--- a/utils/networkFailureDiagnosis.ts
+++ b/utils/networkFailureDiagnosis.ts
@@ -1,0 +1,256 @@
+// 全局 fetch 拦截器（context/OSContext.tsx）抓到「请求压根没拿到响应」时，把浏览器那句
+// 光秃秃的 `TypeError: Failed to fetch` 翻成一条能照着排查的日志。
+//
+// 为什么值得单开一份：
+//   1. 浏览器出于安全，把「DNS 解析不了」「梯子把连接掐了」「扩展屏蔽了」「对方返回的
+//      响应没有 CORS 头」这四件完全不同的事，统统报成同一句 Failed to fetch，不带任何
+//      细节。用户把日志复制出来发到群里，信息量是零——这份文件的活就是把能补的旁证
+//      （耗时、在线状态、是否跨域、Resource Timing 里那条记录）全补上，再给一句初判。
+//   2. 其中最关键的一条旁证是「换 no-cors 再打一次这个域名」：no-cors 不做 CORS 校验，
+//      只要网络路径通就会拿到一个 opaque 响应。它成功而原请求失败 ⇒ 网络没问题，是响应
+//      头/CORS 的事（多半是对方挡在 Cloudflare 限流页或人机验证页后面）；它也失败 ⇒ 这台
+//      设备到这个域名是真的不通，该去查梯子规则 / DNS / 防火墙 / 扩展。这一刀把排查范围
+//      直接砍掉一半，是整份文件存在的理由。
+//   3. 判定全是纯函数，能脱开浏览器单测；探测那部分把 fetch 当参数传进来，测试塞假的。
+//
+// ⚠️ 探测必须用**未被拦截的原生 fetch**（拦截器里的 originalFetch），否则探测自己失败会
+// 再写一条日志，一条网络错误滚成一屏。
+
+/** 连接失败的粗分类。用于选那句初判，也用于决定要不要做 no-cors 复检。 */
+export type FetchFailureKind =
+    | 'aborted'        // 调用方主动取消 / 超时控制器掐的
+    | 'offline'        // navigator.onLine === false，浏览器自己知道没网
+    | 'mixed-content'  // https 页面打 http 地址，被浏览器直接拦
+    | 'bad-url'        // 地址本身就不合法（拼错、少了协议头）
+    | 'blocked'        // 拿不到响应：代理/DNS/扩展/CORS 四选一，靠复检再分
+    | 'unknown';
+
+export interface FetchFailureContext {
+    url: string;
+    /** 请求方法，取不到按 GET 记。 */
+    method?: string;
+    /** 从发起到抛错的毫秒数。 */
+    durationMs?: number;
+    error?: unknown;
+    /** 以下三项默认读全局，测试里显式传。 */
+    online?: boolean;
+    pageOrigin?: string;
+    pageProtocol?: string;
+}
+
+const readError = (error: unknown): { name: string; message: string } => {
+    if (error instanceof Error) return { name: error.name || 'Error', message: error.message || String(error) };
+    if (error && typeof error === 'object') {
+        const anyErr = error as { name?: unknown; message?: unknown };
+        return {
+            name: typeof anyErr.name === 'string' ? anyErr.name : 'Error',
+            message: typeof anyErr.message === 'string' ? anyErr.message : String(error),
+        };
+    }
+    return { name: 'Error', message: String(error ?? '') };
+};
+
+/**
+ * 各家浏览器对「连不上」的说法不一样，漏认一种就会掉进 unknown：
+ * Chrome/Edge 是 Failed to fetch，Safari 是 Load failed，Firefox 是
+ * NetworkError when attempting to fetch resource。
+ */
+const looksLikeNetworkError = (message: string) => (
+    /failed to fetch/i.test(message)
+    || /load failed/i.test(message)
+    || /networkerror/i.test(message)
+    || /network request failed/i.test(message)
+);
+
+/** 把 URL 拆成 origin/host，拆不动（相对路径、拼错）时用当前页面兜底。 */
+export const parseTargetUrl = (url: string, base?: string): { ok: boolean; origin: string; host: string; protocol: string; href: string } => {
+    try {
+        const parsed = new URL(url, base || (typeof location !== 'undefined' ? location.href : undefined));
+        return { ok: true, origin: parsed.origin, host: parsed.host, protocol: parsed.protocol, href: parsed.href };
+    } catch {
+        return { ok: false, origin: '', host: '', protocol: '', href: url };
+    }
+};
+
+/** http://localhost / 127.0.0.1 在 Chrome 里算可信来源，不当混合内容拦；Firefox 会拦。 */
+const isLoopbackHost = (host: string) => /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/i.test(host);
+
+export const classifyFetchFailure = (ctx: FetchFailureContext): FetchFailureKind => {
+    const { name, message } = readError(ctx.error);
+    if (name === 'AbortError' || /aborted|abort/i.test(message)) return 'aborted';
+
+    const target = parseTargetUrl(ctx.url);
+    if (!target.ok) return 'bad-url';
+
+    const pageProtocol = ctx.pageProtocol ?? (typeof location !== 'undefined' ? location.protocol : '');
+    if (pageProtocol === 'https:' && target.protocol === 'http:' && !isLoopbackHost(target.host)) return 'mixed-content';
+
+    const online = ctx.online ?? (typeof navigator !== 'undefined' ? navigator.onLine : true);
+    if (online === false) return 'offline';
+
+    if (looksLikeNetworkError(message) || name === 'TypeError') return 'blocked';
+    return 'unknown';
+};
+
+/** 每种分类给一句「现在能确定什么」+ 一行「可能是什么」。 */
+const VERDICTS: Record<FetchFailureKind, { verdict: string; causes: string }> = {
+    aborted: {
+        verdict: '请求被主动取消（超时控制器掐的，或页面/组件卸载了）。',
+        causes: '对方响应太慢超过了超时阈值 · 中途切走了页面 · 手动点了停止',
+    },
+    offline: {
+        verdict: '浏览器自己报告当前离线，请求根本没发出去。',
+        causes: '网络断了 · 梯子刚切换/掉线 · 设备进了飞行模式',
+    },
+    'mixed-content': {
+        verdict: 'https 页面去打 http 地址，被浏览器的混合内容策略直接拦下，请求没有发出去。',
+        causes: '地址少了 s（http:// 应为 https://） · 自建服务没配证书',
+    },
+    'bad-url': {
+        verdict: '这个地址本身不是合法 URL，请求没有发出去。',
+        causes: '地址填错/少了 https:// · 复制时带进了空格或中文引号',
+    },
+    blocked: {
+        verdict: '请求在拿到响应头之前就失败了——浏览器没告诉我们具体是哪一步断的。',
+        causes: '梯子/代理把这个域名的连接掐了 · DNS 解析不到 · 浏览器扩展（广告拦截/隐私盾/脚本管理器）屏蔽了 · 对方返回的是一张不带 CORS 头的页面（限流、人机验证、网关报错）',
+    },
+    unknown: {
+        verdict: '请求失败，且不符合已知的几种失败形态。',
+        causes: '看下面的错误原文',
+    },
+};
+
+/** Resource Timing 里那条记录能补两个关键旁证：到底有没有收到响应状态码、传了多少字节。 */
+export const readResourceTimingHint = (
+    href: string,
+    perf?: { getEntriesByName?: (name: string, type?: string) => any[] },
+): string => {
+    const target = perf ?? (typeof performance !== 'undefined' ? (performance as any) : undefined);
+    if (!target?.getEntriesByName) return '';
+    let entries: any[] = [];
+    try {
+        entries = target.getEntriesByName(href, 'resource') || [];
+    } catch {
+        return '';
+    }
+    const entry = entries[entries.length - 1];
+    if (!entry) return 'Resource Timing: 没有这条请求的记录（通常说明连接压根没建立起来，或被扩展在发出前就拦掉了）';
+    const parts: string[] = [];
+    if (typeof entry.responseStatus === 'number') parts.push(`responseStatus=${entry.responseStatus}`);
+    if (typeof entry.transferSize === 'number') parts.push(`transferSize=${entry.transferSize}`);
+    if (typeof entry.duration === 'number') parts.push(`duration=${Math.round(entry.duration)}ms`);
+    let note = '';
+    if (typeof entry.responseStatus === 'number' && entry.responseStatus > 0) {
+        note = ` → 对方其实回了 HTTP ${entry.responseStatus}，是响应被 CORS 拦掉的，不是网络不通`;
+    }
+    return `Resource Timing: ${parts.join(', ') || '有记录'}${note}`;
+};
+
+/**
+ * 拼出写进调试终端 detail 的那一段。同步、无副作用——no-cors 复检结论由
+ * describeReachabilityProbe() 单独产出，异步补到这段后面。
+ */
+export const buildFetchFailureDetail = (
+    ctx: FetchFailureContext,
+    opts?: { perf?: { getEntriesByName?: (name: string, type?: string) => any[] } },
+): string => {
+    const { name, message } = readError(ctx.error);
+    const kind = classifyFetchFailure(ctx);
+    const target = parseTargetUrl(ctx.url);
+    const pageOrigin = ctx.pageOrigin ?? (typeof location !== 'undefined' ? location.origin : '');
+    const online = ctx.online ?? (typeof navigator !== 'undefined' ? navigator.onLine : true);
+    const method = (ctx.method || 'GET').toUpperCase();
+
+    const lines: string[] = [];
+    lines.push(`URL: ${ctx.url}`);
+    const durationText = typeof ctx.durationMs === 'number' ? ` · 失败于 ${ctx.durationMs}ms` : '';
+    lines.push(`请求: ${method}${durationText}`);
+    lines.push(`错误: ${name}: ${message}`);
+    if (target.ok) {
+        const crossOrigin = pageOrigin && target.origin !== pageOrigin;
+        lines.push(`目标域名: ${target.host}${crossOrigin ? '（跨域请求，受 CORS 约束）' : '（同源）'}`);
+    }
+    if (pageOrigin) lines.push(`本页来源: ${pageOrigin}`);
+    lines.push(`浏览器联网状态: ${online === false ? '离线' : '在线'}`);
+    const timing = readResourceTimingHint(target.href, opts?.perf);
+    if (timing) lines.push(timing);
+    lines.push(`初判: ${VERDICTS[kind].verdict}`);
+    lines.push(`可能原因: ${VERDICTS[kind].causes}`);
+    return lines.join('\n');
+};
+
+// ─── no-cors 连通性复检 ───
+
+export type ReachabilityVerdict = 'reachable' | 'unreachable' | 'timeout' | 'skipped';
+
+/** 同一个域名 30s 内只复检一次，避免一串请求同时炸时打出一片探测流量。 */
+const probeCooldown = new Map<string, number>();
+const PROBE_COOLDOWN_MS = 30_000;
+
+export const resetReachabilityProbeCooldown = () => probeCooldown.clear();
+
+/**
+ * 用 no-cors 打一次目标域名的根路径，只为回答一个问题：这台设备到底能不能碰到这个域名。
+ *
+ * - 打根路径而不是原地址：原地址可能是有副作用的接口（下单、发消息），复检不该顺手触发它；
+ *   而 DNS / 梯子 / 防火墙 / 扩展这几层拦的都是整个域名，打根路径一样能测出来。
+ * - no-cors 拿到的是 opaque 响应，读不出状态码——但「拿到了」本身就是结论。
+ */
+export const probeOriginReachability = async (
+    url: string,
+    fetchImpl: typeof fetch,
+    opts?: { timeoutMs?: number; now?: () => number },
+): Promise<ReachabilityVerdict> => {
+    const target = parseTargetUrl(url);
+    if (!target.ok || !target.origin || target.origin === 'null') return 'skipped';
+
+    const now = opts?.now ?? (() => Date.now());
+    const last = probeCooldown.get(target.origin);
+    const at = now();
+    if (typeof last === 'number' && at - last < PROBE_COOLDOWN_MS) return 'skipped';
+    probeCooldown.set(target.origin, at);
+
+    const timeoutMs = opts?.timeoutMs ?? 6000;
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : undefined;
+    const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : undefined;
+    try {
+        await fetchImpl(`${target.origin}/`, {
+            method: 'GET',
+            mode: 'no-cors',
+            cache: 'no-store',
+            credentials: 'omit',
+            redirect: 'follow',
+            signal: controller?.signal,
+        });
+        return 'reachable';
+    } catch (e) {
+        const { name } = readError(e);
+        return name === 'AbortError' ? 'timeout' : 'unreachable';
+    } finally {
+        if (timer !== undefined) clearTimeout(timer);
+    }
+};
+
+/** 把复检结论翻成给人看的一句话 + 下一步该往哪查。 */
+export const describeReachabilityProbe = (verdict: ReachabilityVerdict, host: string): string => {
+    const who = host || '该域名';
+    switch (verdict) {
+        case 'reachable':
+            return `连通性复检: no-cors 直连 ${who} 成功 → 网络路径是通的，问题出在响应本身（对方没回 CORS 头，多半是限流页 / 人机验证页 / 网关错误页）。换个网络或过几分钟重试，仍旧的话把这条日志发给作者。`;
+        case 'unreachable':
+            return `连通性复检: no-cors 直连 ${who} 同样失败 → 这台设备到 ${who} 是真的连不上。按顺序查：梯子的分流规则（把该域名放进代理）、DNS、浏览器扩展（广告拦截/隐私盾）、系统或路由器防火墙。`;
+        case 'timeout':
+            return `连通性复检: no-cors 直连 ${who} 超时（连接挂住不返回）→ 多半是代理/网关把连接吞了，或对方正被限速。优先换一个梯子节点再试。`;
+        default:
+            return '';
+    }
+};
+
+/** 给调试终端用的通用自查清单——网络类错误一律先照这个走一遍。 */
+export const NETWORK_SELF_CHECK_STEPS: string[] = [
+    '换一个梯子节点，或先关掉梯子直连试一次——两种都失败才说明不是线路问题',
+    '把浏览器扩展（广告拦截、隐私盾、脚本管理器）全禁掉再试，或换用无痕窗口',
+    '在新标签页直接打开日志里那个 URL：能出 JSON 说明网络通，是页面这边的跨域被拦；打不开就是线路/DNS 的事',
+    '换一个浏览器或换手机热点各试一次，能定位到是「这台设备」还是「这个网络」',
+    '如果只有部分功能报错，去设置里看对应的服务地址是不是填错了（少 https://、多空格、多结尾斜杠）',
+];

--- a/utils/xhsMcpClient.ts
+++ b/utils/xhsMcpClient.ts
@@ -10,6 +10,8 @@
  * Skills Server: https://github.com/autoclaw-cc/xiaohongshu-skills
  */
 
+import { classifyFetchFailure, parseTargetUrl } from './networkFailureDiagnosis';
+
 export interface McpToolResult {
     success: boolean;
     data?: any;
@@ -510,6 +512,30 @@ const extractFirstXsecToken = (data: any): string | undefined => {
     return undefined;
 };
 
+/**
+ * 连接测试失败时给一句人话。裸传 e.message 的话，用户在设置页只会看到
+ * 「Failed to fetch」——那句话不区分「地址填错」「梯子拦了」「对方在限流页后面」，
+ * 到头来只能来问作者。分类逻辑复用调试终端那份，两处口径保持一致。
+ */
+const describeXhsConnectFailure = (e: any, serverUrl: string): string => {
+    const host = parseTargetUrl(serverUrl).host || serverUrl;
+    const kind = classifyFetchFailure({ url: serverUrl, error: e });
+    switch (kind) {
+        case 'aborted':
+            return `连接 ${host} 超时（10 秒没有响应）。多半是代理/网关把连接吞了，换个梯子节点再试。`;
+        case 'offline':
+            return '当前处于离线状态，请检查网络或梯子是否掉线。';
+        case 'mixed-content':
+            return `SullyOS 跑在 https 上，不能连 http 地址（${host}）。请把服务地址改成 https://，或用本地 http 打开 SullyOS。`;
+        case 'bad-url':
+            return `服务器地址不是合法 URL：${serverUrl}。检查有没有漏掉 https://、多了空格或用了中文标点。`;
+        case 'blocked':
+            return `连不上 ${host}：浏览器在拿到响应前就失败了。常见原因——梯子/代理拦了这个域名、DNS 解析不到、浏览器扩展（广告拦截/隐私盾）屏蔽了，或对方正返回限流/人机验证页。可在新标签页直接打开 ${serverUrl.replace(/\/+$/, '')}/health 验证；详细旁证见「系统调试终端」。`;
+        default:
+            return e?.message || '连接失败';
+    }
+};
+
 // ==================== Public API (双模式) ====================
 
 export const XhsMcpClient = {
@@ -534,7 +560,11 @@ export const XhsMcpClient = {
         if (mode === 'bridge') {
             try {
                 const baseUrl = serverUrl.replace(/\/+$/, '').replace(/\/api$/, '');
-                const healthResp = await fetch(`${baseUrl}/api/health`);
+                // 探活必须自带超时：代理/网关把连接吞掉时裸 fetch 会一直挂着，界面永远停在
+                // 「连接中」，用户只能当成卡死。10s 到点主动断，走下面的 catch 出一句人话。
+                const healthResp = await fetch(`${baseUrl}/api/health`, {
+                    signal: typeof AbortSignal !== 'undefined' && AbortSignal.timeout ? AbortSignal.timeout(10000) : undefined,
+                });
                 if (!healthResp.ok) return { connected: false, error: `Bridge 服务未响应 (HTTP ${healthResp.status})` };
 
                 const loginResult = await bridgePost(serverUrl, 'check-login');
@@ -564,7 +594,7 @@ export const XhsMcpClient = {
                 }
                 return { connected: true, tools, nickname, userId, loggedIn, xsecToken };
             } catch (e: any) {
-                return { connected: false, error: e.message };
+                return { connected: false, error: describeXhsConnectFailure(e, serverUrl) };
             }
         }
 


### PR DESCRIPTION
浏览器把「梯子拦了」「DNS 解析不到」「扩展屏蔽了」「对方回了没有 CORS 头的
限流/人机验证页」四件事统统报成同一句 Failed to fetch，旧日志只记一行 URL，
用户复制出来发到群里信息量是零。

新增 utils/networkFailureDiagnosis.ts：

- 失败分类：aborted / offline / mixed-content / bad-url / blocked，各给确定结论；
  Chrome 的 Failed to fetch、Safari 的 Load failed、Firefox 的 NetworkError 三种
  说法都认。
- 补齐旁证：方法、耗时、是否跨域、在线状态，以及 Resource Timing 里那条记录——
  responseStatus 跨域也能读，> 0 就说明对方其实回了，是 CORS 而非网络不通。
- no-cors 连通性复检：只要网络路径通就能拿到 opaque 响应。它成功而原请求失败
  ⇒ 响应头/限流页的事；它也失败 ⇒ 这台设备到该域名真连不上。结论异步回填到同
  一条日志。复检走未打补丁的 originalFetch（否则探测自身失败会滚雪球）、只打域名
  根路径（原地址可能有副作用）、同域名 30s 冷却、只对 blocked 类做。

顺带：

- StatusBar 调试终端在有网络类错误时折叠展示自查清单（换节点/关梯子、禁扩展、
  新标签页直开该 URL、换浏览器或热点、检查服务地址填写）。
- 小红书 bridge 探活 /api/health 加 10s 超时（此前裸 fetch 会一直挂着，界面停在
  「连接中」像卡死），失败时按分类给人话而不是透传 Failed to fetch。
- docs/dev-debug.md 补第十二节，说明这套诊断和改动时的坑。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MvtmXC65ZHUDJtBpM9M3rg