### PR TITLE
chore: publish Android v3.4.3 update manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,16 +1,15 @@
 {
   "schemaVersion": 1,
-  "versionCode": 30402,
-  "versionName": "3.4.2",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.2/SullyOS-Android-v3.4.2.apk",
-  "sha256": "9380cf50cf6316f123c642ed394f59de764632799cf3212ef7fac309602e3e80",
-  "sizeBytes": 37003588,
-  "publishedAt": "2026-08-13T15:10:42Z",
+  "versionCode": 30403,
+  "versionName": "3.4.3",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.3/SullyOS-Android-v3.4.3.apk",
+  "sha256": "39470456606d2e1204401df937452d3ba552618a9caff31d598f0e1f41c83890",
+  "sizeBytes": 36823006,
+  "publishedAt": "2026-08-13T16:22:03Z",
   "releaseNotes": [
-    "新增“设置 → 检查更新”按钮",
-    "下载后校验包名、版本号、固定签名与 SHA-256，再拉起 Android 安装器",
-    "首次使用可能需要允许 SullyOS 安装未知应用",
-    "延续 UnifiedPush / ntfy 与 Android PDF 导入修复",
-    "沿用固定正式签名，覆盖安装保留数据"
+    "对齐最新 master daefc4d1（含 PR #575）",
+    "修复并优化故事剧场归档记录浏览",
+    "延续 UnifiedPush / ntfy 原生通知、应用内检查更新和 Android PDF 导入",
+    "沿用固定正式签名，可覆盖安装并保留 localStorage / IndexedDB 数据"
   ]
 }


### PR DESCRIPTION
## Android v3.4.3

- 指向已发布的 GitHub Release APK
- 更新 versionCode/versionName、SHA-256、文件大小与发布时间
- 更新发布说明，保留固定签名/UnifiedPush/ntfy/PDF 导入说明

本 PR 仅修改 public/sullyos-update.json。