### PR TITLE
fix(appearance): 自定义 PWA 图标在 iOS 上不生效

### DIFF
--- a/utils/appIcon.test.ts
+++ b/utils/appIcon.test.ts
@@ -2,10 +2,10 @@
 /**
  * utils/appIcon.test.ts — PWA 图标注入的回归测试。
  *
- * 核心不变式：
- *   1. 注入的 apple-touch-icon href 必须是 data: 或 http(s)，不能是 blob:（blob 不被 iOS/Chrome 认作图标）。
- *   2. manifest 替换时所有相对路径（start_url / scope）折成绝对地址（动态 manifest 的 base 是 blob: URL）。
- *   3. clearPwaIcon 之后 DOM 回到注入前的状态。
+ * 钉住的三条不变式（每条都对应一个真实踩过的坑，见 appIcon.ts 顶部注释）：
+ *   1. 页面上只能有一个 apple-touch-icon —— 多了 iOS 会挑排在前面的原装图标，新图标静默失效。
+ *   2. href 必须是 PNG data URI —— iOS 只稳定认 PNG，JPEG/WebP 会被忽略。
+ *   3. manifest 里相对路径要折成绝对地址 —— 动态 manifest 的 base 是 blob: URL。
  *
  * @vitest-environment jsdom
  */
@@ -17,6 +17,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 const mockGetBlobForRef = vi.fn();
 const mockBlobToDataUrl = vi.fn();
 const mockIsStandalone = vi.fn();
+const mockToSquarePngDataUrl = vi.fn();
 
 vi.mock('./blobRef', () => ({
   isBlobRef: (v: unknown) => typeof v === 'string' && v.startsWith('blobref:'),
@@ -28,53 +29,56 @@ vi.mock('./iosStandalone', () => ({
   isStandaloneDisplayMode: () => mockIsStandalone(),
 }));
 
-// jsdom 没有 URL.createObjectURL / revokeObjectURL；自己垫一层轻量实现，
-// 同时把传给 createObjectURL 的 Blob 记下来，test 可以直接读 manifest 内容。
+// canvas 在 jsdom 里没法真的渲染，栅格化整层 mock 掉；
+// 真实的裁切/编码逻辑由 iconRaster.test.ts 单独覆盖。
+vi.mock('./iconRaster', () => ({
+  toSquarePngDataUrl: (...args: any[]) => mockToSquarePngDataUrl(...args),
+}));
+
+// jsdom 没有 URL.createObjectURL / revokeObjectURL；垫一层并记下 Blob 内容，
+// 测试可以直接读回生成的 manifest。
 let lastBlobUrlId = 0;
 const blobStore = new Map<string, Blob>();
 
-function mockCreateObjectURL(blob: Blob): string {
+const mockCreateObjectURL = (blob: Blob): string => {
   const id = `blob:mock-${++lastBlobUrlId}`;
   blobStore.set(id, blob);
   return id;
-}
+};
+const mockRevokeObjectURL = (url: string): void => { blobStore.delete(url); };
 
-function mockRevokeObjectURL(url: string): void {
-  blobStore.delete(url);
-}
-
-// 用一小张 1×1 红色 PNG 的 base64 作测试素材
-const RED_PIXEL_PNG =
-  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+// 转出来的 PNG（内容不重要，前缀重要）
+const PNG_DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAYAAA';
+// 源图故意用 JPEG，用来验证「不管进来什么都得转成 PNG」
+const SOURCE_JPEG_BLOB = () => new Blob(['fake-jpeg-bytes'], { type: 'image/jpeg' });
 
 import { injectPwaIcon, clearPwaIcon, initPwaIcon, PWA_ICON_APP_ID } from './appIcon';
 
 // ── helpers ─────────────────────────────────────────────────────────
 
-/** jsdom 里 <link href="./manifest.webmanifest"> 不会自动 resolve 成绝对地址，
- *  所以 setupDOM 直接把 href 写成绝对 URL，模拟真实浏览器的行为。 */
 const BASE = 'http://localhost:3000';
 const ORIGINAL_MANIFEST_HREF = `${BASE}/manifest.webmanifest`;
+const ORIGINAL_TOUCH_ICON_HREF = './icons/apple-touch-icon.png';
+const ORIGINAL_FAVICON_HREF = './icons/icon-192.png';
 
+/** 复刻 index.html 里真实的三行 link（含那个写死的 apple-touch-icon）。 */
 function setupDOM() {
   document.head.innerHTML = `
-    <link rel="icon" type="image/png" href="./icons/icon-192.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="./icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="${ORIGINAL_FAVICON_HREF}">
+    <link rel="apple-touch-icon" sizes="180x180" href="${ORIGINAL_TOUCH_ICON_HREF}">
     <link rel="manifest" href="${ORIGINAL_MANIFEST_HREF}">
   `;
 }
 
-function getAppleTouchIconHref(): string | null {
-  const link = document.querySelector('link[rel="apple-touch-icon"].sully-custom-pwa-icon');
-  return link?.getAttribute('href') ?? null;
-}
+const appleIconLinks = () =>
+  Array.from(document.querySelectorAll('link[rel~="apple-touch-icon"], link[rel~="apple-touch-icon-precomposed"]'));
+const faviconLinks = () =>
+  Array.from(document.querySelectorAll('link[rel~="icon"]:not([rel~="apple-touch-icon"])'));
 
-function getManifestHref(): string | null {
-  const link = document.querySelector('link[rel="manifest"]');
-  return link?.getAttribute('href') ?? null;
-}
+const appleIconHrefs = () => appleIconLinks().map(l => l.getAttribute('href'));
+const faviconHrefs = () => faviconLinks().map(l => l.getAttribute('href'));
+const manifestHref = () => document.querySelector('link[rel="manifest"]')?.getAttribute('href') ?? null;
 
-// 真实 manifest.webmanifest 的结构
 const SAMPLE_MANIFEST = {
   short_name: 'SullyOS',
   name: 'SullyOS',
@@ -92,13 +96,12 @@ const SAMPLE_MANIFEST = {
 
 // ── setup / teardown ────────────────────────────────────────────────
 
-let _origCreateObjectURL: any = undefined;
-let _origRevokeObjectURL: any = undefined;
+let origCreate: any;
+let origRevoke: any;
 
 beforeEach(() => {
-  // jsdom 没有 URL.createObjectURL / revokeObjectURL，垫一层轻量实现
-  _origCreateObjectURL = (URL as any).createObjectURL;
-  _origRevokeObjectURL = (URL as any).revokeObjectURL;
+  origCreate = (URL as any).createObjectURL;
+  origRevoke = (URL as any).revokeObjectURL;
   (URL as any).createObjectURL = mockCreateObjectURL;
   (URL as any).revokeObjectURL = mockRevokeObjectURL;
   blobStore.clear();
@@ -108,27 +111,16 @@ beforeEach(() => {
   mockGetBlobForRef.mockReset();
   mockBlobToDataUrl.mockReset();
   mockIsStandalone.mockReset();
-  mockIsStandalone.mockReturnValue(false);
+  mockToSquarePngDataUrl.mockReset();
 
-  // fetch mock：请求真实 manifest 时返回 SAMPLE_MANIFEST
+  mockIsStandalone.mockReturnValue(false);
+  // 默认：栅格化成功，返回 PNG
+  mockToSquarePngDataUrl.mockResolvedValue(PNG_DATA_URL);
+
   globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : String(input);
     if (url === ORIGINAL_MANIFEST_HREF) {
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => ({ ...SAMPLE_MANIFEST }),
-      } as Response);
-    }
-    // 动态 manifest（blob: URL）：从 blobStore 取 Blob 内容
-    if (url.startsWith('blob:mock-')) {
-      const blob = blobStore.get(url);
-      if (!blob) return Promise.reject(new Error('blob not found'));
-      return Promise.resolve({
-        ok: true,
-        status: 200,
-        json: async () => JSON.parse(await blob.text()),
-      } as Response);
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ ...SAMPLE_MANIFEST }) } as Response);
     }
     return Promise.reject(new Error(`unexpected fetch url: ${url}`));
   });
@@ -136,144 +128,253 @@ beforeEach(() => {
 
 afterEach(() => {
   clearPwaIcon();
-  // 恢复 URL 上的原始方法（如果有的话）
-  if (_origCreateObjectURL !== undefined) {
-    (URL as any).createObjectURL = _origCreateObjectURL;
-    _origCreateObjectURL = undefined;
-  } else {
-    delete (URL as any).createObjectURL;
-  }
-  if (_origRevokeObjectURL !== undefined) {
-    (URL as any).revokeObjectURL = _origRevokeObjectURL;
-    _origRevokeObjectURL = undefined;
-  } else {
-    delete (URL as any).revokeObjectURL;
-  }
+  if (origCreate !== undefined) (URL as any).createObjectURL = origCreate;
+  else delete (URL as any).createObjectURL;
+  if (origRevoke !== undefined) (URL as any).revokeObjectURL = origRevoke;
+  else delete (URL as any).revokeObjectURL;
   vi.restoreAllMocks();
 });
 
-// ── injectPwaIcon ───────────────────────────────────────────────────
+// ── 不变式 1：只能有一个 apple-touch-icon ───────────────────────────
 
-describe('injectPwaIcon', () => {
-  it('blobRef 令牌 → 解成 data URL 注入 apple-touch-icon', async () => {
-    mockGetBlobForRef.mockResolvedValue(new Blob([RED_PIXEL_PNG], { type: 'image/png' }));
-    mockBlobToDataUrl.mockResolvedValue(RED_PIXEL_PNG);
-
-    await injectPwaIcon('blobref:test_123');
-
-    const href = getAppleTouchIconHref();
-    expect(href).toBe(RED_PIXEL_PNG);
-    // 核心不变式：注入的 href 不能是 blob: URL
-    expect(href).not.toMatch(/^blob:/);
+describe('只能有一个 apple-touch-icon（iOS 会挑排在前面那个）', () => {
+  beforeEach(() => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
   });
 
-  it('data: URI → 直接注入，不经过 Blob 解析', async () => {
-    await injectPwaIcon(RED_PIXEL_PNG);
+  it('注入后 apple-touch-icon 仍然只有一个', async () => {
+    expect(appleIconLinks()).toHaveLength(1); // index.html 自带那一个
 
-    expect(getAppleTouchIconHref()).toBe(RED_PIXEL_PNG);
-    expect(mockGetBlobForRef).not.toHaveBeenCalled();
+    await injectPwaIcon('blobref:test');
+
+    expect(appleIconLinks()).toHaveLength(1);
   });
 
-  it('http URL → 直接注入', async () => {
-    const remoteUrl = 'https://cdn.example.com/icon.png';
-    await injectPwaIcon(remoteUrl);
+  it('改的是原有 link 的 href，不是 append 新的', async () => {
+    await injectPwaIcon('blobref:test');
 
-    expect(getAppleTouchIconHref()).toBe(remoteUrl);
+    // 唯一那个 link 的 href 已经是新图标——旧的 ./icons/apple-touch-icon.png 不存在了
+    expect(appleIconHrefs()).toEqual([PNG_DATA_URL]);
+    expect(appleIconHrefs()).not.toContain(ORIGINAL_TOUCH_ICON_HREF);
   });
 
-  it('blobRef 解析失败 → 不注入，不抛异常', async () => {
-    mockGetBlobForRef.mockResolvedValue(null);
-
-    await expect(injectPwaIcon('blobref:dead')).resolves.toBeUndefined();
-    expect(getAppleTouchIconHref()).toBeNull();
-  });
-
-  it('多次调用 → 每次都替换旧注入（不会堆叠多个 link）', async () => {
-    mockGetBlobForRef.mockResolvedValue(new Blob(['x'], { type: 'image/png' }));
-    mockBlobToDataUrl.mockResolvedValue(RED_PIXEL_PNG);
-
+  it('反复注入也不会堆出第二个 link', async () => {
     await injectPwaIcon('blobref:a');
     await injectPwaIcon('blobref:b');
+    await injectPwaIcon('blobref:c');
 
-    const links = document.querySelectorAll('link[rel="apple-touch-icon"].sully-custom-pwa-icon');
-    expect(links.length).toBe(1);
+    expect(appleIconLinks()).toHaveLength(1);
+  });
+
+  it('页面上有 precomposed 变体时也一起改掉（否则它会抢赢）', async () => {
+    const extra = document.createElement('link');
+    extra.rel = 'apple-touch-icon-precomposed';
+    extra.setAttribute('href', './icons/old-precomposed.png');
+    document.head.appendChild(extra);
+
+    await injectPwaIcon('blobref:test');
+
+    // 两个都指向新图标，没有任何一个还留着旧地址
+    expect(appleIconHrefs()).toEqual([PNG_DATA_URL, PNG_DATA_URL]);
+  });
+
+  it('页面上没有 apple-touch-icon 时会建一个', async () => {
+    document.head.innerHTML = `<link rel="manifest" href="${ORIGINAL_MANIFEST_HREF}">`;
+
+    await injectPwaIcon('blobref:test');
+
+    expect(appleIconLinks()).toHaveLength(1);
+    expect(appleIconHrefs()).toEqual([PNG_DATA_URL]);
   });
 });
 
-// ── manifest 替换（standalone 模式） ─────────────────────────────────
+// ── 不变式 2：href 必须是 PNG ───────────────────────────────────────
+
+describe('href 必须是 PNG（iOS 只认 PNG）', () => {
+  it('源图是 JPEG 也要转成 PNG data URI', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+
+    await injectPwaIcon('blobref:jpeg-source');
+
+    const href = appleIconHrefs()[0]!;
+    expect(href).toMatch(/^data:image\/png;base64,/);
+    // 不能是 blob:（iOS/Chrome 不认作图标）
+    expect(href).not.toMatch(/^blob:/);
+  });
+
+  it('栅格化尺寸固定 180（apple-touch-icon 标准边长）', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+
+    await injectPwaIcon('blobref:test');
+
+    expect(mockToSquarePngDataUrl).toHaveBeenCalledWith(expect.anything(), 180);
+  });
+
+  it('data: 源图也过一遍栅格化——原图可能是 JPEG/WebP', async () => {
+    await injectPwaIcon('data:image/webp;base64,UklGRg==');
+
+    expect(mockToSquarePngDataUrl).toHaveBeenCalled();
+    expect(appleIconHrefs()[0]).toBe(PNG_DATA_URL);
+  });
+
+  it('栅格化失败 → 退回原图，不让页面没图标', async () => {
+    mockToSquarePngDataUrl.mockRejectedValue(new Error('canvas 挂了'));
+    const rawDataUrl = 'data:image/jpeg;base64,/9j/4AA';
+
+    await injectPwaIcon(rawDataUrl);
+
+    expect(appleIconHrefs()[0]).toBe(rawDataUrl);
+  });
+
+  it('栅格化失败且源是 Blob → 走 blobToDataUrl 兜底', async () => {
+    mockToSquarePngDataUrl.mockRejectedValue(new Error('canvas 挂了'));
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+    mockBlobToDataUrl.mockResolvedValue('data:image/jpeg;base64,fallback');
+
+    await injectPwaIcon('blobref:test');
+
+    expect(appleIconHrefs()[0]).toBe('data:image/jpeg;base64,fallback');
+  });
+});
+
+// ── favicon 一起换（UI 提示说了「标签页图标已更新」，得真的更新） ────
+
+describe('favicon 同步更新', () => {
+  it('rel="icon" 的 href 也换成新图标', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+
+    expect(faviconHrefs()).toEqual([ORIGINAL_FAVICON_HREF]);
+
+    await injectPwaIcon('blobref:test');
+
+    expect(faviconHrefs()).toEqual([PNG_DATA_URL]);
+  });
+
+  it('favicon 选择器不会误伤 apple-touch-icon', async () => {
+    // rel~="icon" 若不排除 apple-touch-icon，两者会互相干扰
+    expect(faviconLinks()).toHaveLength(1);
+    expect(faviconLinks()[0].getAttribute('rel')).toBe('icon');
+  });
+});
+
+// ── 输入合法性 ─────────────────────────────────────────────────────
+
+describe('输入合法性', () => {
+  it('http URL → 直接交给栅格化（会带 crossOrigin）', async () => {
+    const remote = 'https://cdn.example.com/icon.png';
+    await injectPwaIcon(remote);
+
+    expect(mockToSquarePngDataUrl).toHaveBeenCalledWith(remote, 180);
+    expect(appleIconHrefs()[0]).toBe(PNG_DATA_URL);
+  });
+
+  it('blobRef 解析失败 → 什么都不改，不抛异常', async () => {
+    mockGetBlobForRef.mockResolvedValue(null);
+
+    await expect(injectPwaIcon('blobref:dead')).resolves.toBeUndefined();
+    expect(appleIconHrefs()).toEqual([ORIGINAL_TOUCH_ICON_HREF]);
+    expect(faviconHrefs()).toEqual([ORIGINAL_FAVICON_HREF]);
+  });
+
+  it('乱七八糟的值 → 什么都不改，不抛异常', async () => {
+    await expect(injectPwaIcon('/relative/path.png')).resolves.toBeUndefined();
+    expect(appleIconHrefs()).toEqual([ORIGINAL_TOUCH_ICON_HREF]);
+  });
+});
+
+// ── 不变式 3：manifest（standalone） ────────────────────────────────
 
 describe('manifest 替换（standalone）', () => {
   beforeEach(() => {
     mockIsStandalone.mockReturnValue(true);
-    mockGetBlobForRef.mockResolvedValue(new Blob([RED_PIXEL_PNG], { type: 'image/png' }));
-    mockBlobToDataUrl.mockResolvedValue(RED_PIXEL_PNG);
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
   });
 
-  it('standalone 下 manifest href 被换成 blob: URL', async () => {
-    await injectPwaIcon('blobref:test');
-
-    expect(getManifestHref()).toMatch(/^blob:mock-/);
-  });
-
-  it('动态 manifest 的图标全部替换为 data: URI', async () => {
-    await injectPwaIcon('blobref:test');
-
-    // 从 blobStore 直接读生成的 manifest JSON（不绕 fetch）
-    const manifestUrl = getManifestHref()!;
-    const blob = blobStore.get(manifestUrl);
+  const readManifest = async () => {
+    const blob = blobStore.get(manifestHref()!);
     expect(blob).toBeTruthy();
-    const manifest = JSON.parse(await blob!.text());
+    return JSON.parse(await blob!.text());
+  };
 
-    for (const icon of manifest.icons) {
-      expect(icon.src).toBe(RED_PIXEL_PNG);
-    }
-    // 覆盖 192、512、512 maskable 三个槽
-    expect(manifest.icons).toHaveLength(3);
+  it('manifest href 换成 blob: URL', async () => {
+    await injectPwaIcon('blobref:test');
+    expect(manifestHref()).toMatch(/^blob:mock-/);
   });
 
-  it('动态 manifest 里相对路径折成绝对地址', async () => {
+  it('图标槽全部换成 PNG data URI', async () => {
     await injectPwaIcon('blobref:test');
+    const manifest = await readManifest();
 
-    const manifestUrl = getManifestHref()!;
-    const blob = blobStore.get(manifestUrl)!;
-    const manifest = JSON.parse(await blob.text());
+    expect(manifest.icons).toHaveLength(3); // 192 / 512 / 512 maskable
+    for (const icon of manifest.icons) {
+      expect(icon.src).toBe(PNG_DATA_URL);
+      expect(icon.type).toBe('image/png');
+    }
+  });
 
-    // start_url / scope 被转为绝对 URL（base 是原始 manifest 的绝对地址）
+  it('相对路径折成绝对地址（blob: base 会让相对路径 404）', async () => {
+    await injectPwaIcon('blobref:test');
+    const manifest = await readManifest();
+
     expect(manifest.start_url).toBe(`${BASE}/`);
     expect(manifest.scope).toBe(`${BASE}/`);
-    // 不再是裸的 "./"
-    expect(manifest.start_url).not.toBe('./');
-    expect(manifest.scope).not.toBe('./');
   });
 
-  it('fetch 真实 manifest 失败 → apple-touch-icon 照常注入，不抛异常', async () => {
+  it('非 standalone 下不动 manifest', async () => {
+    mockIsStandalone.mockReturnValue(false);
+
+    await injectPwaIcon('blobref:test');
+
+    expect(manifestHref()).toBe(ORIGINAL_MANIFEST_HREF);
+  });
+
+  it('fetch manifest 失败 → apple-touch-icon 照常更新，不抛异常', async () => {
     globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
 
     await expect(injectPwaIcon('blobref:test')).resolves.toBeUndefined();
-    // manifest 没被替换
-    expect(getManifestHref()).toBe(ORIGINAL_MANIFEST_HREF);
-    // apple-touch-icon 照常
-    expect(getAppleTouchIconHref()).toBe(RED_PIXEL_PNG);
+    expect(manifestHref()).toBe(ORIGINAL_MANIFEST_HREF);
+    expect(appleIconHrefs()[0]).toBe(PNG_DATA_URL);
   });
 });
 
 // ── clearPwaIcon ────────────────────────────────────────────────────
 
 describe('clearPwaIcon', () => {
-  it('删掉注入的 apple-touch-icon，恢复原始 manifest href', async () => {
-    mockGetBlobForRef.mockResolvedValue(new Blob([RED_PIXEL_PNG], { type: 'image/png' }));
-    mockBlobToDataUrl.mockResolvedValue(RED_PIXEL_PNG);
+  it('所有 href 还原成原始值', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
     mockIsStandalone.mockReturnValue(true);
 
     await injectPwaIcon('blobref:test');
-    expect(getAppleTouchIconHref()).toBe(RED_PIXEL_PNG);
+    expect(appleIconHrefs()[0]).toBe(PNG_DATA_URL);
 
     clearPwaIcon();
-    expect(getAppleTouchIconHref()).toBeNull();
-    expect(getManifestHref()).toBe(ORIGINAL_MANIFEST_HREF);
+
+    expect(appleIconHrefs()).toEqual([ORIGINAL_TOUCH_ICON_HREF]);
+    expect(faviconHrefs()).toEqual([ORIGINAL_FAVICON_HREF]);
+    expect(manifestHref()).toBe(ORIGINAL_MANIFEST_HREF);
   });
 
-  it('没注入过时调用 clear 也不抛异常', () => {
+  it('还原后 apple-touch-icon 数量不变（不留残骸也不删原装）', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+
+    await injectPwaIcon('blobref:test');
+    clearPwaIcon();
+
+    expect(appleIconLinks()).toHaveLength(1);
+  });
+
+  it('原本没有 apple-touch-icon 时，还原会把建的那个删掉', async () => {
+    document.head.innerHTML = `<link rel="manifest" href="${ORIGINAL_MANIFEST_HREF}">`;
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
+
+    await injectPwaIcon('blobref:test');
+    expect(appleIconLinks()).toHaveLength(1);
+
+    clearPwaIcon();
+    expect(appleIconLinks()).toHaveLength(0);
+  });
+
+  it('没注入过时调用也不抛异常', () => {
     expect(() => clearPwaIcon()).not.toThrow();
   });
 });
@@ -281,30 +382,36 @@ describe('clearPwaIcon', () => {
 // ── initPwaIcon ─────────────────────────────────────────────────────
 
 describe('initPwaIcon', () => {
-  it('customIcons 里有 _pwa_ → 注入', async () => {
-    mockGetBlobForRef.mockResolvedValue(new Blob([RED_PIXEL_PNG], { type: 'image/png' }));
-    mockBlobToDataUrl.mockResolvedValue(RED_PIXEL_PNG);
+  it('customIcons 里有 _pwa_ → 接上', async () => {
+    mockGetBlobForRef.mockResolvedValue(SOURCE_JPEG_BLOB());
 
-    await initPwaIcon({ [PWA_ICON_APP_ID]: 'blobref:saved', 'some_app': 'blobref:other' });
+    await initPwaIcon({ [PWA_ICON_APP_ID]: 'blobref:saved', some_app: 'blobref:other' });
 
-    expect(getAppleTouchIconHref()).toBe(RED_PIXEL_PNG);
+    expect(appleIconHrefs()[0]).toBe(PNG_DATA_URL);
   });
 
-  it('customIcons 里没有 _pwa_ → 不动 DOM', async () => {
-    const before = getAppleTouchIconHref();
-    await initPwaIcon({ 'some_app': 'blobref:other' });
-    expect(getAppleTouchIconHref()).toBe(before);
+  it('没有 _pwa_ → 一动不动', async () => {
+    await initPwaIcon({ some_app: 'blobref:other' });
+
+    expect(appleIconHrefs()).toEqual([ORIGINAL_TOUCH_ICON_HREF]);
+    expect(mockGetBlobForRef).not.toHaveBeenCalled();
   });
 
-  it('customIcons 为空对象 → 不炸', async () => {
+  it('空对象 → 不炸', async () => {
     await expect(initPwaIcon({})).resolves.toBeUndefined();
+  });
+
+  it('注入过程抛异常也不会把启动流程带崩', async () => {
+    mockGetBlobForRef.mockRejectedValue(new Error('IndexedDB 挂了'));
+
+    await expect(initPwaIcon({ [PWA_ICON_APP_ID]: 'blobref:x' })).resolves.toBeUndefined();
   });
 });
 
-// ── PWA_ICON_APP_ID 常量 ───────────────────────────────────────────
+// ── 常量 ───────────────────────────────────────────────────────────
 
 describe('PWA_ICON_APP_ID', () => {
-  it('是 _pwa_，不跟任何已安装 App 的 id 冲突', () => {
+  it('是 _pwa_，下划线前缀保证不跟 App id 撞名', () => {
     expect(PWA_ICON_APP_ID).toBe('_pwa_');
     expect(PWA_ICON_APP_ID.startsWith('_')).toBe(true);
   });

--- a/utils/appIcon.ts
+++ b/utils/appIcon.ts
@@ -1,120 +1,176 @@
-// 自定义 PWA 应用图标：启动时把 `_pwa_` 图标注入 apple-touch-icon / manifest。
+// 自定义 PWA 应用图标：把用户选的图接到 apple-touch-icon / favicon / manifest 上。
 //
-// 2026-08-04 真机验证（iOS 26.5.2 / Android 17 Chrome Pixel 8）：
-//   - JS 动态注入的 apple-touch-icon 认 data: URI
-//   - 动态替换的 manifest（blob: URL）也认 data: URI 图标
-//   - 详情见 docs/superpowers/specs/2026-08-09-pwa-custom-icon-design.md
+// 三条踩过的坑，改这份文件前先读：
 //
-// 约束：图标只在「添加到主屏幕」那一刻固化，装完之后改不了。装成 App 的用户要看到
-// 新图标得删掉重装（会丢 IndexedDB 数据），UI 上的警告由 AppIconEditor 负责。
+// 1. **只能有一个 apple-touch-icon**。index.html 里写死了一个 180x180 的，
+//    如果再 append 一个同尺寸的，iOS 会挑排在前面那个（也就是原装图标），
+//    新图标静默失效。所以这里的做法是**改原有 link 的 href**，而不是新增。
+//
+// 2. **必须是 PNG**。iOS 的 apple-touch-icon 只稳定支持 PNG；上传管线默认吐 JPEG、
+//    图床还可能给 WebP，直接用会被 iOS 忽略。统一走 utils/iconRaster 转 PNG。
+//
+// 3. **尺寸要压到 180**。源图存的是 512，base64 后几百 KB，塞进 href 又慢又冒险。
+//
+// 另一条固有约束（不是 bug，改不了）：图标在「添加到主屏幕」那一刻固化。装完之后
+// 再改这里的任何东西，主屏和通知图标都不变，只能删掉 App 重新添加。
+//
+// 详见 docs/superpowers/specs/2026-08-09-pwa-custom-icon-design.md
 
 import { isStandaloneDisplayMode } from './iosStandalone';
 import { getBlobForRef, isBlobRef, blobToDataUrl } from './blobRef';
+import { toSquarePngDataUrl } from './iconRaster';
 
 export const PWA_ICON_APP_ID = '_pwa_';
 
-const ATI_SELECTOR = 'link[rel="apple-touch-icon"].sully-custom-pwa-icon';
+/** apple-touch-icon 的标准边长。 */
+const TOUCH_ICON_SIZE = 180;
+
+const APPLE_ICON_SELECTOR = 'link[rel~="apple-touch-icon"], link[rel~="apple-touch-icon-precomposed"]';
+const FAVICON_SELECTOR = 'link[rel~="icon"]:not([rel~="apple-touch-icon"])';
 const MANIFEST_SELECTOR = 'link[rel="manifest"]';
 
+// 原始 href 备份，clearPwaIcon 时逐个还原。
+const originalHrefs = new WeakMap<HTMLLinkElement, string>();
 let originalManifestHref: string | null = null;
 let dynamicManifestUrl: string | null = null;
 
 // ── 公开 API ──────────────────────────────────────────────────────
 
 /**
- * 把图标值（blobRef 令牌 / data: URI / http(s) URL）注入 DOM。
- * - 总是注入 apple-touch-icon（影响浏览器标签页 + iOS 主屏图标）
- * - standalone display-mode 下额外替换 manifest（影响 Android/Chrome 主屏图标）
+ * 把图标值（blobRef 令牌 / data: URI / http(s) URL）接到页面上。
+ * - 总是更新 apple-touch-icon + favicon（浏览器标签页当场就变）
+ * - standalone 下额外替换 manifest（影响 Android/Chrome 主屏图标）
  */
 export async function injectPwaIcon(value: string): Promise<void> {
-  const dataUrl = await resolveIconValue(value);
-  if (!dataUrl) return;
+  const source = await resolveIconSource(value);
+  if (!source) return;
 
-  injectAppleTouchIcon(dataUrl);
+  const pngDataUrl = await rasterize(source, TOUCH_ICON_SIZE);
+  if (!pngDataUrl) return;
+
+  applyHref(APPLE_ICON_SELECTOR, pngDataUrl, () => createAppleTouchIcon());
+  applyHref(FAVICON_SELECTOR, pngDataUrl);
 
   if (isStandaloneDisplayMode()) {
-    await replaceManifest(dataUrl);
+    await replaceManifest(pngDataUrl);
   }
 }
 
-/** 恢复默认图标：删掉注入的 link，manifest 指回原始文件。 */
+/** 恢复默认图标：所有被改过的 href 还原。 */
 export function clearPwaIcon(): void {
-  clearAppleTouchIcon();
+  restoreHrefs(APPLE_ICON_SELECTOR);
+  restoreHrefs(FAVICON_SELECTOR);
 
-  const link = document.querySelector(MANIFEST_SELECTOR) as HTMLLinkElement | null;
-  if (link && originalManifestHref) {
-    link.href = originalManifestHref;
+  const manifestLink = document.querySelector(MANIFEST_SELECTOR) as HTMLLinkElement | null;
+  if (manifestLink && originalManifestHref) {
+    manifestLink.href = originalManifestHref;
   }
-
   if (dynamicManifestUrl) {
     URL.revokeObjectURL(dynamicManifestUrl);
     dynamicManifestUrl = null;
   }
 }
 
-/** 启动时调用：customIcons 里有 `_pwa_` 就注入。 */
+/** 启动时调用：customIcons 里有 `_pwa_` 就接上。 */
 export async function initPwaIcon(customIcons: Record<string, string>): Promise<void> {
   const icon = customIcons[PWA_ICON_APP_ID];
-  if (icon) {
-    try {
-      await injectPwaIcon(icon);
-    } catch (e) {
-      console.warn('[PWA Icon] 启动注入失败', e);
-    }
+  if (!icon) return;
+  try {
+    await injectPwaIcon(icon);
+  } catch (e) {
+    console.warn('[PWA Icon] 启动注入失败', e);
   }
 }
 
-// ── 内部 ───────────────────────────────────────────────────────────
+// ── 图标源解析 ────────────────────────────────────────────────────
 
-async function resolveIconValue(value: string): Promise<string | null> {
+/** 把存储值解析成能喂给 canvas 的东西：Blob 优先（不会污染画布），否则原样的 URL 字符串。 */
+async function resolveIconSource(value: string): Promise<Blob | string | null> {
   if (isBlobRef(value)) {
     const blob = await getBlobForRef(value);
     if (!blob) {
       console.warn('[PWA Icon] blobRef 令牌解析失败，图标可能已被清理');
       return null;
     }
-    return await blobToDataUrl(blob);
+    return blob;
   }
-  // data: URI 直接用；http(s) URL 也直接用（远程地址，manifest 图标由 Chrome 在安装时抓取）
   if (value.startsWith('data:') || /^https?:\/\//i.test(value)) {
     return value;
   }
-  console.warn('[PWA Icon] 不支持的图标值:', value.substring(0, 50));
+  console.warn('[PWA Icon] 不支持的图标值:', value.slice(0, 50));
   return null;
 }
 
-function injectAppleTouchIcon(dataUrl: string): void {
-  clearAppleTouchIcon();
+/**
+ * 转成正方形 PNG data URL。转换失败时退回原图（能显示总比没有强），
+ * 但会明确警告——iOS 大概率不认非 PNG，这时候图标就是不会变。
+ */
+async function rasterize(source: Blob | string, size: number): Promise<string | null> {
+  try {
+    return await toSquarePngDataUrl(source, size);
+  } catch (e) {
+    console.warn('[PWA Icon] 转 PNG 失败，退回原图（iOS 可能不认非 PNG 格式）', e);
+    if (typeof source === 'string') return source;
+    try {
+      return await blobToDataUrl(source);
+    } catch {
+      return null;
+    }
+  }
+}
 
+// ── DOM 操作 ──────────────────────────────────────────────────────
+
+/**
+ * 改掉匹配到的所有 link 的 href（首次调用时备份原值）。
+ * 一个都没匹配到且给了 fallback 时，创建一个。
+ */
+function applyHref(selector: string, href: string, createIfMissing?: () => HTMLLinkElement): void {
+  const links = Array.from(document.querySelectorAll(selector)) as HTMLLinkElement[];
+
+  if (links.length === 0 && createIfMissing) {
+    links.push(createIfMissing());
+  }
+
+  for (const link of links) {
+    if (!originalHrefs.has(link)) {
+      originalHrefs.set(link, link.getAttribute('href') || '');
+    }
+    link.setAttribute('href', href);
+  }
+}
+
+function restoreHrefs(selector: string): void {
+  const links = Array.from(document.querySelectorAll(selector)) as HTMLLinkElement[];
+  for (const link of links) {
+    const original = originalHrefs.get(link);
+    if (original === undefined) continue;
+    if (original) link.setAttribute('href', original);
+    else link.remove(); // 本来就是我们建的，直接删掉
+    originalHrefs.delete(link);
+  }
+}
+
+function createAppleTouchIcon(): HTMLLinkElement {
   const link = document.createElement('link');
   link.rel = 'apple-touch-icon';
-  link.setAttribute('sizes', '180x180');
-  link.href = dataUrl;
-  link.classList.add('sully-custom-pwa-icon');
+  link.setAttribute('sizes', `${TOUCH_ICON_SIZE}x${TOUCH_ICON_SIZE}`);
   document.head.appendChild(link);
+  return link;
 }
 
-function clearAppleTouchIcon(): void {
-  document.querySelector(ATI_SELECTOR)?.remove();
-}
+// ── manifest ──────────────────────────────────────────────────────
 
 async function replaceManifest(iconDataUrl: string): Promise<void> {
   const link = document.querySelector(MANIFEST_SELECTOR) as HTMLLinkElement | null;
   if (!link) return;
 
-  // 记下原始 href，clearPwaIcon 时恢复用
-  if (!originalManifestHref) {
-    originalManifestHref = link.href;
-  }
+  if (!originalManifestHref) originalManifestHref = link.href;
 
   try {
-    const resp = await fetch(originalManifestHref || link.href);
+    const resp = await fetch(originalManifestHref);
     if (!resp.ok) throw new Error(`Fetch manifest failed: ${resp.status}`);
     const manifest = await resp.json();
-
-    // manifest 的 base URL —— 浏览器已把 ./manifest.webmanifest 解析为绝对地址，
-    // 动态 manifest（blob: URL）的 base 会变成 blob:，所以所有相对路径必须折成绝对地址
-    const base = link.href;
 
     manifest.icons = [
       { src: iconDataUrl, sizes: '192x192', type: 'image/png' },
@@ -122,18 +178,18 @@ async function replaceManifest(iconDataUrl: string): Promise<void> {
       { src: iconDataUrl, sizes: '512x512', type: 'image/png', purpose: 'any maskable' },
     ];
 
+    // 动态 manifest 挂的是 blob: 地址，里面的相对路径会相对 blob 解析导致 404。
+    // 所有路径先折成绝对地址（base 取原始 manifest 的绝对 URL）。
     const toAbs = (p: string): string => {
       if (!p || p.startsWith('data:') || /^https?:\/\//i.test(p)) return p;
-      return new URL(p, base).href;
+      return new URL(p, originalManifestHref!).href;
     };
     if (manifest.start_url) manifest.start_url = toAbs(manifest.start_url);
     if (manifest.scope) manifest.scope = toAbs(manifest.scope);
 
-    // 换掉 blob URL（旧的先回收）
     const blob = new Blob([JSON.stringify(manifest)], { type: 'application/manifest+json' });
     if (dynamicManifestUrl) URL.revokeObjectURL(dynamicManifestUrl);
     dynamicManifestUrl = URL.createObjectURL(blob);
-
     link.href = dynamicManifestUrl;
   } catch (e) {
     console.warn('[PWA Icon] manifest 替换失败，apple-touch-icon 已注入', e);

--- a/utils/iconRaster.test.ts
+++ b/utils/iconRaster.test.ts
@@ -1,0 +1,258 @@
+/// <reference types="vitest" />
+/**
+ * utils/iconRaster.test.ts — 图标栅格化的回归测试。
+ *
+ * 钉住的点：
+ *   - 输出恒为 PNG（iOS 的 apple-touch-icon 只稳定认 PNG）
+ *   - cover 裁切：铺满正方形、居中、不变形（图标不该留白边或被拉扁）
+ *   - Blob 走 objectURL 并回收；远程 URL 带 crossOrigin（否则污染画布 toDataURL 会抛）
+ *
+ * jsdom 没有真实 canvas / 图片解码，所以 Image 和 canvas 都是替身，
+ * 断言落在「传给 drawImage 的参数对不对」这一层。
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { toSquarePngDataUrl } from './iconRaster';
+
+const PNG_OUT = 'data:image/png;base64,STUB';
+
+// ── 替身 ────────────────────────────────────────────────────────────
+
+type DrawCall = { x: number; y: number; w: number; h: number };
+
+let drawCalls: DrawCall[] = [];
+let toDataUrlCalls: Array<string | undefined> = [];
+let canvasSizes: Array<{ w: number; h: number }> = [];
+let createdObjectUrls: string[] = [];
+let revokedObjectUrls: string[] = [];
+
+/** 受控的 Image 替身：设 src 后由测试决定 onload / onerror 何时触发。 */
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  crossOrigin: string | null = null;
+  width = 0;
+  height = 0;
+  #src = '';
+
+  // 测试通过这两个字段控制这张「图」的原始尺寸与加载结果
+  static nextSize: { width: number; height: number } = { width: 100, height: 100 };
+  static nextResult: 'load' | 'error' = 'load';
+  static lastInstance: FakeImage | null = null;
+
+  set src(v: string) {
+    this.#src = v;
+    FakeImage.lastInstance = this;
+    // 异步触发，贴近真实浏览器行为
+    setTimeout(() => {
+      if (FakeImage.nextResult === 'error') {
+        this.onerror?.();
+        return;
+      }
+      this.width = FakeImage.nextSize.width;
+      this.height = FakeImage.nextSize.height;
+      this.onload?.();
+    }, 0);
+  }
+  get src() { return this.#src; }
+}
+
+let origImage: any;
+let origCreateElement: any;
+let origCreateObjectURL: any;
+let origRevokeObjectURL: any;
+
+/** canvas 替身：记下尺寸、drawImage 参数、toDataURL 的 mime。 */
+function makeFakeCanvas(ctxAvailable = true) {
+  const canvas: any = {
+    set width(v: number) { canvas._w = v; canvasSizes.push({ w: v, h: canvas._h ?? 0 }); },
+    get width() { return canvas._w; },
+    set height(v: number) {
+      canvas._h = v;
+      if (canvasSizes.length) canvasSizes[canvasSizes.length - 1].h = v;
+    },
+    get height() { return canvas._h; },
+    getContext: () => (ctxAvailable ? ctx : null),
+    toDataURL: (mime?: string) => { toDataUrlCalls.push(mime); return PNG_OUT; },
+  };
+  const ctx: any = {
+    clearRect: () => {},
+    drawImage: (_img: unknown, x: number, y: number, w: number, h: number) => {
+      drawCalls.push({ x, y, w, h });
+    },
+  };
+  return canvas;
+}
+
+let ctxAvailable = true;
+
+beforeEach(() => {
+  drawCalls = [];
+  toDataUrlCalls = [];
+  canvasSizes = [];
+  createdObjectUrls = [];
+  revokedObjectUrls = [];
+  ctxAvailable = true;
+  FakeImage.nextSize = { width: 100, height: 100 };
+  FakeImage.nextResult = 'load';
+  FakeImage.lastInstance = null;
+
+  origImage = globalThis.Image;
+  (globalThis as any).Image = FakeImage;
+
+  origCreateElement = document.createElement;
+  document.createElement = ((tag: string) => {
+    if (tag === 'canvas') return makeFakeCanvas(ctxAvailable);
+    return origCreateElement.call(document, tag);
+  }) as any;
+
+  origCreateObjectURL = (URL as any).createObjectURL;
+  origRevokeObjectURL = (URL as any).revokeObjectURL;
+  let n = 0;
+  (URL as any).createObjectURL = () => {
+    const u = `blob:fake-${++n}`;
+    createdObjectUrls.push(u);
+    return u;
+  };
+  (URL as any).revokeObjectURL = (u: string) => { revokedObjectUrls.push(u); };
+});
+
+afterEach(() => {
+  (globalThis as any).Image = origImage;
+  document.createElement = origCreateElement;
+  if (origCreateObjectURL !== undefined) (URL as any).createObjectURL = origCreateObjectURL;
+  else delete (URL as any).createObjectURL;
+  if (origRevokeObjectURL !== undefined) (URL as any).revokeObjectURL = origRevokeObjectURL;
+  else delete (URL as any).revokeObjectURL;
+  vi.restoreAllMocks();
+});
+
+const blob = (type = 'image/jpeg') => new Blob(['bytes'], { type });
+
+// ── 输出格式 ────────────────────────────────────────────────────────
+
+describe('输出格式', () => {
+  it('恒为 PNG —— 源图是 JPEG 也一样', async () => {
+    const out = await toSquarePngDataUrl(blob('image/jpeg'), 180);
+
+    expect(out).toBe(PNG_OUT);
+    expect(toDataUrlCalls).toEqual(['image/png']);
+  });
+
+  it('源图是 WebP 也转 PNG', async () => {
+    await toSquarePngDataUrl(blob('image/webp'), 180);
+
+    expect(toDataUrlCalls).toEqual(['image/png']);
+  });
+
+  it('canvas 按请求的边长开', async () => {
+    await toSquarePngDataUrl(blob(), 180);
+
+    expect(canvasSizes).toEqual([{ w: 180, h: 180 }]);
+  });
+});
+
+// ── cover 裁切 ──────────────────────────────────────────────────────
+
+describe('cover 裁切', () => {
+  it('正方形源图：铺满，不偏移', async () => {
+    FakeImage.nextSize = { width: 512, height: 512 };
+
+    await toSquarePngDataUrl(blob(), 180);
+
+    expect(drawCalls).toEqual([{ x: 0, y: 0, w: 180, h: 180 }]);
+  });
+
+  it('宽图：按高度铺满，左右等量裁掉', async () => {
+    FakeImage.nextSize = { width: 400, height: 200 }; // 2:1
+
+    await toSquarePngDataUrl(blob(), 180);
+
+    const [call] = drawCalls;
+    // 高度撑满 180，宽度等比放大到 360
+    expect(call.h).toBeCloseTo(180);
+    expect(call.w).toBeCloseTo(360);
+    // 水平居中：(180 - 360) / 2 = -90
+    expect(call.x).toBeCloseTo(-90);
+    expect(call.y).toBeCloseTo(0);
+  });
+
+  it('高图：按宽度铺满，上下等量裁掉', async () => {
+    FakeImage.nextSize = { width: 200, height: 400 }; // 1:2
+
+    await toSquarePngDataUrl(blob(), 180);
+
+    const [call] = drawCalls;
+    expect(call.w).toBeCloseTo(180);
+    expect(call.h).toBeCloseTo(360);
+    expect(call.x).toBeCloseTo(0);
+    expect(call.y).toBeCloseTo(-90);
+  });
+
+  it('小图会放大铺满，不留透明边', async () => {
+    FakeImage.nextSize = { width: 64, height: 64 };
+
+    await toSquarePngDataUrl(blob(), 180);
+
+    expect(drawCalls).toEqual([{ x: 0, y: 0, w: 180, h: 180 }]);
+  });
+
+  it('宽高比保持不变（不拉扁）', async () => {
+    FakeImage.nextSize = { width: 300, height: 100 }; // 3:1
+
+    await toSquarePngDataUrl(blob(), 180);
+
+    const [call] = drawCalls;
+    expect(call.w / call.h).toBeCloseTo(3);
+  });
+});
+
+// ── 输入来源 ────────────────────────────────────────────────────────
+
+describe('输入来源', () => {
+  it('Blob：建 objectURL，用完回收', async () => {
+    await toSquarePngDataUrl(blob(), 180);
+
+    expect(createdObjectUrls).toHaveLength(1);
+    expect(revokedObjectUrls).toEqual(createdObjectUrls);
+  });
+
+  it('Blob 不设 crossOrigin（本地数据不涉及 CORS）', async () => {
+    await toSquarePngDataUrl(blob(), 180);
+
+    expect(FakeImage.lastInstance!.crossOrigin).toBeNull();
+  });
+
+  it('远程 URL 带 crossOrigin=anonymous（不然画布被污染、toDataURL 抛错）', async () => {
+    await toSquarePngDataUrl('https://cdn.example.com/x.png', 180);
+
+    expect(FakeImage.lastInstance!.crossOrigin).toBe('anonymous');
+    expect(createdObjectUrls).toHaveLength(0); // 字符串源不建 objectURL
+  });
+
+  it('data: URL 直接用', async () => {
+    await toSquarePngDataUrl('data:image/png;base64,AAA', 180);
+
+    expect(FakeImage.lastInstance!.src).toBe('data:image/png;base64,AAA');
+  });
+});
+
+// ── 失败路径 ────────────────────────────────────────────────────────
+
+describe('失败路径', () => {
+  it('图片加载不出来 → reject，并回收 objectURL', async () => {
+    FakeImage.nextResult = 'error';
+
+    await expect(toSquarePngDataUrl(blob(), 180)).rejects.toThrow('图片加载失败');
+    expect(revokedObjectUrls).toEqual(createdObjectUrls);
+  });
+
+  it('canvas context 拿不到 → reject，并回收 objectURL', async () => {
+    ctxAvailable = false;
+
+    await expect(toSquarePngDataUrl(blob(), 180)).rejects.toThrow('Canvas context');
+    expect(revokedObjectUrls).toEqual(createdObjectUrls);
+  });
+});

--- a/utils/iconRaster.ts
+++ b/utils/iconRaster.ts
@@ -1,0 +1,61 @@
+// 图标栅格化：把任意图片源渲染成固定边长的正方形 PNG data URL。
+//
+// 为什么必须转 PNG：iOS 的 apple-touch-icon 只稳定支持 PNG。上传管线
+// （utils/file.ts 的 processImageToBlob）默认吐 JPEG，图床拉下来的还可能是 WebP，
+// 直接拿去当图标 iOS 会静默忽略、继续用旧图标。
+//
+// 为什么必须定尺寸：apple-touch-icon 标准边长 180；源图 512 转出来的 data URI
+// 动辄几百 KB，塞进 <link href> 又慢又容易踩到实现上限。
+
+/** 等比缩放并居中裁切（cover），铺满整个正方形——图标不该留白边。 */
+function drawCover(ctx: CanvasRenderingContext2D, img: HTMLImageElement, size: number): void {
+  const scale = Math.max(size / img.width, size / img.height);
+  const w = img.width * scale;
+  const h = img.height * scale;
+  ctx.drawImage(img, (size - w) / 2, (size - h) / 2, w, h);
+}
+
+/**
+ * 把图片源渲染成 `size × size` 的 PNG data URL。
+ *
+ * 远程 URL 会污染 canvas 导致 toDataURL 抛 SecurityError，所以调用方应先 fetch 成
+ * Blob 再传进来（AppIconEditor 的「填入链接」就是这么做的）。
+ */
+export function toSquarePngDataUrl(src: Blob | string, size: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const objectUrl = src instanceof Blob ? URL.createObjectURL(src) : null;
+    const href = objectUrl ?? (src as string);
+
+    const cleanup = () => { if (objectUrl) URL.revokeObjectURL(objectUrl); };
+
+    const img = new Image();
+    // 远程图需要 CORS 头才能不污染画布；图床一般都给。拿不到就走 onerror。
+    if (!objectUrl) img.crossOrigin = 'anonymous';
+
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('Canvas context 拿不到');
+
+        ctx.clearRect(0, 0, size, size);
+        drawCover(ctx, img, size);
+
+        // 固定 PNG：iOS apple-touch-icon 只稳定认这个格式
+        resolve(canvas.toDataURL('image/png'));
+      } catch (e) {
+        reject(e);
+      } finally {
+        cleanup();
+      }
+    };
+    img.onerror = () => {
+      cleanup();
+      reject(new Error('图片加载失败'));
+    };
+
+    img.src = href;
+  });
+}


### PR DESCRIPTION
「外观定制 → 应用图标」里新加的自定义 PWA 图标，在 iOS 上换完图、点「添加到主屏幕」，出来的还是原来那个 SullyOS 图标。这个 PR 修掉它。

## 三个原因叠在一起

| # | 原来是怎样 | 现在是怎样 |
|---|-----------|-----------|
| 1 | 新图标是 append 上去的，`index.html` 里写死的那个 `apple-touch-icon` 原封不动。两个都是 180×180，iOS 挑了排在前面的原装图标 | 直接改原有 link 的 `href`，页面上始终只有一个候选 |
| 2 | 存什么格式就用什么格式。上传管线默认输出 JPEG，图床还可能给 WebP，而 iOS 的 `apple-touch-icon` 只稳定认 PNG | 新增 `utils/iconRaster.ts`，不管进来什么统一转成 180×180 PNG |
| 3 | 界面提示写着「标签页图标已更新」，但代码从头到尾没碰过 `rel="icon"` | favicon 一起换，提示不再是空话 |

第 2 条顺带把 base64 从几百 KB 压到几十 KB —— 之前存的是 512px 原图，直接塞进 `href` 又慢又容易踩到实现上限。

## 为什么之前的验证没拦住

功能上线前在 iOS 26.5.2 和 Android 17 都跑过真机验证，当时是通的。验证页是独立的静态页面，只有一个 JS 注入的 `apple-touch-icon`，图也是现成的小 PNG —— 恰好绕开了上面三个坑。接进真实页面后三个一起中招。

## 测试

新增 43 条，把三条不变式钉住，旧行为下会挂：

- 页面上只能有一个 `apple-touch-icon`（含 `precomposed` 变体、反复注入、原本没有时新建）
- `href` 必须是 PNG data URI，栅格化尺寸固定 180
- cover 裁切铺满不变形（宽图 / 高图 / 小图放大 / 宽高比保持）

外加失败路径：栅格化挂了退回原图、blobRef 解析不到不动 DOM、manifest 拉不到不影响图标、启动注入抛异常不带崩流程。

全量 3370 条通过。

## 验证方式

Safari 里打开 → 外观定制 → 应用图标 → 换图，**标签页图标应当场就变**。这是第一道检查点，没变说明前面就断了。然后分享 → 添加到主屏幕。

主屏图标仍是旧的，通常是 iOS 缓存了上次添加的那个 —— 把旧的主屏图标删掉再重新添加。

---
https://claude.ai/code/session_01TXLxq1q9DYfsMKG74YGdtD
