### PR TITLE
修复 Live2D 衣柜、触摸区域与纹理稳定性

### DIFF
--- a/components/call/Live2DAvatarCanvas.tsx
+++ b/components/call/Live2DAvatarCanvas.tsx
@@ -1341,7 +1341,8 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
           // desktop's calibrated composition perfectly still.
           const suppressUnanchoredCloseShot = closeShot
             && ambientAutonomyDisabledRef.current
-            && !anchored;
+            && !anchored
+            && !configRef.current.builtIn;
           // 导演机位只在用户构图基础上做温和加减：medium 必须是 1.0，
           // 否则用户校准好的构图会被默认镜头永久放大。锚定后特写倍率交给锚点本身。
           const cameraScale = anchored

--- a/components/call/Live2DAvatarCanvas.tsx
+++ b/components/call/Live2DAvatarCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Application, Assets, Cache, extensions } from 'pixi.js';
 import { AvatarAutonomy, getViewerEyeContactCompensation } from '../../utils/avatarAutonomy';
 import { DEFAULT_AVATAR_PERFORMANCE, type AvatarPerformanceDirection, type AvatarStageFraming } from '../../utils/avatarPerformance';
@@ -16,10 +16,14 @@ import {
 } from '../../utils/live2dModelStore';
 import type { AvatarMotionState } from './VRMAvatarCanvas';
 import {
+  avatarTouchZoneToastLabel,
+  resolveAvatarTouchRegion,
   resolveAvatarTouchTarget,
   type AvatarTouchHit,
   type AvatarTouchRequest,
+  type AvatarTouchZone,
 } from '../../utils/avatarTouch';
+import type { AvatarTouchRegion } from '../../types';
 
 export interface Live2DActionTrigger {
   id: string;
@@ -58,6 +62,11 @@ interface Live2DAvatarCanvasProps {
   touchRequest?: AvatarTouchRequest | null;
   touchImpulseNonce?: number;
   onAvatarTouch?: (hit: AvatarTouchHit) => void;
+  /** Optional draft override while editing; otherwise config.touchRegions is used. */
+  touchRegions?: AvatarTouchRegion[];
+  /** Enables model-local ellipse drawing for one reaction zone. */
+  touchRegionEditingZone?: AvatarTouchZone;
+  onTouchRegionsChange?: (regions: AvatarTouchRegion[]) => void;
   /** Desktop companion mode caps rendering work while preserving interaction. */
   maxFps?: number;
   /** Pins parameters to target values while the advanced editor shows its target state. */
@@ -74,6 +83,14 @@ const registerLive2DPlugin = (plugin: Parameters<typeof extensions.add>[0]) => {
 };
 
 const clamp = (value: number, min = -1, max = 1): number => Math.max(min, Math.min(max, value));
+const clamp01 = (value: number): number => Math.max(0, Math.min(1, value));
+const TOUCH_REGION_COLORS: Record<AvatarTouchZone, string> = {
+  head: '#f5c86a',
+  face: '#ff8fb7',
+  hand: '#77d9dd',
+  body: '#9ba8ff',
+  other: '#c6cbd5',
+};
 const HEAD_LOCK_PARAMETER_IDS = [
   'xin', 'yin', 'zin',
   'ParamAngleX', 'ParamAngleY', 'ParamAngleZ',
@@ -239,6 +256,9 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
   touchRequest,
   touchImpulseNonce,
   onAvatarTouch,
+  touchRegions,
+  touchRegionEditingZone,
+  onTouchRegionsChange,
   maxFps,
   parameterPreview,
   onParametersDiscovered,
@@ -260,6 +280,8 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
   const onErrorRef = useRef(onError);
   const onReadyRef = useRef(onReady);
   const onAvatarTouchRef = useRef(onAvatarTouch);
+  const touchRegionsRef = useRef<AvatarTouchRegion[]>(touchRegions ?? config.touchRegions ?? []);
+  const onTouchRegionsChangeRef = useRef(onTouchRegionsChange);
   const onParametersDiscoveredRef = useRef(onParametersDiscovered);
   const parameterPreviewRef = useRef(parameterPreview);
   // 进行中的参数动作叠加（kind='params'）：短暂把一组参数推到目标值再淡出。
@@ -268,6 +290,16 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
   const directedHeadPoseRef = useRef<{ headX: number; headY: number; headZ: number } | null>(null);
   const framingRef = useRef(framing || config.framing || { scale: 1, offsetX: 0, offsetY: 0 });
   const faceFramingRef = useRef<AvatarStageFraming | undefined>(faceFraming || config.faceFraming);
+  const [touchRegionBounds, setTouchRegionBounds] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
+  const touchRegionBoundsRef = useRef<typeof touchRegionBounds>(null);
+  const [drawingTouchRegion, setDrawingTouchRegion] = useState<AvatarTouchRegion | null>(null);
+  const touchRegionPointerRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    currentX: number;
+    currentY: number;
+  } | null>(null);
   const aiExpressionActiveRef = useRef(false);
   const pointerRef = useRef({ x: 0, y: 0, active: false, lastMoved: 0 });
   const lipSyncKey = config.lipSyncParameterIds.join('\u0000');
@@ -324,6 +356,8 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
   useEffect(() => { onErrorRef.current = onError; }, [onError]);
   useEffect(() => { onReadyRef.current = onReady; }, [onReady]);
   useEffect(() => { onAvatarTouchRef.current = onAvatarTouch; }, [onAvatarTouch]);
+  useEffect(() => { touchRegionsRef.current = touchRegions ?? config.touchRegions ?? []; }, [touchRegions, config.touchRegions]);
+  useEffect(() => { onTouchRegionsChangeRef.current = onTouchRegionsChange; }, [onTouchRegionsChange]);
   useEffect(() => { onParametersDiscoveredRef.current = onParametersDiscovered; }, [onParametersDiscovered]);
   useEffect(() => { parameterPreviewRef.current = parameterPreview; }, [parameterPreview]);
   useEffect(() => {
@@ -333,6 +367,135 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
   useEffect(() => {
     faceFramingRef.current = faceFraming || config.faceFraming;
   }, [faceFraming, config.faceFraming]);
+
+  useEffect(() => {
+    if (!touchRegionEditingZone) {
+      touchRegionBoundsRef.current = null;
+      setTouchRegionBounds(null);
+      setDrawingTouchRegion(null);
+      touchRegionPointerRef.current = null;
+      return;
+    }
+    let frame = 0;
+    const updateBounds = () => {
+      const bounds = (modelRef.current as any)?.getBounds?.();
+      if (bounds?.width > 0 && bounds?.height > 0) {
+        const next = { x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height };
+        const previous = touchRegionBoundsRef.current;
+        if (
+          !previous
+          || Math.abs(previous.x - next.x) > 0.5
+          || Math.abs(previous.y - next.y) > 0.5
+          || Math.abs(previous.width - next.width) > 0.5
+          || Math.abs(previous.height - next.height) > 0.5
+        ) {
+          touchRegionBoundsRef.current = next;
+          setTouchRegionBounds(next);
+        }
+      }
+      frame = window.requestAnimationFrame(updateBounds);
+    };
+    frame = window.requestAnimationFrame(updateBounds);
+    return () => window.cancelAnimationFrame(frame);
+  }, [touchRegionEditingZone, config.assetId]);
+
+  const touchRegionPoint = (event: React.PointerEvent<HTMLDivElement>): { x: number; y: number } | null => {
+    const host = hostRef.current;
+    const bounds = touchRegionBoundsRef.current;
+    if (!host || !bounds?.width || !bounds.height) return null;
+    const rect = host.getBoundingClientRect();
+    return {
+      x: clamp01((event.clientX - rect.left - bounds.x) / bounds.width),
+      y: clamp01((event.clientY - rect.top - bounds.y) / bounds.height),
+    };
+  };
+
+  const draftTouchRegion = (
+    zone: AvatarTouchZone,
+    startX: number,
+    startY: number,
+    currentX: number,
+    currentY: number,
+  ): AvatarTouchRegion => ({
+    id: '__drawing__',
+    zone,
+    shape: 'ellipse',
+    x: (Math.min(startX, currentX) + Math.max(startX, currentX)) / 2,
+    y: (Math.min(startY, currentY) + Math.max(startY, currentY)) / 2,
+    width: Math.abs(currentX - startX),
+    height: Math.abs(currentY - startY),
+  });
+
+  const handleTouchRegionPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!touchRegionEditingZone || (event.button !== 0 && event.pointerType === 'mouse')) return;
+    const point = touchRegionPoint(event);
+    const bounds = touchRegionBoundsRef.current;
+    const host = hostRef.current?.getBoundingClientRect();
+    if (!point || !bounds || !host) return;
+    const localX = event.clientX - host.left;
+    const localY = event.clientY - host.top;
+    if (localX < bounds.x || localX > bounds.x + bounds.width || localY < bounds.y || localY > bounds.y + bounds.height) return;
+    touchRegionPointerRef.current = {
+      pointerId: event.pointerId,
+      startX: point.x,
+      startY: point.y,
+      currentX: point.x,
+      currentY: point.y,
+    };
+    setDrawingTouchRegion(draftTouchRegion(touchRegionEditingZone, point.x, point.y, point.x, point.y));
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+  };
+
+  const handleTouchRegionPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const pointer = touchRegionPointerRef.current;
+    if (!pointer || pointer.pointerId !== event.pointerId || !touchRegionEditingZone) return;
+    const point = touchRegionPoint(event);
+    if (!point) return;
+    pointer.currentX = point.x;
+    pointer.currentY = point.y;
+    setDrawingTouchRegion(draftTouchRegion(
+      touchRegionEditingZone,
+      pointer.startX,
+      pointer.startY,
+      pointer.currentX,
+      pointer.currentY,
+    ));
+  };
+
+  const finishTouchRegion = (event: React.PointerEvent<HTMLDivElement>, save: boolean) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const pointer = touchRegionPointerRef.current;
+    if (!pointer || pointer.pointerId !== event.pointerId || !touchRegionEditingZone) return;
+    const point = touchRegionPoint(event);
+    if (point) {
+      pointer.currentX = point.x;
+      pointer.currentY = point.y;
+    }
+    const draft = draftTouchRegion(
+      touchRegionEditingZone,
+      pointer.startX,
+      pointer.startY,
+      pointer.currentX,
+      pointer.currentY,
+    );
+    touchRegionPointerRef.current = null;
+    setDrawingTouchRegion(null);
+    if (!save || draft.width < 0.025 || draft.height < 0.025) return;
+    const region: AvatarTouchRegion = {
+      ...draft,
+      id: typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `touch-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    };
+    const next = [...touchRegionsRef.current, region];
+    touchRegionsRef.current = next;
+    onTouchRegionsChangeRef.current?.(next);
+  };
 
   useEffect(() => {
     if (!touchRequest) return;
@@ -360,12 +523,15 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
       }
     } catch { /* ignore invalid first-frame bounds */ }
     if (!insideBounds) return;
-    const target = resolveAvatarTouchTarget(rawAreas, fallbackY, fallbackX);
+    const customTarget = resolveAvatarTouchRegion(touchRegionsRef.current, fallbackX, fallbackY);
+    const target = customTarget
+      ? { zone: customTarget.zone, part: customTarget.part }
+      : resolveAvatarTouchTarget(rawAreas, fallbackY, fallbackX);
     onAvatarTouchRef.current?.({
       ...touchRequest,
       ...target,
-      source: rawAreas.length ? 'live2d-hit-area' : 'live2d-bounds',
-      rawAreas,
+      source: customTarget ? 'live2d-custom-region' : rawAreas.length ? 'live2d-hit-area' : 'live2d-bounds',
+      rawAreas: customTarget ? [`custom:${customTarget.regionId}`, ...rawAreas] : rawAreas,
     });
   }, [touchRequest]);
 
@@ -1283,7 +1449,66 @@ const Live2DAvatarCanvas: React.FC<Live2DAvatarCanvasProps> = ({
     };
   }, [config.assetId, lipSyncKey, maxFps]);
 
-  return <div ref={hostRef} className="absolute inset-0 overflow-hidden" aria-label="Live2D 角色舞台" />;
+  const displayedTouchRegions = touchRegionEditingZone
+    ? [...(touchRegions ?? config.touchRegions ?? []), ...(drawingTouchRegion ? [drawingTouchRegion] : [])]
+    : [];
+
+  return (
+    <div ref={hostRef} className="absolute inset-0 overflow-hidden" aria-label="Live2D 角色舞台">
+      {touchRegionEditingZone && touchRegionBounds && (
+        <div
+          className="absolute inset-0 z-10 touch-none cursor-crosshair"
+          onPointerDown={handleTouchRegionPointerDown}
+          onPointerMove={handleTouchRegionPointerMove}
+          onPointerUp={event => finishTouchRegion(event, true)}
+          onPointerCancel={event => finishTouchRegion(event, false)}
+          data-testid="live2d-touch-region-editor"
+          aria-label={`正在圈选${avatarTouchZoneToastLabel(touchRegionEditingZone)}触摸区域`}
+        >
+          <div
+            className="pointer-events-none absolute border border-dashed border-white/30"
+            style={{
+              left: touchRegionBounds.x,
+              top: touchRegionBounds.y,
+              width: touchRegionBounds.width,
+              height: touchRegionBounds.height,
+            }}
+            aria-hidden
+          />
+          {displayedTouchRegions.map(region => {
+            const color = TOUCH_REGION_COLORS[region.zone];
+            const drawing = region.id === '__drawing__';
+            const active = region.zone === touchRegionEditingZone;
+            return (
+              <div
+                key={region.id}
+                className="pointer-events-none absolute flex items-center justify-center rounded-[50%] border"
+                style={{
+                  left: touchRegionBounds.x + (region.x - region.width / 2) * touchRegionBounds.width,
+                  top: touchRegionBounds.y + (region.y - region.height / 2) * touchRegionBounds.height,
+                  width: region.width * touchRegionBounds.width,
+                  height: region.height * touchRegionBounds.height,
+                  borderColor: color,
+                  borderStyle: drawing ? 'dashed' : 'solid',
+                  borderWidth: active ? 2 : 1,
+                  background: `${color}${active ? '28' : '12'}`,
+                  boxShadow: active ? `0 0 18px ${color}55` : undefined,
+                }}
+                data-touch-region-zone={region.zone}
+                aria-hidden
+              >
+                {region.width > 0.08 && region.height > 0.05 && (
+                  <span className="rounded-full bg-black/55 px-1.5 py-0.5 text-[8px] font-semibold text-white/90 backdrop-blur">
+                    {avatarTouchZoneToastLabel(region.zone)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default Live2DAvatarCanvas;

--- a/components/call/VRMVideoCallStage.tsx
+++ b/components/call/VRMVideoCallStage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { ArrowClockwise, ArrowsOutCardinal, CaretDown, FileZip, FolderOpen, ImageSquare, Play, SlidersHorizontal, UploadSimple, WarningCircle } from '@phosphor-icons/react';
-import type { CharacterProfile } from '../../types';
+import type { AvatarTouchRegion, CharacterProfile } from '../../types';
 import { getAvatarModelBlob } from '../../utils/avatarModelStore';
 import {
   clampStageFraming,
@@ -17,6 +17,7 @@ import {
   isAvatarTouchGesture,
   type AvatarTouchHit,
   type AvatarTouchRequest,
+  type AvatarTouchZone,
 } from '../../utils/avatarTouch';
 import StaticCompanionPortrait from '../os/StaticCompanionPortrait';
 
@@ -68,6 +69,10 @@ interface VRMVideoCallStageProps {
   stageCrop?: AvatarStageCrop;
   /** Shows the exact crop window while the desktop composition editor is open. */
   showCropGuide?: boolean;
+  /** Live2D-only model-local touch-region draft and editor controls. */
+  touchRegions?: AvatarTouchRegion[];
+  touchRegionEditingZone?: AvatarTouchZone;
+  onTouchRegionsChange?: (regions: AvatarTouchRegion[]) => void;
   maxFps?: number;
 }
 
@@ -118,9 +123,12 @@ const VRMVideoCallStage: React.FC<VRMVideoCallStageProps> = ({
   framingEditable,
   stageCrop = DEFAULT_STAGE_CROP,
   showCropGuide = false,
+  touchRegions,
+  touchRegionEditingZone,
+  onTouchRegionsChange,
   maxFps,
 }) => {
-  const canAdjustFraming = framingEditable ?? !companionMode;
+  const canAdjustFraming = !touchRegionEditingZone && (framingEditable ?? !companionMode);
   // 动作/表情快捷按钮默认收起——一排药丸浮在模型上视觉太吵，想用再展开。
   const [actionChipsOpen, setActionChipsOpen] = useState(() => {
     try { return localStorage.getItem('sully-call-action-chips-v1') === 'open'; } catch { return false; }
@@ -469,6 +477,9 @@ const VRMVideoCallStage: React.FC<VRMVideoCallStageProps> = ({
               touchRequest={touchRequest}
               touchImpulseNonce={touchImpulseNonce}
               onAvatarTouch={onAvatarTouch}
+              touchRegions={touchRegions}
+              touchRegionEditingZone={touchRegionEditingZone}
+              onTouchRegionsChange={onTouchRegionsChange}
               maxFps={maxFps}
               onReady={onModelReady}
               onLoadingChange={(loading, stage) => {

--- a/components/call/VRMVideoCallStage.tsx
+++ b/components/call/VRMVideoCallStage.tsx
@@ -462,7 +462,7 @@ const VRMVideoCallStage: React.FC<VRMVideoCallStageProps> = ({
             />
           ) : model?.format === 'live2d' ? (
             <Live2DAvatarCanvas
-              key={`${model.assetId}-${live2DRetryKey}`}
+              key={`${model.assetId}-${model.textureQuality === 'hd' ? 'hd' : 'balanced'}-${live2DRetryKey}`}
               config={model}
               motionState={motionState}
               audioFeed={audioFeed}

--- a/components/os/CompanionHome.tsx
+++ b/components/os/CompanionHome.tsx
@@ -16,7 +16,7 @@ import {
   UploadSimple,
 } from '@phosphor-icons/react';
 import { useOS } from '../../context/OSContext';
-import { AppID, type CompanionStartupSettings, type CompanionTouchReaction, type DailySchedule } from '../../types';
+import { AppID, type AvatarTouchRegion, type CompanionStartupSettings, type CompanionTouchReaction, type DailySchedule } from '../../types';
 import { Icons, INSTALLED_APPS } from '../../constants';
 import VRMVideoCallStage from '../call/VRMVideoCallStage';
 import { ScheduleFullscreenViewer } from '../schedule/ScheduleHomeWidget';
@@ -454,10 +454,12 @@ const CompanionHome: React.FC = () => {
   const [vrmExpressions, setVrmExpressions] = useState<string[]>([]);
   const [editing, setEditing] = useState(false);
   const [editingPanel, setEditingPanel] = useState<'character' | 'stage'>('character');
-  const [compositionFramingMode, setCompositionFramingMode] = useState<'base' | 'face'>('base');
+  const [compositionFramingMode, setCompositionFramingMode] = useState<'base' | 'face' | 'touch'>('base');
   const [framingDraft, setFramingDraft] = useState<AvatarStageFraming>(() => character?.videoAvatar?.companionFraming || DEFAULT_STAGE_FRAMING);
   const [faceFramingDraft, setFaceFramingDraft] = useState<AvatarStageFraming>(() => character?.videoAvatar?.faceFraming || { scale: 1.8, offsetX: 0, offsetY: 0 });
   const [faceAnchorDraftEnabled, setFaceAnchorDraftEnabled] = useState(() => Boolean(character?.videoAvatar?.faceFraming));
+  const [touchRegionsDraft, setTouchRegionsDraft] = useState<AvatarTouchRegion[]>(() => character?.videoAvatar?.format === 'live2d' ? character.videoAvatar.touchRegions || [] : []);
+  const [touchRegionEditingZone, setTouchRegionEditingZone] = useState<AvatarTouchZone>('face');
   const [cropDraft, setCropDraft] = useState<AvatarStageCrop>(() => character?.videoAvatar?.companionCrop || DEFAULT_STAGE_CROP);
   const [frameStyle, setFrameStyle] = useState<CompanionFrameStyleId>(loadCompanionFrameStyle);
   const editingRef = useRef(false);
@@ -751,6 +753,8 @@ const CompanionHome: React.FC = () => {
     setFramingDraft(character?.videoAvatar?.companionFraming || (isBuiltinSullyLive2D(character?.videoAvatar) ? { ...BUILTIN_SULLY_DEFAULT_FRAMING } : DEFAULT_STAGE_FRAMING));
     setFaceFramingDraft(character?.videoAvatar?.faceFraming || { scale: 1.8, offsetX: 0, offsetY: 0 });
     setFaceAnchorDraftEnabled(Boolean(character?.videoAvatar?.faceFraming));
+    setTouchRegionsDraft(character?.videoAvatar?.format === 'live2d' ? character.videoAvatar.touchRegions || [] : []);
+    setTouchRegionEditingZone('face');
     setCropDraft(character?.videoAvatar?.companionCrop || DEFAULT_STAGE_CROP);
     setPerformance(shouldPrepareStartup
       ? (startup?.enabled && normalizeCompanionDialogue(startup.line, character?.name || '')
@@ -1130,6 +1134,8 @@ const CompanionHome: React.FC = () => {
     setFramingDraft(companionFraming || defaultCompanionFraming);
     setFaceFramingDraft(makeFaceFramingSeed());
     setFaceAnchorDraftEnabled(Boolean(character?.videoAvatar?.faceFraming));
+    setTouchRegionsDraft(character?.videoAvatar?.format === 'live2d' ? character.videoAvatar.touchRegions || [] : []);
+    setTouchRegionEditingZone('face');
     setCropDraft(companionCrop || DEFAULT_STAGE_CROP);
     setEditing(true);
   };
@@ -1137,6 +1143,8 @@ const CompanionHome: React.FC = () => {
     setFramingDraft(companionFraming || defaultCompanionFraming);
     setFaceFramingDraft(makeFaceFramingSeed());
     setFaceAnchorDraftEnabled(Boolean(character?.videoAvatar?.faceFraming));
+    setTouchRegionsDraft(character?.videoAvatar?.format === 'live2d' ? character.videoAvatar.touchRegions || [] : []);
+    setTouchRegionEditingZone('face');
     setCompositionFramingMode('base');
     setCropDraft(companionCrop || DEFAULT_STAGE_CROP);
     setEditing(false);
@@ -1150,12 +1158,18 @@ const CompanionHome: React.FC = () => {
           companionFraming: builtinSullyAvatar || !framingIsDefault(framingDraft) ? framingDraft : undefined,
           faceFraming: faceAnchorDraftEnabled ? faceFramingDraft : undefined,
           companionCrop: cropIsDefault(cropDraft) ? undefined : clampStageCrop(cropDraft),
+          ...(prev.videoAvatar.format === 'live2d' ? { touchRegions: touchRegionsDraft.length ? touchRegionsDraft : undefined } : {}),
         },
       } : {}
     ));
     setCompositionFramingMode('base');
     setEditing(false);
-    addToast(faceAnchorDraftEnabled ? '角色构图与面部特写锚点已保存' : '角色构图已保存', 'success');
+    addToast(
+      touchRegionsDraft.length
+        ? `角色构图与 ${touchRegionsDraft.length} 个触摸圈已保存`
+        : faceAnchorDraftEnabled ? '角色构图与面部特写锚点已保存' : '角色构图已保存',
+      'success',
+    );
   };
   const chooseBuiltinSullyQuality = (quality: BuiltinSullyLive2DQuality) => {
     if (!character || !builtinSullyAvatar || builtinSullyAvatar.builtinQuality === quality) return;
@@ -2189,12 +2203,15 @@ const CompanionHome: React.FC = () => {
             accentColor={accentColor}
             baseFraming={activeCompanionFraming}
             framingEditable={editing}
-            onFramingChange={editing ? setCompositionFramingDraft : undefined}
+            onFramingChange={editing && compositionFramingMode !== 'touch' ? setCompositionFramingDraft : undefined}
             stageCrop={activeCompanionCrop}
             showCropGuide={editing && editingPanel === 'character' && compositionFramingMode === 'base'}
+            touchRegions={editing && character.videoAvatar?.format === 'live2d' ? touchRegionsDraft : undefined}
+            touchRegionEditingZone={editing && editingPanel === 'character' && compositionFramingMode === 'touch' && character.videoAvatar?.format === 'live2d' ? touchRegionEditingZone : undefined}
+            onTouchRegionsChange={editing ? setTouchRegionsDraft : undefined}
             onChooseModel={() => openApp(AppID.Call)}
             onExpressionsDiscovered={setVrmExpressions}
-            onAvatarTouch={hit => { void respondToTouch(hit); }}
+            onAvatarTouch={editing ? undefined : hit => { void respondToTouch(hit); }}
             onModelReady={handleStageModelReady}
             onModelError={handleStageModelError}
             touchImpulseNonce={lastHit?.nonce}
@@ -3298,7 +3315,7 @@ const CompanionHome: React.FC = () => {
                           </div>
                         </div>
                       )}
-                      <div className="mb-3 grid grid-cols-2 gap-1.5" data-testid="companion-framing-mode-picker">
+                      <div className={`mb-3 grid gap-1.5 ${character.videoAvatar.format === 'live2d' ? 'grid-cols-3' : 'grid-cols-2'}`} data-testid="companion-framing-mode-picker">
                         <button
                           type="button"
                           aria-pressed={compositionFramingMode === 'base'}
@@ -3317,14 +3334,73 @@ const CompanionHome: React.FC = () => {
                           className={`border px-2 py-2 text-[9px] transition ${compositionFramingMode === 'face' ? 'bg-white/12 text-white' : 'border-white/10 text-white/42'}`}
                           style={compositionFramingMode === 'face' ? { borderColor: `${uiTint}88` } : undefined}
                         >面部特写锚点{faceAnchorDraftEnabled ? ' · 已设' : ''}</button>
+                        {character.videoAvatar.format === 'live2d' && (
+                          <button
+                            type="button"
+                            aria-pressed={compositionFramingMode === 'touch'}
+                            data-testid="companion-touch-region-mode"
+                            onClick={() => setCompositionFramingMode('touch')}
+                            className={`border px-2 py-2 text-[9px] transition ${compositionFramingMode === 'touch' ? 'bg-white/12 text-white' : 'border-white/10 text-white/42'}`}
+                            style={compositionFramingMode === 'touch' ? { borderColor: `${uiTint}88` } : undefined}
+                          >触摸圈选{touchRegionsDraft.length ? ` · ${touchRegionsDraft.length}` : ''}</button>
+                        )}
                       </div>
                       {compositionFramingMode === 'face' && (
                         <div className="mb-3 border-l px-2.5 py-2 text-[8px] leading-relaxed text-white/48" style={{ borderColor: `${uiTint}88`, background: `${uiTint}0f` }}>
                           把脸拖到画面中心并调整到理想大小。保存后，摸脸或 AI 使用「拉近」镜头只会落到这个位置，不再按全身比例猜。
                         </div>
                       )}
+                      {compositionFramingMode === 'touch' && character.videoAvatar.format === 'live2d' && (
+                        <div className="mb-3 rounded-2xl border border-white/10 bg-black/15 p-2.5" data-testid="companion-touch-region-editor-panel">
+                          <div className="text-[8px] leading-relaxed text-white/55">
+                            先选部位，再在左侧模型上按住拖动，圈出椭圆区域。同一部位可画多个圈；圈会跟随这个模型，不受半身、全身或构图缩放影响。
+                          </div>
+                          <div className="mt-2 grid grid-cols-5 gap-1">
+                            {([
+                              { zone: 'head', label: '头', color: '#f5c86a' },
+                              { zone: 'face', label: '脸', color: '#ff8fb7' },
+                              { zone: 'hand', label: '手', color: '#77d9dd' },
+                              { zone: 'body', label: '身体', color: '#9ba8ff' },
+                              { zone: 'other', label: '其他', color: '#c6cbd5' },
+                            ] as const).map(item => {
+                              const count = touchRegionsDraft.filter(region => region.zone === item.zone).length;
+                              const active = touchRegionEditingZone === item.zone;
+                              return (
+                                <button
+                                  key={item.zone}
+                                  type="button"
+                                  onClick={() => setTouchRegionEditingZone(item.zone)}
+                                  className={`min-w-0 rounded-xl border px-1 py-2 text-[8px] transition active:scale-95 ${active ? 'bg-white/12 text-white' : 'border-white/8 text-white/42'}`}
+                                  style={active ? { borderColor: item.color, boxShadow: `inset 0 0 14px ${item.color}18` } : undefined}
+                                  data-testid={`companion-touch-region-zone-${item.zone}`}
+                                >
+                                  <span className="mx-auto mb-1 block h-1.5 w-1.5 rounded-full" style={{ background: item.color }} />
+                                  {item.label}{count ? ` ${count}` : ''}
+                                </button>
+                              );
+                            })}
+                          </div>
+                          <div className="mt-2 flex items-center justify-between border-t border-white/8 pt-2">
+                            <span className="text-[8px] text-white/35">重叠时优先较小的圈</span>
+                            <span className="flex gap-1">
+                              <button
+                                type="button"
+                                disabled={!touchRegionsDraft.some(region => region.zone === touchRegionEditingZone)}
+                                onClick={() => setTouchRegionsDraft(current => current.filter(region => region.zone !== touchRegionEditingZone))}
+                                className="rounded-full px-2 py-1 text-[8px] text-rose-200/65 disabled:opacity-25"
+                              >清除此部位</button>
+                              <button
+                                type="button"
+                                disabled={!touchRegionsDraft.length}
+                                onClick={() => setTouchRegionsDraft([])}
+                                className="rounded-full px-2 py-1 text-[8px] text-rose-200/65 disabled:opacity-25"
+                              >全部清除</button>
+                            </span>
+                          </div>
+                        </div>
+                      )}
                       <div className="flex items-center justify-between">
-                        <div className="text-[9px] font-semibold tracking-[0.16em] text-white/48">{compositionFramingMode === 'face' ? '面部锚点大小与位置' : '大小与位置'}</div>
+                        <div className="text-[9px] font-semibold tracking-[0.16em] text-white/48">{compositionFramingMode === 'face' ? '面部锚点大小与位置' : compositionFramingMode === 'touch' ? '圈选时的模型位置' : '大小与位置'}</div>
                         <button
                           onClick={() => {
                             if (compositionFramingMode === 'face') setFaceFramingDraft(makeFaceFramingSeed());
@@ -3332,7 +3408,7 @@ const CompanionHome: React.FC = () => {
                           }}
                           className="inline-flex items-center gap-1 rounded-full border border-white/12 px-2 py-1 text-[9px] text-white/50 active:scale-95"
                         >
-                          <ArrowClockwise size={10} weight="bold" /> {compositionFramingMode === 'face' ? '重置锚点' : '全部重置'}
+                          <ArrowClockwise size={10} weight="bold" /> {compositionFramingMode === 'face' ? '重置锚点' : compositionFramingMode === 'touch' ? '重置构图' : '全部重置'}
                         </button>
                       </div>
 

--- a/components/os/CompanionHome.tsx
+++ b/components/os/CompanionHome.tsx
@@ -1176,6 +1176,24 @@ const CompanionHome: React.FC = () => {
     updateCharacter(character.id, { videoAvatar: setBuiltinSullyLive2DQuality(builtinSullyAvatar, quality) });
     addToast(quality === 'hd' ? 'Sully 已切到高清 4K；低端设备建议使用 2K' : 'Sully 已切回轻量 2K', quality === 'hd' ? 'info' : 'success');
   };
+  const chooseImportedLive2DTextureQuality = (quality: 'balanced' | 'hd') => {
+    if (!character?.videoAvatar || character.videoAvatar.format !== 'live2d' || character.videoAvatar.builtIn) return;
+    const current = character.videoAvatar.textureQuality === 'hd' ? 'hd' : 'balanced';
+    if (current === quality) return;
+    updateCharacter(character.id, prev => (
+      prev.videoAvatar?.format === 'live2d' && !prev.videoAvatar.builtIn
+        ? { videoAvatar: { ...prev.videoAvatar, textureQuality: quality } }
+        : {}
+    ));
+    setStageReady(false);
+    setStageCurtainPhase('covered');
+    addToast(
+      quality === 'hd'
+        ? '模型已切到高清 4K；首次切换会建立独立运行缓存'
+        : '模型已切回默认轻量 2K；更省内存、更不易闪退',
+      quality === 'hd' ? 'info' : 'success',
+    );
+  };
 
   const chooseCompanionFrameStyle = (nextStyle: CompanionFrameStyleId) => {
     setFrameStyle(nextStyle);
@@ -1709,9 +1727,14 @@ const CompanionHome: React.FC = () => {
     stopTouchVoice();
     setLastHit(hit);
     const touchForce = resolveAvatarTouchForce(hit);
+    const keepBuiltinSullyHeadClose = (direction: AvatarPerformanceDirection): AvatarPerformanceDirection => (
+      isBuiltinSullyLive2D(character.videoAvatar) && (hit.zone === 'head' || hit.zone === 'face')
+        ? { ...direction, camera: 'close' }
+        : direction
+    );
     setRipple({ nonce: hit.nonce, x: hit.normalizedX, y: hit.normalizedY, force: touchForce });
     showTouchBanner(hit, `你戳了戳${character.name}的${avatarTouchTargetLabel(hit)}`);
-    setPerformance(applyAvatarTouchForce(buildImmediateTouchPerformance(hit.zone), hit));
+    setPerformance(applyAvatarTouchForce(keepBuiltinSullyHeadClose(buildImmediateTouchPerformance(hit.zone)), hit));
     setMotionState('speaking');
 
     const settings = character.companionTouchSettings;
@@ -1741,7 +1764,7 @@ const CompanionHome: React.FC = () => {
       if (!mountedRef.current) return;
       setLine({ text, translation: translation || undefined, label: `触摸 · ${avatarTouchZoneLabel(hit.zone)}`, kind: 'touch' });
       setPerformance(applyAvatarTouchForce(
-        reaction.performance || buildImmediateTouchPerformance(hit.zone),
+        keepBuiltinSullyHeadClose(reaction.performance || buildImmediateTouchPerformance(hit.zone)),
         hit,
       ));
       setMotionState('speaking');
@@ -3309,6 +3332,33 @@ const CompanionHome: React.FC = () => {
                                   onClick={() => chooseBuiltinSullyQuality(option.value)}
                                   className={`rounded-xl border py-2 text-[9px] font-medium transition active:scale-[.98] ${active ? 'bg-white/14 text-white' : 'border-white/8 bg-white/[.025] text-white/42'}`}
                                   style={active ? { borderColor: `${uiTint}88` } : undefined}
+                                >{active && <Check size={10} weight="bold" className="mr-1 inline" />}{option.label}</button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+                      {character.videoAvatar.format === 'live2d' && !builtinSullyAvatar && (
+                        <div className="mb-3 rounded-2xl border border-white/10 bg-black/15 p-2.5" data-testid="companion-live2d-texture-quality-picker">
+                          <div>
+                            <div className="text-[9px] font-semibold tracking-[0.16em] text-white/48">运行纹理画质</div>
+                            <div className="mt-0.5 text-[8px] leading-relaxed text-white/32">默认 2K 更稳；4K 会占用更多内存，并单独建立运行缓存</div>
+                          </div>
+                          <div className="mt-2 grid grid-cols-2 gap-1.5">
+                            {([
+                              { value: 'balanced' as const, label: '轻量 2K' },
+                              { value: 'hd' as const, label: '高清 4K' },
+                            ]).map(option => {
+                              const currentQuality = character.videoAvatar?.format === 'live2d' && character.videoAvatar.textureQuality === 'hd' ? 'hd' : 'balanced';
+                              const active = currentQuality === option.value;
+                              return (
+                                <button
+                                  key={option.value}
+                                  type="button"
+                                  onClick={() => chooseImportedLive2DTextureQuality(option.value)}
+                                  className={`rounded-xl border py-2 text-[9px] font-medium transition active:scale-[.98] ${active ? 'bg-white/14 text-white' : 'border-white/8 bg-white/[.025] text-white/42'}`}
+                                  style={active ? { borderColor: `${uiTint}88` } : undefined}
+                                  data-testid={`companion-live2d-texture-quality-${option.value}`}
                                 >{active && <Check size={10} weight="bold" className="mr-1 inline" />}{option.label}</button>
                               );
                             })}

--- a/types.ts
+++ b/types.ts
@@ -2575,6 +2575,8 @@ export interface CharacterProfile {
       builtinModelUrl?: string;
       /** balanced = 2K 默认纹理，hd = 4K 可选纹理。 */
       builtinQuality?: 'balanced' | 'hd';
+      /** 导入模型的运行纹理档位；默认 balanced(2K)，源模型最多保留到 4K 以便切换。 */
+      textureQuality?: 'balanced' | 'hd';
       /** 内置 Sully 的一次性默认构图迁移版本。 */
       builtinFramingVersion?: 1 | 2;
       /** ZIP 包内 model3.json 的完整相对路径。 */

--- a/types.ts
+++ b/types.ts
@@ -2417,6 +2417,18 @@ export interface CharMusicProfile {
 
 export type CompanionTouchZone = 'head' | 'face' | 'hand' | 'body' | 'other';
 
+export interface AvatarTouchRegion {
+  id: string;
+  zone: CompanionTouchZone;
+  /** Regions are normalized against this Live2D model's rendered bounds, not the screen. */
+  shape: 'ellipse';
+  /** Ellipse center and size, all in model-local 0..1 coordinates. */
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface CompanionPerformancePrecision {
   /** Temporarily suspend ambient turns/glances and keep the authored pose authoritative. */
   lockAutonomy?: boolean;
@@ -2599,6 +2611,8 @@ export interface CharacterProfile {
           bottom: number;
           left: number;
       };
+      /** 用户为这个 Live2D 模型单独圈选的触摸区域；未命中时仍回退模型自己的 HitArea。 */
+      touchRegions?: AvatarTouchRegion[];
       /** model3.json Groups 中声明的口型参数；没有声明时使用标准参数。 */
       lipSyncParameterIds: string[];
       /** 每个模型自己的动作/表情权限。AI 只能调用 permission=ai 的项目。 */

--- a/utils/avatarModelBackup.test.ts
+++ b/utils/avatarModelBackup.test.ts
@@ -120,6 +120,8 @@ describe('avatar model backup', () => {
     ]);
     expect(dbMock.saveCharacter).toHaveBeenCalledTimes(2);
     expect(dbMock.deleteBlobAsset).toHaveBeenCalledWith(`${live2dConfig.assetId}:live2d-runtime-store-v1`);
+    expect(dbMock.deleteBlobAsset).toHaveBeenCalledWith(`${live2dConfig.assetId}:live2d-runtime-store-v1:balanced`);
+    expect(dbMock.deleteBlobAsset).toHaveBeenCalledWith(`${live2dConfig.assetId}:live2d-runtime-store-v1:hd`);
   });
 
   it('skips a model when its character has not been restored yet', async () => {

--- a/utils/avatarModelBackup.ts
+++ b/utils/avatarModelBackup.ts
@@ -1,7 +1,7 @@
 import JSZip from 'jszip';
 import type { CharacterProfile } from '../types';
 import { DB } from './db';
-import { live2DRuntimeCacheAssetId } from './avatarModelStore';
+import { live2DRuntimeCacheAssetIds } from './avatarModelStore';
 
 export const AVATAR_MODEL_BACKUP_FORMAT = 'sully-avatar-models';
 export const AVATAR_MODEL_BACKUP_VERSION = 1;
@@ -270,7 +270,7 @@ export const restoreAvatarModelBackup = async (
     const config = { ...item.config, byteLength: blob.size } as VideoAvatarConfig;
     await DB.putBlobAsset(config.assetId, blob);
     if (config.format === 'live2d') {
-      await DB.deleteBlobAsset(live2DRuntimeCacheAssetId(config.assetId));
+      await Promise.all(live2DRuntimeCacheAssetIds(config.assetId).map(id => DB.deleteBlobAsset(id)));
     }
     const updatedTarget = item.slot === 'wardrobe'
       ? {

--- a/utils/avatarModelStore.test.ts
+++ b/utils/avatarModelStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { inspectAvatarFile, live2DRuntimeCacheAssetId } from './avatarModelStore';
+import { inspectAvatarFile, live2DRuntimeCacheAssetId, live2DRuntimeCacheAssetIds } from './avatarModelStore';
 
 const namedBlob = (name: string, bytes: number[]): Blob & { name: string } => {
   const blob = new Blob([new Uint8Array(bytes)]) as Blob & { name: string };
@@ -10,6 +10,8 @@ const namedBlob = (name: string, bytes: number[]): Blob & { name: string } => {
 describe('VRM 文件识别', () => {
   it('为 Live2D 派生运行缓存生成稳定且不碰撞原包的 key', () => {
     expect(live2DRuntimeCacheAssetId('video-avatar-live2d-1')).toBe('video-avatar-live2d-1:live2d-runtime-store-v1');
+    expect(live2DRuntimeCacheAssetId('video-avatar-live2d-1', 'balanced')).toBe('video-avatar-live2d-1:live2d-runtime-store-v1:balanced');
+    expect(live2DRuntimeCacheAssetIds('video-avatar-live2d-1')).toHaveLength(3);
   });
   it('识别标准 GLB/VRM magic', async () => {
     const result = await inspectAvatarFile(namedBlob('skylar.vrm', [0x67, 0x6c, 0x54, 0x46, 0, 0, 0, 0]));

--- a/utils/avatarModelStore.ts
+++ b/utils/avatarModelStore.ts
@@ -61,7 +61,18 @@ const makeAssetId = (): string => {
 };
 
 /** Existing compressed Live2D packages get a derived persistent STORE cache. */
-export const live2DRuntimeCacheAssetId = (assetId: string): string => `${assetId}:live2d-runtime-store-v1`;
+export type Live2DTextureQuality = 'balanced' | 'hd';
+
+export const live2DRuntimeCacheAssetId = (
+  assetId: string,
+  quality?: Live2DTextureQuality,
+): string => `${assetId}:live2d-runtime-store-v1${quality ? `:${quality}` : ''}`;
+
+export const live2DRuntimeCacheAssetIds = (assetId: string): string[] => [
+  live2DRuntimeCacheAssetId(assetId),
+  live2DRuntimeCacheAssetId(assetId, 'balanced'),
+  live2DRuntimeCacheAssetId(assetId, 'hd'),
+];
 
 export async function saveAvatarModel(file: File): Promise<VideoAvatarConfig> {
   const inspection = await inspectAvatarFile(file);
@@ -93,6 +104,6 @@ export const deleteAvatarModel = async (config?: VideoAvatarConfig | null): Prom
   if (config.format === 'live2d' && config.builtIn) return;
   await DB.deleteBlobAsset(config.assetId);
   if (config.format === 'live2d') {
-    await DB.deleteBlobAsset(live2DRuntimeCacheAssetId(config.assetId));
+    await Promise.all(live2DRuntimeCacheAssetIds(config.assetId).map(id => DB.deleteBlobAsset(id)));
   }
 };

--- a/utils/avatarTouch.test.ts
+++ b/utils/avatarTouch.test.ts
@@ -12,6 +12,7 @@ import {
   parseAvatarTouchReactionPackPartial,
   consumePendingAvatarTouches,  isAvatarTouchGesture,
   normalizeAvatarTouchZone,
+  resolveAvatarTouchRegion,
   resolveAvatarTouchTarget,
   resolveAvatarTouchForce,
   parseAvatarTouchReply,
@@ -44,6 +45,17 @@ describe('角色触碰互动', () => {
     expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.58, 0.08).part).toBe('arm');
     expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.58, 0.5).part).toBe('chest');
     expect(avatarTouchTargetLabel({ zone: 'body', part: 'chest' })).toBe('胸口');
+  });
+
+  it('优先使用每个模型自己的圈选区域，重叠时选择更小的区域', () => {
+    const regions = [
+      { id: 'head', zone: 'head' as const, shape: 'ellipse' as const, x: 0.5, y: 0.25, width: 0.5, height: 0.45 },
+      { id: 'face', zone: 'face' as const, shape: 'ellipse' as const, x: 0.5, y: 0.3, width: 0.24, height: 0.2 },
+    ];
+
+    expect(resolveAvatarTouchRegion(regions, 0.5, 0.3)).toMatchObject({ zone: 'face', part: 'face', regionId: 'face' });
+    expect(resolveAvatarTouchRegion(regions, 0.38, 0.2)).toMatchObject({ zone: 'head', part: 'head', regionId: 'head' });
+    expect(resolveAvatarTouchRegion(regions, 0.9, 0.9)).toBeNull();
   });
 
   it('即时本地反馈不会等待模型台词', () => {

--- a/utils/avatarTouch.test.ts
+++ b/utils/avatarTouch.test.ts
@@ -28,15 +28,13 @@ describe('角色触碰互动', () => {
     expect(normalizeAvatarTouchZone([], 0.55, 0.5)).toBe('body');
   });
 
-  it('在兼容旧反馈分区的同时细分头发、脸、肩膀、手臂、手、胸口和下肢', () => {
+  it('在兼容旧反馈分区的同时细分头发、脸、肩膀、手臂、手和胸口', () => {
     expect(resolveAvatarTouchTarget(['FrontHair'])).toEqual({ zone: 'head', part: 'hair' });
     expect(resolveAvatarTouchTarget(['Face'])).toEqual({ zone: 'face', part: 'face' });
     expect(resolveAvatarTouchTarget(['LeftShoulder'])).toEqual({ zone: 'body', part: 'shoulder' });
     expect(resolveAvatarTouchTarget(['Arm_L'])).toEqual({ zone: 'hand', part: 'arm' });
     expect(resolveAvatarTouchTarget(['RightHand'])).toEqual({ zone: 'hand', part: 'hand' });
     expect(resolveAvatarTouchTarget(['Bust'])).toEqual({ zone: 'body', part: 'chest' });
-    expect(resolveAvatarTouchTarget(['LeftLeg'])).toEqual({ zone: 'body', part: 'leg' });
-    expect(resolveAvatarTouchTarget(['RightFoot'])).toEqual({ zone: 'body', part: 'foot' });
   });
 
   it('用模型内坐标拆分只有 Head/Body 粗命中区的 Live2D 模型', () => {
@@ -44,11 +42,8 @@ describe('角色触碰互动', () => {
     expect(resolveAvatarTouchTarget(['HitAreaHead'], 0.25, 0.5).part).toBe('face');
     expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.42, 0.3).part).toBe('shoulder');
     expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.58, 0.08).part).toBe('arm');
-    expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.58, 0.5).part).toBe('waist');
-    expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.82, 0.5).part).toBe('leg');
-    expect(resolveAvatarTouchTarget(['TouchChest'], 0.82, 0.5).part).toBe('leg');
+    expect(resolveAvatarTouchTarget(['HitAreaBody'], 0.58, 0.5).part).toBe('chest');
     expect(avatarTouchTargetLabel({ zone: 'body', part: 'chest' })).toBe('胸口');
-    expect(avatarTouchTargetLabel({ zone: 'body', part: 'leg' })).toBe('腿');
   });
 
   it('即时本地反馈不会等待模型台词', () => {

--- a/utils/avatarTouch.ts
+++ b/utils/avatarTouch.ts
@@ -19,7 +19,7 @@ import { voiceLanguageLabel } from './voiceLanguage';
 
 export const AVATAR_TOUCH_ZONES = ['head', 'face', 'hand', 'body', 'other'] as const;
 export type AvatarTouchZone = typeof AVATAR_TOUCH_ZONES[number];
-export const AVATAR_TOUCH_PARTS = ['hair', 'head', 'face', 'shoulder', 'arm', 'hand', 'chest', 'waist', 'body', 'leg', 'foot', 'other'] as const;
+export const AVATAR_TOUCH_PARTS = ['hair', 'head', 'face', 'shoulder', 'arm', 'hand', 'chest', 'waist', 'body', 'other'] as const;
 export type AvatarTouchPart = typeof AVATAR_TOUCH_PARTS[number];
 export const DEFAULT_COMPANION_TOUCH_ZONES: AvatarTouchZone[] = ['head', 'face', 'hand', 'body'];
 export type AvatarTouchReactionPack = Partial<Record<AvatarTouchZone, CompanionTouchReaction[]>>;
@@ -104,8 +104,6 @@ const TOUCH_PART_LABELS: Record<AvatarTouchPart, string> = {
   chest: '胸口',
   waist: '腰部',
   body: '身体',
-  leg: '腿',
-  foot: '脚',
   other: '身边',
 };
 
@@ -220,7 +218,7 @@ const zoneForTouchPart = (part: AvatarTouchPart): AvatarTouchZone => {
   if (part === 'hair' || part === 'head') return 'head';
   if (part === 'face') return 'face';
   if (part === 'hand' || part === 'arm') return 'hand';
-  if (part === 'shoulder' || part === 'chest' || part === 'waist' || part === 'body' || part === 'leg' || part === 'foot') return 'body';
+  if (part === 'shoulder' || part === 'chest' || part === 'waist' || part === 'body') return 'body';
   return 'other';
 };
 
@@ -229,14 +227,14 @@ const geometricTouchPart = (fallbackY: number, fallbackX: number): AvatarTouchPa
   const y = Math.max(0, Math.min(1, fallbackY));
   if (y < 0.14) return 'hair';
   if (y < 0.34) return x > 0.22 && x < 0.78 ? 'face' : 'hair';
-  if (y < 0.48) {
+  if (y < 0.5) {
     if (x < 0.18 || x > 0.82) return 'arm';
     if (x < 0.4 || x > 0.6) return 'shoulder';
     return 'chest';
   }
-  if (y < 0.65) return x < 0.22 || x > 0.78 ? 'arm' : 'waist';
-  if (y < 0.93) return 'leg';
-  return 'foot';
+  if (y < 0.72) return x < 0.25 || x > 0.75 ? 'arm' : 'chest';
+  if (y < 0.9) return 'waist';
+  return 'other';
 };
 
 export const resolveAvatarTouchTarget = (
@@ -252,26 +250,15 @@ export const resolveAvatarTouchTarget = (
           : /(shoulder|clavicle|肩|锁骨|鎖骨)/i.test(value) ? 'shoulder'
             : /(chest|bust|breast|胸)/i.test(value) ? 'chest'
               : /(waist|hip|pelvis|腰|胯|臀)/i.test(value) ? 'waist'
-                : /(foot|feet|shoe|ankle|脚|足|鞋|踝)/i.test(value) ? 'foot'
-                  : /(leg|thigh|knee|calf|腿|膝)/i.test(value) ? 'leg'
-                    : null;
+                : null;
+  if (precisePart) return { zone: zoneForTouchPart(precisePart), part: precisePart };
 
   const hasGeometry = Number.isFinite(fallbackY) && Number.isFinite(fallbackX);
-  const geometricPart = hasGeometry ? geometricTouchPart(fallbackY!, fallbackX!) : null;
-  if (precisePart) {
-    // Imported hit-area polygons are not always tight. Some full-body models
-    // call one torso polygon "Chest" even though it extends through both legs.
-    // A strong lower-body coordinate contradiction should follow the tap.
-    const contradictsLowerBody = geometricPart === 'leg' || geometricPart === 'foot';
-    if (!contradictsLowerBody || precisePart === 'leg' || precisePart === 'foot') {
-      return { zone: zoneForTouchPart(precisePart), part: precisePart };
-    }
-    return { zone: zoneForTouchPart(geometricPart), part: geometricPart };
-  }
   const genericHead = /(head|hat|ear|头|頭|帽|耳)/i.test(value);
   const genericBody = /(body|torso|身体|身體|躯干|軀幹)/i.test(value);
   if (hasGeometry) {
-    return { zone: zoneForTouchPart(geometricPart!), part: geometricPart! };
+    const part = geometricTouchPart(fallbackY!, fallbackX!);
+    return { zone: zoneForTouchPart(part), part };
   }
   if (genericHead) return { zone: 'head', part: 'head' };
   if (genericBody) return { zone: 'body', part: 'body' };

--- a/utils/avatarTouch.ts
+++ b/utils/avatarTouch.ts
@@ -1,5 +1,6 @@
 import type {
   APIConfig,
+  AvatarTouchRegion,
   CharacterProfile,
   CompanionTouchReaction,
   UserProfile,
@@ -43,7 +44,7 @@ export interface AvatarTouchHit extends AvatarTouchRequest {
   zone: AvatarTouchZone;
   /** Precise visual target; zone remains the backward-compatible reaction bucket. */
   part?: AvatarTouchPart;
-  source: 'live2d-hit-area' | 'live2d-bounds' | 'vrm-raycast' | 'portrait-bounds';
+  source: 'live2d-custom-region' | 'live2d-hit-area' | 'live2d-bounds' | 'vrm-raycast' | 'portrait-bounds';
   rawAreas: string[];
 }
 
@@ -220,6 +221,46 @@ const zoneForTouchPart = (part: AvatarTouchPart): AvatarTouchZone => {
   if (part === 'hand' || part === 'arm') return 'hand';
   if (part === 'shoulder' || part === 'chest' || part === 'waist' || part === 'body') return 'body';
   return 'other';
+};
+
+const partForTouchZone = (zone: AvatarTouchZone): AvatarTouchPart => {
+  if (zone === 'head') return 'head';
+  if (zone === 'face') return 'face';
+  if (zone === 'hand') return 'hand';
+  if (zone === 'body') return 'body';
+  return 'other';
+};
+
+/**
+ * Resolve user-authored model-local ellipses. Smaller overlapping regions win,
+ * so a face ellipse can safely sit inside a larger head ellipse.
+ */
+export const resolveAvatarTouchRegion = (
+  regions: AvatarTouchRegion[] | undefined,
+  normalizedX: number,
+  normalizedY: number,
+): { zone: AvatarTouchZone; part: AvatarTouchPart; regionId: string } | null => {
+  if (!Array.isArray(regions) || !Number.isFinite(normalizedX) || !Number.isFinite(normalizedY)) return null;
+  const hit = regions
+    .filter(region => (
+      AVATAR_TOUCH_ZONES.includes(region.zone as AvatarTouchZone)
+      && Number.isFinite(region.x)
+      && Number.isFinite(region.y)
+      && Number.isFinite(region.width)
+      && Number.isFinite(region.height)
+      && region.width > 0
+      && region.height > 0
+    ))
+    .filter(region => {
+      const radiusX = region.width / 2;
+      const radiusY = region.height / 2;
+      const dx = (normalizedX - region.x) / radiusX;
+      const dy = (normalizedY - region.y) / radiusY;
+      return dx * dx + dy * dy <= 1;
+    })
+    .sort((a, b) => a.width * a.height - b.width * b.height)[0];
+  if (!hit) return null;
+  return { zone: hit.zone, part: partForTouchZone(hit.zone), regionId: hit.id };
 };
 
 const geometricTouchPart = (fallbackY: number, fallbackX: number): AvatarTouchPart => {

--- a/utils/companionHomeRuntimeReferences.test.ts
+++ b/utils/companionHomeRuntimeReferences.test.ts
@@ -121,6 +121,11 @@ describe('CompanionHome touch request boundaries', () => {
     expect(source).toContain('showCropGuide={editing && editingPanel === \'character\' && compositionFramingMode === \'base\'}');
     expect(source).toContain('data-testid="companion-face-anchor-mode"');
     expect(source).toContain('faceFraming: faceAnchorDraftEnabled ? faceFramingDraft : undefined');
+    expect(source).toContain('data-testid="companion-touch-region-mode"');
+    expect(source).toContain('data-testid="companion-touch-region-editor-panel"');
+    expect(source).toContain('touchRegions: touchRegionsDraft.length ? touchRegionsDraft : undefined');
+    expect(source).toContain("compositionFramingMode === 'touch'");
+    expect(source).toContain('onTouchRegionsChange={editing ? setTouchRegionsDraft : undefined}');
     expect(source).toContain('data-testid="companion-appearance-rail-button"');
     expect(source).toContain('data-testid="companion-real-wardrobe-button"');
     expect(source).toContain('<CompanionWardrobeDrawer');

--- a/utils/companionHomeRuntimeReferences.test.ts
+++ b/utils/companionHomeRuntimeReferences.test.ts
@@ -126,6 +126,9 @@ describe('CompanionHome touch request boundaries', () => {
     expect(source).toContain('touchRegions: touchRegionsDraft.length ? touchRegionsDraft : undefined');
     expect(source).toContain("compositionFramingMode === 'touch'");
     expect(source).toContain('onTouchRegionsChange={editing ? setTouchRegionsDraft : undefined}');
+    expect(source).toContain('data-testid="companion-live2d-texture-quality-picker"');
+    expect(source).toContain("textureQuality: quality");
+    expect(source).toContain("isBuiltinSullyLive2D(character.videoAvatar) && (hit.zone === 'head' || hit.zone === 'face')");
     expect(source).toContain('data-testid="companion-appearance-rail-button"');
     expect(source).toContain('data-testid="companion-real-wardrobe-button"');
     expect(source).toContain('<CompanionWardrobeDrawer');

--- a/utils/live2dModelStore.test.ts
+++ b/utils/live2dModelStore.test.ts
@@ -13,6 +13,7 @@ import {
   getLive2DWardrobeActions,
   inferLive2DActionTags,
   inspectLive2DPackage,
+  Live2DMissingFilesError,
   readLive2DTextureDimensions,
   removeLive2DWardrobeAction,
   sniffImageMime,
@@ -94,9 +95,43 @@ describe('Live2D 模型导入解析', () => {
     });
   });
 
-  it('模型引用缺文件时拒绝导入并指出包不完整', async () => {
-    await expect(inspectLive2DPackage(packageEntries.filter(entry => !entry.path.endsWith('texture_00.png'))))
-      .rejects.toThrow('模型引用的文件不完整');
+  it('模型引用缺文件时保留短提示，并向控制台返回完整路径诊断', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const entries = packageEntries.filter(entry => !entry.path.endsWith('texture_00.png'));
+    try {
+      await inspectLive2DPackage(entries);
+      throw new Error('expected missing-file rejection');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Live2DMissingFilesError);
+      expect((error as Live2DMissingFilesError).message).toContain('模型引用的文件不完整');
+      expect((error as Live2DMissingFilesError).missingFiles).toEqual([
+        expect.objectContaining({
+          reference: 'textures/texture_00.png',
+          resolvedPath: 'Skylar/textures/texture_00.png',
+          referencedBy: 'Skylar/Skylar.model3.json',
+        }),
+      ]);
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('完整缺失引用诊断'));
+      expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Skylar/textures/texture_00.png'));
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('缺失诊断指出大小写错误和同名文件所在位置', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const entries = packageEntries
+      .filter(entry => !entry.path.endsWith('texture_00.png'))
+      .concat({ path: 'Skylar/Textures/TEXTURE_00.PNG', blob: blob('png') });
+    try {
+      await inspectLive2DPackage(entries);
+      throw new Error('expected missing-file rejection');
+    } catch (error) {
+      const detail = (error as Live2DMissingFilesError).missingFiles[0];
+      expect(detail.caseInsensitiveMatch).toBe('Skylar/Textures/TEXTURE_00.PNG');
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('解析 VTube Studio 热键、未登记表情、待机动画和保存的构图', async () => {

--- a/utils/live2dModelStore.test.ts
+++ b/utils/live2dModelStore.test.ts
@@ -6,6 +6,8 @@ import {
   downscaleOversizedLive2DTextures,
   findLive2DActionsForPerformance,
   getLive2DTextureResizeTarget,
+  getLive2DTextureMaxDimension,
+  getLive2DTextureQuality,
   getLive2DAIActions,
   getActiveLive2DWardrobeParameters,
   getLive2DWardrobeActions,
@@ -283,6 +285,14 @@ describe('Live2D 模型导入解析', () => {
     });
     expect(getLive2DTextureResizeTarget(8192, 4096)).toEqual({ width: 4096, height: 2048 });
     expect(getLive2DTextureResizeTarget(2048, 4096)).toBeNull();
+  });
+
+  it('导入模型默认使用 2K 运行纹理，并允许显式切到 4K', () => {
+    const base = { format: 'live2d', textureQuality: undefined } as Live2DAvatarConfig;
+    expect(getLive2DTextureQuality(base)).toBe('balanced');
+    expect(getLive2DTextureMaxDimension(base)).toBe(2048);
+    expect(getLive2DTextureQuality({ ...base, textureQuality: 'hd' })).toBe('hd');
+    expect(getLive2DTextureMaxDimension({ ...base, textureQuality: 'hd' })).toBe(4096);
   });
 
   it('导入时自动降档模型引用的超大贴图，并关闭临时位图释放解码内存', async () => {

--- a/utils/live2dModelStore.ts
+++ b/utils/live2dModelStore.ts
@@ -1,7 +1,7 @@
 import JSZip from 'jszip';
 import type { CharacterProfile } from '../types';
 import { DB } from './db';
-import { live2DRuntimeCacheAssetId } from './avatarModelStore';
+import { live2DRuntimeCacheAssetId, type Live2DTextureQuality } from './avatarModelStore';
 import { isBuiltinSullyLive2D } from './builtinSullyLive2D';
 
 export type Live2DAvatarConfig = Extract<NonNullable<CharacterProfile['videoAvatar']>, { format: 'live2d' }>;
@@ -155,7 +155,19 @@ const finiteOr = (value: unknown, fallback: number): number => (
 );
 const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(max, value));
 
+/** Source packages retain at most 4K so users can switch between runtime tiers. */
 export const LIVE2D_MAX_TEXTURE_DIMENSION = 4096;
+export const LIVE2D_BALANCED_TEXTURE_DIMENSION = 2048;
+
+export const getLive2DTextureQuality = (config: Live2DAvatarConfig): Live2DTextureQuality => (
+  config.textureQuality === 'hd' ? 'hd' : 'balanced'
+);
+
+export const getLive2DTextureMaxDimension = (config: Live2DAvatarConfig): number => (
+  getLive2DTextureQuality(config) === 'hd'
+    ? LIVE2D_MAX_TEXTURE_DIMENSION
+    : LIVE2D_BALANCED_TEXTURE_DIMENSION
+);
 
 export interface Live2DTextureDimensions {
   width: number;
@@ -696,14 +708,24 @@ const makeAssetId = (): string => {
 
 const createConfig = async (
   blob: Blob,
-  entries: PackageEntry[],
+  sourceEntries: PackageEntry[],
   fileName: string,
   parsed?: ParsedPackage,
+  runtimeEntries: PackageEntry[] = sourceEntries,
+  persistRuntimeCache = false,
 ): Promise<Live2DAvatarConfig> => {
-  const inspected = parsed || await parsePackage(entries);
+  const inspected = parsed || await parsePackage(sourceEntries);
   const assetId = makeAssetId();
   await DB.putBlobAsset(assetId, blob);
-  seedLive2DRuntimePackage(assetId, entries);
+  if (persistRuntimeCache) {
+    try {
+      const runtimeBlob = await buildStoredLive2DPackage(runtimeEntries);
+      await DB.putBlobAsset(live2DRuntimeCacheAssetId(assetId, 'balanced'), runtimeBlob);
+    } catch (error) {
+      console.warn('[live2d] 2K import cache write skipped:', error);
+    }
+  }
+  seedLive2DRuntimePackage(assetId, runtimeEntries, 'balanced');
   return {
     version: 1,
     format: 'live2d',
@@ -711,9 +733,10 @@ const createConfig = async (
     fileName: fileName || inspected.modelName,
     modelPath: inspected.modelPath,
     byteLength: blob.size,
-    fileCount: entries.length,
+    fileCount: sourceEntries.length,
     importedAt: Date.now(),
     runtimePackageEncoding: 'store-v1',
+    textureQuality: 'balanced',
     actionPolicyVersion: 2,
     framing: inspected.framing || { scale: 1, offsetX: 0, offsetY: 0 },
     lipSyncParameterIds: inspected.lipSyncParameterIds,
@@ -734,16 +757,29 @@ export const saveLive2DModelFromFiles = async (
   const entries = sourceFiles.map(file => ({ path: normalizePath(fileRelativePath(file)), blob: file }));
   onProgress?.(`正在扫描 ${entries.length} 个文件和 VTube Studio 热键…`);
   const parsed = await parsePackage(entries);
-  const optimized = await downscaleOversizedLive2DTextures(entries, parsed.texturePaths, onProgress);
-  onProgress?.(optimized.resizedTextures.length
-    ? `已自动降档 ${optimized.resizedTextures.length} 张超大贴图，正在整理本地模型包…`
+  const sourceOptimized = await downscaleOversizedLive2DTextures(entries, parsed.texturePaths, onProgress, LIVE2D_MAX_TEXTURE_DIMENSION);
+  const runtimeOptimized = await downscaleOversizedLive2DTextures(
+    sourceOptimized.entries,
+    parsed.texturePaths,
+    onProgress,
+    LIVE2D_BALANCED_TEXTURE_DIMENSION,
+  );
+  onProgress?.(sourceOptimized.resizedTextures.length || runtimeOptimized.resizedTextures.length
+    ? `已建立默认 2K 纹理（保留最多 4K 源图供切换），正在整理本地模型包…`
     : `已找到 ${parsed.actions.length} 个表情/动作，正在整理本地模型包…`);
   // PNG/JPEG/moc are already compressed. Re-deflating a large 8K texture can
   // freeze the UI for tens of seconds without meaningfully reducing its size.
-  const packageBlob = await buildStoredLive2DPackage(optimized.entries);
+  const packageBlob = await buildStoredLive2DPackage(sourceOptimized.entries);
   const rootName = parsed.modelPath.includes('/') ? parsed.modelPath.split('/')[0] : parsed.modelName;
   onProgress?.('正在写入本地模型库，请保持页面打开…');
-  return createConfig(packageBlob, optimized.entries, rootName, parsed);
+  return createConfig(
+    packageBlob,
+    sourceOptimized.entries,
+    rootName,
+    parsed,
+    runtimeOptimized.entries,
+    runtimeOptimized.resizedTextures.length > 0,
+  );
 };
 
 export const saveLive2DModelFromZip = async (
@@ -770,13 +806,26 @@ export const saveLive2DModelFromZip = async (
   }
   onProgress?.('正在解析 model3、未登记文件与 VTube Studio 热键…');
   const parsed = await parsePackage(entries);
-  const optimized = await downscaleOversizedLive2DTextures(entries, parsed.texturePaths, onProgress);
-  onProgress?.(optimized.resizedTextures.length
-    ? `已自动降档 ${optimized.resizedTextures.length} 张超大贴图，正在建立免解压运行缓存…`
+  const sourceOptimized = await downscaleOversizedLive2DTextures(entries, parsed.texturePaths, onProgress, LIVE2D_MAX_TEXTURE_DIMENSION);
+  const runtimeOptimized = await downscaleOversizedLive2DTextures(
+    sourceOptimized.entries,
+    parsed.texturePaths,
+    onProgress,
+    LIVE2D_BALANCED_TEXTURE_DIMENSION,
+  );
+  onProgress?.(sourceOptimized.resizedTextures.length || runtimeOptimized.resizedTextures.length
+    ? `已建立默认 2K 纹理（保留最多 4K 源图供切换），正在建立免解压运行缓存…`
     : `已找到 ${parsed.actions.length} 个表情/动作，正在建立免解压运行缓存…`);
-  const packageBlob = await buildStoredLive2DPackage(optimized.entries);
+  const packageBlob = await buildStoredLive2DPackage(sourceOptimized.entries);
   onProgress?.('运行缓存已建立，正在写入本地模型库…');
-  return createConfig(packageBlob, optimized.entries, file.name.replace(/\.zip$/i, ''), parsed);
+  return createConfig(
+    packageBlob,
+    sourceOptimized.entries,
+    file.name.replace(/\.zip$/i, ''),
+    parsed,
+    runtimeOptimized.entries,
+    runtimeOptimized.resizedTextures.length > 0,
+  );
 };
 
 const mimeForPath = (path: string): string => {
@@ -925,16 +974,23 @@ const hydrateBuiltinSettings = (
 // the user switches characters.
 const live2DRuntimePackageCache = new Map<string, Promise<Live2DRuntimePackage>>();
 
-const seedLive2DRuntimePackage = (assetId: string, entries: PackageEntry[]): void => {
+const live2DRuntimeMemoryCacheKey = (assetId: string, quality: Live2DTextureQuality): string => `${assetId}:${quality}`;
+
+const seedLive2DRuntimePackage = (
+  assetId: string,
+  entries: PackageEntry[],
+  quality: Live2DTextureQuality = 'balanced',
+): void => {
+  const cacheKey = live2DRuntimeMemoryCacheKey(assetId, quality);
   const runtimePackage: Live2DRuntimePackage = {
     entries: new Map(entries.map(entry => [normalizePath(entry.path), entry.blob])),
     textureDataUrls: new Map<string, Promise<string>>(),
     source: 'stored-package',
     unpackMs: 0,
   };
-  live2DRuntimePackageCache.set(assetId, Promise.resolve(runtimePackage));
-  for (const cachedAssetId of live2DRuntimePackageCache.keys()) {
-    if (cachedAssetId !== assetId) live2DRuntimePackageCache.delete(cachedAssetId);
+  live2DRuntimePackageCache.set(cacheKey, Promise.resolve(runtimePackage));
+  for (const cachedKey of live2DRuntimePackageCache.keys()) {
+    if (cachedKey !== cacheKey) live2DRuntimePackageCache.delete(cachedKey);
   }
 };
 
@@ -955,7 +1011,12 @@ const optimizeStoredRuntimeTextures = async (
     const texturePaths = (settings.FileReferences?.Textures || [])
       .map(reference => resolveModelReference(config.modelPath, reference));
     if (!texturePaths.length) return { entries, resizedTextures: [] };
-    return downscaleOversizedLive2DTextures(entries, texturePaths, onProgress);
+    return downscaleOversizedLive2DTextures(
+      entries,
+      texturePaths,
+      onProgress,
+      getLive2DTextureMaxDimension(config),
+    );
   } catch (error) {
     if (error instanceof SyntaxError) return { entries, resizedTextures: [] };
     throw error;
@@ -968,11 +1029,13 @@ const getLive2DRuntimePackage = async (
 ): Promise<{ runtimePackage: Live2DRuntimePackage; memoryHit: boolean; waitMs: number }> => {
   const startedAt = nowMs();
   const assetId = config.assetId;
-  const cached = live2DRuntimePackageCache.get(assetId);
+  const quality = getLive2DTextureQuality(config);
+  const cacheKey = live2DRuntimeMemoryCacheKey(assetId, quality);
+  const cached = live2DRuntimePackageCache.get(cacheKey);
   if (cached) {
-    live2DRuntimePackageCache.delete(assetId);
-    live2DRuntimePackageCache.set(assetId, cached);
-    onProgress?.('正在从内存缓存恢复模型…');
+    live2DRuntimePackageCache.delete(cacheKey);
+    live2DRuntimePackageCache.set(cacheKey, cached);
+    onProgress?.(`正在从内存缓存恢复${quality === 'hd' ? '高清 4K' : '轻量 2K'}模型…`);
     return {
       runtimePackage: await cached,
       memoryHit: true,
@@ -983,11 +1046,11 @@ const getLive2DRuntimePackage = async (
   const pending = (async () => {
     let packageBlob: Blob | null = null;
     let source: Live2DRuntimePackage['source'];
-    const persistentCacheId = live2DRuntimeCacheAssetId(assetId);
+    const persistentCacheId = live2DRuntimeCacheAssetId(assetId, quality);
     if (config.runtimePackageEncoding === 'store-v1') {
       packageBlob = await DB.getBlobAsset(persistentCacheId);
       if (packageBlob) {
-        onProgress?.('正在读取已优化的模型运行缓存…');
+        onProgress?.(`正在读取已优化的${quality === 'hd' ? '高清 4K' : '轻量 2K'}运行缓存…`);
         source = 'persistent-cache';
       } else {
         onProgress?.('正在读取免解压模型包…');
@@ -997,7 +1060,7 @@ const getLive2DRuntimePackage = async (
     } else {
       packageBlob = await DB.getBlobAsset(persistentCacheId);
       if (packageBlob) {
-        onProgress?.('正在读取持久化运行缓存…');
+        onProgress?.(`正在读取${quality === 'hd' ? '高清 4K' : '轻量 2K'}运行缓存…`);
         source = 'persistent-cache';
       } else {
         onProgress?.('首次优化旧模型：正在解包并建立运行缓存…');
@@ -1040,14 +1103,14 @@ const getLive2DRuntimePackage = async (
     }
     return runtimePackage;
   })().catch(error => {
-    live2DRuntimePackageCache.delete(assetId);
+    live2DRuntimePackageCache.delete(cacheKey);
     throw error;
   });
 
-  live2DRuntimePackageCache.set(assetId, pending);
+  live2DRuntimePackageCache.set(cacheKey, pending);
   while (live2DRuntimePackageCache.size > 1) {
     const oldest = live2DRuntimePackageCache.keys().next().value as string | undefined;
-    if (!oldest || oldest === assetId) break;
+    if (!oldest || oldest === cacheKey) break;
     live2DRuntimePackageCache.delete(oldest);
   }
   return {

--- a/utils/live2dModelStore.ts
+++ b/utils/live2dModelStore.ts
@@ -9,6 +9,45 @@ export type Live2DAction = Live2DAvatarConfig['actions'][number];
 export type Live2DActionPermission = Live2DAction['permission'];
 export type Live2DActionParameterValue = NonNullable<Live2DAction['parameterValues']>[number];
 
+export interface Live2DMissingFileDetail {
+  /** Reference exactly as written in model3/vtube JSON. */
+  reference: string;
+  /** Normalized package path the importer tried to resolve. */
+  resolvedPath: string;
+  /** JSON file that owns the reference. */
+  referencedBy: string;
+  /** Existing path with only letter-case differences, when present. */
+  caseInsensitiveMatch?: string;
+  /** Existing files with the same basename, useful for spotting an extra folder level. */
+  sameNameCandidates?: string[];
+}
+
+export class Live2DMissingFilesError extends Error {
+  readonly code = 'LIVE2D_MISSING_REFERENCES';
+
+  constructor(
+    readonly modelPath: string,
+    readonly missingFiles: Live2DMissingFileDetail[],
+    readonly packageFileCount: number,
+  ) {
+    const names = missingFiles.slice(0, 3).map(item => basename(item.resolvedPath));
+    super(`模型引用的文件不完整：${names.join('、')}${missingFiles.length > 3 ? ` 等 ${missingFiles.length} 个` : ''}`);
+    this.name = 'Live2DMissingFilesError';
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      modelPath: this.modelPath,
+      packageFileCount: this.packageFileCount,
+      missingCount: this.missingFiles.length,
+      missingFiles: this.missingFiles,
+    };
+  }
+}
+
 /** 衣橱动作拥有独立的强制手动通道，旧数据即使残留 ai 权限也不会暴露给模型。 */
 export const isLive2DWardrobeAction = (action: Live2DAction): boolean => action.wardrobe === true;
 export const getLive2DAIActions = (config: Live2DAvatarConfig): Live2DAction[] => (
@@ -528,13 +567,48 @@ const parsePackage = async (entries: PackageEntry[]): Promise<ParsedPackage> => 
     vtube?.FileReferences?.IdleAnimationWhenTrackingLost,
     ...(vtube?.Hotkeys || []).map(hotkey => hotkey.File),
   ].filter((item): item is string => Boolean(item));
-  const missing = [
-    ...collectReferencedFiles(model).map(file => resolveModelReference(modelPath, file)),
-    ...vtubeReferencedFiles.map(file => resolveModelReference(vtubePath || modelPath, file)),
-  ]
-    .filter(path => !byPath.has(path));
+  const referencedFiles = [
+    ...collectReferencedFiles(model).map(reference => ({
+      reference,
+      resolvedPath: resolveModelReference(modelPath, reference),
+      referencedBy: modelPath,
+    })),
+    ...vtubeReferencedFiles.map(reference => ({
+      reference,
+      resolvedPath: resolveModelReference(vtubePath || modelPath, reference),
+      referencedBy: vtubePath || modelPath,
+    })),
+  ];
+  const packagePaths = [...byPath.keys()];
+  const missing = referencedFiles
+    .filter(item => !byPath.has(item.resolvedPath))
+    .filter((item, index, items) => items.findIndex(candidate => (
+      candidate.referencedBy === item.referencedBy
+      && candidate.reference === item.reference
+      && candidate.resolvedPath === item.resolvedPath
+    )) === index)
+    .map((item): Live2DMissingFileDetail => {
+      const lowerPath = item.resolvedPath.toLowerCase();
+      const targetName = basename(item.resolvedPath).toLowerCase();
+      const caseInsensitiveMatch = packagePaths.find(path => path.toLowerCase() === lowerPath);
+      const sameNameCandidates = packagePaths
+        .filter(path => basename(path).toLowerCase() === targetName && path !== caseInsensitiveMatch)
+        .slice(0, 8);
+      return {
+        ...item,
+        ...(caseInsensitiveMatch ? { caseInsensitiveMatch } : {}),
+        ...(sameNameCandidates.length ? { sameNameCandidates } : {}),
+      };
+    });
   if (missing.length) {
-    throw new Error(`模型引用的文件不完整：${missing.slice(0, 3).map(basename).join('、')}${missing.length > 3 ? ` 等 ${missing.length} 个` : ''}`);
+    const error = new Live2DMissingFilesError(modelPath, missing, packagePaths.length);
+    // Keep the user-facing message compact, but make the browser/debug console
+    // fully actionable. JSON text is intentional: embedded WebView consoles
+    // often collapse Error custom fields and only retain Error.message.
+    console.error(
+      `[live2d] ${error.message}\n完整缺失引用诊断：\n${JSON.stringify(error.toJSON(), null, 2)}`,
+    );
+    throw error;
   }
 
   const actions: Live2DAction[] = [];


### PR DESCRIPTION
## 修改内容

- 衣柜支持长按删除用户上传的服装、导入的 Live2D 模型和自定义衣柜动作
- 新导入模型保持未启用状态，只有用户手动选择后才切换，避免超大模型被自动载入导致首页崩溃
- 移除衣柜的隐式自动选择，继续保持 AI 不能自行换装、只能按用户手动操作切换
- 修复全身 Live2D 点击脸部后因缺少锚点而向下移出屏幕的问题
- 在桌面「构图」设置中增加可配置的面部特写缩放与锚定位置
- 恢复 Sully 原有的触摸近景行为，不再用一套固定比例臆测所有模型的腿部和脚部
- 增加每个 Live2D 模型独立的触摸区域圈选配置，半身与全身模型分别保存自己的区域
- Live2D 运行纹理默认限制为 2K，并允许用户选择 4K；旧模型的大纹理首次加载时自动生成对应档位的运行缓存
- 导入模型引用文件不完整时，在报错控制台中列出缺失文件、引用来源与缺失总数，便于定位原模型包问题

## 原因与兼容处理

先前的初版修改已经通过 #553 合入 `master`，后续为了撤回不适用于所有模型的全局腿/脚坐标判断改写过分支历史，导致 #554 与最新主线出现重复提交冲突。本次以最新 `master` 为基线重新整理提交：先明确恢复原有触摸判断，再叠加每模型圈选、纹理档位和缺失引用诊断，最终功能文件树保持不变。

## 影响

- Sully 继续使用原有默认触摸和摸头特写行为
- 导入的半身、全身模型不再共用错误的固定触摸比例
- 旧模型无需重新上传即可获得 2K/4K 运行纹理缓存
- 未完整导入的模型包能够直接看到具体缺失文件
- 不改变 AI 的手动换装边界

## 验证

- Live2D/触摸/模型存储相关 5 个测试文件，共 66 条测试通过
- `npm run build` 生产构建通过
- 重建分支最终文件树与修复前功能分支一致