### PR TITLE
fix(amsg2): 已填 Worker 地址就收起一键部署卡片

### DIFF
--- a/components/settings/ActiveMsgGlobalSettingsModal.tsx
+++ b/components/settings/ActiveMsgGlobalSettingsModal.tsx
@@ -867,6 +867,8 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
           </div>
         ) : null}
 
+        {/* 已经填了 Worker 地址就说明后端装好了，这张卡收起来；重装走「清掉地址再回来」这条路。 */}
+        {config.workerUrl?.trim() ? null : (
         <div className="bg-white border border-slate-200 rounded-2xl p-4 space-y-3">
           <div className="flex items-center justify-between gap-2">
             <span className="font-bold text-slate-700">一键部署（推荐）</span>
@@ -961,6 +963,7 @@ const ActiveMsgGlobalSettingsModal: React.FC<ActiveMsgGlobalSettingsModalProps> 
             以后「更新后端」用的就是它；本页不保存。介意的话可以照下面的手动方式装。
           </p>
         </div>
+        )}
 
         <div className="bg-white border border-slate-200 rounded-2xl p-4 space-y-3">
           <button


### PR DESCRIPTION
## 改了什么

主动消息 2.0 设置里的「一键部署（推荐）」卡片改成按需显示：

- **改之前**：不管后端装没装好，卡片一直摆在那，装完的人看到还以为要再装一遍。
- **改之后**：Worker 地址空着才显示；已经填了地址（= 后端在用了）就整张收起。想重装的话，清掉地址卡片就会回来。

体检、手动部署等其他卡片不受影响。

https://claude.ai/code/session_01DUXFKycByAFdRZcyDr9xtB