### PR TITLE
ci: use Node 22 for Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare-worker.yml
+++ b/.github/workflows/deploy-cloudflare-worker.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## 原因
首次 Cloudflare Workers 部署在最后一步失败：`wrangler@4.122.0` 要求 Node.js 22 以上，而工作流使用 Node 20。

## 修复
- 将 Cloudflare 部署工作流的 Node 版本从 20 调整为 22
- 不改动现有 GitHub Pages 工作流或业务代码

## 验证
- `git diff --check` 通过
- 差异仅 1 行
- 原失败运行中安装依赖与站点构建均已成功