### PR TITLE
fix(amsg2): 第一次接上云端账本不再把存量当补收倒进聊天流

### DIFF
--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -1814,12 +1814,25 @@ export const ActiveMsgClient = {
     if (ids.length === 0) return;
     const config = await ensureWorkerReady();
     const client = await initializeClient(config);
+    let failed = 0;
+    let lastError: unknown = null;
     for (let i = 0; i < ids.length; i += OUTBOX_ACK_BATCH_SIZE) {
       const batch = ids.slice(i, i + OUTBOX_ACK_BATCH_SIZE);
-      const response = await client.ackOutbox(batch);
-      if (!response?.success) {
-        throw new Error(response?.error?.message || '云端消息账本销账失败。');
+      // 一批挂了继续跑后面几批：中途 throw 的话剩下的批次一条都销不掉，账本只会
+      // 越积越多，下一趟又整批拉回来。没销掉的那批下次拉回来有落库那层的去重挡着。
+      try {
+        const response = await client.ackOutbox(batch);
+        if (!response?.success) {
+          throw new Error(response?.error?.message || '云端消息账本销账失败。');
+        }
+      } catch (error) {
+        failed += batch.length;
+        lastError = error;
       }
+    }
+    if (failed > 0) {
+      const detail = lastError instanceof Error ? lastError.message : String(lastError);
+      throw new Error(`云端消息账本销账失败（${failed}/${ids.length} 条没销掉）：${detail}`);
     }
   },
 

--- a/utils/amsgInstantChat.test.ts
+++ b/utils/amsgInstantChat.test.ts
@@ -61,6 +61,7 @@ import { ActiveMsgClient } from './activeMsgClient';
 import {
   AMSG_INSTANT_CHAT_PENDING_LS_KEY,
   AMSG_INSTANT_CHAT_STAGED_NOTICES_LS_KEY,
+  AMSG_OUTBOX_ADOPTED_LS_KEY,
   OUTBOX_BACKFILL_MAX_AGE_MS,
   clearInstantChatPending,
   discardInstantChatExpiredNotices,
@@ -109,6 +110,7 @@ const mockInstantChatFetch = (status: number, body: unknown) => {
 beforeEach(() => {
   localStorage.removeItem(AMSG_INSTANT_CHAT_PENDING_LS_KEY);
   localStorage.removeItem(AMSG_INSTANT_CHAT_STAGED_NOTICES_LS_KEY);
+  localStorage.removeItem(AMSG_OUTBOX_ADOPTED_LS_KEY);
   storeState.inbox = [];
   storeState.saved = [];
   storeState.markedNotices = [];
@@ -721,6 +723,12 @@ describe('推送丢了的补收（服务端账本）', () => {
     vi.spyOn(ActiveMsgClient, 'listOutboxEntries').mockResolvedValue(entries as any);
   };
 
+  // 这一组测的都是「已经接上账本之后」的常规补收。首次接管走的是另一条路（存量整批
+  // 销账、不上屏），单独一组在下面。
+  beforeEach(() => {
+    localStorage.setItem(AMSG_OUTBOX_ADOPTED_LS_KEY, JSON.stringify({ at: Date.now() }));
+  });
+
   it('账本上的那条写进收件箱，字段跟 SW 收真推送时写的一份对得上', async () => {
     const messageId = 'msg_task_7@1700000000000_hook_0';
     stubOutbox([entry(messageId, outboxPush(messageId))]);
@@ -820,5 +828,86 @@ describe('推送丢了的补收（服务端账本）', () => {
     expect(inbox.metadata.messageIndex).toBe(1);
     expect(inbox.metadata.totalMessages).toBe(3);
     expect(inbox.metadata.sessionId).toBe('sess_task_7@1700000000000');
+  });
+});
+
+// 账本上躺着的存量 ≠「我丢了的消息」：服务端从建表那一刻起就在记，而销账是客户端这
+// 一版才有的能力。头一趟要是当补收放进聊天流，用户会被这段时间收过的消息整批重放一遍
+// （角色「疯狂回复」，而且删掉重复消息反而会让近史去重失效、下一趟倒得更凶）。时效
+// 窗口挡不住这一档——存量的年龄本来就在窗口之内，「昨晚更新 worker、今天升级前端」
+// 就是最典型的那条时间线。
+describe('第一次接上服务端账本', () => {
+  const entry = (messageId: string, taskUuid: string) => ({
+    id: 1,
+    messageId,
+    taskUuid,
+    sessionId: 'sess-x',
+    messageIndex: 1,
+    totalMessages: 1,
+    createdAt: Date.now(),
+    deliveredAt: null,
+    push: {
+      messageKind: 'content',
+      message: '这是账本上的存量',
+      messageId,
+      taskUuid,
+      metadata: { charId: CHAR.id, charName: '小满' },
+    },
+  });
+
+  const stubOutboxOnce = (entries: any[]) =>
+    vi.spyOn(ActiveMsgClient, 'listOutboxEntries').mockResolvedValue(entries as any);
+
+  it('存量整批销账，一条都不进聊天流', async () => {
+    stubOutboxOnce([entry('m1', 'uuid-1'), entry('m2', 'uuid-2')]);
+    const ack = vi.spyOn(ActiveMsgClient, 'ackOutboxMessages').mockResolvedValue(undefined);
+
+    const { written, ackNow } = await drainOutbox();
+
+    expect(written).toBe(0);
+    expect(storeState.saved).toHaveLength(0);
+    expect(ack).toHaveBeenCalledWith(['m1', 'm2']);
+    expect(ackNow).toEqual([]);      // 已经在接管里销掉了，不用调用方再销一次
+    expect(localStorage.getItem(AMSG_OUTBOX_ADOPTED_LS_KEY)).toBeTruthy();
+  });
+
+  // 接管那一趟恰好赶上用户发消息时，这一轮的回复不能被当存量销掉——否则他等来的是
+  // 一句「云端已处理，但回复没能取回」。
+  it('此刻正等着的那一轮不算存量，照常补收上屏', async () => {
+    setInstantChatPending(CHAR.id, 'uuid-awaited');
+    stubOutboxOnce([entry('m-old', 'uuid-old'), entry('m-awaited', 'uuid-awaited')]);
+    const ack = vi.spyOn(ActiveMsgClient, 'ackOutboxMessages').mockResolvedValue(undefined);
+
+    const { written } = await drainOutbox();
+
+    expect(written).toBe(1);
+    expect(storeState.saved.map((m: any) => m.messageId)).toEqual(['m-awaited']);
+    expect(ack).toHaveBeenCalledWith(['m-old']);
+  });
+
+  // 先记标记再销账的话，销账一失败，剩下的存量下一趟就会被当成补收倒进聊天流。
+  it('存量没销干净 → 不记标记，下一趟重新接管', async () => {
+    stubOutboxOnce([entry('m1', 'uuid-1')]);
+    vi.spyOn(ActiveMsgClient, 'ackOutboxMessages').mockRejectedValue(new Error('worker 没应答'));
+
+    const { written, ackNow } = await drainOutbox();
+
+    expect(written).toBe(0);
+    expect(storeState.saved).toHaveLength(0);
+    expect(ackNow).toEqual([]);
+    expect(localStorage.getItem(AMSG_OUTBOX_ADOPTED_LS_KEY)).toBeNull();
+  });
+
+  it('接管过一次之后，账本上的新条目照常补收', async () => {
+    const list = stubOutboxOnce([entry('m-backlog', 'uuid-old')]);
+    vi.spyOn(ActiveMsgClient, 'ackOutboxMessages').mockResolvedValue(undefined);
+    await drainOutbox();
+    expect(storeState.saved).toHaveLength(0);
+
+    list.mockResolvedValue([entry('m-new', 'uuid-new')] as any);
+    const { written } = await drainOutbox();
+
+    expect(written).toBe(1);
+    expect(storeState.saved.map((m: any) => m.messageId)).toEqual(['m-new']);
   });
 });

--- a/utils/amsgInstantChat.ts
+++ b/utils/amsgInstantChat.ts
@@ -441,21 +441,76 @@ export interface OutboxDrainResult {
 }
 
 /**
- * 拉一次服务端消息账本，把还没收下的写回收件箱走原路入库。
+ * 「这台设备已经接上服务端账本」的标记。
  *
- * 跟以前那套「本地比对着猜哪些没收到」的关键差别：**账本是服务端记的事实**，
- * 客户端不再需要拿最近几条聊天记录去反推。读失败照常抛——「没读成」和「读到了、
- * 里面确实没有」是两个结论，调用方要拿它下判决时只能认后者。
+ * 账本是服务端从建表那一刻起就在攒的，而销账是客户端这一版才有的能力。所以**第一次**
+ * 拉账本时上面躺着的并不是「我丢了的消息」，而是这套机制生效之前积累下来的存量——
+ * 当成补收放进聊天流的话，用户会被自己这段时间收过的消息重放一遍（定时问候、多段
+ * 回复全部再来一次）。时效窗口挡不住这一档：存量的年龄本来就在窗口之内。
+ *
+ * 所以首次接管那一趟只做一件事：**存量整批销账，一条都不往聊天流里放**。销干净了才
+ * 记这个标记，下一趟起才按正常补收处理。
+ */
+export const AMSG_OUTBOX_ADOPTED_LS_KEY = 'amsg2_outbox_adopted_v1';
+
+const hasAdoptedOutbox = (): boolean => {
+  try {
+    return !!localStorage.getItem(AMSG_OUTBOX_ADOPTED_LS_KEY);
+  } catch {
+    // 存储读不出来（隐私模式 / 存储关停）时按**已接管**处理：这一档下标记永远也写不
+    // 进去，当成未接管的话每一趟都会把当趟条目整批销掉，补收就永久失效了——推送真丢
+    // 的时候一条都补不回来，比偶尔多倒一次存量严重得多。
+    return true;
+  }
+};
+
+const markOutboxAdopted = (): void => {
+  try {
+    localStorage.setItem(AMSG_OUTBOX_ADOPTED_LS_KEY, JSON.stringify({ at: Date.now() }));
+  } catch { /* 写不进去就下次再接管一遍，反正存量已经销掉了 */ }
+};
+
+/**
+ * 首次接管：账本上的存量整批销账、不进聊天流。
+ *
+ * 唯一的例外是用户**此刻正等着的那几轮**（taskUuid 跟待收记录对得上）：那是刚刚发生
+ * 的事，不是历史积压，照常走补收放进聊天流——否则第一次接管恰好赶上用户发消息时，
+ * 那一轮的回复会被当存量销掉，用户等来的是一句「回复没能取回」。
+ *
+ * 销账成功才记标记。没销干净就这一趟什么都不做、也不记标记：没销掉的条目下次还会
+ * 拉回来，那时仍按接管处理。反过来（先记标记再销账）一旦销账失败，剩下的存量下一趟
+ * 就会被当成补收倒进聊天流，正是这里要防的那件事。
+ */
+const adoptOutboxBacklog = async (entries: AmsgOutboxEntry[]): Promise<OutboxDrainResult> => {
+  const awaitedUuids = new Set(listInstantChatPendings().map((pending) => pending.uuid));
+  const isAwaited = (entry: AmsgOutboxEntry) => !!entry.taskUuid && awaitedUuids.has(entry.taskUuid);
+  const backlogIds = entries.filter((entry) => !isAwaited(entry)).map((entry) => entry.messageId);
+
+  if (backlogIds.length > 0) {
+    try {
+      await ActiveMsgClient.ackOutboxMessages(backlogIds);
+    } catch (error) {
+      console.warn(`${HEADER} 账本存量没销干净，这一趟先不接管（下次重来）`, error);
+      return { written: 0, ackNow: [], entries };
+    }
+  }
+  markOutboxAdopted();
+  console.log(`${HEADER} 第一次接上云端账本：存量 ${backlogIds.length} 条直接销账，不往聊天流里放`);
+
+  const { written, ackNow } = await backfillOutboxEntries(entries.filter(isAwaited));
+  return { written, ackNow, entries };
+};
+
+/**
+ * 把账本条目写回收件箱走原路入库。
  *
  * 只有正文类（`content` 与情绪结果）才往收件箱里放。思维链、工具请求、错误通知
  * 这几类补收回来已经没有意义：思维链要挂在正文上、工具请求那头的云端早就收工了、
  * 隔了一阵子的报错弹出来只会让人摸不着头脑。它们照样要销账，不然每次拉都拉回来。
- *
- * 调用方拿到 written > 0 之后要自己 flush 一次收件箱（见文件头注：不在这里 flush
- * 是为了避免和 activeMsgRuntime 成环）。
  */
-export const drainOutbox = async (): Promise<OutboxDrainResult> => {
-  const entries = await ActiveMsgClient.listOutboxEntries();
+const backfillOutboxEntries = async (
+  entries: AmsgOutboxEntry[],
+): Promise<Omit<OutboxDrainResult, 'entries'>> => {
   const now = Date.now();
   const ackNow: string[] = [];
   let written = 0;
@@ -490,6 +545,26 @@ export const drainOutbox = async (): Promise<OutboxDrainResult> => {
   }
 
   if (written > 0) console.log(`${HEADER} 从云端账本补收 ${written} 条（推送多半是丢了）`);
+  return { written, ackNow };
+};
+
+/**
+ * 拉一次服务端消息账本，把还没收下的写回收件箱走原路入库。
+ *
+ * 跟以前那套「本地比对着猜哪些没收到」的关键差别：**账本是服务端记的事实**，
+ * 客户端不再需要拿最近几条聊天记录去反推。读失败照常抛——「没读成」和「读到了、
+ * 里面确实没有」是两个结论，调用方要拿它下判决时只能认后者。
+ *
+ * 头一次拉走的是另一条路（见 adoptOutboxBacklog）：那一趟账本上装的是存量，不是
+ * 「我丢了的消息」。
+ *
+ * 调用方拿到 written > 0 之后要自己 flush 一次收件箱（见文件头注：不在这里 flush
+ * 是为了避免和 activeMsgRuntime 成环）。
+ */
+export const drainOutbox = async (): Promise<OutboxDrainResult> => {
+  const entries = await ActiveMsgClient.listOutboxEntries();
+  if (!hasAdoptedOutbox()) return await adoptOutboxBacklog(entries);
+  const { written, ackNow } = await backfillOutboxEntries(entries);
   return { written, ackNow, entries };
 };
 

--- a/utils/iosStandalone.keyboard.test.ts
+++ b/utils/iosStandalone.keyboard.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="vitest" />
+/**
+ * utils/iosStandalone.keyboard.test.ts — 键盘态布局的回归守卫。
+ *
+ * 背景：iOS 全屏 PWA 下 body 高度会比可视区多出一段底部安全区（给 home 条留位），
+ * `.ios-keyboard-open` 一挂，外壳就铺到那段溢出区、聊天输入栏同时收掉自己的让位间隙。
+ * 两个动作合起来净位移为 0，前提是「标记挂上」和「app 高度收到键盘上方」同时发生。
+ * 只要有一边先动，输入条就整条沉出屏幕、home 条骑到输入框上。
+ *
+ * 这里钉住的不变式：键盘态只认 visualViewport 真的变矮，不认焦点事件。
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const SCREEN_H = 852; // 竖屏可视高度
+const SAFE_BOTTOM = 34; // home 条安全区
+const SAFE_TOP = 44;
+const KEYBOARD_H = 336;
+
+type Listener = () => void;
+let vvListeners: Record<string, Listener[]>;
+let visualViewport: { height: number; offsetTop: number; addEventListener: (t: string, fn: Listener) => void; removeEventListener: () => void };
+
+const setupIOSStandalone = () => {
+    vvListeners = { resize: [], scroll: [] };
+    visualViewport = {
+        height: SCREEN_H,
+        offsetTop: 0,
+        addEventListener: (type: string, fn: Listener) => { (vvListeners[type] ||= []).push(fn); },
+        removeEventListener: () => {},
+    };
+    Object.defineProperty(window, 'visualViewport', { value: visualViewport, configurable: true, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: SCREEN_H, configurable: true, writable: true });
+    Object.defineProperty(navigator, 'userAgent', {
+        value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15',
+        configurable: true,
+    });
+    window.matchMedia = ((query: string) => ({
+        matches: query.includes('standalone'),
+        media: query,
+        onchange: null,
+        addListener: () => {}, removeListener: () => {},
+        addEventListener: () => {}, removeEventListener: () => {},
+        dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    window.scrollTo = vi.fn() as typeof window.scrollTo;
+
+    // jsdom 不认 env()，安全区探针会读到 0，那段 34px 溢出区就不存在、用例也就测不到错位。
+    // 认出探针（fixed + hidden 的临时 div）后返回真机数值，其余元素照常走 jsdom。
+    const realGetComputedStyle = window.getComputedStyle.bind(window);
+    vi.spyOn(window, 'getComputedStyle').mockImplementation(((el: Element, pseudo?: string | null) => {
+        const style = (el as HTMLElement).style;
+        if (style?.position === 'fixed' && style?.visibility === 'hidden') {
+            return { paddingTop: `${SAFE_TOP}px`, paddingBottom: `${SAFE_BOTTOM}px` } as CSSStyleDeclaration;
+        }
+        return realGetComputedStyle(el as Element, pseudo as string | undefined);
+    }) as typeof window.getComputedStyle);
+};
+
+/** 重新加载模块再装载，绕开「只装一次」的单例标志，顺带清掉基线高度等模块级状态。 */
+const install = async () => {
+    vi.resetModules();
+    const mod = await import('./iosStandalone');
+    mod.installIOSStandaloneWorkaround();
+    return mod;
+};
+
+const emitViewportResize = (height: number) => {
+    visualViewport.height = height;
+    vvListeners.resize.forEach(fn => fn());
+};
+
+const focusTextarea = () => {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+    return textarea;
+};
+
+const appHeight = () => document.documentElement.style.getPropertyValue('--app-height');
+const inKeyboardMode = () => document.body.classList.contains('ios-keyboard-open');
+
+describe('iOS 全屏 PWA 键盘态', () => {
+    beforeEach(() => {
+        document.body.className = '';
+        document.body.innerHTML = '';
+        document.documentElement.removeAttribute('style');
+        setupIOSStandalone();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('无键盘时 app 高度 = 可视高度 + 底部安全区（那段溢出区留给 home 条）', async () => {
+        await install();
+        expect(appHeight()).toBe(`${SCREEN_H + SAFE_BOTTOM}px`);
+        expect(inKeyboardMode()).toBe(false);
+    });
+
+    // 回归守卫：输入框拿到焦点不等于键盘弹出来了。设备上键盘弹不出来时（外接键盘、输入法异常），
+    // 旧实现照样挂标记，外壳铺到那 34px 溢出区、输入栏又收掉让位间隙，输入条整条沉出屏幕。
+    it('焦点进来但可视区没变矮 → 不进键盘态，高度不动', async () => {
+        await install();
+        focusTextarea();
+
+        expect(inKeyboardMode()).toBe(false);
+        expect(appHeight()).toBe(`${SCREEN_H + SAFE_BOTTOM}px`);
+    });
+
+    it('可视区真的变矮 → 标记和高度一起进键盘态', async () => {
+        await install();
+        focusTextarea();
+        emitViewportResize(SCREEN_H - KEYBOARD_H);
+
+        expect(inKeyboardMode()).toBe(true);
+        expect(appHeight()).toBe(`${SCREEN_H - KEYBOARD_H}px`);
+    });
+
+    // 回归守卫：聚焦中的输入框被 React 卸载时（退出聊天页），WebKit 不派发 focusout。
+    // 旧实现只有 focusout 能摘标记，于是标记永久卡在 body 上，全局界面底部一直错位。
+    it('输入框被直接移除、没有 focusout → 键盘收起后标记不残留', async () => {
+        await install();
+        const textarea = focusTextarea();
+        emitViewportResize(SCREEN_H - KEYBOARD_H);
+        expect(inKeyboardMode()).toBe(true);
+
+        textarea.remove();
+        emitViewportResize(SCREEN_H);
+
+        expect(inKeyboardMode()).toBe(false);
+        expect(appHeight()).toBe(`${SCREEN_H + SAFE_BOTTOM}px`);
+    });
+
+    it('键盘动画期可视高度报脏值 → 退化成无键盘态，不把布局撑崩', async () => {
+        await install();
+        focusTextarea();
+        emitViewportResize(80);
+
+        expect(inKeyboardMode()).toBe(false);
+        expect(appHeight()).toBe(`${SCREEN_H + SAFE_BOTTOM}px`);
+    });
+});

--- a/utils/iosStandalone.ts
+++ b/utils/iosStandalone.ts
@@ -1,5 +1,8 @@
 let hasInstalledIOSStandaloneWorkaround = false;
 let stableStandaloneHeight = 0;
+// 这台设备要不要做键盘避让（iOS 全屏 PWA / 安卓浏览器）。装载时定下，
+// setViewportVars 靠它决定要不要碰 body 上的键盘态标记——普通桌面浏览器一律不碰。
+let keyboardFixesEnabled = false;
 // 安全区只在旋转 / 窗口尺寸变化时才变，缓存探测结果，避免 visualViewport 滚动、聚焦时反复同步重排。
 // 上下各自独立缓存：某边读到非 0 才锁定；iOS 启动早期某边可能瞬时为 0，此时该边不锁、下次继续探测，
 // 避免「一边真值、一边瞬时 0」被整体锁死（否则 home 条避让会失效，直到旋转/尺寸变化才恢复）。
@@ -103,6 +106,7 @@ const setViewportVars = () => {
 
     let fullAppHeight: number;
     let keyboardInset: number;
+    let keyboardOpen: boolean;
 
     if (shouldStabilizeHeight) {
         // 全屏 PWA 没有地址栏，可视高度只在软键盘弹出时变矮。基线取「见过的最大可视高度」。
@@ -112,7 +116,7 @@ const setViewportVars = () => {
         // 键盘态判据用「可视高度变矮」而非 obscuredHeight：iOS 26 起 standalone 会把 layout viewport 也一起缩，
         // innerHeight 跟着变矮，obscuredHeight 算出来是 0 而失效。viewportHeight > 150 是对 iOS 偶发脏值的护栏——
         // 键盘动画期 visualViewport 偶尔报错值，此时退化成「无键盘态」，宁可不避让也不要把布局撑崩成满屏白。
-        const keyboardOpen = viewportHeight > 150 && viewportHeight < stableStandaloneHeight - 100;
+        keyboardOpen = viewportHeight > 150 && viewportHeight < stableStandaloneHeight - 100;
         // 键盘态：app 高度收到当前可视区（home 条已被键盘盖，不再叠加 safe）；无键盘态：基线 + safe（底部给 home 条留位）。
         fullAppHeight = keyboardOpen ? viewportHeight : stableStandaloneHeight + bottomSafeInset;
         // standalone 下键盘避让改由「app 高度跟随可视区」统一处理，keyboard-inset 置 0，避免 CallApp 等再叠一层 padding。
@@ -128,7 +132,7 @@ const setViewportVars = () => {
         // innerHeight 会跟着缩，obscuredHeight ≈ 0（走无键盘分支，布局自行回流，什么都不用做）；
         // 若不回流而是缩小可视区/顶起整页，obscuredHeight > 120，进入键盘分支统一避让。
         const obscuredHeight = Math.max(0, innerHeight - viewportHeight - viewportOffsetTop);
-        const keyboardOpen = obscuredHeight > 120;
+        keyboardOpen = obscuredHeight > 120;
         // 键盘避让统一用「app 高度跟随可视区」，不再靠 keyboard-inset 让各 App 自己叠 padding。
         keyboardInset = 0;
         if (keyboardOpen) {
@@ -140,6 +144,16 @@ const setViewportVars = () => {
         } else {
             fullAppHeight = Math.max(innerHeight, viewportHeight + viewportOffsetTop);
         }
+    }
+
+    // 键盘态标记和 --app-height 必须同源：标记一挂，外壳就铺到 app 高度多出的那段底部安全区、
+    // 输入栏同时收掉自己的让位间隙，两者净位移为 0 —— 前提是高度也同时收到键盘上方。
+    // 所以判据只认「可视区真的变矮了」，不认「输入框拿到了焦点」：设备上键盘弹不出来时
+    // （接了外接键盘、输入法异常），焦点照样进得来，但可视区纹丝不动，此时挂标记就会把
+    // 输入条整条推出屏幕、home 条骑到输入框上。顺带这样也不再依赖 focusout 来摘标记——
+    // 聚焦中的输入框被直接卸载（退出聊天页）时 WebKit 不派发 focusout，标记会永久卡住。
+    if (keyboardFixesEnabled) {
+        document.body.classList.toggle('ios-keyboard-open', keyboardOpen);
     }
 
     document.documentElement.style.setProperty('--app-height', `${fullAppHeight}px`);
@@ -155,9 +169,10 @@ export const installIOSStandaloneWorkaround = () => {
 
     hasInstalledIOSStandaloneWorkaround = true;
     const useStandaloneFixes = isIOSStandaloneWebApp();
-    // iOS 全屏 PWA 与安卓浏览器都需要「聚焦挂 keyboard 类 + 锁外层滚动」这套键盘避让。
+    // iOS 全屏 PWA 与安卓浏览器都需要这套键盘避让：可视区一变矮就挂 keyboard 类 + 锁外层滚动。
     // 安卓 Chrome/Edge 弹键盘时会把整页顶起，同样靠这套压回去。
     const useKeyboardFixes = useStandaloneFixes || isAndroidDevice();
+    keyboardFixesEnabled = useKeyboardFixes;
     if (useStandaloneFixes) {
         document.documentElement.classList.add('ios-standalone');
         document.body.classList.add('ios-standalone');
@@ -174,9 +189,10 @@ export const installIOSStandaloneWorkaround = () => {
         setViewportVars();
     };
 
+    // 聚焦只当「立刻重算一次」的时机，不直接判键盘态：此刻键盘还没弹起来，
+    // 要等 visualViewport 真的变矮，setViewportVars 才会挂上标记、同时把高度收到键盘上方。
     const handleFocusIn = (event: FocusEvent) => {
         if (!isTextEntryElement(event.target)) return;
-        document.body.classList.add('ios-keyboard-open');
         setViewportVars();
 
         const target = event.target;
@@ -192,13 +208,10 @@ export const installIOSStandaloneWorkaround = () => {
         });
     };
 
+    // 键盘收起由 visualViewport 变化驱动，这里只做一次兜底重算，
+    // 防 iOS 偶发漏发 resize 让高度停在键盘态。
     const handleFocusOut = () => {
-        window.setTimeout(() => {
-            if (!isTextEntryElement(document.activeElement)) {
-                document.body.classList.remove('ios-keyboard-open');
-            }
-            setViewportVars();
-        }, 180);
+        window.setTimeout(setViewportVars, 180);
     };
 
     // 键盘弹出时锁死外层滚动：只放行可滚区（消息列表等 .overflow-y-auto）内部滚动，其余 touchmove 一律拦掉。


### PR DESCRIPTION
## 这次修什么

上线补收之后，有用户反馈「角色开始疯狂重复昨晚到刚刚的所有消息，删都删不过来」。

原因是**服务端账本上躺着的存量被当成了「我丢了的消息」**。账本从建表那一刻起就在记行，而销账是补收这一版才有的能力——所以客户端第一次拉账本时，上面装的是这套机制生效之前积累的存量，用户当时其实都收到过。头一趟把它们全补了回来，角色于是把这段时间的消息重放一遍。

原有的 24 小时时效窗口挡不住这一档：存量的年龄本来就在窗口之内（「昨晚更新 Worker 建表、今天升级前端」是最典型的一条时间线）。而用户删掉重复消息，恰好把落库去重仅有的依据（近史里那条消息的身份）也删了，下一趟倒得更凶。

## 改后是怎样

| | 改前 | 改后 |
|---|---|---|
| 第一次接上账本 | 24 小时内的条目全部当补收放进聊天流 | 存量整批销账，一条都不上屏 |
| 正等着的那一轮 | 混在存量里 | 认 `taskUuid`，照常补收上屏 |
| 销账失败 | 标记照记，剩下的存量下一趟当补收倒出来 | 不记标记，下一趟重新接管 |
| 销账分批 | 一批挂，后面几批全不销（跟注释写的正相反） | 一批挂不拦着后面几批 |

**已经中招的用户不用做任何操作**：这一版上线后第一趟就会把账本上剩下的存量销掉，自动收敛。已经被重放进聊天记录的那些还得自己清。

## 部署

纯前端改动，**不需要更新 Worker**。

## 测试

`utils/amsgInstantChat.test.ts` 加了一组回归守卫（存量不上屏 / 正等着的那轮不算存量 / 销账失败不记标记 / 接管过一次之后照常补收）。把接管逻辑短路掉验证过：四条全挂，修好后全过。相关 6 个套件 342 个测试通过。

## 顺带

分支上还压着一个先前的 `fix(ios): 键盘弹不出来时，聊天输入条不再沉出屏幕`，一并过来。

https://claude.ai/code/session_01GjQcwbeo6eD34jxTR8C5ts