### PR TITLE
chore: refresh Android update package

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -2,12 +2,14 @@
   "schemaVersion": 1,
   "versionCode": 30400,
   "versionName": "3.4.0",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.0/SullyOS-v3.4.0-Distribution.apk",
-  "sha256": "ef72cec1049e61e4e06347ddfa54d4289904b2a15c79fb56cec99803a6a373f9",
-  "sizeBytes": 36663227,
-  "publishedAt": "2026-08-13T12:15:00Z",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.0/SullyOS-v3.4.0-Android.apk",
+  "sha256": "182ef28f9bb8ac51f0f34634a29bf3635bd401598d6689abf988763c6b894c91",
+  "sizeBytes": 36663026,
+  "publishedAt": "2026-08-13T12:47:00Z",
   "releaseNotes": [
     "对齐最新 master",
-    "首个支持应用内检查和下载安装的正式分发版本"
+    "首个支持应用内检查和下载安装的正式分发版本",
+    "沿用旧 CHICK2 签名，可直接覆盖安装并保留数据",
+    "启用与网页版相同的匿名使用统计"
   ]
 }


### PR DESCRIPTION
## What changed

- Point the Android update manifest at the legacy-compatible signed APK.
- Refresh the exact SHA-256 and file size.
- Note that the APK keeps existing CHICK2 data and enables the same anonymous Umami configuration as the web build.

## Validation

- APK signature matches the previous CHICK2 certificate.
- Package name remains com.aetheros.simulator.
- versionCode increases from 1 to 30400.
- APK contains the configured Umami script URL and Website ID.