### PR TITLE
fix(amsg2): 一键部署的报错带上 Cloudflare 原文，读子域名被拒不再劝人换名字

### DIFF
--- a/utils/cfProvision.test.ts
+++ b/utils/cfProvision.test.ts
@@ -18,6 +18,7 @@ import {
     verifyToken,
     isAccountScopedToken,
     uploadWorkerScript,
+    ensureSubdomain,
     type AmsgSecrets,
 } from './cfProvision';
 
@@ -340,6 +341,99 @@ describe('explainCfError', () => {
     it('认不出来的错至少把 CF 的原话带上', () => {
         const msg = explainCfError(500, { errors: [{ code: 12345, message: 'Something odd' }] });
         expect(msg).toContain('Something odd');
+    });
+
+    // 下面三条钉住「翻译之外一定留原文」。翻译是兜底猜的，猜错时用户得有东西可查——
+    // 尤其 401/403 那条：不留原文的话，中转层和 WAF 的 403 都长得跟「token 缺权限」
+    // 一模一样，人会被指使着反复去改一枚本来就没问题的 token。
+    it('权限提示后面带着 CF 原文、code 和 HTTP 状态', () => {
+        const msg = explainCfError(403, { errors: [{ code: 9109, message: 'Unauthorized' }] });
+
+        expect(msg).toContain('Unauthorized');
+        expect(msg).toContain('9109');
+        expect(msg).toContain('403');
+    });
+
+    it('中转层自己回的 403 也要露出原话，别看着像 token 缺权限', () => {
+        // 中转的错误体是 { error }，不是 CF 的 errors 数组，得单独捞。
+        const msg = explainCfError(403, {
+            error: 'This proxy only relays account-scoped Cloudflare API paths',
+        });
+
+        expect(msg).toContain('This proxy only relays');
+    });
+
+    it('响应根本不是 JSON 时，至少把 HTTP 状态说出来', () => {
+        const msg = explainCfError(403, null);
+
+        expect(msg).toContain('403');
+    });
+
+    it('带上出事的那个请求，认得出卡在哪一步', () => {
+        const msg = explainCfError(403, null, 'POST /accounts/acc-1/d1/database');
+
+        expect(msg).toContain('POST /accounts/acc-1/d1/database');
+    });
+});
+
+describe('ensureSubdomain', () => {
+    /** 按路径派响应的假中转，返回它收到的「方法 + 路径」清单。 */
+    const stubRelay = (
+        handler: (path: string, method: string) => { payload: unknown; status?: number },
+    ) => {
+        const seen: string[] = [];
+        vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+            const path = new URL(String(url)).searchParams.get('path') || '';
+            const headers = (init?.headers || {}) as Record<string, string>;
+            const method = headers['X-CF-Method'] || 'GET';
+            seen.push(`${method} ${path}`);
+            const { payload, status = 200 } = handler(path, method);
+            return new Response(JSON.stringify(payload), {
+                status,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }));
+        return seen;
+    };
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('账号已经有子域名就直接用', async () => {
+        stubRelay(() => ({ payload: { success: true, result: { subdomain: 'kaede' } } }));
+
+        expect(await ensureSubdomain('tok', 'acc-1')).toEqual({ ok: true, subdomain: 'kaede' });
+    });
+
+    it('读子域名被 403 时说权限，而不是请用户再起一个名字', async () => {
+        // 读都读不动，注册那一步同样过不去。当成新账号劝人换名字，用户会一直换下去。
+        const seen = stubRelay(() => ({
+            payload: { success: false, errors: [{ code: 9109, message: 'Unauthorized' }] },
+            status: 403,
+        }));
+
+        const result = await ensureSubdomain('tok', 'acc-1', 'kaede');
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.code).toBe('CF_ERROR');
+            expect(result.error).toContain('Unauthorized');
+        }
+        // 注定失败的注册请求也不该发
+        expect(seen).toEqual(['GET /accounts/acc-1/workers/subdomain']);
+    });
+
+    it('403 之外的读失败照旧当新账号处理，别把还没建过子域名的人堵死', async () => {
+        const seen = stubRelay((_path, method) => (method === 'GET'
+            ? { payload: { success: false, errors: [{ code: 10007, message: 'not found' }] }, status: 404 }
+            : { payload: { success: true, result: {} } }));
+
+        const result = await ensureSubdomain('tok', 'acc-1', 'kaede');
+
+        expect(result).toEqual({ ok: true, subdomain: 'kaede' });
+        expect(seen).toContain('PUT /accounts/acc-1/workers/subdomain');
     });
 });
 

--- a/utils/cfProvision.ts
+++ b/utils/cfProvision.ts
@@ -261,27 +261,50 @@ export function scriptNameFromWorkerUrl(workerUrl: string): string | null {
 }
 
 /**
- * 把 Cloudflare 的报错翻译成能照着做的话。
- * 权限类的最常见——用户建 token 时少勾一项，光看「Unauthorized」根本不知道少了哪个。
+ * 把 Cloudflare 的报错翻译成能照着做的话，末尾一律缀上原文。
+ *
+ * 翻译是给用户看的，原文是给排障用的，两个都要有：
+ *
+ * - 权限类最常见——用户建 token 时少勾一项，光看「Unauthorized」根本不知道少了哪个，
+ *   所以要翻译；
+ * - 可 401/403 的不只 Cloudflare。中转层（路径不让走、没带 Authorization）和路上的
+ *   WAF 也回这两个码，一样会被翻成「权限不够」，于是 token 明明没问题的人被指使着
+ *   反复去改 token。原文里有没有 CF 的 code、是不是 proxy 那句话，一眼就分得开。
+ *
+ * 原文取 CF 的 `errors[].message`；中转层的错误体是 `{ error }`，不是同一个形状，
+ * 单独捞一手。两边都没有（非 JSON 响应）就只剩 HTTP 状态码，那也得说出来。
+ *
+ * `request` 是出事的那个请求（方法 + 路径）。部署要连着调七八个接口，光有一句报错
+ * 认不出卡在建库还是传代码，界面上的步骤名又在失败时就清掉了。
  */
-export function explainCfError(status: number, body: unknown): string {
-  const errors = (body as { errors?: Array<{ code?: number; message?: string }> } | null)?.errors;
-  const first = Array.isArray(errors) && errors.length ? errors[0] : null;
-  const code = first?.code;
-  const raw = first?.message || '';
+export function explainCfError(status: number, body: unknown, request?: string): string {
+  const payload = body as {
+    errors?: Array<{ code?: number; message?: string }>;
+    error?: string;
+  } | null;
+  const errors = Array.isArray(payload?.errors) ? payload.errors : [];
+  const code = errors[0]?.code;
+  const raw =
+    errors.map((e) => e?.message).filter(Boolean).join('；')
+    || (typeof payload?.error === 'string' ? payload.error : '');
 
   const PERMISSION_HINT =
     'Token 权限不够。建 token 时这三项都要勾上：Account → Workers Scripts:Edit、'
     + 'Account → D1:Edit、Account → Account Settings:Read。';
 
-  if (code === 6003 || code === 6111) return 'Token 格式不对，多半是复制时多带了空格或换行。';
-  if (code === 9109 || code === 10000 || status === 401 || status === 403) return PERMISSION_HINT;
-  if (code === 10016) return `Worker 名字不合法：${raw}`;
-  if (code === 10027) return 'Worker 代码超过 Cloudflare 的体积上限，装不上去。';
-  if (code === 10037) return '这个账号的 Worker 数量已经到上限了，先去面板删掉不用的。';
-  if (code === 10054 || code === 10055) return `密钥数量或长度超限：${raw}`;
-  if (code === 7003) return '请求路径不对（多半是代理那边的问题，不是你的 token）。';
-  return raw ? `Cloudflare 返回：${raw}（code ${code ?? '?'}）` : `Cloudflare 返回 HTTP ${status}`;
+  const explain = (): string => {
+    if (code === 6003 || code === 6111) return 'Token 格式不对，多半是复制时多带了空格或换行。';
+    if (code === 9109 || code === 10000 || status === 401 || status === 403) return PERMISSION_HINT;
+    if (code === 10016) return 'Worker 名字不合法。';
+    if (code === 10027) return 'Worker 代码超过 Cloudflare 的体积上限，装不上去。';
+    if (code === 10037) return '这个账号的 Worker 数量已经到上限了，先去面板删掉不用的。';
+    if (code === 10054 || code === 10055) return '密钥数量或长度超限。';
+    if (code === 7003) return '请求路径不对（多半是代理那边的问题，不是你的 token）。';
+    return '这个错没见过，照原文查吧。';
+  };
+
+  const detail = `原文：${raw || '（空）'}｜code ${code ?? '无'}｜HTTP ${status}`;
+  return `${explain()}\n${detail}${request ? `｜${request}` : ''}`;
 }
 
 /**
@@ -348,7 +371,7 @@ async function cfApi<T = unknown>(
     ok: success,
     status: res.status,
     body: body as T,
-    error: success ? undefined : explainCfError(res.status, body),
+    error: success ? undefined : explainCfError(res.status, body, `${init.method || 'GET'} ${apiPath}`),
   };
 }
 
@@ -530,7 +553,7 @@ async function ensureDatabase(
  * 拿账号的 workers.dev 子域；没有就用 desiredSubdomain 注册一个。
  * 全新的 Cloudflare 账号是没有子域的，而它决定了最终的 Worker 地址，绕不过去。
  */
-async function ensureSubdomain(
+export async function ensureSubdomain(
   token: string,
   accountId: string,
   desired?: string,
@@ -539,6 +562,17 @@ async function ensureSubdomain(
     token,
     `/accounts/${accountId}/workers/subdomain`,
   );
+  // 401/403 是「没让我读」，不是「这个账号没有子域名」。不单独拎出来的话，下面会把它
+  // 当成新账号，请用户起一个名字——而读都读不动，注册那一步同样过不去，用户于是对着
+  // 「换一个名字再试」换个不停。只挑这两个状态码：账号真没有子域名时 CF 回什么没实测过，
+  // 把所有失败都当权限的话，会把全新账号堵死在这里，那比现在更糟。
+  if (!current.ok && (current.status === 401 || current.status === 403)) {
+    return {
+      ok: false,
+      code: 'CF_ERROR',
+      error: `读不到这个账号的 workers.dev 子域名。\n${current.error}`,
+    };
+  }
   const existing = current.body?.result?.subdomain;
   if (current.ok && existing) return { ok: true, subdomain: existing };
 


### PR DESCRIPTION
部署要连着调七八个 Cloudflare 接口，之前任何一步回 401/403——甚至中转层自己回的 403（路径不让走、WAF 挡了）——前端一律翻成同一句「Token 权限不够，这三项都要勾
上」。翻译猜对了还好，猜错时用户手上没有任何可查的东西，只能反复去改一枚本来就
没问题的 token。

现在翻译后面固定缀一行原文：CF 的 message、code、HTTP 状态，外加出事的那个请求
（方法 + 路径）。中转层的错误体是 { error }，跟 CF 的 errors 数组不是一个形状， 以前整个被丢掉，现在也捞出来，一眼能看出这次是不是 token 的事。路径顺带补回了
「卡在哪一步」：/d1/database 是建库，/workers/scripts/xxx 是传代码。

另一处：读账号的 workers.dev 子域名被 403 时，代码不分「没权限」和「这个账号还没
有子域名」，一律当后者处理、请用户起一个名字——可读都读不动，注册那步同样过不去，
用户只能对着「换一个名字再试」一直换。现在 401/403 单独报权限，其余失败照旧当新
账号处理：账号真没有子域名时 CF 回什么没实测过，全当权限会把全新账号堵死在这儿。

Claude-Session: https://claude.ai/code/session_012SNsqcSMXjKLvFQ1LFekBw