### PR TITLE
fix(amsg2): 网络抖一下不再把即时对话长期打回本地生成

### DIFF
--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -36,6 +36,7 @@ import ChatHeader from '../components/chat/ChatHeaderShell';
 import CharacterEntryTransition from '../components/chat/CharacterEntryTransition';
 import ChromeCssEditor from '../components/chat/ChromeCssEditor';
 import ChatInputArea from '../components/chat/ChatInputArea';
+import InstantChatRouteNotice from '../components/chat/InstantChatRouteNotice';
 import MemoryRepairPortal from '../components/chat/MemoryRepairPortal';
 import ChatModals from '../components/chat/ChatModals';
 import Modal from '../components/os/Modal';
@@ -3650,7 +3651,10 @@ const Chat: React.FC = () => {
                         <button onClick={() => setReplyTarget(null)} className="p-1 text-slate-400 hover:text-slate-600">×</button>
                     </div>
                 )}
-                
+
+                {/* 开关写着「已开启」、这一轮却在本地生成时，把原因说给用户听 */}
+                <InstantChatRouteNotice charId={activeCharacterId} />
+
                 <ChatInputArea
                     input={input} setInput={handleInputChange}
                     isTyping={isTyping} selectionMode={selectionMode}

--- a/components/chat/InstantChatRouteNotice.tsx
+++ b/components/chat/InstantChatRouteNotice.tsx
@@ -1,0 +1,57 @@
+/**
+ * 「这一轮没上云，在本地生成」的提示条（输入框正上方那一条）。
+ *
+ * 为什么要有：即时对话的开关写着「已开启」，消息却在本地生成——这中间的落差过去只留在
+ * console 和观察窗里，用户查不到。他能看到的只有本地直连失败时那条读不懂的网络报错，
+ * 于是以为是自己网络坏了。线上真实故障里，有人就这么卡了四个小时。
+ *
+ * 只报两档，都是「用户想上云、实际没上」的情形：
+ *   worker-outdated     问到了，那台 Worker 确实跑不动 → 指路去更新
+ *   worker-unreachable  这一刻够不着云端 → 别叫人去更新，多半是网络，会自己好
+ *
+ * 用户自己关掉的（disabled / char-disabled）、点单流程那种本该留在本地的，一律不出声——
+ * 那些是正常行为，报了就成骚扰。
+ */
+import React, { useEffect, useState } from 'react';
+import { AMSG_INSTANT_CHAT_ROUTE_EVENT, type InstantChatRouteDetail } from '../../utils/amsgInstantChat';
+
+const NOTICES: Record<string, { title: string; hint: string }> = {
+    'worker-outdated': {
+        title: '这一轮在本地生成',
+        hint: '云端那台 Worker 跑不动这条路，去设置里更新一下',
+    },
+    'worker-unreachable': {
+        title: '这一轮在本地生成',
+        hint: '一时连不上云端，网络恢复后会自己回去',
+    },
+};
+
+const InstantChatRouteNotice: React.FC<{ charId: string }> = ({ charId }) => {
+    const [reason, setReason] = useState<string | null>(null);
+
+    useEffect(() => {
+        // 换会话先清干净：上一个角色那轮的结论跟这个角色没关系。
+        setReason(null);
+        const onRoute = (event: Event) => {
+            const detail = (event as CustomEvent<InstantChatRouteDetail>).detail;
+            if (!detail || detail.charId !== charId) return;
+            // reason 为 null（这一轮走成了云端）或不在名单里的原因，都当「没什么好说的」收起来。
+            setReason(detail.reason && NOTICES[detail.reason] ? detail.reason : null);
+        };
+        window.addEventListener(AMSG_INSTANT_CHAT_ROUTE_EVENT, onRoute);
+        return () => window.removeEventListener(AMSG_INSTANT_CHAT_ROUTE_EVENT, onRoute);
+    }, [charId]);
+
+    const notice = reason ? NOTICES[reason] : null;
+    if (!notice) return null;
+
+    return (
+        <div className="flex items-center gap-2 px-4 py-1.5 bg-amber-50 border-b border-amber-200/70 text-[11px] text-amber-800">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0" />
+            <span className="font-bold shrink-0">{notice.title}</span>
+            <span className="opacity-70 truncate">· {notice.hint}</span>
+        </div>
+    );
+};
+
+export default InstantChatRouteNotice;

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -45,7 +45,7 @@ import { getLastRealUserMessageAt } from '../utils/amsg2ExpireGuard';
 import { getPendingTasks, hasActiveAiTask, isAmsg2EnabledForChar } from '../utils/amsg2Tasks';
 import { buildAmsg2NoticesText, buildAmsg2TaskContextText, collectAmsg2TaskContext } from '../utils/amsg2TaskContext';
 import { resolveCharTimeZone } from '../utils/timezone';
-import { getInstantChatPending, resolveInstantChatReadiness, sendInstantChatTurn, stageInstantChatExpiredNotices } from '../utils/amsgInstantChat';
+import { announceInstantChatRoute, getInstantChatPending, resolveInstantChatReadiness, sendInstantChatTurn, stageInstantChatExpiredNotices } from '../utils/amsgInstantChat';
 // worker 模块的常量叶子（零运行时依赖，前端引它不带进 worker 环境）：
 // 云端 fire 的总时长上限，安全网超时从它推导，worker 调预算时前端自动跟上。
 import { INSTANT_TOTAL_TIMEOUT_MS } from '../worker/amsg/src/instantChat';
@@ -873,16 +873,21 @@ export const useChatAI = ({
                     charId: char.id,
                     reason: skipReason,
                 });
-            } else if (instantChatReadiness.reason === 'worker-outdated') {
-                // 用户把开关开着，是我们判定那台 Worker 跑不动才让位给本地生成的
+            } else if (instantChatReadiness.reason === 'worker-outdated' || instantChatReadiness.reason === 'worker-unreachable') {
+                // 用户把开关开着，是我们判定这一轮上不了云才让位给本地生成的
                 // （见 resolveInstantChatReadiness 的同名门）。上面那条 trace 的条件
                 // （instantChatOn）在这里天然为假，所以单独留一条：这一档比别的更需要
                 // 查得到——用户的主观意愿是「上云」，实际走的却是本地，不留痕就又是一次
                 // 静默分流。拦不拦不用这里管，readiness 已经说了 not ready，
                 // 下面照常走本地生成那条路。
+                //
+                // 两档分开记：worker-outdated 是「问到了、那台 Worker 确实跑不动」（该去更新），
+                // worker-unreachable 是「这一刻够不着云端」（多半是网络，会自己好）。
                 appendInstantTraceEntry({
                     ts: new Date().toISOString(),
-                    event: 'instant-chat-worker-outdated',
+                    event: instantChatReadiness.reason === 'worker-outdated'
+                        ? 'instant-chat-worker-outdated'
+                        : 'instant-chat-worker-unreachable',
                     charId: char.id,
                 });
             } else if (instantChatReadiness.reason === 'config-unreadable') {
@@ -914,6 +919,14 @@ export const useChatAI = ({
                 }
                 console.warn('[AmsgInstantChat] 全局配置读不出来（开没开都不知道），但这一轮本就不走即时对话，照原路继续');
             }
+
+            // 这一轮到底走了哪条路，播给输入框上方那条小提示。**每轮都发**，包括走成了云端
+            // 那一轮（reason=null，提示自己收起来）——只在出问题时发的话，用户会一直盯着一条
+            // 早就过期的提示，猜不出来「现在到底恢复了没有」。
+            announceInstantChatRoute({
+                charId: char.id,
+                reason: instantChatRoute ? null : (instantChatReadiness.reason ?? null),
+            });
 
             const payload = await stageT('payload', buildChatRequestPayload({
                 char: charForGen, userProfile, groups, emojis, categories,

--- a/types.ts
+++ b/types.ts
@@ -328,11 +328,16 @@ export interface ActiveMsg2GlobalConfig {
    */
   instantChatEnabled?: boolean;
   /**
-   * 上一次探到的「那台 Worker 真的跑得动即时对话吗」（见 ActiveMsgClient.probeInstantChatSupport）。
+   * 上一次**明确探到**的「那台 Worker 真的跑得动即时对话吗」
+   * （见 ActiveMsgClient.probeInstantChatSupportDetailed）。
    *
-   * false 时即时对话整个让位给本地生成，**用户开着也不走** —— 跑不动的 Worker 上这条路
-   * 是发一条挂一条，让位比让他对着「已开启」干等强。探测每次都会刷新它，用户更新完
-   * Worker 下一次探测自然翻回 true，不用手动去重开开关。
+   * 只有问到了答案才会写这里：200 + instantTick 写 true，200 但没有 instantTick 写 false。
+   * 网络异常、超时、401、5xx 一律不写——那些说明的是线路或配置有问题，不是这台 Worker
+   * 的能力，拿它们判死刑的话一次抖动就能把即时对话长期钉死在本地生成。
+   *
+   * false 时即时对话让位给本地生成，**用户开着也不走** —— 跑不动的 Worker 上这条路是
+   * 发一条挂一条，让位比让他对着「已开启」干等强。发消息路上会带冷却地现探一次，
+   * 用户更新完 Worker 后自己就翻回来了，不用手动去重开开关。
    *
    * undefined = 还没探过（刚装、没进过设置页），按放行处理：这一档说明我们不知道，
    * 而不是知道它不行；握手时会补探一次，之后就有准数了。

--- a/utils/activeMsgClient.test.ts
+++ b/utils/activeMsgClient.test.ts
@@ -58,6 +58,9 @@ import { KeepAlive } from './keepAlive';
 const TEST_USER_ID = '3f2b1c8a-9d4e-4a1b-8c2d-000000000001';
 
 // cancelTask 要走 ensureWorkerReady（读 IndexedDB 里的 worker 地址），测里给一份固定配置。
+/** 用例想往全局配置里多塞几个字段时改它（比如「上次已经探到 true」）。用完记得清。 */
+const { storeConfigExtra } = vi.hoisted(() => ({ storeConfigExtra: { value: {} as Record<string, unknown> } }));
+
 vi.mock('./activeMsgStore', () => ({
   ActiveMsgStore: {
     ensureUserId: async () => TEST_USER_ID,
@@ -65,6 +68,7 @@ vi.mock('./activeMsgStore', () => ({
       userId: TEST_USER_ID,
       workerUrl: 'https://amsg.example.workers.dev',
       serverToken: '',
+      ...storeConfigExtra.value,
     }),
     // connect() 成功那条路会落盘 initializedAt，走失败分支的用例碰不到它。
     saveGlobalConfig: vi.fn().mockResolvedValue(undefined),
@@ -386,6 +390,64 @@ describe('即时对话能力探测（instantTick）', () => {
     configCheck({ instantChat: true, instantTick: true });
     await ActiveMsgClient.probeInstantChatSupport();
     expect(ActiveMsgStore.saveGlobalConfig).toHaveBeenCalledWith({ instantChatSupported: true });
+  });
+
+  // ★ 核心回归守卫：「探不到」≠「探到了、答案是不行」。
+  //
+  // 这两种从前混用同一个 false，于是一次网络抖动（切代理节点、CF 边缘抖一下、D1 冷启动
+  // 慢）就足以把 instantChatSupported 写死成 false。那份存量是粘的，用户不碰巧打开设置页
+  // 就一直卡在本地生成——线上真实故障就是这么来的：Worker 那头全绿（instantTick:true、
+  // 库也齐），用户却连着几小时每一轮都在本地直连生成，而他的本地直连根本不通，只看得到
+  // 一条读不懂的网络报错，开关还写着「已开启」。
+  describe('探不到的时候一个字都不许写进存量', () => {
+    afterEach(() => { storeConfigExtra.value = {}; });
+
+    /** 上次已经探到「跑得动」，这次没问到答案 → 存量必须原样保留。 */
+    const expectKeepsPreviousTrue = async () => {
+      const { ActiveMsgStore } = await import('./activeMsgStore');
+      (ActiveMsgStore.saveGlobalConfig as any).mockClear();
+      const result = await ActiveMsgClient.probeInstantChatSupportDetailed();
+      expect(result.outcome).toBe('unknown');
+      expect(result.supported).toBe(true);
+      expect(ActiveMsgStore.saveGlobalConfig).not.toHaveBeenCalled();
+    };
+
+    it('网络异常（fetch 直接抛）→ 保留上次探到的 true', async () => {
+      storeConfigExtra.value = { instantChatSupported: true };
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('Load failed'); }));
+      await expectKeepsPreviousTrue();
+    });
+
+    it('401 → 说明共享密钥没填对，跟 Worker 跑不跑得动没关系', async () => {
+      storeConfigExtra.value = { instantChatSupported: true };
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        status: 401,
+        text: async () => JSON.stringify({ success: false, error: { code: 'INVALID_CLIENT_TOKEN' } }),
+        headers: new Headers({ 'content-type': 'application/json' }),
+      })));
+      await expectKeepsPreviousTrue();
+    });
+
+    it('5xx / 中间设备塞回来的网关页 → 说明线路有问题，同样不是答案', async () => {
+      storeConfigExtra.value = { instantChatSupported: true };
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        status: 503,
+        text: async () => '<html>502 Bad Gateway</html>',
+        headers: new Headers({ 'content-type': 'text/html' }),
+      })));
+      await expectKeepsPreviousTrue();
+    });
+
+    // 别矫枉过正：真的问到「跑不动」时该写还得写，否则这道门就形同虚设。
+    it('200 但没有 instantTick → 这是明确答案，照写 false', async () => {
+      storeConfigExtra.value = { instantChatSupported: true };
+      const { ActiveMsgStore } = await import('./activeMsgStore');
+      (ActiveMsgStore.saveGlobalConfig as any).mockClear();
+      configCheck({ instantChat: true });
+      const result = await ActiveMsgClient.probeInstantChatSupportDetailed();
+      expect(result.outcome).toBe('unsupported');
+      expect(ActiveMsgStore.saveGlobalConfig).toHaveBeenCalledWith({ instantChatSupported: false });
+    });
   });
 });
 

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -1262,6 +1262,29 @@ const decryptPayload = async (client: ReiClient, payload: { iv: string; authTag:
 };
 
 /**
+ * 即时对话能力探测这一次到底问到了什么。
+ *
+ * 「探不到」必须和「问到了、答案是不行」分开。混成同一个 false 的话，一次网络抖动
+ * （切代理节点、CF 边缘抖一下、D1 冷启动慢）就会把即时对话长期钉死在本地生成——存量
+ * 是粘的，只有下次探测成功才翻得回来，而重探只挂在握手和打开设置页两处，用户不进设置页
+ * 就一直卡着。线上真踩过：Worker 那头全绿，用户却连着几小时每一轮都在本地直连生成，
+ * 而他的本地直连根本不通，只看得到一条读不懂的网络报错，开关还写着「已开启」。
+ */
+export type InstantChatProbeOutcome =
+  /** 200 + instantTick:true —— 跑得动 */
+  | 'supported'
+  /** 200 但没有 instantTick —— 明确跑不动（老 bundle，或代码新了绑定没接上） */
+  | 'unsupported'
+  /** 压根没问到（网络异常、超时、401、5xx、网关页）—— 这不是答案，不能拿来判死刑 */
+  | 'unknown';
+
+export interface InstantChatProbeResult {
+  outcome: InstantChatProbeOutcome;
+  /** 探完之后真正生效的存量。unknown 时 = 探测前那份（原样不动，可能是 undefined）。 */
+  supported: boolean | undefined;
+}
+
+/**
  * 单条任务此刻的状态（`getRemoteTaskStatus` 的答案）。
  *   pending   —— 行在且还会跑（可能正在重试等待里，retryCount>0）
  *   completed —— 行在但已经出清（对一次性任务就等于失败：发成功的行会被删掉）
@@ -2367,29 +2390,68 @@ export const ActiveMsgClient = {
    * 第一下常常是「代码新了、版本号也对上了、绑定却没接上」，这条路只能回 503。看版本号
    * 的话前端会一边说「已经是最新版」一边发一条挂一条。
    *
-   * 探不到一律 false（老 bundle 根本没这个字段，网络不通也是 false）：这一档会让即时对话
-   * 整个让位给本地生成，宁可少一个后台能力，也不要「开关亮着、发一条挂一条」。
+   * 「探不到」和「问到了、答案是不行」是两回事，只有后者才写进存量——详见
+   * InstantChatProbeOutcome 那段注释。返回值是**探完之后生效的存量**（探不到时
+   * 就是探测前那份），调用方只想要一个「现在能不能上云」时用这个签名即可；要分辨
+   * 这次到底问没问到，用 probeInstantChatSupportDetailed。
    *
    * 结论顺手存进全局配置（`instantChatSupported`）：真正拦下这一轮的是发消息那条路上的
-   * resolveInstantChatReadiness，而它不做逐调用网络探测，只认这份存量。所以每探一次就
-   * 刷一次，用户更新完 Worker 后下一次探测自然把它翻回来，不用手动去重开开关。
+   * resolveInstantChatReadiness，而它只认这份存量（外加存量为 false 时的一次现探）。
    */
-  async probeInstantChatSupport(): Promise<boolean> {
-    let supported = false;
+  async probeInstantChatSupport(options?: { timeoutMs?: number }): Promise<boolean> {
+    return (await this.probeInstantChatSupportDetailed(options)).supported === true;
+  },
+
+  /**
+   * 同上，但把「这次到底问到了什么」一并交出来。发消息路上的重探要靠它区分
+   * 「确认跑不动」（该提示去更新 Worker）和「这一刻连不上」（多半是网络，等会儿自己好）。
+   *
+   * timeoutMs：给现探用的护栏。握手时那次不传（不阻塞任何人），发消息路上那次必须传，
+   * 否则一条连不上的线路会把用户按在发送键上干等。
+   */
+  async probeInstantChatSupportDetailed(options?: { timeoutMs?: number }): Promise<InstantChatProbeResult> {
+    let previous: boolean | undefined;
+    try {
+      previous = (await ActiveMsgStore.getGlobalConfig()).instantChatSupported;
+    } catch {
+      previous = undefined;
+    }
+    let outcome: InstantChatProbeOutcome = 'unknown';
     try {
       const config = await ensureWorkerReady();
-      const { status, body } = await fetchWithAuthRaw('config-check', config, { method: 'GET' }, '即时对话能力探测');
-      supported = status === 200 && body?.success === true && body?.data?.instantTick === true;
+      const init: RequestInit = { method: 'GET' };
+      const timeoutMs = options?.timeoutMs;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      if (typeof timeoutMs === 'number' && timeoutMs > 0 && typeof AbortController !== 'undefined') {
+        const controller = new AbortController();
+        init.signal = controller.signal;
+        timer = setTimeout(() => controller.abort(), timeoutMs);
+      }
+      try {
+        const { status, body } = await fetchWithAuthRaw('config-check', config, init, '即时对话能力探测');
+        // 只有「200 + 这份 JSON 自称成功」才算问到了答案。401（密钥没填对）、5xx、
+        // 中间设备塞回来的网关页……说明的都是「这条线路/这份配置有问题」，而不是
+        // 「那台 Worker 跑不动即时对话」，一律留在 unknown。
+        if (status === 200 && body?.success === true) {
+          outcome = body?.data?.instantTick === true ? 'supported' : 'unsupported';
+        }
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
     } catch {
-      supported = false;
+      // 网络异常 / 超时 / 中止：同上，不是答案。
+      outcome = 'unknown';
     }
+    // 探不到就什么都不写：存量保持原样。这一句就是「一次抖动 ≠ 长期降级」的全部。
+    if (outcome === 'unknown') return { outcome, supported: previous };
+    const supported = outcome === 'supported';
     try {
       await ActiveMsgStore.saveGlobalConfig({ instantChatSupported: supported });
     } catch (error) {
       // 存不下只是这一轮的判断留不到下次，探测结论本身照常返回。
       console.warn('[AmsgInstantChat] 能力探测结果没存下来（下次发消息按上一次的存量判断）', error);
     }
-    return supported;
+    return { outcome, supported };
   },
 
   /**

--- a/utils/amsgInstantChat.test.ts
+++ b/utils/amsgInstantChat.test.ts
@@ -70,6 +70,7 @@ import {
   getInstantChatPending,
   getStagedInstantChatExpiredNotices,
   isInstantChatReady,
+  resetInstantChatReprobeCooldown,
   resolveInstantChatReadiness,
   sendInstantChatTurn,
   setInstantChatPending,
@@ -553,8 +554,22 @@ describe('开关', () => {
   // 新 bundle 少了起跳器直接 503。用户开着开关也得让位给本地生成，否则他对着
   // 「正在输入…」等一条永远不来的回复，而设置页写着「已开启」。
 
-  it('探到 Worker 跑不动 → 用户开着也不走云端（reason worker-outdated）', async () => {
+  // 存量是粘的（只有探测成功才翻得回来），所以让位之前一定要先现探一次——下面四条钉的
+  // 就是这次现探的四种去向。
+
+  /** 存量说跑不动 + 摆好「这次现探会问到什么」。 */
+  const stageOutdatedWithProbe = (outcome: 'supported' | 'unsupported' | 'unknown') => {
     storeState.config = { ...storeState.config, instantChatEnabled: true, instantChatSupported: false };
+    // 冷却是模块级状态，会串到别的用例上去。
+    resetInstantChatReprobeCooldown();
+    return vi.spyOn(ActiveMsgClient, 'probeInstantChatSupportDetailed').mockResolvedValue({
+      outcome,
+      supported: outcome === 'supported' ? true : outcome === 'unsupported' ? false : undefined,
+    });
+  };
+
+  it('现探确认跑不动 → 用户开着也不走云端（reason worker-outdated）', async () => {
+    stageOutdatedWithProbe('unsupported');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => { /* 静音，只数次数 */ });
     const readiness = await resolveInstantChatReadiness();
     expect(readiness).toEqual({ ready: false, reason: 'worker-outdated' });
@@ -563,6 +578,35 @@ describe('开关', () => {
     expect(readiness.reason).not.toBe('disabled');
     // 静默让位正是「静默分流」那个坑，必须留声。
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  // ★ 这条是「一次抖动 ≠ 长期降级」的守卫。
+  // 从前存量一旦是 false 就直接判死，而写下这个 false 的可能只是一次网络抖动——用户不
+  // 碰巧打开设置页就一直卡在本地生成（线上真实故障：Worker 全绿，用户连着几小时全走本地，
+  // 而他的本地直连根本不通）。现在发消息路上会现探一次，好了立刻回到云端。
+  it('存量说跑不动、现探却发现已经好了 → 这一轮就回到云端（不必等用户去开设置页）', async () => {
+    stageOutdatedWithProbe('supported');
+    expect(await resolveInstantChatReadiness()).toEqual({ ready: true });
+  });
+
+  // 够不着云端时不能指人去「更新 Worker」：他多半点不动，而且问题也不在那儿。
+  it('现探够不着云端 → 单独一档 worker-unreachable，不叫人去更新 Worker', async () => {
+    stageOutdatedWithProbe('unknown');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => { /* 静音，只数次数 */ });
+    const readiness = await resolveInstantChatReadiness();
+    expect(readiness).toEqual({ ready: false, reason: 'worker-unreachable' });
+    expect(readiness.reason).not.toBe('worker-outdated');
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  // 现探是加在发消息路上的，连发几条消息不能变成一串 /config-check。
+  it('冷却期内不重复现探（连发三条只探一次）', async () => {
+    const probe = stageOutdatedWithProbe('unsupported');
+    vi.spyOn(console, 'warn').mockImplementation(() => { /* 静音 */ });
+    await resolveInstantChatReadiness();
+    await resolveInstantChatReadiness();
+    await resolveInstantChatReadiness();
+    expect(probe).toHaveBeenCalledTimes(1);
   });
 
   it('没探过（undefined）→ 放行：不知道 ≠ 知道它不行', async () => {

--- a/utils/amsgInstantChat.ts
+++ b/utils/amsgInstantChat.ts
@@ -20,7 +20,7 @@
  */
 
 import { ActiveMsg2InboxMessage, CharacterProfile, GroupProfile, RealtimeConfig, UserProfile } from '../types';
-import { ActiveMsgClient, type AmsgOutboxEntry } from './activeMsgClient';
+import { ActiveMsgClient, type AmsgOutboxEntry, type InstantChatProbeOutcome } from './activeMsgClient';
 import { ActiveMsgStore } from './activeMsgStore';
 import { trackEvent } from './analytics';
 import { announceEmotionDone } from './chatGenEvents';
@@ -221,15 +221,19 @@ export const discardInstantChatExpiredNotices = (charId: string, uuid?: string):
 // ─── 开关 ───
 
 /**
- * ready=false 时卡在哪一道。两档不是「用户没开」，调用方要分开收场：
+ * ready=false 时卡在哪一道。三档不是「用户没开」，调用方要分开收场：
  *   config-unreadable  这一刻问不出来（明确报错等重发，绝不悄悄退回本地）
- *   worker-outdated    开着，但那台 Worker 跑不动（退回本地生成，且必须留痕）
+ *   worker-outdated    问到了，那台 Worker 确实跑不动（退回本地生成，提示去更新 Worker）
+ *   worker-unreachable 这一刻够不着云端（退回本地生成，但别叫人去更新——多半是网络）
+ *
+ * 后两档都得留痕：用户的主观意愿是「上云」，实际走的却是本地，不留痕就是一次静默分流。
  */
 export type InstantChatReadinessReason =
   | 'disabled'
   | 'char-disabled'
   | 'no-worker-url'
   | 'worker-outdated'
+  | 'worker-unreachable'
   | 'config-unreadable';
 
 export interface InstantChatReadiness {
@@ -237,17 +241,78 @@ export interface InstantChatReadiness {
   reason?: InstantChatReadinessReason;
 }
 
+// ─── 存量说「跑不动」时的现探 ───
+//
+// 存量是粘的：一旦写成 false，只有下一次探测成功才翻得回来，而探测原本只挂在握手
+// （一次会话一次）和打开设置页两处。用户不进设置页，就会一直卡在本地生成。
+//
+// 所以这里补一次**懒重探**：只有存量已经是 false 时才探，且带冷却。成本压得很准——
+// 状态正常的人一次额外请求都不加，只有已经降级的人付这点延迟，而他们本来就在走一条
+// 对自己未必通的本地路径，拿 0.4 秒换回云端完全值得。
+
+/** 存量已经是 false 时，最多每隔这么久现探一次，看能不能翻回来。 */
+export const INSTANT_CHAT_REPROBE_COOLDOWN_MS = 30_000;
+
+/** 现探卡这么久还没回话就算了，这一轮照常走本地——绝不把用户按在发送键上干等。 */
+export const INSTANT_CHAT_REPROBE_TIMEOUT_MS = 3_000;
+
+let lastReprobeAt = 0;
+/** 上一次现探问到了什么。冷却期内沿用它，别让同一段时间里的消息报出忽左忽右的原因。 */
+let lastReprobeOutcome: InstantChatProbeOutcome = 'unknown';
+/** 同一刻好几条消息一起进来时共用同一次探测，别打出一串并发的 /config-check。 */
+let reprobeInFlight: Promise<InstantChatProbeOutcome> | null = null;
+
+/**
+ * 把冷却清零，让下一条消息立刻重探。
+ * 网络刚恢复时调（online 事件），换 Worker / 改配置的地方也可以调。
+ */
+export const resetInstantChatReprobeCooldown = (): void => { lastReprobeAt = 0; };
+
+// 切代理节点不会触发 online，所以这个监听只是「便宜的加速」，不是恢复的唯一指望——
+// 真正兜底的是上面那道冷却到期后的现探。
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('online', resetInstantChatReprobeCooldown);
+}
+
+/**
+ * 现探一次，返回这次问到了什么。冷却期内不探，沿用上一次的结论。
+ */
+const reprobeInstantChatSupport = async (): Promise<InstantChatProbeOutcome> => {
+  if (reprobeInFlight) return reprobeInFlight;
+  if (Date.now() - lastReprobeAt < INSTANT_CHAT_REPROBE_COOLDOWN_MS) return lastReprobeOutcome;
+  lastReprobeAt = Date.now();
+  const task = (async () => {
+    try {
+      const result = await ActiveMsgClient.probeInstantChatSupportDetailed({
+        timeoutMs: INSTANT_CHAT_REPROBE_TIMEOUT_MS,
+      });
+      return result.outcome;
+    } catch {
+      return 'unknown' as const;
+    }
+  })();
+  reprobeInFlight = task;
+  try {
+    lastReprobeOutcome = await task;
+    return lastReprobeOutcome;
+  } finally {
+    reprobeInFlight = null;
+  }
+};
+
 /**
  * 即时对话此刻走不走得通，外加「走不通是因为什么」。
  *
  * 门槛四道：角色没单独关（传了 char 才查）、设置页开了、那台 Worker 跑得动、Worker
  * 地址填着。
  *
- * 「跑得动」读的是**存量**（config.instantChatSupported），不是现探——这里现探的话每发
- * 一条消息都要多一次网络往返，而且探测失败时到底算「不支持」还是「网络抖了一下」没有
- * 正确答案。存量由 probeInstantChatSupport 每次探测时刷新（设置页打开时、握手时各一次），
- * 用户更新完 Worker 会自己翻回来，不用手动重开开关。undefined = 还没探过，放行——那一
- * 档说明我们不知道，不是知道它不行。
+ * 「跑得动」平时读的是**存量**（config.instantChatSupported），由 probeInstantChatSupport
+ * 在握手和打开设置页时刷新。走存量是为了省 RTT：状态正常的人一条消息都不该多花一次
+ * 网络往返。undefined = 还没探过，放行——那一档说明我们不知道，不是知道它不行。
+ *
+ * 只有存量已经是 false（= 上一次明确探到跑不动）时，这里才补一次现探，看能不能翻回来，
+ * 详见 reprobeInstantChatSupport。额外开销精确落在已经降级的那批人身上，而他们本来就在
+ * 走一条对自己未必通的本地路径。
  *
  * 为什么这道门非要有：跑不动的 Worker 上这条路是**发一条挂一条**（老 bundle 被 waitUntil
  * 砍在 30 秒，新 bundle 少了起跳器则直接 503），而开关还写着「已开启」。让位给本地生成
@@ -279,11 +344,26 @@ export const resolveInstantChatReadiness = async (
   // 地址排在能力前面：没填地址时那份能力位多半是上一台 Worker 留下的存量，
   // 报「Worker 太旧」会把人指去点一个根本没连上的东西。
   if (!config.workerUrl?.trim()) return { ready: false, reason: 'no-worker-url' };
-  // 开着、地址也在，但那台 Worker 上这条路是坏的。静默让位正是「静默分流」那个老坑，
-  // 所以就地 warn 一声，调用方还会额外留一条 trace——用户至少查得到「为什么开了却走本地」。
+  // 开着、地址也在，但存量说那台 Worker 上这条路是坏的。
+  //
+  // 先现探一次再下结论：这份 false 可能是**旧版本**在一次网络抖动里写下的误判（那会儿
+  // 「探不到」和「探到不行」共用一个 false），也可能是用户当时真的还没更新 Worker。
+  // 不重探的话，前者要一直等到用户碰巧打开设置页才纠正得过来。
   if (config.instantChatSupported === false) {
-    console.warn(`${HEADER} 开关是开的，但那台 Worker 跑不动即时对话（缺起跳器或还是旧 bundle）：这一轮本地生成。去设置页点「更新 Worker」`);
-    return { ready: false, reason: 'worker-outdated' };
+    const outcome = await reprobeInstantChatSupport();
+    if (outcome === 'supported') {
+      console.info(`${HEADER} 重探到那台 Worker 现在跑得动即时对话（存量是过期结论），这一轮照常上云`);
+      return { ready: true };
+    }
+    // 静默让位正是「静默分流」那个老坑，所以两档都就地 warn 一声，调用方还会额外留一条
+    // trace——用户至少查得到「为什么开了却走本地」。两档的去向不同，别混：
+    if (outcome === 'unsupported') {
+      console.warn(`${HEADER} 开关是开的，但那台 Worker 跑不动即时对话（缺起跳器或还是旧 bundle）：这一轮本地生成。去设置页点「更新 Worker」`);
+      return { ready: false, reason: 'worker-outdated' };
+    }
+    // 够不着云端时别叫人去更新 Worker——他多半点不动，而且问题也不在那儿。
+    console.warn(`${HEADER} 开关是开的，但这一刻够不着云端（问不出新结论）：这一轮本地生成，连上了会自己回到云端`);
+    return { ready: false, reason: 'worker-unreachable' };
   }
   return { ready: true };
 };
@@ -291,6 +371,27 @@ export const resolveInstantChatReadiness = async (
 /** 只关心「走不走得通」的调用点用这个（设置页的互斥门）。要区分原因走上面那个。 */
 export const isInstantChatReady = async (): Promise<boolean> =>
   (await resolveInstantChatReadiness()).ready;
+
+// ─── 「这一轮走的哪条路」广播给界面 ───
+//
+// 开关写着「已开启」、消息却在本地生成，这中间的落差过去只留在 console 和观察窗里，
+// 普通用户查不到——他能看到的只有一条读不懂的网络报错。所以每一轮都把结论播出去，
+// 由输入框上方那条小提示接住。
+
+/** detail 是 InstantChatRouteDetail。每一轮都发，包括「这一轮回到云端了」。 */
+export const AMSG_INSTANT_CHAT_ROUTE_EVENT = 'amsg-instant-chat-route';
+
+export interface InstantChatRouteDetail {
+  charId: string;
+  /** null = 这一轮走的云端（界面上把提示收起来）；否则是让位给本地生成的原因。 */
+  reason: InstantChatReadinessReason | null;
+}
+
+export const announceInstantChatRoute = (detail: InstantChatRouteDetail): void => {
+  try {
+    window.dispatchEvent(new CustomEvent(AMSG_INSTANT_CHAT_ROUTE_EVENT, { detail }));
+  } catch { /* SSR / 测试环境无 window */ }
+};
 
 // ─── 发这一轮 ───
 


### PR DESCRIPTION
## 这个改动解决什么

用户反馈：一键部署后即时对话好好的，玩了四个小时又开始报错，之后每条消息都在本地生成，而设置页写着「已开启」。查下来那台 Worker 从头到尾是健康的（`instantTick: true`、库 schema 齐全、无积压任务），坏的是前端的一个判断。

即时对话的能力探测把两件事混成了同一个结论：

| 探测遇到什么 | 改之前 | 改之后 |
|---|---|---|
| 200 + `instantTick: true` | 记「跑得动」 | 记「跑得动」 |
| 200 但没有 `instantTick`（老 bundle） | 记「跑不动」 | 记「跑不动」 |
| 网络异常 / 超时 / 401 / 5xx | **记「跑不动」** | **一个字都不写**，保留上次结论 |

这份结论会落盘，而且是粘的：只有下次探测成功才翻得回来，探测又只发生在握手和打开设置页两处。所以一次网络抖动（切代理节点、边缘抖动、D1 冷启动慢）就足以让即时对话长期停在本地生成，用户不碰巧去开设置页就一直卡着。

## 改后是怎样的

- **只有真的问到答案才写存量**。探不到就当没问过，上次的结论原样保留。这一条挡掉了绝大部分误降级。
- **存量已经是「跑不动」时，发消息前现探一次**，Worker 好了当轮就回到云端，不必等用户去开设置页。带 30 秒冷却、3 秒超时，并发共用同一次探测；网络恢复事件会把冷却清零。状态正常的用户不多花一次请求，额外开销只落在已经降级的那批人身上。
- **降级时输入框上方给一条提示，并交代原因**：确认跑不动的指路去更新 Worker，够不着云端的说明网络恢复后会自己回去。回到云端那一轮提示自己收起，用户不用猜有没有恢复。原来这个落差只留在 console 和观察窗里，普通用户查不到。

## 测试

新增六条回归守卫，每一条都验证过「在旧行为下会挂、改完才过」：

- 网络异常 / 401 / 5xx 时不许把已有的「跑得动」打成「跑不动」（三条）
- 存量说跑不动、现探发现已经好了 → 当轮回到云端
- 现探够不着云端 → 单独一档，不叫人去更新 Worker
- 冷却期内不重复现探（连发三条只探一次）

另有一条反向守卫：真的问到「跑不动」时照写不误，确认没有矫枉过正。

全量 246 个测试文件 / 3342 条测试通过，类型错误数与改动前持平。

## 部署注意

纯前端改动，没有碰 `worker/`，**不需要先部署 Worker**。老用户存下来的错误结论不用手动清，改完后第一次发消息会自动纠正。

https://claude.ai/code/session_01HaZM27c2mg4pNaoYK3GEdL