### PR TITLE
主动消息：推送被退回时不再空转重试，体检也能看见它了

### DIFF
--- a/components/settings/ActiveMsgGlobalSettingsModal.tsx
+++ b/components/settings/ActiveMsgGlobalSettingsModal.tsx
@@ -91,8 +91,14 @@ const REQUIRED_WORKER_FEATURES = [
 //   next.17 — 用户级 LLM 凭据表（PUT/GET/DELETE /llm-credentials）、任务的 credRefs、
 //            fire hook 的 resolveLlmCredential。这一档有独立 flag（上面那条
 //            'llm-credentials'），版本号列在这里只是备个案。
+//   next.20 — 推送被推送服务判死（410 / 404）时当终态，不再空转重试——投递是先生成
+//            后推送，每重试一跳就白跑一整轮 LLM；同时把状态码结构化写进 last_error
+//            的 pushStatus，体检的「这台设备」靠它拆穿「登记全绿但一条都不来」。
+//            另外 client_state 的前缀清理改走字典序范围：D1 把 LIKE pattern 压到
+//            50 字节（官方文档没写），key 一长就整条语句报 pattern too complex，
+//            同批的状态写入跟着一起回滚。
 // 不比版本的话，旧粘贴部署会被误判为最新，问题全在 worker 侧静默发生。
-const REQUIRED_WORKER_VERSION = '2.6.0-next.19';
+const REQUIRED_WORKER_VERSION = '2.6.0-next.20';
 
 /** 装着打包好的 worker 代码的部署仓库：fork 它 → 在 Cloudflare 连上 → 以后点 Sync fork 更新。 */
 const WORKERS_REPO_URL = 'https://github.com/Tosd0/sullyos-workers';

--- a/components/settings/PushSubscriptionPanel.tsx
+++ b/components/settings/PushSubscriptionPanel.tsx
@@ -13,10 +13,15 @@ import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActiveMsgClient,
   compareRemotePushSubscription,
+  fetchWorkerDiagnostics,
   readAmsgFailKind,
   type AmsgPushRegistrationState,
   type AmsgRemotePushSubscription,
 } from '../../utils/activeMsgClient';
+import {
+  judgePushDeliveryFailure,
+  type AmsgPushDeliveryProbe,
+} from '../../utils/amsgDiagnostics';
 import { readBrowserPushState, type BrowserPushState } from '../../utils/pushSubscribeShared';
 import {
   describeElapsed,
@@ -56,6 +61,9 @@ const REGISTRATION_TEXT: Record<AmsgPushRegistrationState, { value: string; bad:
 const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast }) => {
   const [browser, setBrowser] = useState<BrowserPushState | null>(null);
   const [remote, setRemote] = useState<AmsgRemotePushSubscription | null>(null);
+  // 「登记的确实是这台设备，但推送根本送不到」——只有 Worker 那侧的投递结果知道这件事。
+  // null = 还没问到（没填 Worker / 连不上），那时这一行照实说「没查到」。
+  const [delivery, setDelivery] = useState<AmsgPushDeliveryProbe | null>(null);
   const [workerConfigured, setWorkerConfigured] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [resetting, setResetting] = useState(false);
@@ -72,6 +80,10 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
       const configured = Boolean(config?.workerUrl?.trim());
       setWorkerConfigured(configured);
       setRemote(configured ? await ActiveMsgClient.getRemotePushSubscription() : null);
+      // 「推送有没有真的送出去」是 Worker 那侧算好的（见 /debug 的 pushDelivery）。
+      // 这一行和体检面板读的是同一份，不会一个说红一个说绿。
+      const probe = configured ? await fetchWorkerDiagnostics() : null;
+      setDelivery(probe?.reachable ? probe.report.storage.pushDelivery ?? null : null);
     } finally {
       setRefreshing(false);
     }
@@ -119,6 +131,18 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
     : 'worker-unset';
   const registrationText = REGISTRATION_TEXT[registration];
 
+  // 上一次推送到底送没送到。判定跟体检面板共用 judgePushDeliveryFailure——两处各写一套的话，
+  // 用户会看到一个红一个绿，而这正是他判断该不该重置订阅的唯一依据。
+  const deliveryVerdict = judgePushDeliveryFailure(delivery);
+  const deliveryText: { value: string; bad: boolean } = !workerConfigured || !delivery
+    ? { value: '没查到（要先连上 Worker）', bad: false }
+    : !delivery.probed
+      ? { value: delivery.reason === 'unsupported' ? '这台 Worker 还不查' : '没查成', bad: false }
+      : delivery.gone && deliveryVerdict
+        ? { value: `被推送服务退回（${delivery.gone.status}）`, bad: true }
+        // 有旧账但已经不算数了：说清楚「那是上一条订阅的事」，别让人以为从来没坏过。
+        : { value: delivery.gone ? '这条订阅登记之后没被退回过' : '没有被退回的记录', bad: false };
+
   const resetLabel = resetting
     ? (deepMode ? '深度重置中…' : '重置中…')
     : (deepMode ? '深度重置' : '重置订阅');
@@ -145,6 +169,11 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
                 // 「接口全在但这台设备就是建不出订阅」的唯一可见出口。取的是共用层那个
                 // 固定枚举，不含报错原文。
                 lastFailure: liveFailureKind(browser) ?? 'none',
+                // 「登记全对但推送被退回」有多普遍。四个取值全是这儿写死的字面量，
+                // 不带状态码原文、不带端点、不带失败原因。
+                delivery: !delivery || !delivery.probed ? 'unknown'
+                  : delivery.gone && deliveryVerdict ? 'gone'
+                    : delivery.gone ? 'recovered' : 'clean',
               } : undefined);
               void refresh();
             }}
@@ -167,6 +196,9 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
             />
             <Row label="推送通道" value={browser.channel} />
             <Row label="云端登记" value={registrationText.value} bad={registrationText.bad} />
+            {/* 上面每一行答的都是「配好了吗」，这一行答的是「实际推出去了吗」。前面全绿
+                后面照样能红——那正是「任务建得成、到点没消息」最难自己发现的一种坏法。 */}
+            <Row label="上次投递" value={deliveryText.value} bad={deliveryText.bad} />
 
             {browser.endpoint && (
               <div className="pt-2 mt-2 border-t border-slate-200">
@@ -207,6 +239,25 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
                 这个域名全球都不会解析，推送发过去必然失败。点下面的「重置订阅」重建一条就行。
               </div>
             )}
+            {deliveryVerdict?.level === 'bad' && (
+              <div className={`mt-2 p-2 border rounded-lg text-[10px] leading-relaxed ${
+                deliveryVerdict.level === 'bad'
+                  ? 'bg-rose-50 border-rose-200 text-rose-700'
+                  : 'bg-amber-50 border-amber-200 text-amber-700'
+              }`}>
+                <p className="font-semibold mb-1">推送被退回了</p>
+                <p>{deliveryVerdict.what}。</p>
+                {/* 这段解释只在坐实了的时候说：warn 那档是 Worker 问不到，上面几行本来
+                    就红着，再说一句「上面都没问题」只会自相矛盾。 */}
+                {deliveryVerdict.level === 'bad' && (
+                  <p className="mt-1.5 pt-1.5 border-t border-current/20">
+                    上面每一行<b>都没问题</b>，坏的是那条订阅本身——它在推送服务
+                    （Chrome 走 FCM、Firefox 走 Mozilla、iOS 走 Apple）那侧已经作废了，
+                    这件事只有推送服务知道，前面几行谁都查不出来。点下面的「重置订阅」换一条新的。
+                  </p>
+                )}
+              </div>
+            )}
             {registration === 'other-endpoint' && (
               <div className="mt-2 p-2 bg-rose-50 border border-rose-200 rounded-lg text-[10px] text-rose-700 leading-relaxed">
                 Worker 上登记的订阅不是这台设备——主动消息到点会推到<b>别处</b>，这台收不到。
@@ -244,7 +295,7 @@ const PushSubscriptionPanel: React.FC<PushSubscriptionPanelProps> = ({ addToast 
           className={`mt-4 w-full py-2 rounded-xl text-xs font-bold border ${
             resetting || refreshing || browser?.capacitorNative
               ? 'bg-slate-100 text-slate-400 border-slate-200'
-              : deepMode || browser?.endpointDead || registrationText.bad
+              : deepMode || browser?.endpointDead || registrationText.bad || deliveryText.bad
                 ? 'bg-rose-500 text-white border-rose-500 hover:bg-rose-600'
                 : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'
           }`}

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -1053,6 +1053,10 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                       ? resource.href
                       : String(resource);
           const fetchStartedAt = Date.now();
+          // 失败诊断要按发起时刻去 Resource Timing 里认领本次那条记录，而 entry.startTime 跟
+          // performance.now() 同一条时间轴、跟 Date.now() 不是——两者不能混用，详见
+          // utils/networkFailureDiagnosis.ts 的 readResourceTimingHint。
+          const fetchStartedAtPerf = typeof performance !== 'undefined' ? performance.now() : Number.NaN;
           // Bare fetch calls do not carry explicit metadata. Snapshot the active
           // App now; reading the ambient value after a long response would label
           // the request as whichever App the user navigated to in the meantime.
@@ -1225,7 +1229,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                       method,
                       durationMs: Date.now() - fetchStartedAt,
                       error: err,
-                  });
+                  }, { startedAt: fetchStartedAtPerf });
                   setSystemLogs(prev => [{
                       id: logId,
                       timestamp: Date.now(),

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -604,9 +604,15 @@ push endpoint）留在 toast 和 console 里，一个字都不进上报。
 `none` / `other`）、`platform`（`normal` / `ios_needs_pwa` / `capacitor_native`）、
 `registration`（`worker-unset` / `unreachable` / `missing` / `other-endpoint` / `matched`）、
 `lastFailure`（`none` / `channel-unreachable` / `unsupported` / `permission` / `state` /
-`zombie` / `unknown`）。
+`zombie` / `unknown`）、`delivery`（`clean` / `gone` / `recovered` / `unknown`）。
 `registration` 是「worker 上登记的订阅是不是这台设备」，中间那两档对应的是任务建得成、
 到点却一条都不来的静默失联。
+`delivery` 是上一次推送有没有被推送服务退回，结论由 Worker 那侧算好（`/debug` 的
+`pushDelivery`）。`gone` 指现在这条订阅在推送服务那侧已经作废（登记状态可能全对，推过去
+只换回一个 410），`recovered` 指出过这事但之后订阅换过一条了，`unknown` 是没问到——
+没连上 Worker、这台 Worker 上跑的后端还不查这一项、或者它查了没查成，三种都归这一格。
+`gone` 那一格量大说明「全绿但一条不来」正在成批发生；`unknown` 常年居高则说明大批用户
+的 Worker 还停在老版本上。
 `lastFailure` 是最近一次建订阅失败卡在哪类，手上已有活订阅时报 `none`。
 `channel-unreachable` 那一格量大就说明有一批设备（多半是没装谷歌服务的国行安卓机）
 从系统层面就用不了网页推送——这是它唯一能被看见的地方。

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^6.0.0",
-    "@rei-standard/amsg-server": "2.6.0-next.19",
+    "@rei-standard/amsg-server": "2.6.0-next.20",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.1
       '@rei-standard/amsg-server':
-        specifier: 2.6.0-next.19
-        version: 2.6.0-next.19
+        specifier: 2.6.0-next.20
+        version: 2.6.0-next.20
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -858,8 +858,8 @@ packages:
     resolution: {integrity: sha512-GsLzRvSXsp5cbJ/vNwQP+yHoZ4LJiilOvws0LemrzaFoG45ApQ7WW3YHux58DXdXOSN36prT5CsmipA3wUAmQQ==}
     engines: {node: '>=18'}
 
-  '@rei-standard/amsg-server@2.6.0-next.19':
-    resolution: {integrity: sha512-Iq0gGmnLs14N0qv8MSFJuSyBiGoAZQoWGYTLfrFnb7FAiIoPlWVb8JGl2RHcYhBP1B8jXBthJis2uuA9zjaQWg==}
+  '@rei-standard/amsg-server@2.6.0-next.20':
+    resolution: {integrity: sha512-jK9zttm0nRh55S7yQpBrOvm7Z22XDtWSbfQIdgQaaKvu2gT2si+BkjZlIetct0f3z3xr4GyM7hmeS0ygKg8gWA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@neondatabase/serverless': '>=0.9.0'
@@ -2727,7 +2727,7 @@ snapshots:
     dependencies:
       '@rei-standard/amsg-shared': 0.2.0
 
-  '@rei-standard/amsg-server@2.6.0-next.19':
+  '@rei-standard/amsg-server@2.6.0-next.20':
     dependencies:
       '@netlify/blobs': 8.2.0
       '@rei-standard/amsg-shared': 0.4.0-next.5

--- a/utils/amsgDiagnostics.test.ts
+++ b/utils/amsgDiagnostics.test.ts
@@ -39,6 +39,7 @@ const healthyReport = (patch: Partial<AmsgDebugReport> = {}): AmsgDebugReport =>
     missingTables: [],
     missingColumns: [],
     pushSubscriptionRegistered: true,
+    pushDelivery: { probed: true, gone: null, registeredAtMs: Date.parse('2026-08-10T04:00:00.000Z') },
     pendingTasks: 2,
     overdueTasks: 0,
     oldestOverdueMinutes: null,
@@ -144,6 +145,35 @@ describe('parseAmsgDebugReport — 只认形状对得上的回执', () => {
     expect(parseAmsgDebugReport(null)).toBeNull();
     // 有 data 但缺关键字段的，同样不采信。
     expect(parseAmsgDebugReport({ success: true, data: { config: {} } })).toBeNull();
+  });
+
+  // 老 bundle 的回执里压根没有 pushDelivery 这一段。收敛成显式的「没查」而不是让
+  // undefined 一路漏到界面上——判定那侧只要漏写一个 ?. 就又是一个假绿灯。
+  it('缺 pushDelivery 段（老 Worker）收敛成 probed:false / unsupported', () => {
+    const { pushDelivery: _drop, ...storage } = healthyReport().storage;
+    const parsed = parseAmsgDebugReport({ success: true, data: { ...healthyReport(), storage } });
+    expect(parsed?.storage.pushDelivery).toEqual({ probed: false, reason: 'unsupported' });
+  });
+
+  it('worker 显式回 null（自己查不成）收敛成 probed:false / failed', () => {
+    const parsed = parseAmsgDebugReport({
+      success: true,
+      data: healthyReport({ storage: { ...healthyReport().storage, pushDelivery: null as any } }),
+    });
+    expect(parsed?.storage.pushDelivery).toEqual({ probed: false, reason: 'failed' });
+  });
+
+  it('形状不全的 gone（缺状态码或时刻）当没查到，不硬凑成一次失败', () => {
+    const parsed = parseAmsgDebugReport({
+      success: true,
+      data: healthyReport({
+        storage: {
+          ...healthyReport().storage,
+          pushDelivery: { gone: { status: 410 }, registeredAtMs: 1700 } as any,
+        },
+      }),
+    });
+    expect(parsed?.storage.pushDelivery).toEqual({ probed: true, gone: null, registeredAtMs: 1700 });
   });
 
   it('tick 是没见过的值时退回 unknown，不原样透出去', () => {
@@ -424,6 +454,111 @@ describe('buildAmsgDiagnosticRows — 红绿判定', () => {
     expect(rowOf(rows, 'pushDevice').level).toBe('bad');
   });
 
+  // ─── 假绿灯回归守卫 ───
+  // 真实事故：登记状态两边一致（浏览器有订阅、Worker 上也有同一条 endpoint），
+  // 但那条订阅在推送服务那侧早就作废，每次投递换回一个 410。体检当时七项里六项
+  // 绿灯，用户看着一排绿灯完全无从下手。事实一直都在（上游把推送服务回的状态码
+  // 记进了任务的失败记录），只是没人往界面上传。
+  const REGISTERED_AT = Date.parse('2026-08-10T04:00:00.000Z');
+  const stamp = (atMs: number) => new Date(atMs).toISOString();
+  const withDelivery = (pushDelivery: AmsgDebugReport['storage']['pushDelivery']) => healthyReport({
+    storage: { ...healthyReport().storage, pushDelivery },
+  });
+  const goneAt = (at: string, status = 410) => ({
+    probed: true as const,
+    gone: { status, atMs: Date.parse(at) },
+    registeredAtMs: REGISTERED_AT,
+  });
+
+  it('登记状态全对，但上一次推送被判订阅失效 → 这台设备报红并指向「重置订阅」', () => {
+    const rows = buildAmsgDiagnosticRows({
+      probe: { reachable: true, report: withDelivery(goneAt('2026-08-10T05:06:00.000Z')) },
+      localPushSubscribed: true,
+      formatTime: stamp,
+    });
+
+    const device = rowOf(rows, 'pushDevice');
+    expect(device.level).toBe('bad');
+    expect(device.detail).toContain('410');
+    expect(device.detail).toContain('重置订阅');
+    expect(summarizeAmsgDiagnostics(rows)).toBe('bad');
+  });
+
+  it('404（端点根本不存在）同样报红', () => {
+    const rows = buildAmsgDiagnosticRows({
+      probe: { reachable: true, report: withDelivery(goneAt('2026-08-10T05:06:00.000Z', 404)) },
+      localPushSubscribed: true,
+      formatTime: stamp,
+    });
+    expect(rowOf(rows, 'pushDevice').level).toBe('bad');
+  });
+
+  it('失败记录早于订阅登记时刻 = 重置之前的旧账，不报红', () => {
+    // 服务端只在失败时写失败记录、之后成功也不清。不比时刻的话，重置完那条红灯
+    // 会一直挂着——假红灯和假绿灯一样会把人带偏。
+    const rows = buildAmsgDiagnosticRows({
+      probe: { reachable: true, report: withDelivery(goneAt('2026-08-10T03:00:00.000Z')) },
+      localPushSubscribed: true,
+      formatTime: stamp,
+    });
+    expect(rowOf(rows, 'pushDevice').level).toBe('ok');
+  });
+
+  it('问不到订阅登记时刻时报 warn：分不清新旧账，但也不给绿灯', () => {
+    const rows = buildAmsgDiagnosticRows({
+      probe: {
+        reachable: true,
+        report: withDelivery({ ...goneAt('2026-08-10T05:06:00.000Z'), registeredAtMs: null }),
+      },
+      localPushSubscribed: true,
+      formatTime: stamp,
+    });
+    expect(rowOf(rows, 'pushDevice').level).toBe('warn');
+    expect(rowOf(rows, 'pushDevice').detail).toContain('重置订阅');
+  });
+
+  it('Worker 太旧、根本不查这一项 → warn + 指去「更新 Worker」，不给绿灯', () => {
+    // 这一档是升级路上的常态：前端已经会读了，用户那台 Worker 还是老 bundle。
+    // 给绿灯的话，假绿灯就原封不动地回来了。
+    const rows = buildAmsgDiagnosticRows({
+      probe: { reachable: true, report: withDelivery({ probed: false, reason: 'unsupported' }) },
+      localPushSubscribed: true,
+    });
+    const device = rowOf(rows, 'pushDevice');
+    expect(device.level).toBe('warn');
+    expect(device.detail).toContain('更新 Worker');
+    expect(summarizeAmsgDiagnostics(rows)).toBe('warn');
+  });
+
+  it('查了但没查成 → 同样 warn，并说清到点收不到该点哪儿', () => {
+    const rows = buildAmsgDiagnosticRows({
+      probe: { reachable: true, report: withDelivery({ probed: false, reason: 'failed' }) },
+      localPushSubscribed: true,
+    });
+    expect(rowOf(rows, 'pushDevice').level).toBe('warn');
+    expect(rowOf(rows, 'pushDevice').detail).toContain('重置订阅');
+  });
+
+  it('云端压根没登记收件设备时不提投递——该修的是上一层', () => {
+    const rows = buildAmsgDiagnosticRows({
+      probe: {
+        reachable: true,
+        report: healthyReport({
+          storage: {
+            ...healthyReport().storage,
+            pushSubscriptionRegistered: false,
+            pushDelivery: goneAt('2026-08-10T05:06:00.000Z'),
+          },
+        }),
+      },
+      localPushSubscribed: true,
+    });
+    const device = rowOf(rows, 'pushDevice');
+    expect(device.level).toBe('bad');
+    expect(device.detail).toContain('开启通知与推送');
+    expect(device.detail).not.toContain('410');
+  });
+
   it('定时任务停摆时说出积压条数和该去哪儿看日志', () => {
     const rows = buildAmsgDiagnosticRows({
       probe: {
@@ -511,3 +646,4 @@ describe('resolveInstantChatBlocker — 即时对话卡在哪一道', () => {
     expect(Object.keys(INSTANT_CHAT_BLOCKER_HINTS)).toHaveLength(codes.length);
   });
 });
+

--- a/utils/amsgDiagnostics.ts
+++ b/utils/amsgDiagnostics.ts
@@ -149,6 +149,12 @@ export interface AmsgDebugReport {
     missingTables?: string[];
     missingColumns?: string[];
     pushSubscriptionRegistered?: boolean;
+    /**
+     * 推送到底推没推出去。三态由 parseAmsgDebugReport 收敛，**认下来的回执里一定有值**
+     * ——界面不用猜「缺字段」是什么意思。可选只是为了让「库根本读不到」那种桩不用凑
+     * 一个没有意义的值；那种时候上面几行早就红了，压根走不到这一项。
+     */
+    pushDelivery?: AmsgPushDeliveryProbe;
     pendingTasks?: number;
     overdueTasks?: number;
     oldestOverdueMinutes?: number | null;
@@ -184,12 +190,57 @@ export const parseAmsgDebugReport = (body: unknown): AmsgDebugReport | null => {
         ? config.warnings.filter((item: any) => typeof item?.code === 'string' && typeof item?.message === 'string')
         : [],
     },
-    storage,
+    storage: { ...storage, pushDelivery: normalizePushDeliveryProbe(storage.pushDelivery) },
     tick: ['idle', 'healthy', 'stalled'].includes(data.tick) ? data.tick : 'unknown',
     server: data.server && typeof data.server === 'object'
       ? { version: data.server.version ?? null, featureCount: Number(data.server.featureCount) || 0 }
       : null,
     vapidPublicKey: typeof data.vapidPublicKey === 'string' ? data.vapidPublicKey : null,
+  };
+};
+
+// ─── 推送服务说「这条订阅已经没了」───
+//
+// 这是「登记状态全绿、到点一条都不来」的最后一块拼图。浏览器手里有订阅、Worker 上
+// 也登记着同一条 endpoint——两边都自洽，但那条 endpoint 在推送服务（FCM/Mozilla/
+// Apple）那侧早就作废了，推过去只会换回一个 410。这件事只有推送服务知道，前端和
+// Worker 自己都查不出来。
+//
+// 事实由上游 amsg-server 产生并结构化保存（投递失败时把推送服务回的状态码写进任务的
+// last_error），Worker 的 /debug 把它读出来，这份文件只负责把它翻成红绿灯和人话。
+// 状态码怎么认在 worker/amsg/src/index.ts，那儿离数据最近。
+
+/** 认出来的那一次「订阅已失效」。 */
+export interface AmsgPushGoneFailure {
+  /** 推送服务回的状态码：410 = 已注销/过期，404 = 端点根本不存在。 */
+  status: number;
+  /** 这次失败记录的时刻（epoch 毫秒）。 */
+  atMs: number;
+}
+
+/**
+ * 「推送投递情况」这一项的三种结局。
+ *
+ * `probed: false` 的两档都**不是**「没问题」：`unsupported` 是这台 Worker 上跑的后端
+ * 还不查这一项（老 bundle），`failed` 是查了没查成。界面必须照实说查不了——在唯一能
+ * 拆穿「全绿但一条不来」的地方给假绿灯，比没有这项检查更糟。
+ */
+export type AmsgPushDeliveryProbe =
+  | { probed: false; reason: 'unsupported' | 'failed' }
+  | { probed: true; gone: AmsgPushGoneFailure | null; registeredAtMs: number | null };
+
+/** 认出 /debug 回执里那一段的形状。缺字段 = 老 bundle 不报这一项。 */
+const normalizePushDeliveryProbe = (raw: unknown): AmsgPushDeliveryProbe => {
+  if (raw === undefined) return { probed: false, reason: 'unsupported' };
+  // worker 查不成时显式回 null（老库还没有 last_error 列、查询被拒）。
+  if (!raw || typeof raw !== 'object') return { probed: false, reason: 'failed' };
+  const value = raw as { gone?: any; registeredAtMs?: unknown };
+  const status = Number(value.gone?.status);
+  const atMs = Number(value.gone?.atMs);
+  return {
+    probed: true,
+    gone: Number.isFinite(status) && Number.isFinite(atMs) ? { status, atMs } : null,
+    registeredAtMs: Number.isFinite(Number(value.registeredAtMs)) ? Number(value.registeredAtMs) : null,
   };
 };
 
@@ -213,7 +264,76 @@ export interface AmsgDiagnosticsInput {
   probe: AmsgDiagnosticsProbe;
   /** 这台设备的浏览器有没有推送订阅（本地事实，worker 那侧看不到）。 */
   localPushSubscribed?: boolean;
+  /** 把 epoch 毫秒写成给人看的时间；不传按本机习惯格式化（单测注入固定格式用）。 */
+  formatTime?: (atMs: number) => string;
 }
+
+const defaultFormatTime = (atMs: number): string => new Date(atMs).toLocaleString();
+
+/** 「重置订阅」在哪儿、点了会发生什么。几处文案共用一句，别各写各的。 */
+export const PUSH_RESET_HINT = '去设置页的「推送订阅状态」点「重置订阅」重建一条——它会退订、重订、再覆盖登记回 Worker，点一次就够。';
+
+const WORKER_TOO_OLD_HINT = '这台 Worker 上跑的后端还不查「推送有没有真的送出去」，所以「到点了但一条都不来」这种坏法它看不出来。点上面的「更新 Worker」换成新版就能查了。';
+
+export interface AmsgPushDeliveryVerdict {
+  level: 'bad' | 'warn';
+  /** 发生了什么。几处共用，不带「去哪儿修」。 */
+  what: string;
+  /** 体检那一行的完整说法：发生了什么 + 该去哪儿点哪个按钮。 */
+  detail: string;
+}
+
+/**
+ * 上一次推送到底有没有被推送服务判成「订阅失效」，以及那笔账现在还算不算数。
+ * 没问题（查过了、没发生过 / 是重置之前的旧账）返回 null。
+ *
+ * 体检的「这台设备」和设置页的推送订阅面板共用这一份判定：两处各写一套的话，
+ * 用户会看到一个红一个绿，而这正是他唯一能拿来判断该不该重置订阅的依据。
+ *
+ * @param formatTime 把 epoch 毫秒写成给人看的时间；不传按本机习惯格式化。
+ */
+export const judgePushDeliveryFailure = (
+  probe: AmsgPushDeliveryProbe | null | undefined,
+  formatTime: (atMs: number) => string = defaultFormatTime,
+): AmsgPushDeliveryVerdict | null => {
+  if (!probe) return null;
+
+  // 查不了不是「没问题」。报 warn 而不是红：这时并没有任何证据说明推送坏了，
+  // 但也绝不能给绿灯——它恰恰是唯一能拆穿「全绿但一条不来」的那一项。
+  if (!probe.probed) {
+    const what = probe.reason === 'unsupported'
+      ? '这次没查「推送有没有真的送出去」'
+      : '「推送有没有真的送出去」这一项没查成（后端读不到任务的失败记录）';
+    return {
+      level: 'warn',
+      what,
+      detail: probe.reason === 'unsupported' ? WORKER_TOO_OLD_HINT : `${what}。到点却收不到消息的话，${PUSH_RESET_HINT}`,
+    };
+  }
+
+  const { gone, registeredAtMs } = probe;
+  if (!gone) return null;
+
+  const when = formatTime(gone.atMs);
+  const what = `${when} 那次推送被推送服务退回来了，理由是「这条订阅已经失效」（${gone.status}）`;
+
+  // 登记时刻问不到就没法分辨新旧账。报 warn 不报红：重置过订阅的人不该被一条
+  // 永远消不掉的红灯追着跑，但也不能给绿灯——那正是这条要拆穿的假象。
+  if (registeredAtMs == null) {
+    const uncertain = '这次问不到 Worker 上那行订阅是什么时候登记的，没法确认它是不是重置之前的旧账';
+    return {
+      level: 'warn',
+      what: `${what}。${uncertain}`,
+      detail: `${what}。${uncertain}；最近没重置过的话，${PUSH_RESET_HINT}`,
+    };
+  }
+
+  // 那之后订阅换过一条了：这笔是上一条订阅的旧账，服务端只在失败时写、成功不会清。
+  if (gone.atMs <= registeredAtMs) return null;
+
+  const stillBroken = `${what}，而 Worker 上登记的还是它——到点的消息全都推不出去`;
+  return { level: 'bad', what: stillBroken, detail: `${stillBroken}。${PUSH_RESET_HINT}` };
+};
 
 const DB_MISSING_HINT = 'Worker 没有绑定 D1 数据库。多半是部署第一步填完 Database ID 之后没点那个「Add」就直接 Deploy 了。回 Cloudflare 的 Settings → Bindings 加一条 D1 database，变量名填大写的 DB。';
 const MASTER_KEY_MISSING_HINT = 'Worker 上没有 AMSG_MASTER_KEY。去 Settings → Variables and secrets 添加，类型一定要选 Secret——选成 Text 的话下次部署就会消失。';
@@ -341,15 +461,22 @@ export const buildAmsgDiagnosticRows = (input: AmsgDiagnosticsInput): AmsgDiagno
   });
 
   const remoteRegistered = storage.pushSubscriptionRegistered === true;
+  // 两边都登记着，也不等于推得出去：那条 endpoint 可能在推送服务那侧早就作废了。
+  // 只有投递结果知道这件事，登记状态是绿的时候更要看它——「全绿但一条不来」就是
+  // 这么来的。云端压根没登记时不看这个：那时该修的是上一层，说两件事只会分散注意力。
+  const deliveryVerdict = remoteRegistered
+    ? judgePushDeliveryFailure(storage.pushDelivery, input.formatTime)
+    : null;
   rows.push({
     key: 'pushDevice',
     label: '这台设备',
-    level: !localPushSubscribed ? 'bad' : remoteRegistered ? 'ok' : 'bad',
+    level: !localPushSubscribed ? 'bad' : !remoteRegistered ? 'bad' : deliveryVerdict?.level || 'ok',
     detail: !localPushSubscribed
       ? '这台设备还没订阅推送，点下面的「开启通知与推送」。'
-      : remoteRegistered
-        ? '浏览器已订阅，Worker 上也登记了收件设备。换设备或换浏览器之后要在新的那台上再点一次「开启通知与推送」。'
-        : '浏览器订阅好了，但 Worker 上没有登记收件设备——到点的消息发不出去。点下面的「开启通知与推送」补登记一次。',
+      : !remoteRegistered
+        ? '浏览器订阅好了，但 Worker 上没有登记收件设备——到点的消息发不出去。点下面的「开启通知与推送」补登记一次。'
+        : deliveryVerdict?.detail
+          || '浏览器已订阅，Worker 上也登记了收件设备，最近一次推送也没被退回来。换设备或换浏览器之后要在新的那台上再点一次「开启通知与推送」。',
   });
 
   const overdue = storage.overdueTasks || 0;

--- a/utils/networkFailureDiagnosis.test.ts
+++ b/utils/networkFailureDiagnosis.test.ts
@@ -7,6 +7,8 @@
 //   3. no-cors 复检的两个结论必须泾渭分明：「通了」指向 CORS/限流，「没通」指向线路，
 //      两边要查的东西完全相反，说反了比不说更糟。
 //   4. 探测有 30s 冷却：一串请求同时炸时不能对同一个域名连打探测。
+//   5. Resource Timing 只认本次请求那条记录。同一个地址被反复请求时，timeline 里躺着
+//      早先成功过的记录，误取会打出「对方其实回了 200」这种跟事实相反的结论。
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
     NETWORK_SELF_CHECK_STEPS,
@@ -93,7 +95,7 @@ describe('buildFetchFailureDetail', () => {
         online: true,
         pageOrigin: 'https://sullyos.example.com',
         pageProtocol: 'https:',
-    }, { perf: { getEntriesByName: () => [] } });
+    }, { startedAt: 0, perf: { getEntriesByName: () => [] } });
 
     it('把能补的旁证全补上', () => {
         const text = detail();
@@ -115,7 +117,7 @@ describe('buildFetchFailureDetail', () => {
             online: true,
             pageOrigin: 'https://sullyos.example.com',
             pageProtocol: 'https:',
-        }, { perf: { getEntriesByName: () => [] } });
+        }, { startedAt: 0, perf: { getEntriesByName: () => [] } });
         expect(text).toContain('同源');
         expect(text).not.toContain('跨域请求');
     });
@@ -127,7 +129,7 @@ describe('buildFetchFailureDetail', () => {
             online: true,
             pageOrigin: 'https://sullyos.example.com',
             pageProtocol: 'https:',
-        }, { perf: { getEntriesByName: () => [] } });
+        }, { startedAt: 0, perf: { getEntriesByName: () => [] } });
         expect(text).toContain('混合内容');
         expect(text).not.toContain('DNS 解析不到');
     });
@@ -145,7 +147,7 @@ describe('buildFetchFailureDetail', () => {
             online: true,
             pageOrigin: 'https://qegj567-cloud.github.io',
             pageProtocol: 'https:',
-        }, { perf: { getEntriesByName: () => [] } });
+        }, { startedAt: 0, perf: { getEntriesByName: () => [] } });
         expect(text).toContain('请求超时');
         expect(text).toContain('连接建立阶段被吞');
         expect(text).not.toContain('不符合已知');
@@ -160,10 +162,35 @@ describe('buildFetchFailureDetail', () => {
             pageOrigin: 'https://sullyos.example.com',
             pageProtocol: 'https:',
         }, {
-            perf: { getEntriesByName: () => [{ responseStatus: 429, transferSize: 0, duration: 120 }] },
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [{ startTime: 50_010, responseStatus: 429, transferSize: 0, duration: 120 }],
+            },
         });
         expect(text).toContain('responseStatus=429');
         expect(text).toContain('CORS');
+    });
+
+    // 整条日志级别的守卫：早先那次成功的记录不能反过来推翻本次「挂了 10s、一个字节没收到」
+    // 的判断。两句结论同时出现在一条日志里，用户只会更懵。
+    it('挂 10s 的失败不能被历史记录改口成「对方其实回了 200」', () => {
+        const text = buildFetchFailureDetail({
+            url: 'https://sullyos-amsg.example.workers.dev/client-state',
+            method: 'PUT',
+            durationMs: 10078,
+            error: failedToFetch(),
+            online: true,
+            pageOrigin: 'https://qegj567-cloud.github.io',
+            pageProtocol: 'https:',
+        }, {
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [{ startTime: 9_000, responseStatus: 200, transferSize: 0, duration: 1038 }],
+            },
+        });
+        expect(text).toContain('连接建立阶段被吞');
+        expect(text).not.toContain('对方其实回了');
+        expect(text).not.toContain('responseStatus=200');
     });
 });
 
@@ -196,21 +223,87 @@ describe('readStallHint', () => {
 
 describe('readResourceTimingHint', () => {
     it('没有记录时说明「连接可能压根没建立」', () => {
-        expect(readResourceTimingHint('https://a.example.com/x', { getEntriesByName: () => [] }))
-            .toContain('没有这条请求的记录');
+        expect(readResourceTimingHint('https://a.example.com/x', {
+            startedAt: 1000, perf: { getEntriesByName: () => [] },
+        })).toContain('没有这条请求的记录');
     });
 
-    it('取最后一条记录（同一 URL 重试过多次）', () => {
+    it('同一 URL 请求过多次时，取本次这条', () => {
         const hint = readResourceTimingHint('https://a.example.com/x', {
-            getEntriesByName: () => [{ responseStatus: 200 }, { responseStatus: 503 }],
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [
+                    { startTime: 9_000, responseStatus: 200, duration: 1038 },
+                    { startTime: 50_120, responseStatus: 503, duration: 88 },
+                ],
+            },
         });
         expect(hint).toContain('503');
+        expect(hint).not.toContain('1038');
+    });
+
+    // 线上翻车实录：/client-state 被反复 PUT，timeline 里躺着早先成功那次的 200。本次连接
+    // 压根没建立、什么都没往 timeline 里写，旧版取「最后一条」就把那条陈旧的 200 当成了本次
+    // 的响应，打出「对方其实回了 HTTP 200，是响应被 CORS 拦掉的」——跟同一条日志里「挂了
+    // 10.1s 一个字节没收到」「no-cors 也连不上」直接打架，把人往查 CORS 的方向带。
+    it('不能把早先成功那次的记录当成本次失败的证据', () => {
+        const hint = readResourceTimingHint('https://sullyos-amsg.example.workers.dev/client-state', {
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [
+                    { startTime: 9_000, responseStatus: 200, transferSize: 0, duration: 1038 },
+                ],
+            },
+        });
+        expect(hint).toContain('没有这条请求的记录');
+        expect(hint).not.toContain('200');
+        expect(hint).not.toContain('CORS');
+    });
+
+    // 跨域拿不到 Timing-Allow-Origin 授权时，responseStatus / transferSize 被规范统统置 0。
+    // 直接印出来会被读成「状态码是 0」「一个字节都没传」——后者尤其坑，跟「连接被吞」是完全
+    // 不同的两回事。这时候只有耗时可信，其余整个不印，并说清为什么少了。
+    it('拿不到 Timing-Allow-Origin 时只报耗时，不印那两个恒为 0 的字段', () => {
+        const hint = readResourceTimingHint('https://a.example.com/x', {
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [
+                    { startTime: 50_010, responseStart: 0, responseStatus: 0, transferSize: 0, duration: 10_078 },
+                ],
+            },
+        });
+        expect(hint).not.toContain('responseStatus');
+        expect(hint).not.toContain('transferSize');
+        expect(hint).toContain('10078ms');
+        expect(hint).toContain('Timing-Allow-Origin');
+    });
+
+    // 有授权时 transferSize=0 才真的是「没传字节」，得照常给。这条同时钉住 responseStart
+    // 这个探针：Safari 没有 responseStatus 字段，只能靠它判断有没有授权。
+    it('有 Timing-Allow-Origin 授权时照常给字节数', () => {
+        const hint = readResourceTimingHint('https://a.example.com/x', {
+            startedAt: 50_000,
+            perf: {
+                getEntriesByName: () => [{ startTime: 50_010, responseStart: 50_050, transferSize: 0, duration: 88 }],
+            },
+        });
+        expect(hint).toContain('transferSize=0');
+        expect(hint).not.toContain('Timing-Allow-Origin');
     });
 
     it('performance 不可用时静默返回空串，不能抛', () => {
-        expect(readResourceTimingHint('https://a.example.com/x', {})).toBe('');
+        expect(readResourceTimingHint('https://a.example.com/x', { startedAt: 0, perf: {} })).toBe('');
         expect(readResourceTimingHint('https://a.example.com/x', {
-            getEntriesByName: () => { throw new Error('boom'); },
+            startedAt: 0,
+            perf: { getEntriesByName: () => { throw new Error('boom'); } },
+        })).toBe('');
+    });
+
+    // 没有 performance.now() 就没法分辨哪条记录是本次的，这时候整段不出比瞎猜强。
+    it('拿不到发起时刻时整段不出，不退回「取最后一条」', () => {
+        expect(readResourceTimingHint('https://a.example.com/x', {
+            startedAt: Number.NaN,
+            perf: { getEntriesByName: () => [{ startTime: 9_000, responseStatus: 200 }] },
         })).toBe('');
     });
 });

--- a/utils/networkFailureDiagnosis.ts
+++ b/utils/networkFailureDiagnosis.ts
@@ -129,12 +129,25 @@ const VERDICTS: Record<FetchFailureKind, { verdict: string; causes: string }> = 
     },
 };
 
-/** Resource Timing 里那条记录能补两个关键旁证：到底有没有收到响应状态码、传了多少字节。 */
+/**
+ * Resource Timing 里那条记录能补两个关键旁证：到底有没有收到响应状态码、传了多少字节。
+ *
+ * ⚠️ 必须按发起时刻筛。getEntriesByName() 捞的是整个页面生命周期内打过这个地址的**全部**
+ * 记录，而像 /client-state 这种反复请求的端点，timeline 里一直躺着早先成功那次的 200。
+ * 偏偏「连接压根没建立」的失败什么都不会往 timeline 里写——于是不筛的话，越是老用户、
+ * 越是之前一直用得好好的地址，越会拿到一条陈旧的成功记录，并据此打出「对方其实回了 200，
+ * 是被 CORS 拦的」，跟同一条日志里的耗时线索和 no-cors 复检结论正面打架。
+ *
+ * startedAt 用 performance.now() 的基准（跟 entry.startTime 同一条时间轴，不能换成
+ * Date.now()）。取不到就整段不出——宁可少说一句，也不能说反。
+ */
 export const readResourceTimingHint = (
     href: string,
-    perf?: { getEntriesByName?: (name: string, type?: string) => any[] },
+    opts: { startedAt: number; perf?: { getEntriesByName?: (name: string, type?: string) => any[] } },
 ): string => {
-    const target = perf ?? (typeof performance !== 'undefined' ? (performance as any) : undefined);
+    const { startedAt } = opts;
+    if (!Number.isFinite(startedAt)) return '';
+    const target = opts.perf ?? (typeof performance !== 'undefined' ? (performance as any) : undefined);
     if (!target?.getEntriesByName) return '';
     let entries: any[] = [];
     try {
@@ -142,15 +155,29 @@ export const readResourceTimingHint = (
     } catch {
         return '';
     }
-    const entry = entries[entries.length - 1];
+    const entry = entries
+        .filter(item => typeof item?.startTime === 'number' && item.startTime >= startedAt)
+        .pop();
     if (!entry) return 'Resource Timing: 没有这条请求的记录（通常说明连接压根没建立起来，或被扩展在发出前就拦掉了）';
+    // 跨域资源拿不到 Timing-Allow-Origin 授权时，规范要求把 responseStatus、transferSize、
+    // 各阶段时间戳统统置 0。这时候「transferSize=0」的意思是「没授权看」，不是「一个字节都
+    // 没传」——照字面读会得出跟事实相反的结论，所以这些字段整个不印，改成一句说明。
+    // responseStart 是判断有没有授权最稳的探针：它比 responseStatus 老得多，Safari 也有。
+    const timingAllowed = (typeof entry.responseStart === 'number' && entry.responseStart > 0)
+        || (typeof entry.responseStatus === 'number' && entry.responseStatus > 0);
     const parts: string[] = [];
-    if (typeof entry.responseStatus === 'number') parts.push(`responseStatus=${entry.responseStatus}`);
-    if (typeof entry.transferSize === 'number') parts.push(`transferSize=${entry.transferSize}`);
+    if (timingAllowed) {
+        if (typeof entry.responseStatus === 'number' && entry.responseStatus > 0) {
+            parts.push(`responseStatus=${entry.responseStatus}`);
+        }
+        if (typeof entry.transferSize === 'number') parts.push(`transferSize=${entry.transferSize}`);
+    }
     if (typeof entry.duration === 'number') parts.push(`duration=${Math.round(entry.duration)}ms`);
     let note = '';
-    if (typeof entry.responseStatus === 'number' && entry.responseStatus > 0) {
+    if (timingAllowed && typeof entry.responseStatus === 'number' && entry.responseStatus > 0) {
         note = ` → 对方其实回了 HTTP ${entry.responseStatus}，是响应被 CORS 拦掉的，不是网络不通`;
+    } else if (!timingAllowed) {
+        note = '（对方没给 Timing-Allow-Origin，状态码和字节数看不到，只有耗时可信）';
     }
     return `Resource Timing: ${parts.join(', ') || '有记录'}${note}`;
 };
@@ -179,7 +206,7 @@ export const readStallHint = (durationMs?: number, kind?: FetchFailureKind): str
  */
 export const buildFetchFailureDetail = (
     ctx: FetchFailureContext,
-    opts?: { perf?: { getEntriesByName?: (name: string, type?: string) => any[] } },
+    opts: { startedAt: number; perf?: { getEntriesByName?: (name: string, type?: string) => any[] } },
 ): string => {
     const { name, message } = readError(ctx.error);
     const kind = classifyFetchFailure(ctx);
@@ -199,7 +226,7 @@ export const buildFetchFailureDetail = (
     }
     if (pageOrigin) lines.push(`本页来源: ${pageOrigin}`);
     lines.push(`浏览器联网状态: ${online === false ? '离线' : '在线'}`);
-    const timing = readResourceTimingHint(target.href, opts?.perf);
+    const timing = readResourceTimingHint(target.href, { startedAt: opts.startedAt, perf: opts.perf });
     if (timing) lines.push(timing);
     const stall = readStallHint(ctx.durationMs, kind);
     if (stall) lines.push(stall);

--- a/worker/amsg/src/index.test.ts
+++ b/worker/amsg/src/index.test.ts
@@ -5,11 +5,13 @@
 // 顺序：charId 校验 → 活跃会话租约(skip) → fire_pack 存在(否则抛) → 防穿帮闸(skip)
 //      → 任务指令存在(否则抛) → 挂 scratch + 填槽返回
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
 
 import worker, {
   amsgFireSettled, amsgHooks, amsgReasoningKey, amsgStaleSkip, attachScheduledTasks,
   buildWorkerConfig, configureInstantErrorPush, inspectWorkerEnv,
   offloadOversizedPush, resolveVapidEmail, runFireCancelTool, runFireRenewTool,
+  inspectPushDelivery,
   runFireScheduleTool, runMcpFireTool, splitSchemaMissing, classifySchemaProbeError,
 } from './index';
 import * as workerEntry from './index';
@@ -40,6 +42,7 @@ import { AMSG_TOOL_CONFIG_KEY, AMSG_TOOL_PACK_KEY } from '../../../utils/amsgToo
 import { buildMcpNameMap, MCP_FIRE_NAME_BUDGET, type McpFireServer } from '../../../utils/mcpFireCore';
 import { MAX_FIRE_SCHEDULES } from '../../../utils/amsgFireSchedule';
 import { MAX_ACTIVE_TASKS_PER_CHAR, shortTaskId } from '../../../utils/amsg2Tasks';
+import { isAmsgServerVersionAtLeast } from '../../../utils/amsgWorkerVersion';
 
 const CHAR_ID = 'preset-nyah';
 const TASK_UUID = '3637dae1-1461-4444-a747-34e406f67acc';
@@ -4092,5 +4095,133 @@ describe('即时对话终态失败的直发 error push', () => {
       error: new Error('LLM 上游 502'),
       scratch, writeState: store.writeState,
     } as any)).resolves.toBeUndefined();
+  });
+});
+
+// 回归守卫：「登记状态全绿、到点一条都不来」的唯一出口。
+//
+// 浏览器有订阅、库里也登记着同一条 endpoint，两边都自洽，但那条 endpoint 在推送服务
+// 那侧已经作废——推过去只换回一个 410。这件事只有推送服务知道，所以事实由上游
+// amsg-server 结构化写进 last_error.pushStatus，这里只负责读出来。
+//
+// 关键约束：**只认 pushStatus 这个结构化字段，不去解析 reason 那句人话**。reason 是
+// 给用户看的自由文本，拿它当接口用的话，上游改个措辞这里就静默失效，而且不会有任何
+// 测试挂——那正是「全绿但一条不来」重新长出来的方式。
+describe('inspectPushDelivery — 推送有没有真的送出去', () => {
+  const REGISTERED_AT = Date.parse('2026-08-10T04:00:00.000Z');
+
+  /** 一个只回 last_error 列的假 D1。 */
+  const fakeDb = (rows: Array<{ last_error: string | null }>, explode = false) => ({
+    prepare: () => ({
+      all: async () => {
+        if (explode) throw new Error('no such column: last_error');
+        return { results: rows };
+      },
+      bind: () => ({ first: async () => null }),
+      first: async () => null,
+    }),
+  }) as any;
+
+  const failureRow = (at: string, extra: Record<string, unknown>) => ({
+    last_error: JSON.stringify({ at, occurrence: at, reason: '随便什么人话摘要', ...extra }),
+  });
+
+  it('认结构化的 410，交出状态码和时刻', async () => {
+    const result = await inspectPushDelivery(
+      fakeDb([failureRow('2026-08-10T05:06:00.000Z', { pushStatus: 410 })]),
+      REGISTERED_AT,
+    );
+    expect(result).toEqual({
+      gone: { status: 410, atMs: Date.parse('2026-08-10T05:06:00.000Z') },
+      registeredAtMs: REGISTERED_AT,
+    });
+  });
+
+  it('404（端点根本不存在）同样算失效', async () => {
+    const result = await inspectPushDelivery(
+      fakeDb([failureRow('2026-08-10T05:06:00.000Z', { pushStatus: 404 })]),
+      REGISTERED_AT,
+    );
+    expect(result?.gone?.status).toBe(404);
+  });
+
+  it('reason 里写着 410 但没有 pushStatus → 不认', async () => {
+    // 这条就是「别把人话当接口」的守卫：上游给不出结构化字段时，宁可报「没查到」，
+    // 也不去正则匹配一句随时会变的错误摘要。
+    const result = await inspectPushDelivery(
+      fakeDb([{
+        last_error: JSON.stringify({
+          at: '2026-08-10T05:06:00.000Z',
+          reason: 'Web Push delivery failed: 410 Gone — push subscription has unsubscribed or expired.',
+        }),
+      }]),
+      REGISTERED_AT,
+    );
+    expect(result).toEqual({ gone: null, registeredAtMs: REGISTERED_AT });
+  });
+
+  it('别的推送失败（403 / 500）不算订阅失效——重置订阅治不了那些', async () => {
+    const result = await inspectPushDelivery(
+      fakeDb([
+        failureRow('2026-08-10T05:06:00.000Z', { pushStatus: 403 }),
+        failureRow('2026-08-10T05:07:00.000Z', { pushStatus: 500 }),
+      ]),
+      REGISTERED_AT,
+    );
+    expect(result?.gone).toBeNull();
+  });
+
+  it('多条里挑最近的那次——用户要判断的是「现在还坏不坏」', async () => {
+    const result = await inspectPushDelivery(
+      fakeDb([
+        failureRow('2026-08-10T05:06:00.000Z', { pushStatus: 410 }),
+        failureRow('2026-08-10T06:30:00.000Z', { pushStatus: 410 }),
+        failureRow('2026-08-10T02:00:00.000Z', { pushStatus: 410 }),
+      ]),
+      REGISTERED_AT,
+    );
+    expect(result?.gone?.atMs).toBe(Date.parse('2026-08-10T06:30:00.000Z'));
+  });
+
+  it('坏 JSON / 时刻解析不出来的行跳过，不带崩整次自查', async () => {
+    const result = await inspectPushDelivery(
+      fakeDb([
+        { last_error: '不是 JSON' },
+        { last_error: null },
+        failureRow('不是时间', { pushStatus: 410 }),
+      ]),
+      REGISTERED_AT,
+    );
+    expect(result).toEqual({ gone: null, registeredAtMs: REGISTERED_AT });
+  });
+
+  it('查询本身挂了（老库没有 last_error 列）→ null = 这一项没查出来', async () => {
+    // 界面拿 null 显示「没查成」，不是绿灯——假绿灯正是这一整条链要治的病。
+    expect(await inspectPushDelivery(fakeDb([], true), REGISTERED_AT)).toBeNull();
+  });
+});
+
+// 交付顺序守卫（这条挂着 = 这活还没干完，不是坏了）。
+//
+// 上面那段 inspectPushDelivery 读的是上游写进 last_error 的 pushStatus，而**上游从
+// 2.6.0-next.20 才开始写它**。依赖还锁在更早的版本时打出来的 bundle 是最坏的组合：
+// 「查了这一项」（probed: true）+「一次都没被退回」（gone 永远是 null）= 一个理直气壮
+// 的绿灯，而整条改动的存在意义就是干掉这个绿灯。
+//
+// 所以这条测试就是发布门禁：上游发版、这边 pnpm up 到 next.20 之后它自己会变绿。
+describe('打包进来的 amsg-server 得会写 pushStatus', () => {
+  it('依赖版本 >= 2.6.0-next.20（低于它 inspectPushDelivery 会一路绿灯说谎）', async () => {
+    const pkg = JSON.parse(
+      await readFile(new URL('../../../package.json', import.meta.url), 'utf-8'),
+    );
+    const version = String(
+      pkg.devDependencies?.['@rei-standard/amsg-server']
+      ?? pkg.dependencies?.['@rei-standard/amsg-server'],
+    );
+    expect(
+      isAmsgServerVersionAtLeast(version, '2.6.0-next.20'),
+      `package.json 里还锁着 ${version}：那个版本的上游不写 last_error.pushStatus，`
+      + '打出来的 worker 会把「推送投递」这一项一路报绿。等上游发版后升到 next.20 再打 bundle。',
+    ).toBe(true);
   });
 });

--- a/worker/amsg/src/index.ts
+++ b/worker/amsg/src/index.ts
@@ -34,6 +34,9 @@ import {
 } from '@rei-standard/amsg-server/cloudflare';
 import { stripReasoningTags } from '@rei-standard/amsg-shared';
 import { AMSG_BUNDLE_VERSION } from '../../../utils/amsgBundleVersion';
+// 「上一次推送被判订阅失效」的形状，跟前端体检共用一个类型定义（那份是零依赖纯叶子；
+// 往里加任何浏览器依赖都会连累这个 bundle）。这里只产出事实，红绿灯和文案归前端。
+import type { AmsgPushGoneFailure } from '../../../utils/amsgDiagnostics';
 import type { UserProfile } from '../../../types';
 import {
   AMSG_CHAT_FAIL_KEY,
@@ -2492,11 +2495,71 @@ type D1Like = {
   };
 };
 
+/** 推送服务判定订阅已失效时回的状态码：410 = 已注销/过期，404 = 端点根本不存在。 */
+const PUSH_GONE_STATUSES = [410, 404];
+
+/**
+ * 推送到底推没推出去：最近一次被推送服务判成「这条订阅已经失效」是什么时候。
+ *
+ * 这是「登记状态全绿、到点一条都不来」的最后一块拼图。浏览器手里有订阅、库里也
+ * 登记着同一条 endpoint，两边都自洽，但那条 endpoint 在推送服务（FCM / Mozilla /
+ * Apple）那侧早就作废了，推过去只换回一个 410。这件事只有推送服务知道，前端和
+ * Worker 自己都查不出来。
+ *
+ * 事实由上游 amsg-server 产生：投递失败时它把推送服务回的状态码结构化写进任务的
+ * `last_error.pushStatus`。这里只是把它读出来——**不去解析 `reason` 那句人话**，
+ * 那是给用户看的自由文本，拿它当接口用的话，上游改个措辞这里就静默失效。
+ *
+ * 只回状态码和时刻，不回 `last_error` 原文：那是一段没有约束的错误摘要，而
+ * `/debug` 这个端点是不设防的。
+ *
+ * 查不成（老库还没有 last_error 列、查询被拒）返回 null = 「这一项没查出来」，
+ * 界面照实说查不了，不会因此给一个假绿灯。
+ */
+export const inspectPushDelivery = async (
+  db: D1Like,
+  registeredAtMs: number | null,
+): Promise<{ gone: AmsgPushGoneFailure | null; registeredAtMs: number | null } | null> => {
+  try {
+    // 只看有失败记录的行，按最近更新排。订阅一旦作废，每条到点的任务都会撞上同一个
+    // 410，最近那次必然排在最前面——取 20 条足够，不必把整个任务表读一遍。
+    const rows = await db
+      .prepare(
+        `SELECT last_error FROM scheduled_messages
+          WHERE last_error IS NOT NULL
+          ORDER BY updated_at DESC
+          LIMIT 20`,
+      )
+      .all<{ last_error: string | null }>();
+
+    let gone: AmsgPushGoneFailure | null = null;
+    for (const row of rows.results || []) {
+      let record: { at?: unknown; pushStatus?: unknown } | null = null;
+      try {
+        const parsed = JSON.parse(row.last_error || 'null');
+        record = parsed && typeof parsed === 'object' ? parsed : null;
+      } catch {
+        continue; // 存进去的不是 JSON（不该发生），跳过这一条就是了
+      }
+      const status = Number(record?.pushStatus);
+      if (!PUSH_GONE_STATUSES.includes(status)) continue;
+      const atMs = Date.parse(String(record?.at ?? ''));
+      if (!Number.isFinite(atMs)) continue;
+      if (!gone || atMs > gone.atMs) gone = { status, atMs };
+    }
+
+    return { gone, registeredAtMs };
+  } catch {
+    return null;
+  }
+};
+
 /**
  * 只读地看一眼库里的状况：表齐不齐、列全不全、有没有到点却没人处理的任务。
  *
- * 全程不写库，也不读任何一条任务的内容——只数数和比对 schema。数出来的东西
- * （待发条数、最老的一条过期了多久）不指向任何角色、时间点或正文。
+ * 全程不写库，也不读任何一条任务的内容——只数数、比对 schema，以及从失败记录里
+ * 认一个状态码。数出来的东西（待发条数、最老的一条过期了多久）不指向任何角色、
+ * 时间点或正文。
  */
 const inspectStorage = async (
   env: Env,
@@ -2539,8 +2602,12 @@ const inspectStorage = async (
       .bind(nowIso, nowIso)
       .first<{ pending: number; overdue: number | null; oldest: string | null }>();
 
+    // 一行表，条数和登记时刻一次拿全。登记时刻是判断投递失败还算不算数的标尺：
+    // 重置订阅会覆盖这一行、刷新时刻，比它更早的失败都是上一条订阅的旧账。
     const pushRow = present.has('push_subscriptions')
-      ? await db.prepare('SELECT COUNT(*) AS n FROM push_subscriptions').first<{ n: number }>()
+      ? await db
+        .prepare('SELECT COUNT(*) AS n, MAX(updated_at) AS updatedAt FROM push_subscriptions')
+        .first<{ n: number; updatedAt: number | null }>()
       : null;
 
     return {
@@ -2553,6 +2620,7 @@ const inspectStorage = async (
       // 单用户 worker 只存一行。到点却发不出去最常见的原因就是这行是空的——
       // 换了一台 worker 之后云端订阅是空的，而浏览器那侧的订阅一个字都没变。
       pushSubscriptionRegistered: (pushRow?.n ?? 0) > 0,
+      pushDelivery: await inspectPushDelivery(db, pushRow?.updatedAt ?? null),
       pendingTasks: stats?.pending ?? 0,
       overdueTasks: stats?.overdue ?? 0,
       oldestOverdueMinutes: stats?.oldest

--- a/worker/amsg/worker.bundle.js
+++ b/worker/amsg/worker.bundle.js
@@ -3,7 +3,7 @@
 // worker/amsg/src/index.ts
 import { DurableObject } from "cloudflare:workers";
 
-// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.19/node_modules/@rei-standard/amsg-server/dist/chunk-5FXVSC5O.mjs
+// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.20/node_modules/@rei-standard/amsg-server/dist/chunk-5FXVSC5O.mjs
 var UPDATABLE_COLUMNS = /* @__PURE__ */ new Set([
   "user_id",
   "uuid",
@@ -817,7 +817,7 @@ function stringifyDecisionForError(value) {
   }
 }
 
-// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.19/node_modules/@rei-standard/amsg-server/dist/chunk-PRQHHRAK.mjs
+// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.20/node_modules/@rei-standard/amsg-server/dist/chunk-HTGYGGUH.mjs
 var DAY_MS = 24 * 60 * 60 * 1e3;
 var MAX_LISTED_SKIPPED_OCCURRENCES = 32;
 var MAX_ADJUST_STEPS = 32;
@@ -1685,6 +1685,9 @@ function projectTask(row, decryptedPayload, options = {}) {
     // reason 'stale' 表示错过触发时刻太久被判定不再补发；其余是投递失败的
     // 错误信息。payload 里没有时退回行上的 last_error 列（同形状的脱敏摘要，
     // 等重试期间的失败也记在那里）。没有记录 → null。
+    // 记进去的字段整份带出来，不再挑一遍——`pushStatus`（410 = 订阅已注销，
+    // 404 = 端点不存在）这类机读标注就是给客户端看的，白名单挡在这一层的话，
+    // 客户端只能回去正则匹配 reason 那句人话。
     lastError: payload.lastError ?? parseRowLastError(row.last_error)
   };
 }
@@ -2510,6 +2513,7 @@ async function processSingleMessage(task, ctx, providedMasterKey, predecrypted =
       messagesSent: 0,
       error: error.message,
       errorCode: error.code || null,
+      pushStatusCode: Number.isInteger(error.statusCode) ? error.statusCode : null,
       permanent: isNonRetryableError(error)
     };
   }
@@ -2838,6 +2842,10 @@ var CLAIM_LEASE_MARGIN_MS = 2 * 60 * 1e3;
 var DEFAULT_LEASE_HEARTBEAT_MS = 30 * 1e3;
 var DEFAULT_HEARTBEAT_LEASE_TTL_MS = 90 * 1e3;
 var STALE_AFTER_MS = 60 * 60 * 1e3;
+var TERMINAL_PUSH_STATUSES = /* @__PURE__ */ new Set([404, 410]);
+function toPushStatus(value) {
+  return Number.isInteger(value) ? value : null;
+}
 function resolveStaleAfterMs(ctx) {
   return positiveNumber(ctx.staleAfterMs) || STALE_AFTER_MS;
 }
@@ -3020,27 +3028,30 @@ async function deliverTasks(ctx, tasks) {
       console.warn("[amsg-server] onStaleSkip hook \u629B\u9519\uFF08\u5DF2\u5FFD\u7565\uFF09:", hookError && hookError.message);
     }
   }
-  async function handleDeliveryFailure(task, reason, recurrenceType, decryptedPayload, userKey, errorCode = null, permanentFlag = false) {
+  async function handleDeliveryFailure(task, reason, recurrenceType, decryptedPayload, userKey, failure = {}) {
     results.failedCount++;
+    const errorCode = failure.errorCode ?? null;
+    const pushStatus = toPushStatus(failure.pushStatus);
     const tzId = decryptedPayload ? decryptedPayload.tzId ?? null : null;
-    const permanent = permanentFlag === true || errorCode === "PUSH_SUBSCRIPTION_MISSING" || errorCode === "PUSH_SUBSCRIPTION_STORE_UNSUPPORTED";
+    const permanent = failure.permanent === true || errorCode === "PUSH_SUBSCRIPTION_MISSING" || errorCode === "PUSH_SUBSCRIPTION_STORE_UNSUPPORTED" || TERMINAL_PUSH_STATUSES.has(pushStatus);
+    const errorExtra = pushStatus === null ? void 0 : { pushStatus };
     try {
       if (permanent || task.retry_count >= 3) {
-        const encrypted = await encryptPayloadWithLastError(task, decryptedPayload, userKey, reason);
+        const encrypted = await encryptPayloadWithLastError(task, decryptedPayload, userKey, reason, errorExtra);
         if (isRecurringType(recurrenceType)) {
           const nextSendAt = nextFutureOccurrence(Date.parse(task.next_send_at), recurrenceType, Date.now(), tzId);
           await updateAndRelease(task.id, {
             next_send_at: nextSendAt,
             retry_count: 0,
             ...encrypted ? { encrypted_payload: encrypted } : {},
-            ...supportsLastError ? { last_error: lastErrorJson(task, reason) } : {}
+            ...supportsLastError ? { last_error: lastErrorJson(task, reason, errorExtra) } : {}
           });
           results.failedTasks.push({ taskId: task.id, reason, retryCount: task.retry_count, status: "occurrence_skipped", nextSendAt, ...permanent ? { permanent: true } : {} });
         } else {
           await updateAndRelease(task.id, {
             status: "failed",
             ...encrypted ? { encrypted_payload: encrypted } : {},
-            ...supportsLastError ? { last_error: lastErrorJson(task, reason) } : {}
+            ...supportsLastError ? { last_error: lastErrorJson(task, reason, errorExtra) } : {}
           });
           results.failedTasks.push({ taskId: task.id, reason, retryCount: task.retry_count, status: "permanently_failed", ...permanent ? { permanent: true } : {} });
         }
@@ -3051,7 +3062,7 @@ async function deliverTasks(ctx, tasks) {
             retry_after: nextRetryTime.toISOString(),
             lease_until: null,
             retry_count: task.retry_count + 1,
-            ...supportsLastError ? { last_error: lastErrorJson(task, reason) } : {}
+            ...supportsLastError ? { last_error: lastErrorJson(task, reason, errorExtra) } : {}
           });
         } else {
           await db.updateTaskById(task.id, { next_send_at: nextRetryTime.toISOString(), retry_count: task.retry_count + 1 });
@@ -3196,8 +3207,7 @@ async function deliverTasks(ctx, tasks) {
         recurrenceType,
         decryptedPayload,
         userKey,
-        error.code || null,
-        error.permanent === true
+        { errorCode: error.code || null, permanent: error.permanent === true, pushStatus: error.statusCode }
       );
       return;
     }
@@ -3208,8 +3218,7 @@ async function deliverTasks(ctx, tasks) {
         recurrenceType,
         decryptedPayload,
         userKey,
-        sendResult.errorCode || null,
-        sendResult.permanent === true
+        { errorCode: sendResult.errorCode || null, permanent: sendResult.permanent === true, pushStatus: sendResult.pushStatusCode }
       );
       return;
     }
@@ -3992,8 +4001,35 @@ var SQLITE_REQUIRED_SCHEMA = Object.freeze({
   ])),
   indexes: Object.freeze(SQLITE_INDEXES.filter((index) => index.critical).map((index) => index.name))
 });
-function escapeLikePrefix(prefix) {
-  return prefix.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+function prefixRangeEnd(prefix) {
+  const points = Array.from(prefix);
+  while (points.length > 0) {
+    const cp = points[points.length - 1].codePointAt(0);
+    if (cp === 55295) {
+      points[points.length - 1] = String.fromCodePoint(57344);
+      return points.join("");
+    }
+    if (cp < 1114111) {
+      points[points.length - 1] = String.fromCodePoint(cp + 1);
+      return points.join("");
+    }
+    points.pop();
+  }
+  return "";
+}
+var D1_MAX_BOUND_PARAMS = 100;
+function chunkForBoundParams(values, fixedParams) {
+  const perStatement = D1_MAX_BOUND_PARAMS - fixedParams;
+  if (perStatement < 1) {
+    throw new Error(
+      `[amsg-server D1] \u56FA\u5B9A\u53C2\u6570\u5DF2\u5360\u6EE1 ${D1_MAX_BOUND_PARAMS} \u4E2A\u7ED1\u5B9A\u4F4D\uFF0CIN \u5217\u8868\u653E\u4E0D\u4E0B`
+    );
+  }
+  const batches = [];
+  for (let i = 0; i < values.length; i += perStatement) {
+    batches.push(values.slice(i, i + perStatement));
+  }
+  return batches;
 }
 var INTERNAL_TABLE_PREFIXES = ["sqlite_", "_cf_"];
 function isInternalTableName(name) {
@@ -4015,6 +4051,50 @@ var D1Adapter = class {
       throw new Error(`[amsg-server D1] invalid timestamp: ${value}`);
     }
     return d.toISOString();
+  }
+  /**
+   * 组一组带 `IN (...)` 的语句：值多到一条塞不下时，按 D1 的绑定参数上限切成
+   * 几条（见 chunkForBoundParams）。
+   *
+   * 只有拿得到事务的绑定才切。没有 batch() 的绑定（测试 shim、自定义适配器，
+   * 都不是真实 D1）原样发一条不切的语句：切批是为 D1 那条上限服务的，这类绑
+   * 定不受它约束，切了反倒会因为没有事务而多出一个「写一半」的中间态。
+   *
+   * @private
+   * @param {(placeholders: string) => string} buildSql - 拿占位符串（`?, ?, ?`）组 SQL
+   * @param {unknown[]} leadingParams - IN 列表之前的固定参数，按出现顺序
+   * @param {unknown[]} values - IN 列表里的全部值
+   * @returns {any[]} 已经 bind 好的语句
+   */
+  _prepareInClauseStatements(buildSql, leadingParams, values) {
+    const batches = typeof this._db.batch === "function" ? chunkForBoundParams(values, leadingParams.length) : [values];
+    return batches.map((batch) => this._db.prepare(buildSql(batch.map(() => "?").join(", "))).bind(...leadingParams, ...batch));
+  }
+  /**
+   * 带 `IN (...)` 的批量写，切成几条也仍然是一次原子操作。
+   *
+   * 一条语句本来天然原子，拆开之后这份保证得自己补回来，否则就会多出「只删掉
+   * 前 99 个」「只 ack 了前 98 条」这类比原问题更难查的中间态。D1 的 batch()
+   * 是隐式事务——其中一条失败，整批回滚——正好接住这件事。
+   *
+   * 一条就够时照旧单发，跟切批以前走的是同一条路，常见调用（一次三五个 id）
+   * 的行为一个字节都没变。
+   *
+   * @private
+   * @param {(placeholders: string) => string} buildSql
+   * @param {unknown[]} leadingParams
+   * @param {unknown[]} values
+   * @returns {Promise<number>} 各批影响行数之和
+   */
+  async _runInClauseWrite(buildSql, leadingParams, values) {
+    const statements = this._prepareInClauseStatements(buildSql, leadingParams, values);
+    if (statements.length === 0) return 0;
+    if (statements.length === 1) {
+      const res = await statements[0].run();
+      return res.meta.changes || 0;
+    }
+    const results = await this._db.batch(statements);
+    return results.reduce((n, res) => n + (res.meta.changes || 0), 0);
   }
   async initSchema() {
     await this._db.prepare(SQLITE_TABLE_SQL).run();
@@ -4399,11 +4479,11 @@ var D1Adapter = class {
          updated_at = excluded.updated_at
        WHERE excluded.updated_at >= client_state.updated_at`;
     const CLEANUP_PREFIX_SQL = `DELETE FROM client_state
-       WHERE user_id = ? AND namespace = ? AND key LIKE ? ESCAPE '\\' AND updated_at <= ?`;
+       WHERE user_id = ? AND namespace = ? AND key >= ? AND key < ? AND updated_at <= ?`;
     const CLEANUP_KEY_SQL = `DELETE FROM client_state
        WHERE user_id = ? AND namespace = ? AND key = ? AND updated_at <= ?`;
     const buildStatements = () => [
-      ...cleanups.map((c) => typeof c.key === "string" ? this._db.prepare(CLEANUP_KEY_SQL).bind(userId, c.namespace, c.key, c.updatedAt) : this._db.prepare(CLEANUP_PREFIX_SQL).bind(userId, c.namespace, `${escapeLikePrefix(c.keyPrefix)}%`, c.updatedAt)),
+      ...cleanups.map((c) => typeof c.key === "string" ? this._db.prepare(CLEANUP_KEY_SQL).bind(userId, c.namespace, c.key, c.updatedAt) : this._db.prepare(CLEANUP_PREFIX_SQL).bind(userId, c.namespace, c.keyPrefix, prefixRangeEnd(c.keyPrefix), c.updatedAt)),
       ...entries.map(
         (entry) => this._db.prepare(UPSERT_SQL).bind(userId, entry.namespace, entry.key, entry.value, entry.updatedAt)
       )
@@ -4532,13 +4612,19 @@ var D1Adapter = class {
    */
   async getLlmCredentials(userId, credIds) {
     if (!credIds || credIds.length === 0) return [];
-    const placeholders = credIds.map(() => "?").join(", ");
-    const res = await this._db.prepare(
-      `SELECT cred_id, encrypted_value, updated_at
-       FROM llm_credentials
-       WHERE user_id = ? AND cred_id IN (${placeholders})`
-    ).bind(userId, ...credIds).all();
-    return res.results || [];
+    const statements = this._prepareInClauseStatements(
+      (placeholders) => `SELECT cred_id, encrypted_value, updated_at
+         FROM llm_credentials
+         WHERE user_id = ? AND cred_id IN (${placeholders})`,
+      [userId],
+      credIds
+    );
+    const rows = [];
+    for (const stmt of statements) {
+      const res = await stmt.all();
+      rows.push(...res.results || []);
+    }
+    return rows;
   }
   /**
    * 这个用户名下所有凭据的对账清单（只有 cred_id 和 updated_at，密文不出
@@ -4564,18 +4650,17 @@ var D1Adapter = class {
    */
   async deleteLlmCredentials(userId, credIds = null) {
     if (credIds !== null && credIds.length === 0) return 0;
-    let res;
     if (credIds === null) {
-      res = await this._db.prepare(
+      const res = await this._db.prepare(
         "DELETE FROM llm_credentials WHERE user_id = ?"
       ).bind(userId).run();
-    } else {
-      const placeholders = credIds.map(() => "?").join(", ");
-      res = await this._db.prepare(
-        `DELETE FROM llm_credentials WHERE user_id = ? AND cred_id IN (${placeholders})`
-      ).bind(userId, ...credIds).run();
+      return res.meta.changes || 0;
     }
-    return res.meta.changes || 0;
+    return this._runInClauseWrite(
+      (placeholders) => `DELETE FROM llm_credentials WHERE user_id = ? AND cred_id IN (${placeholders})`,
+      [userId],
+      credIds
+    );
   }
   // ── message_outbox（服务端消息收件箱，客户端 ack）────────────────────────
   /**
@@ -4631,12 +4716,12 @@ var D1Adapter = class {
    */
   async markOutboxDelivered(userId, messageIds, deliveredAt) {
     if (!messageIds || messageIds.length === 0) return 0;
-    const placeholders = messageIds.map(() => "?").join(", ");
-    const res = await this._db.prepare(
-      `UPDATE message_outbox SET delivered_at = ?
-       WHERE user_id = ? AND message_id IN (${placeholders})`
-    ).bind(deliveredAt, userId, ...messageIds).run();
-    return res.meta.changes || 0;
+    return this._runInClauseWrite(
+      (placeholders) => `UPDATE message_outbox SET delivered_at = ?
+         WHERE user_id = ? AND message_id IN (${placeholders})`,
+      [deliveredAt, userId],
+      messageIds
+    );
   }
   /**
    * 未 ack 的行（id 升序，游标翻页）。payload 仍是密文，解密在 handler。
@@ -4668,12 +4753,12 @@ var D1Adapter = class {
    */
   async ackOutboxMessages(userId, messageIds, ackedAt) {
     if (!messageIds || messageIds.length === 0) return 0;
-    const placeholders = messageIds.map(() => "?").join(", ");
-    const res = await this._db.prepare(
-      `UPDATE message_outbox SET acked_at = ?
-       WHERE user_id = ? AND acked_at IS NULL AND message_id IN (${placeholders})`
-    ).bind(ackedAt, userId, ...messageIds).run();
-    return res.meta.changes || 0;
+    return this._runInClauseWrite(
+      (placeholders) => `UPDATE message_outbox SET acked_at = ?
+         WHERE user_id = ? AND acked_at IS NULL AND message_id IN (${placeholders})`,
+      [ackedAt, userId],
+      messageIds
+    );
   }
   /**
    * outbox 的例行清理（run-tick 每跳顺手调）：已 ack 的行留短一些，未 ack 的
@@ -4943,7 +5028,7 @@ function createClientStateHandler(ctx) {
   }
   return { PUT, GET, DELETE };
 }
-var SERVER_VERSION = true ? "2.6.0-next.19" : "0.0.0-dev";
+var SERVER_VERSION = true ? "2.6.0-next.20" : "0.0.0-dev";
 var SERVER_FEATURES = Object.freeze([
   "client-state",
   "client-state-chunking",
@@ -11879,6 +11964,35 @@ var splitSchemaMissing = (missing) => ({
   missingTables: missing.filter((item) => item.startsWith("table:") || item.startsWith("index:")).map((item) => item.slice(item.indexOf(":") + 1)),
   missingColumns: missing.filter((item) => item.startsWith("column:")).map((item) => item.slice("column:".length))
 });
+var PUSH_GONE_STATUSES = [410, 404];
+var inspectPushDelivery = async (db, registeredAtMs) => {
+  try {
+    const rows = await db.prepare(
+      `SELECT last_error FROM scheduled_messages
+          WHERE last_error IS NOT NULL
+          ORDER BY updated_at DESC
+          LIMIT 20`
+    ).all();
+    let gone = null;
+    for (const row of rows.results || []) {
+      let record = null;
+      try {
+        const parsed = JSON.parse(row.last_error || "null");
+        record = parsed && typeof parsed === "object" ? parsed : null;
+      } catch {
+        continue;
+      }
+      const status = Number(record?.pushStatus);
+      if (!PUSH_GONE_STATUSES.includes(status)) continue;
+      const atMs = Date.parse(String(record?.at ?? ""));
+      if (!Number.isFinite(atMs)) continue;
+      if (!gone || atMs > gone.atMs) gone = { status, atMs };
+    }
+    return { gone, registeredAtMs };
+  } catch {
+    return null;
+  }
+};
 var inspectStorage = async (env, probe) => {
   const { schema, error: schemaError } = probe;
   const db = env.DB;
@@ -11898,7 +12012,7 @@ var inspectStorage = async (env, probe) => {
                 MIN(CASE WHEN next_send_at <= ? THEN next_send_at END) AS oldest
            FROM scheduled_messages WHERE status = 'pending'`
     ).bind(nowIso, nowIso).first();
-    const pushRow = present.has("push_subscriptions") ? await db.prepare("SELECT COUNT(*) AS n FROM push_subscriptions").first() : null;
+    const pushRow = present.has("push_subscriptions") ? await db.prepare("SELECT COUNT(*) AS n, MAX(updated_at) AS updatedAt FROM push_subscriptions").first() : null;
     return {
       reachable: true,
       schemaReady,
@@ -11909,6 +12023,7 @@ var inspectStorage = async (env, probe) => {
       // 单用户 worker 只存一行。到点却发不出去最常见的原因就是这行是空的——
       // 换了一台 worker 之后云端订阅是空的，而浏览器那侧的订阅一个字都没变。
       pushSubscriptionRegistered: (pushRow?.n ?? 0) > 0,
+      pushDelivery: await inspectPushDelivery(db, pushRow?.updatedAt ?? null),
       pendingTasks: stats?.pending ?? 0,
       overdueTasks: stats?.overdue ?? 0,
       oldestOverdueMinutes: stats?.oldest ? Math.floor((Date.now() - Date.parse(stats.oldest)) / 6e4) : null
@@ -12080,6 +12195,7 @@ export {
   classifySchemaProbeError,
   configureInstantErrorPush,
   src_default as default,
+  inspectPushDelivery,
   inspectWorkerEnv,
   offloadOversizedPush,
   resolveVapidEmail,


### PR DESCRIPTION
## 这次修的是什么

主动消息到点却一条都不来，最难自己发现的是这一种：推送订阅在推送服务（Chrome 走 FCM、Firefox 走 Mozilla、iOS 走 Apple）那侧已经作废了。浏览器手里有订阅、Worker 上也登记着同一条 endpoint，两边都自洽，推过去只换回一个 410。

体检面板当时七项里六项绿灯——它只查「浏览器订阅了吗」和「Worker 上登记了吗」，从不问「上一次推送到底送到没有」。用户对着一排绿灯完全无从下手。

Worker 那边还在按 2/4/6 分钟重试三轮。而投递是**先生成后推送**，每重试一跳就重新跑一整轮 LLM，再拿结果去推一个已经不存在的地址。也就是说订阅一旦失效，每条到点的任务白烧四轮 token，一条也送不出去。

## 改后是怎样

| 位置 | 现在的行为 |
|---|---|
| Worker（410 / 404） | 当终态，不再重试。一次性任务标失败，循环任务跳到下一次 |
| 体检「这台设备」 | 多看一项「上一次推送有没有被退回」，红了直接指向「重置订阅」 |
| 设置页推送订阅面板 | 加一行「上次投递」，与体检共用同一份判定，不会一个说红一个说绿 |
| Worker 版本旧 / 查不成 | 照实说「查不了」并指向「更新 Worker」，不给绿灯 |

判定带时效：只有当失败记录比云端订阅的登记时刻更新，才算「现在还坏着」。重置订阅会刷新登记时刻，红灯自动消失，不会变成一个永远消不掉的假红灯。

## 顺带修好的 D1 报错

`amsg-server` 同一版还修了 `client_state` 的前缀清理。D1 把 LIKE pattern 的长度压到 50 字节（官方文档没写这一条），key 一长整条语句就报 `LIKE or GLOB pattern too complex`，而 `batch()` 是原子的，同批的状态写入跟着一起回滚。现在改走字典序范围比较，没有长度上限，还能直接吃主键索引。

## 用户要做什么

**点一次「更新 Worker」**。上面这些全在 Worker 里，不更新吃不到。

设置页的版本门槛跟着升到了 `2.6.0-next.20`，还没更新的人会看到提示。

已经撞上这个问题的（任务卡在「已到点·待处理」、错误里写着 410）：去设置页 → 推送订阅状态 → 「重置订阅」，它会退订、按 Worker 自己的 VAPID 重订、再覆盖登记回去。任务还在「待处理」就会自己发出去，已经标失败的要重新排一条。

## 验证

- 3133 条测试通过，类型检查干净，`vite build` 通过
- 上游 `amsg-server` 侧 403 条通过（新增 6 条，覆盖 410/404 终态、500 仍走重试梯子、循环任务跳次）
- 本仓库新增的回归守卫：假绿灯（登记全对但被退回 → 报红）、假红灯（旧账不再报）、Worker 太旧不给绿灯、只认结构化状态码不解析上游文案

## 范围说明

这个 PR 还带上了 dev 上先前的一个提交：`fix(debug): 网络失败日志不再拿历史记录当本次的响应证据`。

https://claude.ai/code/session_01Nw9js9Mt7zeMijHwipVVe9