### PR TITLE
fix: create Android update cache directory

### DIFF
--- a/utils/androidAppUpdate.test.ts
+++ b/utils/androidAppUpdate.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from 'vitest';
-import { parseAndroidUpdateManifest } from './androidAppUpdate';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { filesystemMocks, installerMocks } = vi.hoisted(() => ({
+  filesystemMocks: {
+    mkdir: vi.fn(),
+    deleteFile: vi.fn(),
+    addListener: vi.fn(),
+    downloadFile: vi.fn(),
+    getUri: vi.fn(),
+  },
+  installerMocks: {
+    getInstalledInfo: vi.fn(),
+    verifyApk: vi.fn(),
+    installApk: vi.fn(),
+    openInstallPermissionSettings: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => 'android',
+  },
+  registerPlugin: () => installerMocks,
+}));
+
+vi.mock('@capacitor/filesystem', () => ({
+  Directory: { Cache: 'CACHE' },
+  Filesystem: filesystemMocks,
+}));
+
+import { downloadAndVerifyAndroidUpdate, parseAndroidUpdateManifest } from './androidAppUpdate';
 
 const validManifest = {
   schemaVersion: 1,
@@ -10,6 +40,22 @@ const validManifest = {
   sizeBytes: 37_000_000,
   releaseNotes: ['修复更新按钮', '', 123],
 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  filesystemMocks.mkdir.mockResolvedValue(undefined);
+  filesystemMocks.deleteFile.mockResolvedValue(undefined);
+  filesystemMocks.downloadFile.mockResolvedValue(undefined);
+  filesystemMocks.getUri.mockResolvedValue({ uri: 'file:///cache/updates/SullyOS-update.apk' });
+  installerMocks.verifyApk.mockResolvedValue({
+    valid: true,
+    packageName: 'com.aetheros.simulator',
+    versionCode: validManifest.versionCode,
+    versionName: validManifest.versionName,
+    certificateSha256: 'b'.repeat(64),
+    canRequestPackageInstalls: true,
+  });
+});
 
 describe('parseAndroidUpdateManifest', () => {
   it('accepts and normalizes a valid manifest', () => {
@@ -29,5 +75,30 @@ describe('parseAndroidUpdateManifest', () => {
     ['bad size', { ...validManifest, sizeBytes: -1 }],
   ])('rejects %s', (_name, manifest) => {
     expect(() => parseAndroidUpdateManifest(manifest)).toThrow();
+  });
+});
+
+describe('downloadAndVerifyAndroidUpdate', () => {
+  it('creates the nested cache directory before the first download', async () => {
+    filesystemMocks.deleteFile.mockRejectedValueOnce(new Error('file does not exist'));
+
+    await expect(downloadAndVerifyAndroidUpdate(validManifest)).resolves.toBe(
+      'file:///cache/updates/SullyOS-update.apk',
+    );
+
+    expect(filesystemMocks.mkdir).toHaveBeenCalledWith({
+      path: 'updates',
+      directory: 'CACHE',
+      recursive: true,
+    });
+    expect(filesystemMocks.downloadFile).toHaveBeenCalledWith(expect.objectContaining({
+      url: validManifest.apkUrl,
+      path: 'updates/SullyOS-update.apk',
+      directory: 'CACHE',
+      recursive: true,
+    }));
+    expect(filesystemMocks.mkdir.mock.invocationCallOrder[0]).toBeLessThan(
+      filesystemMocks.downloadFile.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/utils/androidAppUpdate.ts
+++ b/utils/androidAppUpdate.ts
@@ -36,6 +36,7 @@ interface ApkInstallerPlugin {
 }
 
 const ApkInstaller = registerPlugin<ApkInstallerPlugin>('ApkInstaller');
+const UPDATE_DIRECTORY = 'updates';
 const UPDATE_PATH = 'updates/SullyOS-update.apk';
 
 export const getAndroidUpdateManifestUrl = (): string =>
@@ -92,6 +93,12 @@ export const downloadAndVerifyAndroidUpdate = async (
   manifest: AndroidUpdateManifest,
   onProgress?: (fraction: number) => void,
 ): Promise<string> => {
+  await Filesystem.mkdir({
+    path: UPDATE_DIRECTORY,
+    directory: Directory.Cache,
+    recursive: true,
+  });
+
   try {
     await Filesystem.deleteFile({ path: UPDATE_PATH, directory: Directory.Cache });
   } catch {


### PR DESCRIPTION
## 修复

Android 首次使用应用内更新时，先显式创建 Cache/updates，再下载 APK，避免 ENOENT。

## 验证

- androidAppUpdate.test.ts：7 项通过
- vite build --mode capacitor：通过