### PR TITLE
ci: deploy site to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -1,0 +1,48 @@
+name: Deploy site to Cloudflare Workers
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-worker-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CI: 'true'
+      CLOUDFLARE_ACCOUNT_ID: 2cd975a0e2a9d667b85119c456d9478f
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      VITE_UMAMI_SCRIPT_URL: ${{ vars.UMAMI_SCRIPT_URL }}
+      VITE_UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site
+        run: pnpm run build
+
+      - name: Deploy Worker
+        run: npx --yes wrangler@4.122.0 deploy


### PR DESCRIPTION
## Summary
- add an independent GitHub Actions deployment for the Cloudflare site Worker
- deploy only from pushes to master (plus manual dispatch)
- reuse the existing Umami repository variables
- leave the existing GitHub Pages workflow unchanged

## Deployment
- Worker name comes from wrangler.jsonc: sully-os-site`n- Cloudflare account: 2cd975a0e2a9d667b85119c456d9478f`n- requires repository secret CLOUDFLARE_API_TOKEN before merge