### PR TITLE
fix: resolve call companion XHS and iOS regressions

### DIFF
--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -3002,10 +3002,10 @@ ${sentencePlan}`;
   const latestCallBubble = bubbles[bubbles.length - 1];
   const compactVideoTranscript = callMode === 'video' && videoCallLayout === 'stage' && !videoTranscriptExpanded;
   const videoStageSize = videoCallLayout === 'stage'
-    ? 'min-h-[260px]'
+    ? 'min-h-0'
     : videoCallLayout === 'mini'
-      ? 'h-[clamp(170px,26vh,230px)] min-h-[170px]'
-      : 'h-[clamp(215px,34vh,300px)] min-h-[215px]';
+      ? 'h-[clamp(140px,26dvh,230px)] min-h-0'
+      : 'h-[clamp(170px,34dvh,300px)] min-h-0';
   const callControlSize = callMode === 'video' ? 'h-10 w-10' : 'h-14 w-14';
   return (
     <div
@@ -3042,11 +3042,11 @@ ${sentencePlan}`;
             style={{ top: p.top, left: p.left, width: p.s, height: p.s, opacity: 0.5, animationDelay: `${i * 0.4}s`, boxShadow: `0 0 6px ${accentColor}` }} />
         ))}
       </div>
-      <div className="relative z-10 flex flex-col h-full">
+      <div className="relative z-10 flex h-full min-h-0 flex-col overflow-hidden">
         {/* 键盘避让不在这里做 paddingBottom 兜底：交给全局 interactive-widget=resizes-content
             与 iOS 全屏 PWA 的 app 高度跟随可视区（见 utils/iosStandalone.ts），和聊天等其它 App 一致。 */}
       {/* top channel bar */}
-      <div className="relative px-5" style={{ paddingTop: 'max(2.25rem, var(--safe-top))' }}>
+      <div className="relative shrink-0 px-5" style={{ paddingTop: 'max(2.25rem, var(--safe-top))' }}>
         <div className="absolute left-5 leading-tight" style={{ top: 'max(2.25rem, var(--safe-top))' }}>
           <div className="text-[9px] tracking-[0.28em] text-white/45 font-semibold">{callMode === 'video' ? 'SULLYOS · VIDEO DATE' : 'PRIVATE CHANNEL'}</div>
           <div className="mt-1.5 flex items-center gap-1.5 text-[8px] tracking-[0.22em] text-white/35">
@@ -3354,7 +3354,7 @@ ${sentencePlan}`;
       </div>
       )}
       {showInputPanel && (
-        <div className={callMode === 'video' ? 'px-3 pb-1.5' : 'px-4 pb-2'}>
+        <div className={`shrink-0 ${callMode === 'video' ? 'px-3 pb-1.5' : 'px-4 pb-2'}`}>
           <div className={`${callMode === 'video' ? 'rounded-[1.15rem] p-1.5' : 'rounded-2xl p-2'} border border-white/12 bg-black/30 backdrop-blur-md flex gap-2 items-center`} style={{ boxShadow: `inset 0 0 20px ${accentColor}1f` }}>
             {sttSupported && (
               <button
@@ -3380,7 +3380,7 @@ ${sentencePlan}`;
           {isListening && <div className="text-[10px] text-white/40 mt-1 px-1 animate-pulse">正在聆听，点麦克风结束</div>}
         </div>
       )}
-      <div className={`${callMode === 'video' ? 'px-3 pb-2 pt-0.5' : 'px-7 pb-7 pt-1.5'}`} data-testid={callMode === 'video' ? 'video-call-compact-controls' : undefined}>
+      <div className={`shrink-0 ${callMode === 'video' ? 'px-3 pb-2 pt-0.5' : 'px-7 pb-2 pt-1.5'}`} data-testid={callMode === 'video' ? 'video-call-compact-controls' : undefined}>
         <div
           className={`${callMode === 'video' ? 'grid grid-cols-5 items-center gap-1 rounded-[1.35rem] border border-white/12 bg-black/30 px-1.5 py-1.5 backdrop-blur-xl' : 'flex items-start justify-between'}`}
           style={callMode === 'video' ? { boxShadow: `inset 0 1px 0 ${accentColor}32, 0 14px 32px rgba(0,0,0,.2)` } : undefined}

--- a/apps/NovelApp.tsx
+++ b/apps/NovelApp.tsx
@@ -228,7 +228,7 @@ const NovelApp: React.FC = () => {
     if (view === 'library') {
         return (
             <div className="h-full w-full bg-slate-50 flex flex-col font-sans">
-                <div className="bg-white/80 backdrop-blur-md border-b border-slate-200 shrink-0 sticky top-0 z-20" style={{ paddingTop: 'var(--safe-top)' }}>
+                <div className="bg-white/80 backdrop-blur-md border-b border-slate-200 shrink-0 sticky top-0 z-20" style={{ paddingTop: 'var(--chrome-top)' }}>
                     <div className="flex items-center px-6 py-3">
                     <div className="flex justify-between items-center w-full">
                         <button onClick={() => setView('shelf')} className="p-2 -ml-2 rounded-full hover:bg-slate-100 active:scale-90 transition-transform">
@@ -291,7 +291,7 @@ const NovelApp: React.FC = () => {
         return (
             <div className="h-full w-full bg-slate-50 flex flex-col font-sans relative">
                 <ConfirmDialog isOpen={!!confirmDialog} title={confirmDialog?.title || ''} message={confirmDialog?.message || ''} variant={confirmDialog?.variant} confirmText={confirmDialog?.confirmText || (confirmDialog?.onConfirm ? '确认' : 'OK')} onConfirm={confirmDialog?.onConfirm || (() => setConfirmDialog(null))} onCancel={() => setConfirmDialog(null)} />
-                <div className="bg-white/80 backdrop-blur-md z-20 shrink-0 border-b border-slate-100" style={{ paddingTop: 'var(--safe-top)' }}>
+                <div className="bg-white/80 backdrop-blur-md z-20 shrink-0 border-b border-slate-100" style={{ paddingTop: 'var(--chrome-top)' }}>
                     <div className="flex items-center justify-between px-6 py-3">
                     <button onClick={closeApp} className="p-3 -ml-3 rounded-full hover:bg-slate-100 active:scale-95 transition-all"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" className="w-6 h-6 text-slate-600"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg></button>
                     <span className="font-black text-2xl text-slate-800 tracking-tight">我的手稿</span>
@@ -331,7 +331,7 @@ const NovelApp: React.FC = () => {
         return (
             <div className="h-full w-full bg-slate-50 flex flex-col font-sans relative">
                 <ConfirmDialog isOpen={!!confirmDialog} title={confirmDialog?.title || ''} message={confirmDialog?.message || ''} variant={confirmDialog?.variant} confirmText={confirmDialog?.confirmText || (confirmDialog?.onConfirm ? '确认' : 'OK')} onConfirm={confirmDialog?.onConfirm || (() => setConfirmDialog(null))} onCancel={() => setConfirmDialog(null)} />
-                <div className="bg-white border-b border-slate-200 shrink-0 sticky top-0 z-20" style={{ paddingTop: 'var(--safe-top)' }}>
+                <div className="bg-white border-b border-slate-200 shrink-0 sticky top-0 z-20" style={{ paddingTop: 'var(--chrome-top)' }}>
                     <div className="h-16 flex items-center justify-between px-4">
                     <button onClick={() => setView(view === 'create' ? 'shelf' : 'write')} className="text-slate-500 text-sm">取消</button>
                     <span className="font-bold text-slate-800">{view === 'create' ? '新建书稿' : '小说设定'}</span>

--- a/components/novel/NovelWriter.tsx
+++ b/components/novel/NovelWriter.tsx
@@ -491,7 +491,10 @@ ${chapterText.substring(0, 200000)}
 
             {/* Header */}
             {/* Removed 'sticky top-0' to fix layout overlap. It is now a standard flex child. */}
-            <div className={`flex flex-col border-b border-black/5 shrink-0 z-20 backdrop-blur-md ${activeTheme.bg}/90 transition-all`}>
+            <div
+                className={`flex flex-col border-b border-black/5 shrink-0 z-20 backdrop-blur-md ${activeTheme.bg}/90 transition-all`}
+                style={{ paddingTop: 'var(--chrome-top)' }}
+            >
                 <div className="h-16 flex items-center justify-between px-4 pt-2">
                     <button onClick={onBack} className="p-3 -ml-3 rounded-full hover:bg-black/5 active:scale-90 transition-transform">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className={`w-6 h-6 ${activeTheme.text}`}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>

--- a/utils/applyAssistantPostProcessing.test.ts
+++ b/utils/applyAssistantPostProcessing.test.ts
@@ -318,6 +318,65 @@ describe('renderAndPersist XHS mimicked-card fallback', () => {
         expect(text).not.toContain('\u6807\u9898:');
         expect(text).not.toContain('\u4e92\u52a8:');
     }, 20000);
+
+    it('recovers consecutive cards when the next marker is glued to the previous description', async () => {
+        const charId = `c-xhs-mimic-glued-${Date.now()}`;
+        const ctx = makeCtx(charId, []);
+        ctx.instantRender = true;
+        ctx.lastXhsNotesRef = {
+            current: [
+                {
+                    noteId: 'note-doll',
+                    title: '只需发照片定制人偶可撕拉盲盒',
+                    desc: '完整盲盒简介',
+                    likes: 11,
+                    collects: 0,
+                    commentCount: 0,
+                    shareCount: 0,
+                    author: 'StoyTuned小铺',
+                    authorId: 'author-doll',
+                    coverUrl: 'https://example.test/doll.jpg',
+                },
+                {
+                    noteId: 'note-couple-app',
+                    title: '情侣必备的治愈系app',
+                    desc: '完整应用简介',
+                    likes: 991,
+                    collects: 0,
+                    commentCount: 0,
+                    shareCount: 0,
+                    author: '小猫女士',
+                    authorId: 'author-cat',
+                    coverUrl: 'https://example.test/couple.jpg',
+                },
+            ],
+        };
+        const raw = [
+            '[你分享了小红书笔记]',
+            '标题: 只需发照片定制人偶可撕拉盲盒',
+            '作者: StoyTuned小铺',
+            '互动: 11赞 0收藏 0评论 0分享',
+            '简介: 无[你分享了小红书笔记]',
+            '标题: 情侣必备的治愈系app',
+            '作者: 小猫女士',
+            '互动: 991赞 0收藏 0评论 0分享',
+            '简介: 无',
+        ].join('\n');
+
+        await applyAssistantPostProcessing(raw, ctx);
+
+        const msgs = (await DB.getRecentMessagesByCharId(charId, 50)).filter(m => m.role === 'assistant');
+        const cards = msgs.filter(m => m.type === 'xhs_card');
+        const leakedText = msgs.filter(m => m.type === 'text').map(m => m.content).join('\n');
+        expect(cards).toHaveLength(2);
+        expect(cards.map(card => card.metadata?.xhsNote?.noteId)).toEqual(['note-doll', 'note-couple-app']);
+        expect(cards.map(card => card.metadata?.xhsNote?.coverUrl)).toEqual([
+            'https://example.test/doll.jpg',
+            'https://example.test/couple.jpg',
+        ]);
+        expect(leakedText).not.toContain('分享了小红书笔记');
+        expect(leakedText).not.toContain('991赞');
+    }, 20000);
 });
 
 // push 路径上 LIFE / NEWS_CARD 的副作用改走 worker classifier 的 directive 通道

--- a/utils/applyAssistantPostProcessing.ts
+++ b/utils/applyAssistantPostProcessing.ts
@@ -79,7 +79,15 @@ const MIMICKED_XHS_SHARE_RE = /(^|\r?\n)[ \t]*\[[^\]\r\n]{0,32}分享了小红�
 
 const extractMimickedXhsShares = (content: string): { cleanedContent: string; shares: MimickedXhsShareBlock[] } => {
     const shares: MimickedXhsShareBlock[] = [];
-    const cleanedContent = content.replace(
+    // Some models glue the next history-shaped card directly after the previous
+    // description (`简介: 无[你分享了小红书笔记]`). Put the marker back on its own
+    // line before scanning so every card is recovered instead of leaking the
+    // second card as five ordinary chat bubbles.
+    const normalizedBlocks = content.replace(
+        /([^\r\n])(\[[^\]\r\n]{0,32}分享了小红书笔记\])/gu,
+        '$1\n$2',
+    );
+    const cleanedContent = normalizedBlocks.replace(
         MIMICKED_XHS_SHARE_RE,
         (_match, leadingBreak: string, title: string, author: string, interactionText: string, desc: string) => {
             shares.push({
@@ -91,7 +99,7 @@ const extractMimickedXhsShares = (content: string): { cleanedContent: string; sh
             return leadingBreak || '';
         },
     ).replace(/\n{3,}/g, '\n\n').trim();
-    return { cleanedContent, shares };
+    return { cleanedContent: shares.length > 0 ? cleanedContent : content, shares };
 };
 
 const normalizeXhsCardKey = (value: string): string => String(value || '')

--- a/utils/avatarTouch.ts
+++ b/utils/avatarTouch.ts
@@ -870,7 +870,13 @@ export const requestAvatarTouchReactionPack = async (options: {
       max_tokens: 4800,
       stream: false,
     }),
-  }, 0, 60_000, {
+  // A complete pack can contain dozens of lines plus translations and
+  // performance data.  The previous 60s wall-clock timeout also kept ticking
+  // while a healthy streamed response was arriving, so slower providers were
+  // locally aborted at almost exactly 60s. Keep this a single model attempt,
+  // but align its timeout policy with normal chat instead of killing valid
+  // long generations before the optional TTS phase has even started.
+  }, 0, 0, {
     appName: '触感陪伴',
     charId: character.id,
     charName: character.name,

--- a/utils/callAppRuntimeReferences.test.ts
+++ b/utils/callAppRuntimeReferences.test.ts
@@ -66,7 +66,11 @@ describe('CallApp runtime references', () => {
     expect(source).toContain('data-testid="video-call-subtitle"');
     expect(source).toContain('data-testid={callMode === \'video\' ? \'video-call-compact-controls\' : undefined}');
     expect(source).toContain("videoCallLayout === 'stage' ? 'flex-1 min-h-0' : 'shrink-0'");
-    expect(source).toContain("? 'min-h-[260px]'");
+    expect(source).toContain("? 'min-h-0'");
+    expect(source).not.toContain('min-h-[260px]');
+    expect(source).toContain('relative z-10 flex h-full min-h-0 flex-col overflow-hidden');
+    expect(source).toContain("'px-7 pb-2 pt-1.5'");
+    expect(source).not.toContain('px-7 pb-7');
     expect(source).toContain("callMode === 'video' ? 'h-10 w-10'");
     expect(source).toContain("videoCallLayout === 'stage'");
     expect(source).toContain('setVideoTranscriptExpanded(true)');
@@ -176,6 +180,24 @@ describe('CallApp runtime references', () => {
     expect(guideSource).toContain('静态机位永远不随消息发送');
     expect(stageSource).toContain('testId="video-call-static-portrait-stage"');
     expect(stageSource).toContain('staticAvatarActive ? `static-${staticAvatarSource}`');
+  });
+
+  it('stores static companion imports as the original File in blob_assets from both entry points', () => {
+    const callSource = readFileSync(path.resolve(__dirname, '../apps/CallApp.tsx'), 'utf8');
+    const appearanceSource = readFileSync(path.resolve(__dirname, '../apps/Appearance.tsx'), 'utf8');
+    const callImport = callSource.slice(
+      callSource.indexOf('const chooseStaticAvatarImage = () =>'),
+      callSource.indexOf('const chooseVideoAvatarSource ='),
+    );
+    const appearanceImport = appearanceSource.slice(
+      appearanceSource.indexOf('const handleCompanionPortraitUpload = async'),
+      appearanceSource.indexOf('const chooseCompanionOutfit ='),
+    );
+
+    for (const importer of [callImport, appearanceImport]) {
+      expect(importer).toContain('const imageRef = await putImageBlob(file)');
+      expect(importer).not.toMatch(/processImage(?:ToBlob)?\(|FileReader|canvas|toDataURL|toBlob/);
+    }
   });
 
   it('requires explicit acknowledgement before saving a VRM test import', () => {

--- a/utils/companionHomeRuntimeReferences.test.ts
+++ b/utils/companionHomeRuntimeReferences.test.ts
@@ -12,11 +12,12 @@ describe('CompanionHome touch request boundaries', () => {
     expect(source).not.toContain('requestAvatarTouchReply');
     expect(source).not.toContain('DB.saveMessage');
   });
-  it('makes one touch-pack model attempt with no automatic repair or retry', () => {
+  it('makes one touch-pack model attempt without retry or an artificial 60s cutoff', () => {
     const touchSource = readFileSync(path.resolve(__dirname, './avatarTouch.ts'), 'utf8');
 
     expect(touchSource).toContain("purpose: '一次性生成桌面触摸反馈包（不重试）'");
-    expect(touchSource).toContain('}, 0, 60_000, {');
+    expect(touchSource).toContain('}, 0, 0, {');
+    expect(touchSource).not.toContain('}, 0, 60_000, {');
     expect(touchSource).not.toContain('自动补全缺失部位');
     expect(touchSource).not.toContain('requestForZones');
     expect(touchSource).not.toContain('repairData');

--- a/utils/safeAreaApps.test.ts
+++ b/utils/safeAreaApps.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { AppID } from '../types';
 import { shellHandlesSafeArea, SELF_SAFE_AREA_APPS } from './safeAreaApps';
 
@@ -25,5 +27,13 @@ describe('shellHandlesSafeArea', () => {
     // 双向一致：名单里有的断言里也要有，反之亦然，防止以后加/删 App 时漏更新其中一处。
     it('自理名单与断言列表一一对应（防漏登记）', () => {
         expect([...SELF_HANDLED].sort()).toEqual([...SELF_SAFE_AREA_APPS].sort());
+    });
+
+    it('笔友会所有顶栏都避开共享状态栏点击层', () => {
+        const appSource = readFileSync(path.resolve(__dirname, '../apps/NovelApp.tsx'), 'utf8');
+        const writerSource = readFileSync(path.resolve(__dirname, '../components/novel/NovelWriter.tsx'), 'utf8');
+
+        expect(appSource.match(/paddingTop: 'var\(--chrome-top\)'/g)).toHaveLength(3);
+        expect(writerSource).toContain("style={{ paddingTop: 'var(--chrome-top)' }}");
     });
 });


### PR DESCRIPTION
修复视频通话底部超出屏幕、语音按钮过高；短屏允许视频舞台收缩，输入区和控制栏固定保留。
确认 L2D 静态图从电话、外观两个入口均以原始 Blob 写入 IndexedDB，无压缩和重编码，并补回归检查。
修复连续小红书分享卡片黏连后被拆成普通聊天气泡。
修复笔友会 iOS 顶部安全区，返回、历史章节、结束本章按钮不再被状态栏截获。
移除仅存在于触感陪伴反馈包的 60 秒硬超时；仍然单次请求、不自动重试，不影响普通聊天和 TTS。