### PR TITLE
chore: publish Android update manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "versionCode": 30400,
+  "versionName": "3.4.0",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.0/SullyOS-v3.4.0-Distribution.apk",
+  "sha256": "ef72cec1049e61e4e06347ddfa54d4289904b2a15c79fb56cec99803a6a373f9",
+  "sizeBytes": 36663227,
+  "publishedAt": "2026-08-13T12:15:00Z",
+  "releaseNotes": [
+    "对齐最新 master",
+    "首个支持应用内检查和下载安装的正式分发版本"
+  ]
+}


### PR DESCRIPTION
## What changed

- Add the static `public/sullyos-update.json` manifest used by the distributed Android APK.
- Point the manifest at the signed `android-v3.4.0` GitHub Release asset.
- Publish the exact version code, file size, and SHA-256 required by the native installer verifier.

## Why

This keeps update checks on GitHub Pages and APK downloads on GitHub Releases, so the self-update path does not consume Cloudflare Worker requests.

## Validation

- Parsed the manifest as JSON and validated the version, URL, and SHA-256 format.
- `npm run test:run -- utils/apkUpdater.test.ts` (2 tests passed).
- Rebuilt and verified the production-signed APK against the latest `master`.
