### PR TITLE
fix(amsg2): 一键部署重装不再撞 10079 乐观锁

### DIFF
--- a/utils/cfProvision.test.ts
+++ b/utils/cfProvision.test.ts
@@ -17,6 +17,7 @@ import {
     scriptNameFromWorkerUrl,
     verifyToken,
     isAccountScopedToken,
+    uploadWorkerScript,
     type AmsgSecrets,
 } from './cfProvision';
 
@@ -235,6 +236,90 @@ describe('verifyToken', () => {
         expect(isAccountScopedToken('cfat_abc')).toBe(true);
         expect(isAccountScopedToken('  cfat_abc  ')).toBe(true);
         expect(isAccountScopedToken('abcdef123')).toBe(false);
+    });
+});
+
+describe('uploadWorkerScript', () => {
+    /**
+     * 装一个假的中转，按次序吐响应，并把每次上传的 metadata 记下来。
+     */
+    const stubUploadRelay = (responses: Array<{ status: number; payload: unknown }>) => {
+        const metadatas: Array<Record<string, unknown>> = [];
+        vi.stubGlobal('fetch', vi.fn(async (_url: string, init?: RequestInit) => {
+            const form = init?.body as FormData;
+            const metaBlob = form.get('metadata') as Blob;
+            metadatas.push(JSON.parse(await metaBlob.text()));
+            const next = responses[Math.min(metadatas.length - 1, responses.length - 1)];
+            return new Response(JSON.stringify(next.payload), {
+                status: next.status,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }));
+        return metadatas;
+    };
+
+    const FRESH_METADATA = {
+        main_module: 'worker.bundle.js',
+        bindings: [{ type: 'durable_object_namespace', name: 'INSTANT_TICK', class_name: 'InstantTickDO' }],
+        migrations: { new_tag: 'amsg-instant-tick-v1', new_sqlite_classes: ['InstantTickDO'] },
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * 回归守卫：对着已经装过的 Worker 重装（清了地址重跑、换设备再部署）。
+     *
+     * metadata 里的 migrations 断言「全新部署」，这时 CF 会回 10079 乐观锁冲突把整次
+     * 上传顶回来——修法是去掉 migrations 重传（namespace 本来就在），binding 原样保留。
+     */
+    it('撞上 10079 就去掉 migrations 重传一次，并标记这是覆盖更新', async () => {
+        const metadatas = stubUploadRelay([
+            {
+                status: 400,
+                payload: {
+                    success: false,
+                    errors: [{ code: 10079, message: "Actor migration tag precondition failed, got tag '' when expected tag is 'amsg-instant-tick-v1'." }],
+                },
+            },
+            { status: 200, payload: { success: true, result: {} } },
+        ]);
+
+        const result = await uploadWorkerScript('tok', 'acct', 'sullyos-amsg', FRESH_METADATA, 'export default {}');
+
+        expect(result.ok).toBe(true);
+        expect(result.reusedExistingWorker).toBe(true);
+        expect(metadatas).toHaveLength(2);
+        expect(metadatas[1].migrations).toBeUndefined();
+        // 只该去掉 migrations，binding 等其余字段原样保留
+        expect(metadatas[1].bindings).toEqual(metadatas[0].bindings);
+        expect(metadatas[1].main_module).toBe(metadatas[0].main_module);
+    });
+
+    it('全新部署一次成功就不重试，也不标记覆盖更新', async () => {
+        const metadatas = stubUploadRelay([{ status: 200, payload: { success: true, result: {} } }]);
+
+        const result = await uploadWorkerScript('tok', 'acct', 'sullyos-amsg', FRESH_METADATA, 'export default {}');
+
+        expect(result.ok).toBe(true);
+        expect(result.reusedExistingWorker).toBeUndefined();
+        expect(metadatas).toHaveLength(1);
+    });
+
+    it('其他错误不套这个重试——盲目去掉 migrations 只会把真错误拖成两次', async () => {
+        const metadatas = stubUploadRelay([
+            {
+                status: 400,
+                payload: { success: false, errors: [{ code: 10037, message: 'workers limit reached' }] },
+            },
+        ]);
+
+        const result = await uploadWorkerScript('tok', 'acct', 'sullyos-amsg', FRESH_METADATA, 'export default {}');
+
+        expect(result.ok).toBe(false);
+        expect(metadatas).toHaveLength(1);
     });
 });
 

--- a/utils/cfProvision.ts
+++ b/utils/cfProvision.ts
@@ -352,6 +352,55 @@ async function cfApi<T = unknown>(
   };
 }
 
+/** DO migration 的乐观锁冲突：这个 Worker 已经应用过 migration，「全新部署」的断言不成立。 */
+const MIGRATION_TAG_CONFLICT = 10079;
+
+function firstCfErrorCode(body: unknown): number | null {
+  const errors = (body as { errors?: Array<{ code?: number }> } | null)?.errors;
+  return (Array.isArray(errors) && errors.length ? errors[0]?.code : null) ?? null;
+}
+
+async function putScript(
+  token: string,
+  accountId: string,
+  scriptName: string,
+  metadata: Record<string, unknown>,
+  code: string,
+): Promise<CfResponse> {
+  const form = new FormData();
+  form.set('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
+  form.set(MAIN_MODULE, new Blob([code], { type: 'application/javascript+module' }), MAIN_MODULE);
+  return cfApi(token, `/accounts/${accountId}/workers/scripts/${encodeURIComponent(scriptName)}`, {
+    method: 'PUT',
+    body: form,
+  });
+}
+
+/**
+ * 上传 Worker 脚本。metadata 带着建 DO namespace 的 migrations，等于断言「全新部署」；
+ * 对着一个已经装过的 Worker 重装（清了地址重跑、换设备对同一个账号再部署）时这个断言
+ * 不成立，CF 会回 10079 把整次上传顶回来。
+ *
+ * 这时 namespace 本来就已经在了，migrations 纯属多余——去掉重传一次即可，binding 原样
+ * 保留（与 worker 侧 selfUpdate 的补建路径同一套实测结论：migration_tag 不变、DO 类还在）。
+ * 只对 10079 重试：全新部署一次就过，其他错误照旧当场返回。
+ */
+export async function uploadWorkerScript(
+  token: string,
+  accountId: string,
+  scriptName: string,
+  metadata: Record<string, unknown>,
+  code: string,
+): Promise<CfResponse & { reusedExistingWorker?: boolean }> {
+  const first = await putScript(token, accountId, scriptName, metadata, code);
+  if (first.ok || firstCfErrorCode(first.body) !== MIGRATION_TAG_CONFLICT) return first;
+
+  const withoutMigrations = { ...metadata };
+  delete withoutMigrations.migrations;
+  const second = await putScript(token, accountId, scriptName, withoutMigrations, code);
+  return second.ok ? { ...second, reusedExistingWorker: true } : second;
+}
+
 /** 当前生效的网络代理 Worker 支不支持一键部署（老版本没有 /cf-api 这条路由）。 */
 export async function checkRelayAvailable(): Promise<boolean> {
   try {
@@ -795,24 +844,17 @@ export async function provisionAmsgBackend(input: ProvisionInput): Promise<Provi
     // 官方的 multipart-upload-metadata 文档没把 observability 列进合法字段，但实测是认的
     // ——上传 enabled:false 能关掉、true 能开起来、不带就没有，三向都验过。
     observability: { enabled: true, logs: { enabled: true } },
-    // 建即时对话起跳器的 Durable Object namespace。这里是全新部署，所以只给 new_tag
-    // （不给 old_tag 即断言「还没应用过任何 migration」）。注意它是一个对象，不是
-    // wrangler.toml 里那种数组——传数组会被 10021 顶回来。
+    // 建即时对话起跳器的 Durable Object namespace。不给 old_tag 即断言「还没应用过
+    // 任何 migration」；重装撞上 10079 时由 uploadWorkerScript 去掉它重传。注意它是
+    // 一个对象，不是 wrangler.toml 里那种数组——传数组会被 10021 顶回来。
     migrations: INSTANT_TICK_MIGRATIONS,
   };
-  const form = new FormData();
-  form.set('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
-  form.set(
-    MAIN_MODULE,
-    new Blob([bundle.code], { type: 'application/javascript+module' }),
-    MAIN_MODULE,
-  );
-  const uploaded = await cfApi(token, `/accounts/${accountId}/workers/scripts/${encodeURIComponent(scriptName)}`, {
-    method: 'PUT',
-    body: form,
-  });
+  const uploaded = await uploadWorkerScript(token, accountId, scriptName, metadata, bundle.code);
   if (!uploaded.ok) {
     return { ok: false, code: 'UPLOAD_FAILED', message: uploaded.error || '上传 Worker 失败。' };
+  }
+  if (uploaded.reusedExistingWorker) {
+    warnings.push(`账号里已经有一套装好的 ${scriptName}，这次是在它上面覆盖更新。`);
   }
 
   report('cron', '设置定时触发…');


### PR DESCRIPTION
## 改了什么

对着一个已经装过后端的账号再跑一键部署（清了地址重跑、换设备再部署），会被 Cloudflare 顶回来：

> Actor migration tag precondition failed, got tag '' when expected tag is 'amsg-instant-tick-v1'.（code 10079）

原因是上传时带的 Durable Object migrations 等于断言「全新部署」，账号里已有装好的 Worker 时这个断言不成立。

- **改之前**：重装直接失败，只能先去 Cloudflare 面板把 Worker（连同 DO）删掉再装。
- **改之后**：撞上 10079 自动去掉 migrations 重传一次（namespace 本来就在，binding 原样保留，与 worker 侧 selfUpdate 补建路径同一套实测结论），装完会提示「这次是在已有 Worker 上覆盖更新」。全新部署路径不变，一次就过；其他错误不套这个重试。

带了三条回归测试钉住：10079 重试且只去 migrations、全新部署不重试、其他错误不重试。

纯前端改动，不涉及 worker 部署顺序。

https://claude.ai/code/session_01DUXFKycByAFdRZcyDr9xtB