### PR TITLE
Instant Push 下线预告 + 云端那轮聊天进 API 调用记录

### DIFF
--- a/components/InstantPushSunsetEvent.tsx
+++ b/components/InstantPushSunsetEvent.tsx
@@ -1,0 +1,136 @@
+/**
+ * InstantPushSunsetEvent.tsx
+ * Instant Push 下线通知弹窗。
+ *
+ * 聊天上云这条路现在由「主动消息 2.0 · 即时对话」接管：它覆盖了 Instant Push 的全部
+ * 能力，部署还从「手动复制 bundle 去粘贴」变成填一枚 Cloudflare Token 一键装好。
+ * 2026-08-27 起 Instant Push 不再维护，这个弹窗负责在此之前把还开着它的人捞去迁移。
+ *
+ * 只对**当前开着** Instant Push 的用户弹；没配、配了没开的人完全不受打扰。
+ * 每天最多弹一次：关掉只记当天的日期 key，第二天照弹，直到用户自己把 Instant Push
+ * 关掉为止——这是下线通知，没有「永久别再提醒」这个选项。
+ */
+
+import React from 'react';
+import { loadInstantConfig } from '../utils/instantPushClient';
+import { getLocalDateKey } from '../utils/localDate';
+import { trackEvent } from '../utils/analytics';
+
+/** Instant Push 停止维护的日子。文案里所有出现的日期都从这里来，别各写各的。 */
+export const INSTANT_PUSH_SUNSET_DATE = '2026-08-27';
+
+/** 迁移教程（Discord 频道）。 */
+export const INSTANT_PUSH_MIGRATION_GUIDE_URL =
+  'https://discord.com/channels/1487742660314923100/1535999029090066512';
+
+/** 记「今天已经弹过了」的日期 key，取值形如 2026-08-13。 */
+const SUNSET_NOTICE_SHOWN_KEY = 'sullyos_instant_push_sunset_seen_date';
+
+/**
+ * 是否要弹下线通知：
+ *  - 只对现在真开着 Instant Push 的人弹（没配 / 配了没开的人不打扰）
+ *  - 今天已经弹过就不再弹，第二天重新开始
+ */
+export const shouldShowInstantPushSunsetNotice = (): boolean => {
+  try {
+    if (!loadInstantConfig().enabled) return false;
+    return localStorage.getItem(SUNSET_NOTICE_SHOWN_KEY) !== getLocalDateKey();
+  } catch {
+    return false;
+  }
+};
+
+/** 标记「今天弹过了」。用户点任何按钮关掉弹窗都走这里。 */
+export const markInstantPushSunsetNoticeShown = (): void => {
+  try {
+    localStorage.setItem(SUNSET_NOTICE_SHOWN_KEY, getLocalDateKey());
+  } catch { /* ignore */ }
+};
+
+interface InstantPushSunsetPopupProps {
+  onClose: () => void;
+}
+
+export const InstantPushSunsetPopup: React.FC<InstantPushSunsetPopupProps> = ({ onClose }) => {
+  React.useEffect(() => {
+    trackEvent('弹出 Instant Push 下线通知');
+  }, []);
+
+  const dismiss = () => {
+    markInstantPushSunsetNoticeShown();
+    onClose();
+  };
+
+  const handleOpenGuide = () => {
+    trackEvent('打开 Instant Push 迁移教程');
+    window.open(INSTANT_PUSH_MIGRATION_GUIDE_URL, '_blank', 'noopener,noreferrer');
+    dismiss();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9998] flex items-center justify-center p-5 animate-fade-in">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-md" />
+      <div className="relative w-full max-w-sm bg-white/95 backdrop-blur-xl rounded-[2.5rem] shadow-2xl border border-white/30 overflow-hidden animate-slide-up">
+        <div className="pt-7 pb-3 px-6 text-center">
+          <img
+            src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/1f4e6.png"
+            alt="instant push sunset"
+            className="w-10 h-10 mx-auto mb-2"
+          />
+          <h2 className="text-lg font-extrabold text-slate-800">Instant Push 要下线了</h2>
+          <p className="text-[11px] text-slate-400 mt-1">{INSTANT_PUSH_SUNSET_DATE} 起不再维护</p>
+        </div>
+
+        <div className="px-6 pb-4 space-y-3">
+          <div className="bg-gradient-to-br from-amber-50 to-rose-50 border border-amber-100 rounded-2xl p-4 space-y-2">
+            <p className="text-[13px] text-slate-700 leading-relaxed">
+              聊天上云这条路交给<strong>主动消息 2.0 · 即时对话</strong>了。它能做的事把
+              Instant Push 全包住，还多出一截：
+            </p>
+            <ul className="text-[12px] text-slate-600 leading-relaxed list-disc pl-5 space-y-1">
+              <li>
+                <strong>部署简单得多</strong>：填一枚 Cloudflare Token 点一下就装好后端，
+                不用再复制 bundle 代码去粘贴，也不用自己盯着 Worker 版本手动更新。
+              </li>
+              <li>
+                <strong>聊天照样上云</strong>：发完就能退出，回复在云端生成好推给你；
+                当时没收到的，下次上线自动补回来。
+              </li>
+              <li>
+                <strong>还有 Instant Push 没有的</strong>：定时主动消息、云端跑 MCP 工具、
+                天气热搜节日感知。
+              </li>
+            </ul>
+            <p className="text-[11px] text-slate-500 leading-relaxed pt-1">
+              迁过去不用动聊天记录和角色，跟着下面的教程配一遍就行。
+              {INSTANT_PUSH_SUNSET_DATE} 之后 Instant Push 这条路不再维护。
+            </p>
+          </div>
+        </div>
+
+        <div className="px-6 pb-7 pt-2 space-y-2">
+          <button
+            onClick={handleOpenGuide}
+            className="w-full py-3.5 font-bold rounded-2xl text-sm transition-transform active:scale-95 bg-gradient-to-r from-amber-500 to-rose-500 text-white shadow-lg shadow-amber-200"
+          >
+            看迁移教程 →
+          </button>
+          <button
+            onClick={dismiss}
+            className="w-full py-2.5 text-slate-400 font-medium text-[12px]"
+          >
+            知道了（今天不再提醒）
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+interface InstantPushSunsetControllerProps {
+  onClose: () => void;
+}
+
+export const InstantPushSunsetController: React.FC<InstantPushSunsetControllerProps> = ({ onClose }) => {
+  return <InstantPushSunsetPopup onClose={onClose} />;
+};

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -132,6 +132,7 @@ setAppPayloadWarmer((id: AppID) => { const c = APP_BY_ID[id]; if (c) warmLazy(c)
 import { Like520Controller, shouldShowLike520Popup } from './Like520Event';
 import { UpdateNotificationController, shouldShowUpdateNotification } from './UpdateNotificationEvent';
 import { WorkerUpdateReminderController, shouldShowWorkerUpdateReminder, rearmWorkerUpdateReminder } from './WorkerUpdateReminderEvent';
+import { InstantPushSunsetController, shouldShowInstantPushSunsetNotice } from './InstantPushSunsetEvent';
 import { loadInstantConfig, probeInstantWorkerVersion } from '../utils/instantPushClient';
 import { BackupReminderController } from './BackupReminderEvent';
 import { shouldShowBackupReminder, markBackupReminderShown, daysSinceLastBackup } from '../utils/backupReminder';
@@ -612,13 +613,23 @@ const PhoneShell: React.FC = () => {
     if (shouldShowLike520Popup()) setShowLike520Popup(true);
   }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, isDataLoaded]);
 
-  // Worker 后端更新提醒 — 只对启用了 Instant Push 的用户弹，且当前 worker 版本未确认过
-  const [showWorkerUpdateReminder, setShowWorkerUpdateReminder] = useState(false);
+  // Instant Push 下线通知 — 只对现在开着它的人弹，每天最多一次。
+  // 排在 Worker 更新提醒前面：这两条都只找同一批人，而「这功能要没了」比
+  // 「去把它更新到最新版」重要，同一天里先说前者。
+  const [showInstantPushSunset, setShowInstantPushSunset] = useState(false);
   useEffect(() => {
     if (showDisclaimer || showImportRecoveryPrompt || showAuthorLetter || showUpdateNotification || showLike520Popup) return;
     if (!isDataLoaded) return;
-    if (shouldShowWorkerUpdateReminder()) setShowWorkerUpdateReminder(true);
+    if (shouldShowInstantPushSunsetNotice()) setShowInstantPushSunset(true);
   }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, isDataLoaded]);
+
+  // Worker 后端更新提醒 — 只对启用了 Instant Push 的用户弹，且当前 worker 版本未确认过
+  const [showWorkerUpdateReminder, setShowWorkerUpdateReminder] = useState(false);
+  useEffect(() => {
+    if (showDisclaimer || showImportRecoveryPrompt || showAuthorLetter || showUpdateNotification || showLike520Popup || showInstantPushSunset) return;
+    if (!isDataLoaded) return;
+    if (shouldShowWorkerUpdateReminder()) setShowWorkerUpdateReminder(true);
+  }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, showInstantPushSunset, isDataLoaded]);
 
   // 部署漂移自检：启动后异步 GET {workerUrl}/version（每 24h 最多一次）。
   // 常量比对只能发现「前端更新了」，发现不了「用户 seen 过但实际没部署 / 部署的是更老的包」——
@@ -646,14 +657,14 @@ const PhoneShell: React.FC = () => {
   // 「该备份啦」提醒 — local-first 数据只在本机，隔 N 天（默认 7，可在设置里改）没导出就弹一次
   const [showBackupReminder, setShowBackupReminder] = useState(false);
   useEffect(() => {
-    if (showDisclaimer || showImportRecoveryPrompt || showAuthorLetter || showUpdateNotification || showLike520Popup || showWorkerUpdateReminder) return;
+    if (showDisclaimer || showImportRecoveryPrompt || showAuthorLetter || showUpdateNotification || showLike520Popup || showInstantPushSunset || showWorkerUpdateReminder) return;
     if (!isDataLoaded || isLocked) return;
     if (shouldShowBackupReminder()) {
       setShowBackupReminder(true);
       // 只报「从未备份 / 已过期」这一个二选一，不报具体天数、也不报用户设的提醒间隔。
       trackEvent('弹出该备份啦提醒', { state: daysSinceLastBackup() == null ? '从未备份' : '已过期' });
     }
-  }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, showWorkerUpdateReminder, isDataLoaded, isLocked]);
+  }, [showDisclaimer, showImportRecoveryPrompt, showAuthorLetter, showUpdateNotification, showLike520Popup, showInstantPushSunset, showWorkerUpdateReminder, isDataLoaded, isLocked]);
 
   const dismissBackupReminder = () => {
     markBackupReminderShown();
@@ -1019,15 +1030,22 @@ const PhoneShell: React.FC = () => {
          />
        )}
 
+       {/* Instant Push 下线通知（仅现在开着它的用户，每天最多一次） */}
+       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && showInstantPushSunset && (
+         <InstantPushSunsetController
+           onClose={() => setShowInstantPushSunset(false)}
+         />
+       )}
+
        {/* Worker 后端更新提醒（仅启用 Instant Push 的用户，每个 worker 版本一次） */}
-       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && showWorkerUpdateReminder && (
+       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && !showInstantPushSunset && showWorkerUpdateReminder && (
          <WorkerUpdateReminderController
            onClose={() => setShowWorkerUpdateReminder(false)}
          />
        )}
 
        {/* 「该备份啦」提醒（local-first 数据只在本机，隔 N 天没导出弹一次） */}
-       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && !showWorkerUpdateReminder && showBackupReminder && (
+       {!showDisclaimer && !showImportRecoveryPrompt && !showAuthorLetter && !showUpdateNotification && !showLike520Popup && !showInstantPushSunset && !showWorkerUpdateReminder && showBackupReminder && (
          <BackupReminderController
            onDismiss={dismissBackupReminder}
            onGoBackup={goBackupFromReminder}

--- a/components/settings/ApiCallLogModal.tsx
+++ b/components/settings/ApiCallLogModal.tsx
@@ -169,6 +169,24 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                     <p>
                         想判断有没有被偷偷换模型，要几个信号<span className="font-semibold">一起看</span>：token 数是否突然对不上（比如平时 4 万这次 1.5 万）、速度是否突变、角色是否突然变笨/掉格式。只有一个信号异常时，先观望，多攒几轮再说。
                     </p>
+                    <div className="pt-2 border-t border-amber-200/60 space-y-2">
+                        <p className="font-bold text-sky-700">带「☁️ 云端」的那些是什么</p>
+                        <p>
+                            开了<span className="font-semibold">即时对话</span>之后，聊天不再由这个页面发出去，而是交给你自己那台 Worker 在云端发——发完就能关页面，回复照样回得来。这类调用一样记在这里，只是有几处看不到：
+                        </p>
+                        <p>
+                            <span className="font-semibold">「生成中」</span>：云端已经收下，回复还没回来。收到回复才会变成成功。
+                        </p>
+                        <p>
+                            <span className="font-semibold">没有耗时、没有实际后端</span>：请求在云端发出，本地既量不到时间，也看不到对面自报的模型名。
+                        </p>
+                        <p>
+                            <span className="font-semibold text-amber-600">「只算末轮」</span>：角色查了东西再接着说的那种，一轮里会调好几次模型，而云端只报得回最后一次的 token。这条记录上的数字<span className="font-semibold">比实际用量小</span>，别拿它去跟账单对齐。
+                        </p>
+                        <p>
+                            <span className="font-semibold">「已顶替」</span>：这条还没等到回复你就又发了一句，云端把两句合成一次回。这一轮不再单独等回复了。
+                        </p>
+                    </div>
                 </div>
             )}
 
@@ -230,13 +248,26 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                                         <span className="text-[11px] font-bold text-slate-400 shrink-0">{day}</span>
                                         <span className="text-[11px] font-mono text-slate-500 shrink-0">{time}</span>
                                     </div>
-                                    <span
-                                        className={`text-[10px] font-bold px-2 py-0.5 rounded-full shrink-0 ${
-                                            e.ok ? 'bg-emerald-100 text-emerald-600' : 'bg-rose-100 text-rose-600'
-                                        }`}
-                                    >
-                                        {e.ok ? '成功' : `失败${e.status ? ` ${e.status}` : ''}`}
-                                    </span>
+                                    <div className="flex items-center gap-1.5 shrink-0">
+                                        {/* 这条不是浏览器自己发的，是云端那台 Worker 发的。不标出来的话，
+                                            同一条记录里「没有耗时、没有实际后端、Token 偏小」全都没法解释 */}
+                                        {e.route && (
+                                            <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-sky-100 text-sky-600">
+                                                ☁️ 云端
+                                            </span>
+                                        )}
+                                        <span
+                                            className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+                                                e.superseded ? 'bg-slate-100 text-slate-500'
+                                                    : e.pending ? 'bg-amber-100 text-amber-600'
+                                                        : e.ok ? 'bg-emerald-100 text-emerald-600' : 'bg-rose-100 text-rose-600'
+                                            }`}
+                                        >
+                                            {e.superseded ? '已顶替'
+                                                : e.pending ? '生成中'
+                                                    : e.ok ? '成功' : `失败${e.status ? ` ${e.status}` : ''}`}
+                                        </span>
+                                    </div>
                                 </div>
                                 <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-[11px]">
                                     <Field label="API" value={e.presetName} accent />
@@ -273,6 +304,9 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                                                 <span className="text-slate-400">
                                                     {' '}（入 {(e.promptTokens ?? 0).toLocaleString('en-US')} · 出 {(e.completionTokens ?? 0).toLocaleString('en-US')}）
                                                 </span>
+                                                {/* 云端这一轮调了不止一次模型时，回传的用量只有最后那次。
+                                                    不注明的话这个数拿去对账永远对不上，还会以为是被多扣了 */}
+                                                {e.tokensPartial && <span className="text-amber-500"> · 只算末轮</span>}
                                             </span>
                                         </div>
                                     )}
@@ -283,7 +317,14 @@ const ApiCallLogModal: React.FC<ApiCallLogModalProps> = ({ isOpen, onClose }) =>
                                     </div>
                                 )}
                                 {expanded && e.promptBreakdown && (
-                                    <PromptBreakdownView blocks={e.promptBreakdown} promptTokens={e.promptTokens} />
+                                    <>
+                                        {e.route && (
+                                            <p className="mt-2 text-[10px] text-slate-400 leading-relaxed">
+                                                这里统计的是本地拼好、交给云端的那份。云端真正发出前还会补上当前时间、天气热搜这些当下才知道的内容，所以实际输入会比下面略大一点。
+                                            </p>
+                                        )}
+                                        <PromptBreakdownView blocks={e.promptBreakdown} promptTokens={e.promptTokens} />
+                                    </>
                                 )}
                             </div>
                         );

--- a/components/settings/InstantPushSettingsModal.tsx
+++ b/components/settings/InstantPushSettingsModal.tsx
@@ -19,6 +19,10 @@ import { isInstantChatReady } from '../../utils/amsgInstantChat';
 import {
   markWorkerBuildSeen,
 } from '../WorkerUpdateReminderEvent';
+import {
+  INSTANT_PUSH_SUNSET_DATE,
+  INSTANT_PUSH_MIGRATION_GUIDE_URL,
+} from '../InstantPushSunsetEvent';
 import { INSTANT_WORKER_VERSION } from '../../utils/instantWorkerVersion';
 import { trackEvent } from '../../utils/analytics';
 import { FAQ_TARGET_SECTION_KEY, CHANGELOG_2026_05_27 } from '../UpdateNotificationEvent';
@@ -52,6 +56,10 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
   // 有一道同款的门，这里是反方向那一半：少了它，用户可以先开即时对话、再回这里把
   // IP 勾回来，聊天就会静默走 IP、即时对话开关亮着却不生效。
   const [instantChatOn, setInstantChatOn] = useState(false);
+  // Instant Push 停止接入：打开面板时存档里没开着的人，一律不允许再勾上。
+  // 依据必须是**存档里的状态**而不是界面上的实时勾选 —— 拿实时值的话，已经开着的人
+  // 手滑取消一下，勾选框立刻锁死、再也勾不回来。
+  const [enableLocked, setEnableLocked] = useState(false);
 
   const [testStatus, setTestStatus] = useState('');
   const [testBusy, setTestBusy] = useState(false);
@@ -82,6 +90,7 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
     setWorkerUrl(cfg.workerUrl);
     setClientToken(cfg.clientToken ?? '');
     setEnabled(cfg.enabled);
+    setEnableLocked(!cfg.enabled);
     setAutoTriggerOnSend(cfg.autoTriggerOnSend ?? false);
     setUseD1BlobStore(!!cfg.useD1BlobStore && !!cfg.d1Available);
     setD1Available(!!cfg.d1Available);
@@ -102,6 +111,9 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
   const canUseD1 = !!d1Available && !!normalizedWorkerUrl && d1CheckedWorkerUrl === normalizedWorkerUrl;
   // 即时对话开着、IP 还没开：勾选框锁死 + 底下那句提示都看这一个值，取消永远不受影响。
   const enableBlockedByInstantChat = instantChatOn && !enabled;
+  // 勾选框到底能不能点：停止接入这道门更宽（谁都不许新开），互斥那道门留着当兜底。
+  // 两道门都只挡「开」，取消永远放行。
+  const enableBlocked = enableLocked || enableBlockedByInstantChat;
 
   const resetD1State = () => {
     setD1Available(false);
@@ -324,21 +336,29 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
 
   const handleSave = async () => {
     const cfg = currentCfg();
-    // 存档前现查一次即时对话状态兜底：instantChatOn 是异步读回来的，modal 刚打开还没落地
-    // 那一小段时间里手快把 IP 勾上就点保存，能在探测结果生效前把 off→on 抢跑过去——这正是
-    // 这道反向门要挡住的情况。这里只夹 enabled 这一个字段，其余字段照常存盘；已经是 on
-    // 的 IP 不受影响，取消永远放行。
-    const raceBlocked = !loadInstantConfig().enabled && cfg.enabled && await isInstantChatReady();
-    if (raceBlocked) {
+    // 存档这一层也要有跟界面上同一道门：勾选框锁死只挡住了正常操作，modal 刚打开
+    // instantChatOn / enableLocked 还没落地那一小段时间里手快勾上就点保存，能在它们生效前
+    // 把 off→on 抢跑过去。这里只夹 enabled 这一个字段，其余字段照常存盘；已经是 on 的 IP
+    // 不受影响，取消永远放行。
+    const turningOn = !loadInstantConfig().enabled && cfg.enabled;
+    // 停止接入之后任何 off→on 都不成立；即时对话开没开只决定提示词怎么写（反向互斥门）。
+    const raceBlocked = turningOn && await isInstantChatReady();
+    if (turningOn) {
       cfg.enabled = false;
       setEnabled(false);
-      setInstantChatOn(true);
+      setEnableLocked(true);
+      if (raceBlocked) setInstantChatOn(true);
     }
     saveInstantConfig(cfg);
     // 保存为启用状态视为「已按当前 worker 版本配好」，避免随后被无意义地提醒更新。
     if (cfg.enabled) markWorkerBuildSeen();
-    if (raceBlocked) {
-      addToast('主动消息 2.0 的「即时对话」已经开着，Instant Push 没法一起启用，其余设置已保存。', 'error');
+    if (turningOn) {
+      addToast(
+        raceBlocked
+          ? '主动消息 2.0 的「即时对话」已经开着，Instant Push 没法一起启用，其余设置已保存。'
+          : `Instant Push 已停止接入（${INSTANT_PUSH_SUNSET_DATE} 下线），没法再开启，其余设置已保存。`,
+        'error',
+      );
       return;
     }
     addToast('Instant Push 配置已保存', 'success');
@@ -376,6 +396,27 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
       }
     >
       <div className="space-y-5 text-sm">
+
+        {/* 下线通告 — 排在最上面，进面板第一眼就看见 */}
+        <div className="rounded-2xl p-3 bg-amber-50 border border-amber-200 space-y-2">
+          <p className="text-[12px] font-bold text-amber-800">
+            Instant Push 将于 {INSTANT_PUSH_SUNSET_DATE} 下线
+          </p>
+          <p className="text-[11px] text-amber-700 leading-relaxed">
+            聊天上云改由「主动消息 2.0 · 即时对话」接管：能力全覆盖，部署只要填一枚
+            Cloudflare Token，还多了定时主动消息、云端跑 MCP 工具、天气热搜节日感知。
+            那天之后这条路不再维护。
+          </p>
+          <a
+            href={INSTANT_PUSH_MIGRATION_GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => trackEvent('打开 Instant Push 迁移教程')}
+            className="block w-full text-center py-2 rounded-xl text-[11px] font-bold bg-amber-500 text-white hover:bg-amber-600"
+          >
+            看迁移教程 →
+          </a>
+        </div>
 
         {/* 顶部教程入口 — 打开面板第一眼就能看到，方便第一次自己配的用户 */}
         <button
@@ -453,19 +494,21 @@ export const InstantPushSettingsModal: React.FC<InstantPushSettingsModalProps> =
             </div>
           </div>
 
-          <label className={`flex items-center gap-2 ${enableBlockedByInstantChat ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}>
+          <label className={`flex items-center gap-2 ${enableBlocked ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}>
             <input
               type="checkbox"
               checked={enabled}
-              disabled={enableBlockedByInstantChat}
+              disabled={enableBlocked}
               onChange={(e) => setEnabled(e.target.checked)}
               className="accent-indigo-500"
             />
             <span className="text-[12px] text-slate-600 font-medium">启用 Instant Push</span>
           </label>
-          {enableBlockedByInstantChat && (
+          {enableBlocked && (
             <p className="text-[11px] text-amber-600 leading-relaxed">
-              主动消息 2.0 的「即时对话」已经接管了聊天上云，这里不用再开。想换回 Instant Push 的话，先去 2.0 设置里关掉即时对话。
+              Instant Push 已停止接入，{INSTANT_PUSH_SUNSET_DATE} 起不再维护。聊天上云请用
+              「主动消息 2.0 · 即时对话」——它覆盖了 Instant Push 的全部能力，部署也只要填一枚
+              Cloudflare Token。
             </p>
           )}
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -486,6 +486,7 @@ Performance 标签页看：
 - 复制最新 Worker 代码
 - 导入恢复提醒选稍后再说
 - 导出调试日志
+- 弹出 Instant Push 下线通知
 - 弹出 Worker 更新提醒
 - 弹出上次导入未完成提醒
 - 弹出导入中断恢复提醒
@@ -566,6 +567,7 @@ Performance 标签页看：
 - 打开 Cloudflare Dashboard
 - 打开 Deno 控制台
 - 打开 Instant Push 视频教程
+- 打开 Instant Push 迁移教程
 - 打开实际后端字段说明
 - 探测 2.0 Worker 能力
 - 即时对话能不能开
@@ -642,6 +644,12 @@ push endpoint）留在 toast 和 console 里，一个字都不进上报。
 
 「切换即时对话」报 `开` / `关`。配置快照里那一格只看得到「此刻开着没」，
 开了之后又关掉的人在那儿跟从没开过的人是同一个样子，而这两种要修的东西完全不同。
+
+「弹出 Instant Push 下线通知」和「打开 Instant Push 迁移教程」都不带属性，配对起来看：
+前者是「今天有多少人被拦下来看了这条通知」（只弹给现在真开着 Instant Push 的人，
+每天最多一次），后者是「其中有多少人点进了迁移教程」。配置快照里的 `InstantPush`
+那一格看的是同一批人**迁走了没有**——`开` 这一档往下掉，才是迁移真的发生了。
+下线日期与迁移链接在 `components/InstantPushSunsetEvent.tsx`。
 
 **像素家园**
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -57,7 +57,7 @@ SullyOS 的功能已经多到一个人扫不完了，而我们对「哪些功能
 
 ## 数据发到哪
 
-自托管的 umami 实例：`https://stats.palm.cdsv.cc`（站点 id `3f775277-882d-4453-be2c-3226eddab438`）。
+自托管的 umami 实例：`https://stats.friedsully.com`（站点 id `3f775277-882d-4453-be2c-3226eddab438`）。
 后台只有维护者能进，不接任何外部服务。
 
 这两个值**不写在源码里**，由构建环境注入：

--- a/plans/amsg2-instant-chat-contract.md
+++ b/plans/amsg2-instant-chat-contract.md
@@ -107,7 +107,11 @@
 - 回程（push metadata）：`amsgEmotionUpdate` / `amsgEmotionDone` / `amsgEmotionError`
   （评估结果 / 熄灯信号 / 脱敏后的失败原因）、`amsgReasoning`（思考链，只挂第一条 push、
   只在即时对话轮）、`amsgToolTrace`（`[{name,count}]`，只数真跑过的调用、只挂末条 push、
+  只在即时对话轮）、`amsgUsage`（`{promptTokens, completionTokens}`，同样只挂末条 push、
   只在即时对话轮）。
+- `amsgUsage` 的去处：客户端把它补进「设置 → API 调用记录」里那笔云端调用（发出时先落
+  一笔 pending，收到末条推送时回填 Token）。它是**最后一次**模型调用的用量——带工具的
+  一轮会连着调好几次模型，中间几次的数云端没留，所以跑过工具时那笔记录会标「只算末轮」。
 - 超限旁路：`amsgEmotionRef` / `amsgReasoningRef`（值挪进 client_state，键
   `emotion_update:<clientTaskId>` / `reasoning:<clientTaskId>`）。
 

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -26,6 +26,7 @@ import {
   failInstantChatPending,
   getInstantChatPending,
   listInstantChatPendings,
+  settleInstantChatApiLog,
   settleInstantChatExpiredNotices,
 } from './amsgInstantChat';
 import { flushAmsgState } from './amsgStateSync';
@@ -1809,6 +1810,9 @@ const flushInboxToChatImpl = async () => {
           || (Number.isFinite(segIndex) && segIndex >= segTotal);
         if (isLastSegment && clearInstantChatPending(message.charId)) {
           scheduleNextInstantChatStatusCheck();
+          // 「API 调用记录」里那笔（发出去时记的）在这里补完：用量挂在末条推送上，
+          // 而这里正好是认末段的地方。
+          settleInstantChatApiLog(pendingForChar.uuid, message.metadata as Record<string, any> | null);
           // 随这一轮上云的「任务被作废」回执到这里才真的销账。发出时（worker 回 202）
           // 只是记账：202 仅表示受理，那一轮要是整个失败了，回执得留着下轮重新注入，
           // 否则角色永远不知道自己许过的那条排程已经没了。认 uuid，上一轮迟到的结论

--- a/utils/amsgInstantChat.test.ts
+++ b/utils/amsgInstantChat.test.ts
@@ -74,6 +74,7 @@ import {
   resolveInstantChatReadiness,
   sendInstantChatTurn,
   setInstantChatPending,
+  settleInstantChatApiLog,
   settleInstantChatExpiredNotices,
   stageInstantChatExpiredNotices,
 } from './amsgInstantChat';
@@ -450,6 +451,114 @@ describe('只有 202 才算发出去', () => {
     expect(result.ok).toBe(false);
     expect(result.error).toContain('时钟');
     expect(getInstantChatPending(CHAR.id)).toBeNull();
+  });
+});
+
+// 「API 调用记录」的记录点挂在全局 fetch 拦截器上，只认 /chat/completions——上云这一轮
+// 本地只发一个 POST 给自己的 Worker，那条拦不到。不专门记的话，开了即时对话之后聊天
+// 在记录里整个消失，看着像调用凭空没了。
+describe('上云的这一轮也进「API 调用记录」', () => {
+  /** 收走写库的那几笔（apiCallLog 走动态 import('./db')，按 DB 单例打桩拦得到）。 */
+  const captureLog = () => {
+    const logged: any[] = [];
+    vi.spyOn(DB, 'appendApiCallLog').mockImplementation(async (entry: any) => { logged.push(entry); });
+    return logged;
+  };
+
+  const sendOnce = async (status: number, body: unknown) => {
+    stubFirePackDeps();
+    mockInstantChatFetch(status, body);
+    const logged = captureLog();
+    await sendInstantChatTurn({
+      char: CHAR, chatMessages: [{ role: 'user', content: '在吗' }], api: API,
+      userProfile: USER, groups: [], realtimeConfig: {} as any,
+    });
+    await vi.waitFor(() => expect(logged).toHaveLength(1));
+    return logged[0];
+  };
+
+  it('202 → 落一笔标着云端的「生成中」记录', async () => {
+    const entry = await sendOnce(202, { status: 'accepted', uuid: 'uuid-log' });
+    expect(entry).toMatchObject({
+      id: 'cloud-uuid-log',
+      route: 'cloud-instant-chat',
+      pending: true,
+      ok: true,
+      baseUrl: API.baseUrl,
+      model: API.model,
+      appName: '消息',
+      charId: CHAR.id,
+      charName: CHAR.name,
+      // 跟本地生成那条路同一个词，两条路在列表里对得起来。
+      purpose: '聊天回复',
+    });
+    // 输入构成照算：这一轮到底交上去多大的东西，本地就这一份线索。
+    expect(entry.promptBreakdown?.length).toBeGreaterThan(0);
+  });
+
+  it('连 202 都没拿到 → 记一笔当场就是终态的失败，不留「生成中」挂着', async () => {
+    const entry = await sendOnce(500, { success: false, error: { code: 'X', message: '云端挂了' } });
+    expect(entry).toMatchObject({ route: 'cloud-instant-chat', pending: false, ok: false });
+    expect(entry.promptBreakdown?.length).toBeGreaterThan(0);
+  });
+
+  it('还没等到回复就又发一条 → 上一笔收成「已顶替」，不会一直转圈到被裁掉', async () => {
+    stubFirePackDeps();
+    mockInstantChatFetch(202, { status: 'accepted', uuid: 'uuid-second' });
+    setInstantChatPending(CHAR.id, 'uuid-first', 1_000);
+    const logged = captureLog();
+    await sendInstantChatTurn({
+      char: CHAR, chatMessages: [{ role: 'user', content: '还在吗' }], api: API,
+      userProfile: USER, groups: [], realtimeConfig: {} as any,
+    });
+    await vi.waitFor(() => expect(logged).toHaveLength(2));
+    // 顶掉的那一轮不算失败：云端把两句合成一次回，只是它不再单独等回复了。
+    expect(logged.find((e) => e.id === 'cloud-uuid-first')).toMatchObject({
+      pending: false, superseded: true, ok: true,
+    });
+    expect(logged.find((e) => e.id === 'cloud-uuid-second')?.pending).toBe(true);
+  });
+
+  it('回复回来 → 同一条记录补上用量，时间戳一个字不动（列表顺序不许跟着回复先后跳）', async () => {
+    const logged = captureLog();
+    settleInstantChatApiLog('uuid-log', { amsgUsage: { promptTokens: 1200, completionTokens: 80 } });
+    await vi.waitFor(() => expect(logged).toHaveLength(1));
+    expect(logged[0]).toMatchObject({
+      id: 'cloud-uuid-log', pending: false, ok: true,
+      promptTokens: 1200, completionTokens: 80,
+      // 云端只报入和出，总数本地自己加——列表顶上的合计读的就是它。
+      totalTokens: 1280,
+    });
+    expect(logged[0].timestamp).toBeUndefined();
+    expect(logged[0].tokensPartial).toBeUndefined();
+  });
+
+  it('这一轮调过工具 → 用量标成只算末轮（云端只报得回最后一次调用的数）', async () => {
+    const logged = captureLog();
+    settleInstantChatApiLog('uuid-log', {
+      amsgUsage: { promptTokens: 1200, completionTokens: 80 },
+      amsgToolTrace: [{ name: 'web_search', count: 1 }],
+    });
+    await vi.waitFor(() => expect(logged).toHaveLength(1));
+    expect(logged[0].tokensPartial).toBe(true);
+  });
+
+  it('云端没回用量 → 只销「生成中」，不往记录里填 0 冒充真数', async () => {
+    const logged = captureLog();
+    settleInstantChatApiLog('uuid-log', {});
+    await vi.waitFor(() => expect(logged).toHaveLength(1));
+    expect(logged[0].pending).toBe(false);
+    expect(logged[0].promptTokens).toBeUndefined();
+    expect(logged[0].totalTokens).toBeUndefined();
+  });
+
+  it('云端点名说这一轮没成 → 那笔跟着收尾成失败，不会一直写着「生成中」', async () => {
+    setInstantChatPending(CHAR.id, 'uuid-dead', 1_000);
+    vi.spyOn(DB, 'saveMessage').mockResolvedValue(undefined as any);
+    const logged = captureLog();
+    await failInstantChatPending(CHAR.id, 'uuid-dead', '云端生成失败');
+    await vi.waitFor(() => expect(logged).toHaveLength(1));
+    expect(logged[0]).toMatchObject({ id: 'cloud-uuid-dead', pending: false, ok: false });
   });
 });
 

--- a/utils/amsgInstantChat.ts
+++ b/utils/amsgInstantChat.ts
@@ -23,6 +23,7 @@ import { ActiveMsg2InboxMessage, CharacterProfile, GroupProfile, RealtimeConfig,
 import { ActiveMsgClient, type AmsgOutboxEntry, type InstantChatProbeOutcome } from './activeMsgClient';
 import { ActiveMsgStore } from './activeMsgStore';
 import { trackEvent } from './analytics';
+import { cloudApiCallLogId, recordCloudApiCall, settleCloudApiCall } from './apiCallLog';
 import { announceEmotionDone } from './chatGenEvents';
 import { DB } from './db';
 import type { AmsgEmotionEvalSpec } from '../worker/amsg/src/emotionEval';
@@ -445,6 +446,16 @@ export const sendInstantChatTurn = async (params: {
 }): Promise<InstantChatSendResult> => {
   const supersedes = getInstantChatPending(params.char.id);
   inFlightSends.add(params.char.id);
+  // 这一轮在「API 调用记录」里的那一笔：本地这条路只经手一个 POST，真正的模型请求
+  // 是云端发的，日志的全局拦截器够不着——不在这儿记，用户就会看到聊天从记录里消失。
+  // meta 跟本地生成那条路对齐（useChatAI 传给 safeFetchJson 的那份），两条路在列表里
+  // 长得一样，只多一个云端标记。
+  const logMeta = {
+    appName: '消息',
+    charId: params.char.id,
+    charName: params.char.name,
+    purpose: '聊天回复',
+  };
   try {
     const { uuid } = await ActiveMsgClient.sendInstantChat({
       char: params.char,
@@ -461,15 +472,65 @@ export const sendInstantChatTurn = async (params: {
     });
     // 先记待收再释放占位（finally），挡板的两个信号无缝交接，不留「都不认」的空窗。
     setInstantChatPending(params.char.id, uuid, Date.now(), params.char.name);
+    recordCloudApiCall({
+      id: cloudApiCallLogId(uuid),
+      route: 'cloud-instant-chat',
+      baseUrl: params.api.baseUrl,
+      model: params.api.model,
+      messages: params.chatMessages,
+      meta: logMeta,
+    });
+    // 顶掉的那一轮也得收尾：客户端从这一刻起不再等它的回复了（云端把两句合成一次回，
+    // 它已经在跑的情况下顶不掉，但那份回复也认不回这条记录）。不收的话它会一直写着
+    // 「云端生成中」，直到 5 天后被裁掉。
+    if (supersedes) {
+      settleCloudApiCall({ id: cloudApiCallLogId(supersedes.uuid), ok: true, superseded: true });
+    }
     return { ok: true, uuid };
   } catch (error: any) {
     // 只报失败、只有事件名（跟送达端那几条同一条口径）：失败原因里带着 HTTP 状态和
     // 上游报文，不进上报。用户侧同一时刻已经有明确的报错提示，这里只记「发生过」。
     trackEvent('即时对话发送失败');
+    // 没交上去的这一轮同样进记录：界面上那句报错关掉就没了，而日志里留得住——
+    // 交不上去往往跟这次要发的东西有多大有关，输入构成就在这条记录里。
+    recordCloudApiCall({
+      id: `cloud-send-failed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      route: 'cloud-instant-chat',
+      baseUrl: params.api.baseUrl,
+      model: params.api.model,
+      messages: params.chatMessages,
+      meta: logMeta,
+      sendFailed: true,
+    });
     return { ok: false, error: error?.message || String(error) };
   } finally {
     inFlightSends.delete(params.char.id);
   }
+};
+
+/**
+ * 这一轮回来了 → 把「API 调用记录」里那笔挂着的补完。
+ *
+ * `metadata` 是这一轮**最后一条**推送带回来的那份：云端把用量（`amsgUsage`）和工具
+ * 痕迹（`amsgToolTrace`）都挂在末条上。补收路径拿到的是同一份（账本存的就是推送信封
+ * 的副本），所以推送丢了也照样补得上。
+ *
+ * 云端回传的用量只有**最后一次**模型调用那一份——带工具的一轮会连着调好几次模型，
+ * 中间几次的数在云端就没留下。跑过工具就把这笔标成「只算末轮」，让用户知道这个数字
+ * 偏小，别拿它去跟账单对齐。
+ */
+export const settleInstantChatApiLog = (uuid: string, metadata?: Record<string, any> | null): void => {
+  const num = (value: unknown): number | undefined =>
+    (typeof value === 'number' && Number.isFinite(value) ? value : undefined);
+  const usage = metadata?.amsgUsage;
+  const toolTrace = metadata?.amsgToolTrace;
+  settleCloudApiCall({
+    id: cloudApiCallLogId(uuid),
+    ok: true,
+    promptTokens: num(usage?.promptTokens),
+    completionTokens: num(usage?.completionTokens),
+    tokensPartial: Array.isArray(toolTrace) && toolTrace.length > 0,
+  });
 };
 
 // ─── 推送丢了的兜底：拉服务端消息账本 ───
@@ -722,6 +783,8 @@ export const failInstantChatPending = async (
   // 只报失败、只有事件名：云端点名说这一轮没成（或回复取不回来）。这一格涨起来说明
   // 云端生成或推送链路在掉队，比用户来报「一直在输入」早得多。
   trackEvent('即时对话云端任务失败');
+  // 「API 调用记录」里那笔挂着的也收尾，否则它会一直写着「云端生成中」直到被裁掉。
+  settleCloudApiCall({ id: cloudApiCallLogId(uuid), ok: false });
   try {
     await DB.saveMessage({
       charId,

--- a/utils/analytics.test.ts
+++ b/utils/analytics.test.ts
@@ -133,7 +133,7 @@ describe('统计请求识别', () => {
 
     it('未配置统计时不误判同路径的业务请求', async () => {
         const a = await loadModule(false);
-        expect(a.isAnalyticsRequestUrl('https://stats.palm.cdsv.cc/api/send')).toBe(false);
+        expect(a.isAnalyticsRequestUrl('https://stats.friedsully.com/api/send')).toBe(false);
     });
 });
 

--- a/utils/apiCallLog.ts
+++ b/utils/apiCallLog.ts
@@ -31,11 +31,41 @@ export interface ApiCallMeta {
     purpose?: string;
 }
 
+/**
+ * 这一次请求是谁发出去的。
+ *
+ * 不填 = 浏览器自己直连模型（绝大多数记录，不占存储）。`cloud-instant-chat` 是主动
+ * 消息 2.0 的即时对话：本地只把这一轮交上去，真正那条 `/chat/completions` 由用户自己
+ * 的 Cloudflare Worker 在云端发出。
+ */
+export type ApiCallRoute = 'cloud-instant-chat';
+
 /** 落库的一条记录。 */
 export interface ApiCallLogEntry extends ApiCallMeta {
     id: string;
     /** 调用发起（实际是响应回来）时间戳 ms */
     timestamp: number;
+    /** 见 ApiCallRoute。空 = 浏览器直连。 */
+    route?: ApiCallRoute;
+    /**
+     * 云端收下了这一轮，结果还没回来。回复落库（或云端点名说这轮没成）时回填掉。
+     * 本地直连的记录没有这一档：那边是响应回来才记，天生就是终态。
+     */
+    pending?: boolean;
+    /**
+     * 这一轮被下一条消息顶掉了（还没等到回复就又发了一条，云端把两句合成一次回）。
+     * 不算失败，但也等不到属于它自己的回复——不单独收尾的话，这笔会一直写着
+     * 「云端生成中」，直到 5 天后被裁掉。
+     */
+    superseded?: boolean;
+    /**
+     * Token 数只覆盖这一轮里的**最后一次**模型调用，不是全部。
+     *
+     * 云端带工具时一轮对话会连着调好几次模型（查完东西再接着说），而回传的用量只有
+     * 最后那次——不标出来的话，用户拿这个数去对供应商账单会一直对不上，还以为是被
+     * 多扣了。只在确实跑过工具时才置位。
+     */
+    tokensPartial?: boolean;
     /** 命中的预设名；匹配不到时回退成 baseUrl 的 host */
     presetName: string;
     baseUrl: string;
@@ -983,5 +1013,105 @@ export function recordApiCall(input: {
             .catch(() => {});
     } catch {
         // best-effort：任何异常都不影响主请求
+    }
+}
+
+// ── 交给云端跑的那一轮 ────────────────────────────────────────────────
+//
+// 这条路上本地只发一个 POST 给用户自己的 Worker，真正那条 `/chat/completions` 是云端
+// 发的——全局 fetch 拦截器只认 `/chat/completions`，够不着它。不专门记的话，开了即时
+// 对话之后「API 调用记录」里聊天这一格就是空的，看着像调用凭空消失了。
+//
+// 同一条记录分两笔写（DB 层按 id 合并非空字段，见 appendApiCallLog）：
+//   1. 云端受理时先落一笔——那会儿只知道「发给谁、用哪个模型、发过去些什么」；
+//   2. 回复回来时把 Token 补上（云端随最后一条推送捎回来）。
+// 中间这段时间记录是 pending，界面上写「云端生成中」。
+
+/** 云端那一轮在本地日志里的记录 id。两笔写入靠它对上号，所以两边都从 uuid 现算。 */
+export const cloudApiCallLogId = (uuid: string): string => `cloud-${uuid}`;
+
+/** 第一笔：云端收下了这一轮。 */
+export function recordCloudApiCall(input: {
+    id: string;
+    route: ApiCallRoute;
+    /** 预设里存的那个形态（`https://host/v1`），云端就用这份凭据去发请求。 */
+    baseUrl: string;
+    model: string;
+    /** 交上去的消息数组，用来算输入构成。 */
+    messages: unknown;
+    meta?: ApiCallMeta;
+    timestamp?: number;
+    /**
+     * 这一轮连交都没交上去（POST 就失败了）。这种记录当场就是终态，不等回填——
+     * 云端根本没收下，不会有回复也不会有用量。输入构成照记：上传超时这类失败正是
+     * 「这次包太大了」的直接线索。
+     */
+    sendFailed?: boolean;
+}): void {
+    try {
+        const baseUrl = stripTrailingSlash(input.baseUrl || '');
+        const meta = hasMeta(input.meta) ? input.meta! : ambientMeta;
+        const entry: ApiCallLogEntry = {
+            id: input.id,
+            timestamp: input.timestamp ?? Date.now(),
+            route: input.route,
+            pending: !input.sendFailed,
+            presetName: resolvePresetName(baseUrl, input.model),
+            baseUrl,
+            model: input.model,
+            // 受理成功本身没出错；这一轮的成败等回填那一笔改写。
+            ok: !input.sendFailed,
+            promptBreakdown: buildPromptBreakdown({ messages: input.messages }),
+            appId: meta.appId,
+            appName: meta.appName,
+            charId: meta.charId,
+            charName: meta.charName,
+            purpose: meta.purpose,
+        };
+        import('./db')
+            .then(({ DB }) => DB.appendApiCallLog(entry))
+            .catch(() => {});
+    } catch {
+        // 同 recordApiCall：记日志不能反过来影响这一轮对话
+    }
+}
+
+/**
+ * 第二笔：云端那一轮有结论了。
+ *
+ * 只写这次才知道的字段，`timestamp` 一个字都不带——记录的时间要停在「发起那一刻」，
+ * 不然列表顺序会随着回复先后跳来跳去。第一笔已经被 5 天裁剪掉时这一笔会落空（合并不
+ * 上、又没有时间戳，写库时当场被裁掉），正是想要的收场。
+ */
+export function settleCloudApiCall(input: {
+    id: string;
+    ok: boolean;
+    promptTokens?: number;
+    completionTokens?: number;
+    /** 见 ApiCallLogEntry.tokensPartial。 */
+    tokensPartial?: boolean;
+    /** 见 ApiCallLogEntry.superseded。 */
+    superseded?: boolean;
+}): void {
+    try {
+        const { promptTokens, completionTokens } = input;
+        const patch: Partial<ApiCallLogEntry> & { id: string } = {
+            id: input.id,
+            pending: false,
+            ok: input.ok,
+            superseded: input.superseded || undefined,
+            promptTokens,
+            completionTokens,
+            // 云端只报入和出两个数，总数这边自己加——列表顶上的合计读的是这个字段。
+            totalTokens: promptTokens != null && completionTokens != null
+                ? promptTokens + completionTokens
+                : undefined,
+            tokensPartial: input.tokensPartial || undefined,
+        };
+        import('./db')
+            .then(({ DB }) => DB.appendApiCallLog(patch))
+            .catch(() => {});
+    } catch {
+        // 同上
     }
 }

--- a/utils/instantPushSunset.test.ts
+++ b/utils/instantPushSunset.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Instant Push 下线通知的两条硬规矩，都是「错了没人会来报」的那种：
+ *  1. 只对现在开着 Instant Push 的人弹 —— 弹给没开的人就是纯骚扰，而且他们根本不知道
+ *     这弹窗在说什么。
+ *  2. 每天最多一次 —— 关掉只记当天日期，第二天照弹。写成「永久已读」的话，一批人
+ *     点完就再也想不起来迁移，14 天窗口白给。
+ *
+ * 顺带钉住 Instant Push 设置面板那道「停止接入」的门：还没开的人一律勾不上，
+ * 已经开着的人照常能取消。
+ */
+
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { saveInstantConfig, clearInstantConfig } from './instantPushClient';
+import {
+  shouldShowInstantPushSunsetNotice,
+  markInstantPushSunsetNoticeShown,
+  INSTANT_PUSH_SUNSET_DATE,
+  INSTANT_PUSH_MIGRATION_GUIDE_URL,
+} from '../components/InstantPushSunsetEvent';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const settingsSrc = readFileSync(
+  resolve(here, '../components/settings/InstantPushSettingsModal.tsx'),
+  'utf8',
+);
+
+const WORKER_URL = 'https://ip.example.workers.dev';
+const enableInstantPush = () => saveInstantConfig({ enabled: true, workerUrl: WORKER_URL });
+
+describe('Instant Push 下线通知弹不弹', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearInstantConfig();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('没配 Instant Push 的人不弹', () => {
+    expect(shouldShowInstantPushSunsetNotice()).toBe(false);
+  });
+
+  it('配了但没开的人也不弹（这批人本来就没在用它）', () => {
+    saveInstantConfig({ enabled: false, workerUrl: WORKER_URL });
+    expect(shouldShowInstantPushSunsetNotice()).toBe(false);
+  });
+
+  it('现在开着的人要弹', () => {
+    enableInstantPush();
+    expect(shouldShowInstantPushSunsetNotice()).toBe(true);
+  });
+
+  it('当天关掉之后不再弹', () => {
+    enableInstantPush();
+    markInstantPushSunsetNoticeShown();
+    expect(shouldShowInstantPushSunsetNotice()).toBe(false);
+  });
+
+  it('第二天重新弹（不是「永久已读」）', () => {
+    enableInstantPush();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 14, 10, 0, 0));
+    markInstantPushSunsetNoticeShown();
+    expect(shouldShowInstantPushSunsetNotice()).toBe(false);
+
+    vi.setSystemTime(new Date(2026, 7, 15, 10, 0, 0));
+    expect(shouldShowInstantPushSunsetNotice()).toBe(true);
+  });
+
+  it('用户自己把 Instant Push 关掉之后就彻底不打扰了', () => {
+    enableInstantPush();
+    markInstantPushSunsetNoticeShown();
+    saveInstantConfig({ enabled: false, workerUrl: WORKER_URL });
+    expect(shouldShowInstantPushSunsetNotice()).toBe(false);
+  });
+});
+
+describe('设置面板停止接入这道门', () => {
+  it('锁的依据是存档里的状态，不是界面上的实时勾选（否则手滑取消一下就再也勾不回来）', () => {
+    expect(settingsSrc).toContain('setEnableLocked(!cfg.enabled)');
+    expect(settingsSrc).not.toContain('setEnableLocked(!enabled)');
+  });
+
+  it('勾选框 disabled 走的是合并后的 enableBlocked，两道门都算数', () => {
+    expect(settingsSrc).toContain('const enableBlocked = enableLocked || enableBlockedByInstantChat');
+    expect(settingsSrc).toContain('disabled={enableBlocked}');
+  });
+
+  it('落盘层挡的是 off→on 而不是「有没有开即时对话」（界面锁死不等于存不进去）', () => {
+    const handleSave = settingsSrc.slice(settingsSrc.indexOf('const handleSave'));
+    expect(handleSave).toContain('const turningOn = !loadInstantConfig().enabled && cfg.enabled');
+    expect(handleSave).toContain('if (turningOn) {');
+    // 反向互斥门还在：即时对话开着时提示词要说得更具体。
+    expect(handleSave).toContain('raceBlocked');
+  });
+
+  it('面板里的下线日期和迁移链接跟弹窗共用同一份常量', () => {
+    expect(settingsSrc).toContain('INSTANT_PUSH_SUNSET_DATE');
+    expect(settingsSrc).toContain('INSTANT_PUSH_MIGRATION_GUIDE_URL');
+    expect(INSTANT_PUSH_SUNSET_DATE).toBe('2026-08-27');
+    expect(INSTANT_PUSH_MIGRATION_GUIDE_URL).toContain('discord.com');
+  });
+});


### PR DESCRIPTION
三件互不相干的事，一起发。

## 1. Instant Push 定于 2026-08-27 下线

聊天上云这条路交给主动消息 2.0 的即时对话了。它把 Instant Push 的能力全包住，部署也从「复制一大段 bundle 代码去粘贴、再自己盯着版本手动更新」变成填一枚 Cloudflare Token 点一下装好；另外还有 Instant Push 没有的定时主动消息、云端跑 MCP 工具、天气热搜节日感知。

**现在还开着它的人**：启动时会看到一张下线卡片，写清停用日期和为什么换，按钮直接进迁移教程。每天最多弹一次，关掉只记当天日期、第二天照弹——这是下线通知，没留「永久别再提醒」这个出口，不然一批人点完就再也想不起来，两周窗口白给。

**没配、配了没开的人**：一次都不会弹。

**设置面板**：顶上常驻同一条通告和教程链接；「启用 Instant Push」对打开面板时还没开着的人锁死，已经开着的照常用到那天、也随时能取消。

下线通知排在 Worker 更新提醒前面——这两条只找同一批人，同一天里先说「这功能要没了」比「去把它更新到最新版」重要，不然两句话自己打自己。

两条容易悄悄退化的规矩用回归测试钉住了：只弹给真开着的人，以及关掉之后第二天要重新弹。

## 2. 上云生成的那一轮，也进 API 调用记录

开着即时对话的时候聊天由用户自己那台 Worker 在云端发出去，而记录点挂在浏览器的 fetch 拦截器上够不着，于是「API 调用记录」里聊天这一格一直是空的，看着像调用凭空消失了。现在这类调用照样进列表，右上角带一枚「☁️ 云端」，跟本地那条路在列表里对得起来。不用更新 Worker。

## 3. 统计实例换了域名

后台搬到 `stats.friedsully.com`。真正生效的值由构建环境注入、不写在源码里，改的是文档里记的那一处和测试里当样例用的地址。

---

## 合并前想确认一件事

**版本号还是 `v3.4 (Live2D)`，而 v3.4 已经在 master 上了。**

统计面板按版本号切分数据，不 bump 的话，下线通知铺开前后的数字会堆在同一个标签下——而「Instant Push 开着的那一档有没有往下掉」正是判断迁移有没有真发生的唯一依据，到时候会答不出来。要升的话改 `utils/buildInfo.ts` 里的 `APP_VERSION`，代号留给你起。

## 下线的第二阶段还没做

这轮纯加警告。到 8-27 之后真正拆掉 `utils/instantPushClient.ts`、`worker/instant-push/`、`useChatAI` 里的分流分支这些，是单独一轮的事。拆之前先看快照埋点 `InstantPush` 的「开」那一档掉到多少。

参考数据（2026-08 单月窗口，session 是设备/IP 指纹不是 UV，比例可用、绝对值别当人数）：

| | 上线至今累计 | 最近两天 |
|---|---|---|
| 主动消息 2.0 开着 | 12.3% | **16.8%** |
| Instant Push 开着 | 2.4% | **1.8%** |
