### PR TITLE
fix(music): 播放器服务地址跟着网络代理走，换回默认不再打旧地址

### DIFF
--- a/apps/MusicApp.tsx
+++ b/apps/MusicApp.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useOS } from '../context/OSContext';
 import { useMusic, musicApi, normalizeCookie, toHttps, Song } from '../context/MusicContext';
-import { getProxyWorkerUrl } from '../utils/proxyWorker';
 import { DB } from '../utils/db';
 import { trackEvent } from '../utils/analytics';
 import { Gear, User as UserIcon, Crosshair, Play as PlayIcon, Pause as PauseIcon } from '@phosphor-icons/react';
@@ -28,7 +27,7 @@ type View = 'search' | 'settings' | 'player' | 'profile' | 'visit_char';
 const MusicApp: React.FC = () => {
   const { closeApp, addToast, characters, userProfile } = useOS();
   const {
-    cfg, setCfg,
+    cfg, setCfg, effectiveWorkerUrl,
     current, playing, progress, duration, loadingSong,
     lyric, tlyric, activeLyricIdx,
     profile, playSong, togglePlay, nextSong, prevSong, seek,
@@ -457,14 +456,11 @@ const MusicApp: React.FC = () => {
   // ════════════════ 设置页 ════════════════
   const renderSettings = () => {
     const setDraft = (updates: Partial<typeof cfg>) => setCfg({ ...cfg, ...updates });
-    // 音乐的 worker 地址是独立持久化的，中心设置里的「恢复默认」管不到它——
-    // 这里必须自己兜底：地址清空就保存 = 跟随中心 worker，立即生效（不然存进空串，
-    // 请求会打相对路径直接挂，要等下次刷新 loadCfg 迁移才恢复）。
     const commit = () => {
-      if (!cfg.workerUrl.trim()) setCfg({ ...cfg, workerUrl: getProxyWorkerUrl() });
       addToast('已保存', 'success');
       setView('search');
     };
+    const followsCentral = !cfg.workerUrl.trim();
     return (
       <div className="flex flex-col h-full relative"
         style={{ background: `linear-gradient(180deg, #ffffff 0%, ${C.bg} 50%, ${C.bgDeep} 100%)` }}>
@@ -474,16 +470,18 @@ const MusicApp: React.FC = () => {
           <div className="rounded-2xl p-3.5 shizuku-glass" style={{ boxShadow: `0 2px 16px ${C.glow}08` }}>
             <div className="text-[10px] mb-2 tracking-wider flex items-center justify-between" style={{ color: C.muted }}>
               <span className="flex items-center gap-1.5"><Sparkle size={6} color={C.glow} delay={0} /> 服务地址</span>
-              {cfg.workerUrl.trim() !== getProxyWorkerUrl() && (
-                <button onClick={() => setDraft({ workerUrl: getProxyWorkerUrl() })}
-                  className="text-[9px] underline" style={{ color: C.muted }}>恢复默认</button>
+              {!followsCentral && (
+                <button onClick={() => setDraft({ workerUrl: '' })}
+                  className="text-[9px] underline" style={{ color: C.muted }}>改回跟随中心</button>
               )}
             </div>
             <input className="w-full rounded-xl px-3 py-2 outline-none text-xs shizuku-glass" value={cfg.workerUrl}
-              onChange={e => setDraft({ workerUrl: e.target.value })} placeholder={getProxyWorkerUrl()}
+              onChange={e => setDraft({ workerUrl: e.target.value })} placeholder={effectiveWorkerUrl}
               style={{ color: C.text }} />
             <div className="text-[9px] mt-1.5 italic" style={{ color: C.faint }}>
-              留空保存 = 跟随「设置 → 自定义网络代理」的地址
+              {followsCentral
+                ? <>跟随「设置 → 网络代理」：{effectiveWorkerUrl}</>
+                : <>只在音乐里用这个地址，「设置 → 网络代理」改了也不跟</>}
             </div>
           </div>
           <div className="rounded-2xl p-3.5 shizuku-glass" style={{ boxShadow: `0 2px 16px ${C.glow}08` }}>
@@ -523,10 +521,10 @@ const MusicApp: React.FC = () => {
                 trackEvent('运行音乐服务诊断');
                 const lines: string[] = [];
                 const ck = normalizeCookie(cfg.cookie);
-                lines.push(`Worker: ${cfg.workerUrl}`);
+                lines.push(`Worker: ${effectiveWorkerUrl}${followsCentral ? '（跟随中心）' : '（音乐单独设的）'}`);
                 lines.push(`Cookie: ${ck ? ck.slice(0, 18) + '...(' + ck.length + 'c)' : '(未填)'}`);
                 try {
-                  const res = await fetch(`${cfg.workerUrl.replace(/\/+$/, '')}/netease/search`, {
+                  const res = await fetch(`${effectiveWorkerUrl}/netease/search`, {
                     method: 'POST', headers: { 'Content-Type': 'application/json', ...(ck ? { 'X-Netease-Cookie': ck } : {}) },
                     body: JSON.stringify({ keyword: '晴天', limit: 3 }),
                   });

--- a/context/MusicContext.tsx
+++ b/context/MusicContext.tsx
@@ -83,47 +83,57 @@ const loadLocalAlbum = (): Song[] => {
 const saveLocalAlbum = (songs: Song[]) => {
   try { localStorage.setItem(LS_LOCAL_ALBUM_KEY, JSON.stringify(songs)); } catch {}
 };
-// 音乐的默认 worker = 中心配置（设置 → 自定义网络代理）。用户没在播放器里单独
-// 设过地址时，跟着中心 worker 走；在播放器里手填过自定义地址的，那个地址覆盖生效。
-const musicDefaultWorker = (): string => getProxyWorkerUrl();
-
+// workerUrl 空串 = 跟随「设置 → 网络代理」的中心地址；非空 = 用户在播放器里手填的，
+// 只在音乐这一处生效。存的是"跟不跟随"这个意图，不是当时中心地址的一份快照——
+// 存快照的话事后分不清"用户敲的"和"当时抄的"，中心一改就留下打不通的幽灵地址。
 export const MUSIC_DEFAULT_CFG: MusicCfg = {
-  workerUrl: musicDefaultWorker(),
+  workerUrl: '',
   cookie: '',
   quality: 'exhigh',
 };
 
 /* ───────────── 工具 ───────────── */
-// worker 地址迁移：把"非自定义"的存量地址一律视为"没单独设过" → 跟随中心 worker。
-//   1. 旧的 sully-n.qegj567.workers.dev 默认（国内超时，早就该弃用）；
-//   2. 旧公共域名 sullymeow.ccwu213.cc（注册已过期、DNS 无法解析，2026-07 起）；
-//   3. 停在公共默认实例（= 中心配置的默认值）上的——中心没改时这是 no-op，
-//      中心换成自部署 worker 后，音乐自动跟着切过去。
-// 只有用户在播放器里手填的、跟默认不一样的地址才原样保留。读到需要改写时落盘一次。
-const normalizeHost = (u: string): string => u.trim().replace(/\/+$/, '').toLowerCase();
+const normalizeHost = (u: string): string => (u || '').trim().replace(/\/+$/, '');
+
+/**
+ * 音乐请求实际要打的地址。每次发请求现算，中心地址改了立刻生效。
+ * @param central 只有 MusicProvider 传：它把中心地址放进了 state，好让界面在中心
+ *                地址变化时重渲染；其余调用方省略，直接现读中心配置。
+ */
+export const resolveMusicWorkerUrl = (
+  cfg?: Pick<MusicCfg, 'workerUrl'> | null,
+  central?: string,
+): string => normalizeHost(cfg?.workerUrl || '') || normalizeHost(central || '') || getProxyWorkerUrl();
+
+// 存量迁移：把"其实是跟着中心走"的地址收敛成空串（= 跟随）。命中三种：
+//   1. 已死的两个历史公共实例（sully-n.qegj567.workers.dev 国内超时、
+//      sullymeow.ccwu213.cc 域名注册过期，2026-07 起 DNS 都解析不到）；
+//   2. 当前的公共默认实例；
+//   3. 跟当前中心地址一模一样的——老版本会把中心地址抄一份存进音乐配置。
+// 只有跟以上都不同的地址才原样保留。读到需要改写时落盘一次。
 const FOLLOW_CENTRAL_HOSTS = [/sully-n\.qegj567\.workers\.dev/i, /sullymeow\.ccwu213\.cc/i];
 const migrateWorkerUrl = (url: string | undefined): string => {
-  const central = musicDefaultWorker();
-  if (!url) return central;
-  const norm = normalizeHost(url);
-  if (norm === normalizeHost(DEFAULT_PROXY_WORKER)) return central;
-  if (FOLLOW_CENTRAL_HOSTS.some((re) => re.test(norm))) return central;
-  return url;
+  const own = normalizeHost(url || '');
+  if (!own) return '';
+  const lower = own.toLowerCase();
+  if (lower === normalizeHost(DEFAULT_PROXY_WORKER).toLowerCase()) return '';
+  if (lower === normalizeHost(getProxyWorkerUrl()).toLowerCase()) return '';
+  if (FOLLOW_CENTRAL_HOSTS.some((re) => re.test(lower))) return '';
+  return own;
 };
 
 const loadCfg = (): MusicCfg => {
   try {
     const raw = localStorage.getItem(LS_CFG_KEY);
-    if (!raw) return { ...MUSIC_DEFAULT_CFG, workerUrl: musicDefaultWorker() };
-    const parsed = JSON.parse(raw);
-    const cfg = { ...MUSIC_DEFAULT_CFG, ...parsed };
+    if (!raw) return { ...MUSIC_DEFAULT_CFG };
+    const cfg = { ...MUSIC_DEFAULT_CFG, ...JSON.parse(raw) };
     const migrated = migrateWorkerUrl(cfg.workerUrl);
     if (migrated !== cfg.workerUrl) {
       cfg.workerUrl = migrated;
       try { localStorage.setItem(LS_CFG_KEY, JSON.stringify(cfg)); } catch {}
     }
     return cfg;
-  } catch { return { ...MUSIC_DEFAULT_CFG, workerUrl: musicDefaultWorker() }; }
+  } catch { return { ...MUSIC_DEFAULT_CFG }; }
 };
 
 /**
@@ -226,7 +236,7 @@ export const musicApi = {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     const cookie = normalizeCookie(cfg.cookie);
     if (cookie) headers['X-Netease-Cookie'] = cookie;
-    const url = `${cfg.workerUrl.replace(/\/+$/, '')}/netease${path.startsWith('/') ? path : '/' + path}`;
+    const url = `${resolveMusicWorkerUrl(cfg)}/netease${path.startsWith('/') ? path : '/' + path}`;
     const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body || {}) });
     const j = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(j?.error || j?.message || `HTTP ${res.status}`);
@@ -307,6 +317,8 @@ type PlayMode = 'loop' | 'shuffle' | 'single';
 interface MusicContextType {
   cfg: MusicCfg;
   setCfg: (next: MusicCfg) => void;
+  /** 当前真正在用的服务地址：cfg.workerUrl 留空时 = 中心代理地址 */
+  effectiveWorkerUrl: string;
 
   // 播放队列 / 当前曲
   queue: Song[];
@@ -372,28 +384,38 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const [cfg, setCfgState] = useState<MusicCfg>(loadCfg);
   const setCfg = useCallback((next: MusicCfg) => {
     setCfgState(prev => {
-      // cookie / workerUrl 变了 → 上一个账号的缓存全部失效，避免看到旧账号数据
-      if (prev.cookie !== next.cookie || prev.workerUrl !== next.workerUrl) {
-        _clearAllCache();
-      }
+      // 换账号 → 上一个账号的缓存全部失效，避免看到旧账号数据。
+      // 换地址那一半由下面 effectiveWorkerUrl 的 effect 统一管（中心地址变化也走那条）。
+      if (prev.cookie !== next.cookie) _clearAllCache();
       return next;
     });
     saveCfg(next);
   }, []);
 
-  // 中心配置（设置 → 自定义网络代理）变了 → 重读音乐 cfg，让"跟随中心"的地址实时切过去。
-  // 音乐 cfg 是挂载时快照进 state 的，不重读就只能等下次刷新页面；地址真的变了才清缓存重拉。
+  // 中心地址（设置 → 网络代理）。cfg.workerUrl 留空时用的就是它，进 state 是为了让
+  // 设置页显示的"当前生效地址"能跟着变——请求那边不看这份，每次现读中心配置。
+  const [centralWorkerUrl, setCentralWorkerUrl] = useState<string>(getProxyWorkerUrl);
   useEffect(() => {
     const onProxyChanged = () => {
+      setCentralWorkerUrl(getProxyWorkerUrl());
+      // 中心变了会带动存量迁移（存的地址正好等于新中心 → 收敛成"跟随"），重读一次。
       setCfgState(prev => {
         const next = loadCfg();
-        if (next.workerUrl !== prev.workerUrl) _clearAllCache();
-        return next;
+        return next.workerUrl === prev.workerUrl ? prev : next;
       });
     };
     window.addEventListener(PROXY_WORKER_CHANGED_EVENT, onProxyChanged);
     return () => window.removeEventListener(PROXY_WORKER_CHANGED_EVENT, onProxyChanged);
   }, []);
+
+  const effectiveWorkerUrl = resolveMusicWorkerUrl(cfg, centralWorkerUrl);
+  // 生效地址真的变了 → 上一个地址拉回来的东西全部作废（首次挂载不算变）
+  const lastWorkerUrlRef = useRef(effectiveWorkerUrl);
+  useEffect(() => {
+    if (lastWorkerUrlRef.current === effectiveWorkerUrl) return;
+    lastWorkerUrlRef.current = effectiveWorkerUrl;
+    _clearAllCache();
+  }, [effectiveWorkerUrl]);
 
   const initialState = useMemo(loadState, []);
   const [queue, setQueueState] = useState<Song[]>(initialState.queue);
@@ -955,7 +977,7 @@ export const MusicProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   }, [current, addListeningPartner]);
 
   const value: MusicContextType = {
-    cfg, setCfg,
+    cfg, setCfg, effectiveWorkerUrl,
     queue, setQueue, idx, current,
     playing, progress, duration, loadingSong,
     lyric, tlyric, activeLyricIdx,

--- a/utils/charLyricCache.ts
+++ b/utils/charLyricCache.ts
@@ -107,7 +107,7 @@ export const getCharLyricSnippet = async (
     seed: string,
     lineCount: number = 6,
 ): Promise<string[]> => {
-    if (!songId || !cfg?.workerUrl) return [];
+    if (!songId || !cfg) return [];
     const full = await getFullLyric(cfg, songId);
     if (!full || full.length === 0) return [];
     return pickWindow(full, seed, lineCount);

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -487,8 +487,8 @@ ${groupLogStr}\n`;
                     charListening = { songId: cur.songId, songName: cur.songName, artists: cur.artists, vibe: cur.vibe };
                     // 拉歌词。优先用调用方传进来的 cfg；没传就从 localStorage 取
                     // —— Proactive / activeMsgClient 走这条路也能享受到歌词。
-                    const cfgForLyric = musicCfg?.workerUrl ? musicCfg : loadMusicCfgStandalone();
-                    if (cfgForLyric?.workerUrl) {
+                    const cfgForLyric = musicCfg ?? loadMusicCfgStandalone();
+                    if (cfgForLyric) {
                         try {
                             const slot = getCurrentSlot(schedule, charNow);
                             const seed = `${char.id}-${today}-${slot?.startTime || '00:00'}-${cur.songId}`;

--- a/utils/musicWorkerUrl.test.ts
+++ b/utils/musicWorkerUrl.test.ts
@@ -1,0 +1,109 @@
+/**
+ * 音乐服务地址跟随中心代理 —— 回归守卫
+ *
+ * 音乐 App 的服务地址是独立持久化的（`sully_music_cfg_v1`），跟「设置 → 网络代理」
+ * 那个中心地址不是同一份存储。这里钉住两件事，别再退化：
+ *   1. 没在播放器里单独填过地址的，永远跟着中心走 —— 中心改了、改回默认了，都立刻跟上；
+ *   2. 在播放器里手填过地址的，中心怎么改都不动它。
+ *
+ * 「跟随」现在存成空串（一个意图），不是把当时的中心地址抄一份存下来（一个快照）。
+ * 快照的问题是事后分不清「用户敲的」和「当时抄的」，中心一改就留下打不通的幽灵地址。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MusicCfg,
+  loadMusicCfgStandalone,
+  musicApi,
+  resolveMusicWorkerUrl,
+} from '../context/MusicContext';
+import { DEFAULT_PROXY_WORKER, setProxyWorkerUrl } from './proxyWorker';
+
+const LS_CFG_KEY = 'sully_music_cfg_v1';
+
+/** 直接往 localStorage 里塞一份音乐配置（模拟存量数据） */
+const seedMusicCfg = (workerUrl: string) => {
+  localStorage.setItem(LS_CFG_KEY, JSON.stringify({ workerUrl, cookie: '', quality: 'exhigh' }));
+};
+
+const storedWorkerUrl = (): string => JSON.parse(localStorage.getItem(LS_CFG_KEY) || '{}').workerUrl;
+
+describe('音乐服务地址：跟随中心代理', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('没单独设过 → 用中心地址，中心改了立刻跟上', () => {
+    expect(resolveMusicWorkerUrl(loadMusicCfgStandalone())).toBe(DEFAULT_PROXY_WORKER);
+
+    setProxyWorkerUrl('https://my-proxy.example.com');
+    expect(resolveMusicWorkerUrl(loadMusicCfgStandalone())).toBe('https://my-proxy.example.com');
+
+    setProxyWorkerUrl('');
+    expect(resolveMusicWorkerUrl(loadMusicCfgStandalone())).toBe(DEFAULT_PROXY_WORKER);
+  });
+
+  it('存量地址跟当前中心一样 → 收敛成「跟随」，中心改回默认后跟着回默认', () => {
+    // 老版本会把当时的中心地址抄进音乐配置。之后中心改回默认，那份快照纹丝不动，
+    // 请求继续打已经不用了的地址 —— 正是这条测试要挡住的退化。
+    setProxyWorkerUrl('https://old-proxy.example.com');
+    seedMusicCfg('https://old-proxy.example.com');
+
+    expect(loadMusicCfgStandalone().workerUrl).toBe('');
+
+    setProxyWorkerUrl('');
+    expect(resolveMusicWorkerUrl(loadMusicCfgStandalone())).toBe(DEFAULT_PROXY_WORKER);
+  });
+
+  it('存量地址是公共默认实例 / 已死的历史实例 → 都当成跟随中心', () => {
+    for (const stale of [
+      DEFAULT_PROXY_WORKER,
+      'https://sully-n.qegj567.workers.dev',
+      'https://sullymeow.ccwu213.cc',
+    ]) {
+      seedMusicCfg(stale);
+      expect(loadMusicCfgStandalone().workerUrl).toBe('');
+    }
+  });
+
+  it('迁移结果落盘，不是每次读都现算', () => {
+    seedMusicCfg('https://sully-n.qegj567.workers.dev');
+    loadMusicCfgStandalone();
+    expect(storedWorkerUrl()).toBe('');
+  });
+
+  it('在播放器里手填过的地址 → 中心怎么改都不动', () => {
+    seedMusicCfg('https://my-own-music.example.com');
+    expect(loadMusicCfgStandalone().workerUrl).toBe('https://my-own-music.example.com');
+
+    setProxyWorkerUrl('https://another-proxy.example.com');
+    expect(resolveMusicWorkerUrl(loadMusicCfgStandalone())).toBe('https://my-own-music.example.com');
+  });
+
+  it('地址结尾的斜杠和空格不影响拼出来的 URL', () => {
+    const cfg = { workerUrl: '  https://my-own-music.example.com//  ', cookie: '', quality: 'exhigh' } as MusicCfg;
+    expect(resolveMusicWorkerUrl(cfg)).toBe('https://my-own-music.example.com');
+  });
+
+  it('发请求时才解析地址 —— 同一份 cfg，中心改了就打到新地址', async () => {
+    const hit: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      hit.push(url);
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+
+    // 组件挂载时快照进 state 的那份 cfg（跟随中心），中途不会重新构造
+    const cfg = loadMusicCfgStandalone();
+    await musicApi._raw(cfg, '/login/qr/key');
+
+    setProxyWorkerUrl('https://my-proxy.example.com');
+    await musicApi._raw(cfg, '/login/qr/key');
+
+    expect(hit).toEqual([
+      `${DEFAULT_PROXY_WORKER}/netease/login/qr/key`,
+      'https://my-proxy.example.com/netease/login/qr/key',
+    ]);
+  });
+});

--- a/utils/proxyWorker.ts
+++ b/utils/proxyWorker.ts
@@ -15,8 +15,9 @@
  * 把自己部署的 worker 地址填进「设置 → 网络代理 (Worker)」即可，
  * 以上全部能力会自动切到你的实例，无需改任何代码。
  *
- * 注意：网易云音乐（MusicContext）和小红书 Lite 各自在自己的 App / 设置里有
- * 独立的 worker 地址输入框，走各自的持久化，不受这里影响。
+ * 网易云音乐（MusicContext）在播放器设置里另有一个服务地址输入框：留空 = 跟随这里，
+ * 填了则只有音乐走那个地址。小红书 Lite 的 serverUrl 指向用户自己电脑上跑的服务，
+ * 跟这里是两回事。
  */
 
 export const DEFAULT_PROXY_WORKER = 'https://sullymeow.ccwu.cc';
@@ -104,8 +105,8 @@ export const isCustomProxyWorker = (): boolean => getProxyWorkerUrl() !== DEFAUL
 
 /**
  * 把指向已死历史实例的 url 改写到当前生效的 worker（保留路径和 query）；
- * 其余地址原样返回。给音乐播放器 / 小红书等「独立持久化 worker 地址」的
- * 模块做存量迁移用——它们各自存的地址不走上面的 LS_KEY，得在自己的读取层调这个。
+ * 其余地址原样返回。给小红书 serverUrl 这类「自己存一份地址」的模块做存量迁移用——
+ * 它们存的地址不走上面的 LS_KEY，得在自己的读取层调这个。
  */
 export const rewriteStaleWorkerUrl = (url: string): string => {
   if (typeof url !== 'string' || !url || !STALE_HOSTS.some((re) => re.test(url))) return url;


### PR DESCRIPTION
## 问题

在「设置 → 网络代理」换过自定义代理、后来又改回默认，音乐 App 却还在打那个已经不用的地址，扫码登录直接 `Load failed`：

```
URL: https://dl.xxxxxxxx.workers.dev/netease/login/qr/key
错误: TypeError: Load failed
```

音乐的服务地址是独立存的一份（跟中心代理不是同一处存储）。以前存进去的是**当时中心地址的一份拷贝**——换过自定义代理之后，只要在播放器里动过任何设置（改 cookie、换音质、扫码登录），那个地址就被抄下来了。之后中心改回默认，音乐这边纹丝不动：代码事后分不清这个地址是「用户手填的」还是「当时抄的」，只能当成手填的保留。

## 改后

服务地址这个框存的是**跟不跟随**，不是一份快照：

| 框里 | 行为 |
|---|---|
| 留空 | 跟随「设置 → 网络代理」，中心改了当场生效（不用刷新页面），旧地址的缓存一并作废 |
| 填了地址 | 只有音乐走这个，中心怎么改都不动它 |

已存的地址在读到时判断，三种情况收敛成「跟随」：已死的两个历史公共实例、当前公共默认地址、跟当前中心地址相同的（即老版本抄下来的快照）。

界面上顺带补了两处看得见的信息：设置页显示当前**真正在用**的地址（跟随时显示中心地址，手填时提示中心改了也不跟），诊断输出的 Worker 那行标明是跟随还是单独设的。以前只能看到一个光秃秃的 URL，看不出它跟中心是两份。

## 存量说明

如果设备上已经存着一个「中心早就改回默认、音乐还停在旧自定义地址」的组合，这次迁移认不出来（它对不上任何一条规则）——进音乐 App → 设置 → 服务地址 → 点「改回跟随中心」，一次即可，之后不会再出现。

## 测试

新增 `utils/musicWorkerUrl.test.ts`，7 条回归守卫，改动前全部失败，其中一条就是本次问题的直接复现：

```
- "https://my-proxy.example.com/netease/login/qr/key"   期望
+ "https://sullymeow.ccwu.cc/netease/login/qr/key"      旧行为：同一份 cfg，中心改了还打老地址
```

全量 `pnpm vitest run`：215 文件 / 3140 用例通过。

https://claude.ai/code/session_018kvhb2bXRBj3CpfM421GeD
