### PR TITLE
Publish Android v3.4.1 update manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,15 +1,16 @@
 {
   "schemaVersion": 1,
-  "versionCode": 30400,
-  "versionName": "3.4.0",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.0/SullyOS-v3.4.0-Android.apk",
-  "sha256": "182ef28f9bb8ac51f0f34634a29bf3635bd401598d6689abf988763c6b894c91",
-  "sizeBytes": 36663026,
-  "publishedAt": "2026-08-13T12:47:00Z",
+  "versionCode": 30401,
+  "versionName": "3.4.1",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.1/SullyOS-Android-v3.4.1.apk",
+  "sha256": "33202475eb83fc8c6c6aaee6f59351286332c41ba1b67019c21b13229f2ff53a",
+  "sizeBytes": 37001510,
+  "publishedAt": "2026-08-13T14:41:51Z",
   "releaseNotes": [
-    "对齐最新 master",
-    "首个支持应用内检查和下载安装的正式分发版本",
-    "沿用旧 CHICK2 签名，可直接覆盖安装并保留数据",
-    "启用与网页版相同的匿名使用统计"
+    "对齐 SullyOS 最新 master（aab15a9f）",
+    "Android 主动消息使用 UnifiedPush / ntfy，不依赖 Firebase",
+    "修复 Android 端 PDF 导入",
+    "沿用固定正式签名，可直接覆盖安装并保留数据",
+    "不内置个人 AMSG2 Worker 地址，由用户在应用内填写自己的配置"
   ]
 }


### PR DESCRIPTION
Updates the GitHub Pages Android update manifest to the verified v3.4.1 Release asset. The manifest includes the exact release URL, versionCode 30401, file size, and SHA-256 digest validated against GitHub asset metadata.