### PR TITLE
chore: publish Android v3.4.4 update manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,15 +1,14 @@
 {
   "schemaVersion": 1,
-  "versionCode": 30403,
-  "versionName": "3.4.3",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.3/SullyOS-Android-v3.4.3.apk",
-  "sha256": "39470456606d2e1204401df937452d3ba552618a9caff31d598f0e1f41c83890",
-  "sizeBytes": 36823006,
-  "publishedAt": "2026-08-13T16:22:03Z",
+  "versionCode": 30404,
+  "versionName": "3.4.4",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.4/SullyOS-Android-v3.4.4.apk",
+  "sha256": "acf3d7dc202a64bd6efbd617afe1e8fd597eab508746fd653e87517e33bbfd65",
+  "sizeBytes": 36822764,
+  "publishedAt": "2026-08-13T16:50:08Z",
   "releaseNotes": [
-    "对齐最新 master daefc4d1（含 PR #575）",
-    "修复并优化故事剧场归档记录浏览",
-    "延续 UnifiedPush / ntfy 原生通知、应用内检查更新和 Android PDF 导入",
-    "沿用固定正式签名，可覆盖安装并保留 localStorage / IndexedDB 数据"
+    "修复首次使用应用内更新时 Cache/updates 目录未创建导致的下载失败",
+    "对齐最新 master 389c8738（含 PR #577）",
+    "延续固定签名、UnifiedPush / ntfy、Android PDF 导入与更新包校验"
   ]
 }


### PR DESCRIPTION
## Android v3.4.4

- 指向已核验的 v3.4.4 热修 APK
- 更新版本号、SHA-256、大小和发布时间
- 说明首次下载目录 ENOENT 修复

仅修改 public/sullyos-update.json。