### PR TITLE
feat: improve chat modes and appearance controls

### DIFF
--- a/apps/Appearance.tsx
+++ b/apps/Appearance.tsx
@@ -922,6 +922,53 @@ const Appearance: React.FC = () => {
         {activeTab === 'theme' ? (
             <>
                 <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100">
+                    <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-1">动画与过场</h2>
+                    <p className="text-[10px] text-slate-400 mb-2">三项都默认开启，可以分别关闭；关闭加载动画后，超过 7 秒的卡死恢复提示仍会保留。</p>
+                    <div className="divide-y divide-slate-100">
+                        {([
+                            {
+                                key: 'bootAnimationEnabled' as const,
+                                title: '开机动画',
+                                description: '启动 SullyOS 时的整机入场过场。',
+                            },
+                            {
+                                key: 'chatCharacterSwitchAnimationEnabled' as const,
+                                title: '聊天切换角色动画',
+                                description: '进入聊天或换角色时的头像登场过场。',
+                            },
+                            {
+                                key: 'appLoadingAnimationEnabled' as const,
+                                title: '进入 App 加载动画',
+                                description: 'App 首次加载较慢时显示的柔光等待画面。',
+                            },
+                        ]).map(option => {
+                            const enabled = theme[option.key] !== false;
+                            return (
+                                <div key={option.key} className="flex items-center gap-3 py-3">
+                                    <div className="min-w-0 flex-1">
+                                        <div className="text-xs font-bold text-slate-700">{option.title}</div>
+                                        <div className="mt-0.5 text-[10px] leading-relaxed text-slate-400">{option.description}</div>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={enabled}
+                                        aria-label={option.title}
+                                        onClick={() => {
+                                            updateTheme({ [option.key]: !enabled });
+                                            trackEvent('设置外观动画', { animation: option.key, enabled: !enabled });
+                                        }}
+                                        className={`relative h-6 w-11 shrink-0 rounded-full transition-colors ${enabled ? 'bg-primary' : 'bg-slate-300'}`}
+                                    >
+                                        <span className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0'}`} style={{ left: 2 }} />
+                                    </button>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </section>
+
+                <section className="bg-white rounded-3xl p-5 shadow-sm border border-slate-100">
                     <h2 className="text-sm font-bold text-slate-400 uppercase tracking-widest mb-1">桌面风格</h2>
                     <p className="text-[10px] text-slate-400 mb-4">一键切换整机主题：壁纸、配色与图标外观联动；触感陪伴不会改动全局聊天装扮。</p>
                     <div className="grid grid-cols-2 gap-3">

--- a/apps/CallApp.tsx
+++ b/apps/CallApp.tsx
@@ -2783,11 +2783,11 @@ ${sentencePlan}`;
     }
   };
 
-  // 一段已经开始的通话安静太久时，角色可以自然接话两次。“谁先开口”
-  // 只决定刚接通时的第一句话，不影响通话进行中的接话。
+  // 一段已经开始的通话安静太久时，角色可以自然接话两次。它是独立的显式偏好，
+  // 默认关闭；“谁先开口”只决定刚接通时的第一句话。
   const idleNudgeBusyRef = useRef(false);
   const fireIdleNudge = async () => {
-    if (idleNudgeBusyRef.current || !selectedChar?.id) return;
+    if (!callPreferences.idleNudgeEnabled || idleNudgeBusyRef.current || !selectedChar?.id) return;
     if (document.visibilityState === 'hidden') return;
     idleNudgeBusyRef.current = true;
     try {
@@ -2863,12 +2863,13 @@ ${sentencePlan}`;
     }
   };
   useEffect(() => {
+    if (!callPreferences.idleNudgeEnabled) return;
     if (viewMode !== 'in-call' || callState !== 'listening' || isAudioPlaying) return;
     if (!bubbles.length || idleNudgeCountRef.current >= 2 || idleNudgeBusyRef.current) return;
     const silenceMs = 50_000 + Math.random() * 30_000 + idleNudgeCountRef.current * 40_000;
     const timer = window.setTimeout(() => { void fireIdleNudge(); }, silenceMs);
     return () => window.clearTimeout(timer);
-  }, [viewMode, callState, isAudioPlaying, bubbles, draftInput]);
+  }, [viewMode, callState, isAudioPlaying, bubbles, draftInput, callPreferences.idleNudgeEnabled]);
 
   // 用户在舞台上拖拽/缩放后的构图，写回角色的 videoAvatar 持久化。
   const handleStageFramingChange = (framing: AvatarStageFraming) => {
@@ -3008,6 +3009,7 @@ ${sentencePlan}`;
               trackEvent('设置通话偏好', {
                 谁先开口: next.characterInitiative ? '角色' : '用户',
                 自动生成并播放语音: next.voiceAutoPlay ? '开启' : '关闭',
+                沉默后主动接话: next.idleNudgeEnabled ? '开启' : '关闭',
               });
             }}
             onOpenSystemSettings={() => {

--- a/apps/Chat.tsx
+++ b/apps/Chat.tsx
@@ -43,6 +43,7 @@ import Modal from '../components/os/Modal';
 import ProactiveSettingsModal from '../components/chat/ProactiveSettingsModal';
 import ActiveMsg2SettingsModal from '../components/chat/ActiveMsg2SettingsModal';
 import ThinkingChainSettingsModal from '../components/chat/ThinkingChainSettingsModal';
+import ScheduleChangeNotice from '../components/chat/ScheduleChangeNotice';
 import { useChatAI } from '../hooks/useChatAI';
 import { cleanTextForTts, parseVoiceOutput } from '../utils/minimaxTts';
 import { collectVoiceBatchSubtitle, isPoisonedVoiceSubtitle } from '../utils/voiceSubtitle';
@@ -61,6 +62,7 @@ import { trackEvent, noteMessageSent, presetOrCustom } from '../utils/analytics'
 import { markAmsgStateDirty, markAmsgStateDirtyForAll } from '../utils/amsgStateSync';
 import { AMSG_INSTANT_CHAT_PENDING_EVENT, AMSG_INSTANT_CHAT_PENDING_LS_KEY, getInstantChatPending } from '../utils/amsgInstantChat';
 import { formatAmsgToolTrace } from '../utils/amsgToolTrace';
+import { SCHEDULE_CHANGE_EVENT, type ScheduleChangeEventDetail } from '../utils/scheduleChange';
 import {
     CONTEXT_RANGE_POLICY_VERSION,
     computeContextRangeSnapshot,
@@ -154,6 +156,8 @@ const Chat: React.FC = () => {
     // 切换角色时收掉装扮气泡：定制是 per-character 的，避免误改到下一个角色
     useEffect(() => { setFineTuneOpen(false); setFineTunePanelOpen(false); }, [activeCharacterId]);
     const [scheduleData, setScheduleData] = useState<DailySchedule | null>(null);
+    const [scheduleChangeNotice, setScheduleChangeNotice] = useState<ScheduleChangeEventDetail | null>(null);
+    const dismissScheduleChangeNotice = useCallback(() => setScheduleChangeNotice(null), []);
     // 小剧场（窥视演出）：正在播放的时段索引（null = 未打开），以及生成中标志
     const [theaterSlotIdx, setTheaterSlotIdx] = useState<number | null>(null);
     const [isTheaterGenerating, setIsTheaterGenerating] = useState(false);
@@ -875,8 +879,12 @@ const Chat: React.FC = () => {
     // 进入/切换角色时触发「登场」过场。useLayoutEffect 在浏览器绘制前置真，
     // 让过场层先盖住，避免一帧闪到新角色的空聊天界面。
     useLayoutEffect(() => {
-        if (activeCharacterId) setShowEntry(true);
-    }, [activeCharacterId]);
+        if (!activeCharacterId || osTheme.chatCharacterSwitchAnimationEnabled === false) {
+            setShowEntry(false);
+            return;
+        }
+        setShowEntry(true);
+    }, [activeCharacterId, osTheme.chatCharacterSwitchAnimationEnabled]);
 
     useEffect(() => {
         let clearTimer: ReturnType<typeof setTimeout> | null = null;
@@ -915,6 +923,19 @@ const Chat: React.FC = () => {
             if (clearTimer) clearTimeout(clearTimer);
         };
     }, []);
+
+    useEffect(() => {
+        const onScheduleChange = (event: Event) => {
+            const detail = (event as CustomEvent<ScheduleChangeEventDetail>).detail;
+            if (!detail || detail.charId !== activeCharIdRef.current) return;
+            setScheduleData(detail.schedule);
+            setScheduleChangeNotice(detail);
+        };
+        window.addEventListener(SCHEDULE_CHANGE_EVENT, onScheduleChange);
+        return () => window.removeEventListener(SCHEDULE_CHANGE_EVENT, onScheduleChange);
+    }, []);
+
+    useEffect(() => setScheduleChangeNotice(null), [activeCharacterId]);
 
     // Auto-generate daily schedule (fire-and-forget on chat load)
     // 总开关关闭时完全跳过：不查询 DB、不调用副 API、不跑兜底
@@ -2916,6 +2937,13 @@ const Chat: React.FC = () => {
                  守护样式统一放在气泡主题 customCss 之后（见下），保证对所有用户 CSS 都能兜底。 */}
              {osTheme.chatChromeCustomCss && <style>{osTheme.chatChromeCustomCss}</style>}
              {char.chromeCustomCss && <style>{char.chromeCustomCss}</style>}
+             {scheduleChangeNotice && (
+               <ScheduleChangeNotice
+                 key={scheduleChangeNotice.eventId}
+                 detail={scheduleChangeNotice}
+                 onDone={dismissScheduleChangeNotice}
+               />
+             )}
              {/* 角色「登场」过场：切换/进入时以 ta 的头像氛围铺底登场，再推进穿过进入聊天。key 切换即重放。 */}
              {showEntry && char && (
                <CharacterEntryTransition
@@ -2927,6 +2955,12 @@ const Chat: React.FC = () => {
              )}
 
              {activeTheme.customCss && <style>{activeTheme.customCss}</style>}
+             {/* 气泡工坊的尾巴频率依赖直接挂在气泡上的稳定类。用户 CSS 即使给
+                 ::before/::after 写了 !important，中间气泡仍会按“仅组末/隐藏”设置收起尾巴。 */}
+             <style>{`
+               .sully-bubble-tail-hidden::before,
+               .sully-bubble-tail-hidden::after { content: none !important; display: none !important; }
+             `}</style>
 
              {/* 心象卡片自定义 CSS（per-character）：作用于 .sully-psyche-* 各零件，编辑入口在心象设置弹窗 */}
              {(char as any).thinkingChainCustomCss && <style>{(char as any).thinkingChainCustomCss}</style>}

--- a/apps/GroupChat.tsx
+++ b/apps/GroupChat.tsx
@@ -12,7 +12,9 @@ import { deleteGroupMemoriesByGroupId } from '../utils/memoryPalace/groupPipelin
 import { processImage } from '../utils/file';
 import { stickerNameFromUrl } from '../utils/messageFormat';
 import { PRESET_THEMES } from '../components/chat/ChatConstants';
-import { resolveChatTheme } from '../utils/groupChat/theme';
+import { resolveChatTheme, scopeBubbleThemeCss } from '../utils/groupChat/theme';
+import { resolveBubbleCornerRadii, shouldHideBubbleTail } from '../utils/bubbleAppearance';
+import { buildChatFineTuneCss } from '../utils/chatFineTuneCss';
 import { parseDirectorActions, stripSkipMarker, parseGroupTopicBox } from '../utils/groupChat/parse';
 import { GroupPacketMeta, PacketReceiptMeta, ClaimResult, claimPacket, effectivePacketStatus, makePacketMeta } from '../utils/groupChat/redpacket';
 import { messageLogText } from '../utils/groupChat/format';
@@ -122,7 +124,16 @@ const GroupMessageItem = React.memo(({
     onReply,
     nameOf,
     onPacketClick,
-    styleConfig
+    styleConfig,
+    themeScopeClass,
+    isFirstInGroup,
+    isLastInGroup,
+    avatarShape = 'circle',
+    avatarSize = 'medium',
+    avatarMode = 'grouped',
+    bubbleVariant = 'modern',
+    messageSpacing = 'default',
+    showTimestamp = 'always',
 }: {
     msg: Message,
     isUser: boolean,
@@ -137,10 +148,50 @@ const GroupMessageItem = React.memo(({
     nameOf: (id: string) => string,
     onPacketClick: (msg: Message) => void,
     /** 气泡样式（用户=群设置选的主题 user 侧；成员=统一或各自私聊主题 ai 侧）。引用需稳定（memo） */
-    styleConfig: BubbleStyle
+    styleConfig: BubbleStyle,
+    /** 将当前成员的气泡工坊 CSS 限定在自己的消息上，防止群成员主题互串。 */
+    themeScopeClass: string,
+    isFirstInGroup: boolean,
+    isLastInGroup: boolean,
+    avatarShape?: 'circle' | 'rounded' | 'square',
+    avatarSize?: 'small' | 'medium' | 'large',
+    avatarMode?: 'grouped' | 'every_message',
+    bubbleVariant?: 'modern' | 'flat' | 'outline' | 'shadow' | 'wechat' | 'ios',
+    messageSpacing?: 'compact' | 'default' | 'spacious',
+    showTimestamp?: 'always' | 'hover' | 'never',
 }) => {
     const avatar = isUser ? userAvatar : char?.avatar;
     const name = isUser ? '我' : char?.name || '未知成员';
+
+    const spacingClass = messageSpacing === 'compact'
+        ? (isLastInGroup ? 'mb-3' : 'mb-0.5')
+        : messageSpacing === 'spacious'
+            ? (isLastInGroup ? 'mb-8' : 'mb-2.5')
+            : (isLastInGroup ? 'mb-6' : 'mb-1.5');
+    const avatarSizeClass = avatarSize === 'small' ? 'w-7 h-7' : avatarSize === 'large' ? 'w-12 h-12' : 'w-9 h-9';
+    const avatarSizePx = avatarSize === 'small' ? 28 : avatarSize === 'large' ? 48 : 36;
+    const avatarRadiusClass = avatarShape === 'square' ? 'rounded-sm' : avatarShape === 'rounded' ? 'rounded-xl' : 'rounded-full';
+    const shouldShowAvatar = avatarMode === 'every_message' || isLastInGroup;
+    const cornerRadii = resolveBubbleCornerRadii(styleConfig);
+    const hideBubbleTail = shouldHideBubbleTail(styleConfig.tailMode, isLastInGroup);
+    const bubbleGroupClasses = [
+        isFirstInGroup ? 'sully-bubble-group-first' : '',
+        isLastInGroup ? 'sully-bubble-group-last' : '',
+        hideBubbleTail ? 'sully-bubble-tail-hidden' : 'sully-bubble-tail-visible',
+    ].filter(Boolean).join(' ');
+    const bubbleStyle: React.CSSProperties = {
+        backgroundColor: bubbleVariant === 'outline' ? 'transparent' : styleConfig.backgroundColor,
+        opacity: styleConfig.opacity ?? 1,
+        borderTopLeftRadius: cornerRadii.topLeft,
+        borderTopRightRadius: cornerRadii.topRight,
+        borderBottomRightRadius: cornerRadii.bottomRight,
+        borderBottomLeftRadius: cornerRadii.bottomLeft,
+        ...(bubbleVariant === 'outline' ? { border: `2px solid ${styleConfig.backgroundColor}`, boxShadow: 'none' } : {}),
+        ...(bubbleVariant === 'shadow' ? { boxShadow: '0 4px 12px rgba(0,0,0,0.12)' } : {}),
+        ...(bubbleVariant === 'flat' ? { boxShadow: 'none' } : {}),
+        ...(bubbleVariant === 'wechat' ? { boxShadow: 'none', border: '1px solid rgba(15,23,42,0.05)' } : {}),
+        ...(bubbleVariant === 'ios' ? { boxShadow: '0 10px 24px rgba(148,163,184,0.16)', border: '1px solid rgba(255,255,255,0.75)', backdropFilter: 'blur(12px)' } : {}),
+    };
 
     // pointer-event 手势（对齐私聊 MessageItem 的方案）：600ms 长按 → 操作菜单；
     // 触屏左滑 ≤-52px → 引用回复（带位移动画）；鼠标右键 → 操作菜单
@@ -154,7 +205,7 @@ const GroupMessageItem = React.memo(({
     const [isReplyGestureActive, setIsReplyGestureActive] = useState(false);
 
     // Time formatting
-    const timeStr = new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const timeStr = new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 
     const clearLongPressTimer = () => {
         if (!longPressTimer.current) return;
@@ -243,6 +294,36 @@ const GroupMessageItem = React.memo(({
         }
     };
 
+    const renderAvatar = (forceVisible = false) => (
+        <div className={`relative ${avatarSizeClass} z-0 sully-chat-message-avatar`}>
+            {(forceVisible || shouldShowAvatar) && (
+                <>
+                    <img
+                        src={avatar}
+                        className={`sully-chat-message-avatar-img w-full h-full ${avatarRadiusClass} object-cover shadow-sm ring-1 ring-black/5 relative z-0`}
+                        alt="avatar"
+                        loading="lazy"
+                        decoding="async"
+                    />
+                    {styleConfig.avatarDecoration && (
+                        <img
+                            src={styleConfig.avatarDecoration}
+                            className="absolute pointer-events-none z-10 max-w-none"
+                            style={{
+                                left: `${styleConfig.avatarDecorationX ?? 50}%`,
+                                top: `${styleConfig.avatarDecorationY ?? 50}%`,
+                                width: `${avatarSizePx * (styleConfig.avatarDecorationScale ?? 1)}px`,
+                                height: 'auto',
+                                transform: `translate(-50%, -50%) rotate(${styleConfig.avatarDecorationRotate ?? 0}deg)`,
+                            }}
+                            alt=""
+                        />
+                    )}
+                </>
+            )}
+        </div>
+    );
+
     // Special Content Renderers
     const renderContent = () => {
         switch (msg.type) {
@@ -276,30 +357,40 @@ const GroupMessageItem = React.memo(({
                 return <HtmlCard html={html} />;
             }
             default:
-                // 核心样式字段对齐私聊 MessageItem 的应用方式（decoration/voiceBar 群聊不做）
                 return (
                     <div
-                        className={`px-3.5 py-2 text-[15px] leading-relaxed shadow-sm whitespace-pre-wrap break-all relative overflow-hidden ${isUser ? '' : 'border border-black/5'}`}
-                        style={{
-                            color: styleConfig.textColor,
-                            backgroundColor: styleConfig.backgroundColor,
-                            opacity: styleConfig.opacity ?? 1,
-                            borderRadius: styleConfig.borderRadius ?? 18,
-                            ...(isUser ? { borderTopRightRadius: 4 } : { borderTopLeftRadius: 4 }),
-                        }}
+                        className={`relative px-5 py-3 text-[15px] leading-relaxed whitespace-pre-wrap break-all overflow-visible active:scale-[0.98] transition-transform ${bubbleVariant === 'flat' || bubbleVariant === 'outline' || bubbleVariant === 'wechat' ? '' : 'shadow-sm'} ${bubbleVariant === 'outline' ? '' : 'border border-black/5'} ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'} ${bubbleGroupClasses}`}
+                        style={bubbleStyle}
                     >
                         {styleConfig.backgroundImage && (
                             <div
-                                className="absolute inset-0 pointer-events-none"
+                                className="absolute inset-0 bg-cover bg-center pointer-events-none z-0"
                                 style={{
                                     backgroundImage: `url(${styleConfig.backgroundImage})`,
-                                    backgroundSize: 'cover',
-                                    backgroundPosition: 'center',
                                     opacity: styleConfig.backgroundImageOpacity ?? 0.5,
+                                    borderRadius: 'inherit',
                                 }}
                             />
                         )}
-                        <span className="relative z-10">{msg.content}</span>
+                        {styleConfig.decoration && (
+                            <img
+                                src={styleConfig.decoration}
+                                className="absolute z-10 w-8 h-8 object-contain drop-shadow-sm pointer-events-none"
+                                style={{
+                                    left: `${styleConfig.decorationX ?? (isUser ? 90 : 10)}%`,
+                                    top: `${styleConfig.decorationY ?? -10}%`,
+                                    transform: `translate(-50%, -50%) scale(${styleConfig.decorationScale ?? 1}) rotate(${styleConfig.decorationRotate ?? 0}deg)`,
+                                }}
+                                alt=""
+                            />
+                        )}
+                        {msg.replyTo && (
+                            <div className="relative z-10 mb-1 text-[10px] bg-black/5 p-1.5 rounded-md border-l-2 border-current opacity-60 flex flex-col gap-0.5 max-w-full overflow-hidden">
+                                <span className="font-bold opacity-90 truncate">{msg.replyTo.name}</span>
+                                <span className="truncate italic">"{msg.replyTo.content.length > 10 ? msg.replyTo.content.slice(0, 10) + '...' : msg.replyTo.content}"</span>
+                            </div>
+                        )}
+                        <div className="relative z-10 select-text" style={{ color: styleConfig.textColor }}>{msg.content}</div>
                     </div>
                 );
         }
@@ -307,58 +398,71 @@ const GroupMessageItem = React.memo(({
 
     return (
         <div
-            className={`flex gap-3 mb-4 w-full relative ${isUser ? 'justify-end' : 'justify-start'} ${selectionMode ? 'pl-8' : ''}`}
-            style={{
-                transform: `translateX(${replyOffset}px)`,
-                transition: isReplyGestureActive ? 'none' : 'transform 0.2s ease-out',
-                touchAction: 'pan-y',
-            }}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerEnd}
-            onPointerCancel={handlePointerCancel}
-            onContextMenu={(e) => {
-                e.preventDefault();
-                if (selectionMode || replyGestureActiveRef.current) return;
-                clearLongPressTimer();
-                activePointerId.current = null;
-                activePointerType.current = '';
-                resetReplyGesture();
-                onLongPress(msg.id);
-            }}
-            onDragStart={(e) => e.preventDefault()}
-            onClick={handleClick}
+            className={`${themeScopeClass} sully-chat-message ${isUser ? 'sully-chat-message-user justify-end' : 'sully-chat-message-ai justify-start'} ${isFirstInGroup ? 'sully-chat-message-group-first' : ''} ${isLastInGroup ? 'sully-chat-message-group-last' : ''} flex items-end ${spacingClass} px-3 w-full group relative transition-[padding] duration-300 ${selectionMode ? 'pl-12' : ''}`}
+            style={{ '--sully-chat-message-avatar-size': `${avatarSizePx}px` } as React.CSSProperties}
         >
             {selectionMode && (
-                <div className="absolute left-0 top-1/2 -translate-y-1/2 cursor-pointer z-10">
+                <div className="absolute left-3 top-1/2 -translate-y-1/2 cursor-pointer z-20" onClick={handleClick}>
                     <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors ${isSelected ? 'bg-violet-500 border-violet-500' : 'border-slate-300 bg-white'}`}>
                         {isSelected && <svg className="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>}
                     </div>
                 </div>
             )}
 
-            {!isUser && (
-                <div className="flex flex-col items-center gap-1 shrink-0">
-                    <img src={avatar} className="w-9 h-9 rounded-full object-cover shadow-sm border border-white" loading="lazy" />
+            {isFirstInGroup && (
+                <div className={`sully-chat-turn-avatar-slot hidden absolute top-0 z-0 ${isUser ? 'right-3' : (selectionMode ? 'left-14' : 'left-3')}`}>
+                    {renderAvatar(true)}
                 </div>
             )}
-            
-            <div className={`flex flex-col ${isUser ? 'items-end' : 'items-start'} max-w-[80%] ${selectionMode ? 'pointer-events-none' : ''}`}>
-                {!isUser && <span className="text-[10px] text-slate-400 ml-1 mb-1">{name}</span>}
-                {/* 引用条（对齐私聊 MessageItem 的极简样式） */}
-                {msg.replyTo && (
-                    <div className="mb-1 text-[10px] bg-black/5 p-1.5 rounded-md border-l-2 border-slate-300 text-slate-500 flex flex-col gap-0.5 max-w-full overflow-hidden">
-                        <span className="font-bold truncate">{msg.replyTo.name}</span>
-                        <span className="truncate italic">"{msg.replyTo.content.length > 10 ? msg.replyTo.content.slice(0, 10) + '...' : msg.replyTo.content}"</span>
+
+            {!isUser && (
+                <div className={`sully-chat-message-avatar-slot absolute bottom-0 z-0 ${selectionMode ? 'left-14' : 'left-3'} transition-[left] duration-300`}>
+                    {renderAvatar()}
+                </div>
+            )}
+
+            <div className={`sully-chat-message-content relative min-w-0 max-w-[72%] ${isUser ? 'mr-12' : 'ml-12'}`}>
+                <div
+                    className={`relative flex flex-col ${isUser ? 'items-end' : 'items-start'} min-w-0 ${selectionMode ? 'pointer-events-none' : ''}`}
+                    style={{
+                        transform: `translateX(${replyOffset}px)`,
+                        transition: isReplyGestureActive ? 'none' : 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)',
+                        touchAction: 'pan-y',
+                        userSelect: 'none',
+                        WebkitUserSelect: 'none',
+                        WebkitTouchCallout: 'none',
+                    } as React.CSSProperties}
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={handlePointerEnd}
+                    onPointerCancel={handlePointerCancel}
+                    onContextMenu={(e) => {
+                        e.preventDefault();
+                        if (selectionMode || replyGestureActiveRef.current) return;
+                        clearLongPressTimer();
+                        activePointerId.current = null;
+                        activePointerType.current = '';
+                        resetReplyGesture();
+                        onLongPress(msg.id);
+                    }}
+                    onDragStart={(e) => e.preventDefault()}
+                    onClick={handleClick}
+                >
+                    {!isUser && isFirstInGroup && (
+                        <span className="sully-chat-message-sender text-[10px] text-slate-400 ml-1 mb-1">{name}</span>
+                    )}
+                    <div className={selectionMode ? 'pointer-events-none' : ''}>
+                        {renderContent()}
                     </div>
-                )}
-                {renderContent()}
-                <span className="text-[9px] text-slate-300 mt-1 px-1">{timeStr}</span>
+                    {isLastInGroup && showTimestamp !== 'never' && (
+                        <span className={`absolute top-full ${isUser ? 'right-0' : 'left-0'} mt-0.5 px-1 text-[9px] text-slate-400/80 font-medium whitespace-nowrap pointer-events-none ${showTimestamp === 'hover' ? 'opacity-0 group-hover:opacity-100 transition-opacity' : ''}`}>{timeStr}</span>
+                    )}
+                </div>
             </div>
 
             {isUser && (
-                <div className="flex flex-col items-center gap-1 shrink-0">
-                    <img src={avatar} className="w-9 h-9 rounded-full object-cover shadow-sm border border-white" loading="lazy" />
+                <div className="sully-chat-message-avatar-slot absolute right-3 bottom-0 z-0">
+                    {renderAvatar()}
                 </div>
             )}
         </div>
@@ -914,23 +1018,43 @@ const GroupChat: React.FC = () => {
     };
 
     // --- Logic: 气泡体系 ---
-    // useMemo 保证引用稳定：GroupMessageItem 是 React.memo，styleConfig 每帧换新对象会导致整列表重渲
-    const userBubble = useMemo<BubbleStyle>(() => (
+    // 保留完整 ChatTheme：群聊不再只摘基础色值，气泡工坊 customCss 也一起复用。
+    const userBubbleTheme = useMemo<ChatTheme>(() => (
         activeGroup?.userBubbleThemeId
-            ? resolveChatTheme(activeGroup.userBubbleThemeId, customThemes, PRESET_THEMES).user
-            : PRESET_THEME_GROUP.user
+            ? resolveChatTheme(activeGroup.userBubbleThemeId, customThemes, PRESET_THEMES)
+            : PRESET_THEME_GROUP
     ), [activeGroup?.userBubbleThemeId, customThemes]);
 
-    const memberBubbles = useMemo(() => {
-        const map = new Map<string, BubbleStyle>();
+    const memberBubbleThemes = useMemo(() => {
+        const map = new Map<string, ChatTheme>();
         if (activeGroup?.memberBubbleIndependent) {
             for (const mid of activeGroup.members) {
                 const c = characters.find(ch => ch.id === mid);
-                map.set(mid, resolveChatTheme(c?.bubbleStyle, customThemes, PRESET_THEMES).ai);
+                map.set(mid, resolveChatTheme(c?.bubbleStyle, customThemes, PRESET_THEMES));
             }
         }
         return map;
     }, [activeGroup?.memberBubbleIndependent, activeGroup?.members, characters, customThemes]);
+
+    const memberThemeScopeClasses = useMemo(() => {
+        const map = new Map<string, string>();
+        activeGroup?.members.forEach((mid, index) => map.set(mid, `sully-group-member-theme-${index}`));
+        return map;
+    }, [activeGroup?.members]);
+
+    const groupBubbleCustomCss = useMemo(() => {
+        const chunks: string[] = [];
+        if (userBubbleTheme.customCss) {
+            chunks.push(scopeBubbleThemeCss(userBubbleTheme.customCss, '.sully-group-user-theme'));
+        }
+        memberBubbleThemes.forEach((theme, mid) => {
+            const scopeClass = memberThemeScopeClasses.get(mid);
+            if (theme.customCss && scopeClass) {
+                chunks.push(scopeBubbleThemeCss(theme.customCss, `.${scopeClass}`));
+            }
+        });
+        return chunks.filter(Boolean).join('\n');
+    }, [userBubbleTheme.customCss, memberBubbleThemes, memberThemeScopeClasses]);
 
     // 表情面板按分类过滤（对齐私聊 ChatInputArea 的行为）
     const filteredEmojis = useMemo(() => emojis.filter(e => {
@@ -1537,14 +1661,60 @@ ${memberTimeline || '(暂无互动记录)'}
     // CHAT VIEW
     // 动森彩蛋模式（与私聊同一开关联动）
     const acnh = osTheme.skin === 'animalcrossing' && osTheme.acnhChatSync !== false;
+    const chatChromeStyle = osTheme.chatChromeStyle || 'soft';
+    const chatBackgroundStyle = osTheme.chatBackgroundStyle || 'plain';
+    const groupChatRootClass = chatChromeStyle === 'pixel'
+        ? 'h-full w-full bg-[#efe1cf] flex flex-col overflow-hidden font-sans relative transition-[background-image,background-color] duration-500'
+        : chatChromeStyle === 'flat'
+            ? 'h-full w-full bg-white flex flex-col overflow-hidden font-sans relative transition-[background-image,background-color] duration-500'
+            : chatChromeStyle === 'floating'
+                ? 'h-full w-full bg-[#eef2ff] flex flex-col overflow-hidden font-sans relative transition-[background-image,background-color] duration-500'
+                : 'h-full w-full bg-[#f1f5f9] flex flex-col overflow-hidden font-sans relative transition-[background-image,background-color] duration-500';
+    const groupChatRootStyle: React.CSSProperties = chatBackgroundStyle === 'grid'
+        ? {
+            backgroundColor: chatChromeStyle === 'pixel' ? '#efe1cf' : '#f8fafc',
+            backgroundImage: 'linear-gradient(rgba(148,163,184,0.14) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.14) 1px, transparent 1px)',
+            backgroundSize: '20px 20px',
+        }
+        : chatBackgroundStyle === 'paper'
+            ? {
+                backgroundColor: chatChromeStyle === 'pixel' ? '#f4e8d9' : '#f9f7f2',
+                backgroundImage: 'radial-gradient(circle at 1px 1px, rgba(148,163,184,0.12) 1px, transparent 0)',
+                backgroundSize: '16px 16px',
+            }
+            : chatBackgroundStyle === 'mesh'
+                ? {
+                    backgroundColor: '#f8fafc',
+                    backgroundImage: 'radial-gradient(circle at 15% 20%, rgba(59,130,246,0.18), transparent 28%), radial-gradient(circle at 85% 15%, rgba(244,114,182,0.18), transparent 24%), radial-gradient(circle at 60% 75%, rgba(45,212,191,0.18), transparent 26%)',
+                }
+                : { backgroundImage: 'none' };
+    const groupFineTuneCss = buildChatFineTuneCss(osTheme);
+    const finalGroupRootClass = acnh
+        ? 'h-full w-full flex flex-col overflow-hidden font-sans relative transition-[background-color] duration-500'
+        : groupChatRootClass;
+    const finalGroupRootStyle = acnh
+        ? { backgroundColor: '#F6F0D8', backgroundImage: 'none' }
+        : groupChatRootStyle;
     return (
-        <div className="sully-chat-root h-full w-full bg-[#f0f4f8] flex flex-col font-sans relative">
+        <div className={`sully-chat-root ${finalGroupRootClass}`} style={finalGroupRootStyle}>
+            {/* 外观 App 的全局聊天细节与私聊共用同一份生成 CSS。 */}
+            {groupFineTuneCss && <style>{groupFineTuneCss}</style>}
             {/* 白框自定义 CSS：全局默认在前、群专属在后（后者叠加覆盖）。作用于 .sully-chat-* 各零件。 */}
             {osTheme.chatChromeCustomCss && <style>{osTheme.chatChromeCustomCss}</style>}
             {activeGroup?.chromeCustomCss && <style>{activeGroup.chromeCustomCss}</style>}
-            {/* 守护样式（注在用户 CSS 之后）：保证返回键永远可见可点，坏 CSS 也能退出群聊 */}
-            {(osTheme.chatChromeCustomCss || activeGroup?.chromeCustomCss) && (
-                <style>{`.sully-chat-back{visibility:visible!important;opacity:1!important;pointer-events:auto!important;}`}</style>
+            {/* 气泡工坊 CSS 排在白框之后，与私聊优先级一致；每套成员主题都限定在自己的消息上。 */}
+            {groupBubbleCustomCss && <style>{groupBubbleCustomCss}</style>}
+            <style>{`
+                .sully-bubble-tail-hidden::before,
+                .sully-bubble-tail-hidden::after { content: none !important; display: none !important; }
+            `}</style>
+            {/* 守护样式（注在用户 CSS 之后）：保证返回键与输入区永远可见可点。 */}
+            {(osTheme.chatChromeCustomCss || activeGroup?.chromeCustomCss || groupBubbleCustomCss) && (
+                <style>{`
+                    .sully-chat-back{visibility:visible!important;opacity:1!important;pointer-events:auto!important;}
+                    .sully-chat-inputbar{visibility:visible!important;opacity:1!important;pointer-events:auto!important;}
+                    .sully-chat-inputbar textarea,.sully-chat-inputbar button{pointer-events:auto!important;visibility:visible!important;}
+                `}</style>
             )}
             {/* 公共话题盒整理状态 — 不阻塞交互 */}
             {groupPalaceStatus && (
@@ -1615,7 +1785,7 @@ ${memberTimeline || '(暂无互动记录)'}
             />
 
             {/* Messages Area */}
-            <div className="flex-1 overflow-y-auto p-4 no-scrollbar space-y-2 bg-[#f0f4f8]" ref={scrollRef}>
+            <div className="flex-1 overflow-y-auto overflow-x-hidden pt-6 pb-6 no-scrollbar" ref={scrollRef}>
                 {collapsedCount > 0 && activeGroup && (
                     <div className="flex justify-center mb-6">
                         <button onClick={async () => {
@@ -1632,6 +1802,17 @@ ${memberTimeline || '(暂无互动记录)'}
                 {displayMessages.map((m, i) => {
                     const isUser = m.role === 'user';
                     const char = characters.find(c => c.id === m.charId);
+                    const prevMessage = i > 0 ? displayMessages[i - 1] : null;
+                    const nextMessage = i < displayMessages.length - 1 ? displayMessages[i + 1] : null;
+                    const messageGroupGapMs = 30 * 60 * 1000;
+                    const sameSpeaker = (other: Message | null) => !!other
+                        && other.role === m.role
+                        && other.charId === m.charId;
+                    const isFirstInGroup = !sameSpeaker(prevMessage)
+                        || Math.abs(m.timestamp - prevMessage!.timestamp) > messageGroupGapMs;
+                    const isLastInGroup = !sameSpeaker(nextMessage)
+                        || Math.abs(nextMessage!.timestamp - m.timestamp) > messageGroupGapMs;
+                    const memberTheme = memberBubbleThemes.get(m.charId);
 
                     return (
                         <GroupMessageItem
@@ -1648,7 +1829,16 @@ ${memberTimeline || '(暂无互动记录)'}
                             onReply={handleGroupReply}
                             nameOf={nameOf}
                             onPacketClick={openPacketDetail}
-                            styleConfig={isUser ? userBubble : (memberBubbles.get(m.charId) || PRESET_THEME_GROUP.ai)}
+                            styleConfig={isUser ? userBubbleTheme.user : (memberTheme?.ai || PRESET_THEME_GROUP.ai)}
+                            themeScopeClass={isUser ? 'sully-group-user-theme' : (memberThemeScopeClasses.get(m.charId) || 'sully-group-default-theme')}
+                            isFirstInGroup={isFirstInGroup}
+                            isLastInGroup={isLastInGroup}
+                            avatarShape={osTheme.chatAvatarShape}
+                            avatarSize={osTheme.chatAvatarSize}
+                            avatarMode={osTheme.chatAvatarMode}
+                            bubbleVariant={osTheme.chatBubbleStyle}
+                            messageSpacing={osTheme.chatMessageSpacing}
+                            showTimestamp={osTheme.chatShowTimestamp}
                         />
                     );
                 })}
@@ -1814,7 +2004,7 @@ ${memberTimeline || '(暂无互动记录)'}
                         <div className="flex items-center justify-between mb-3">
                             <div className="flex-1 pr-3">
                                 <div className="text-xs font-bold text-slate-700">成员独立气泡</div>
-                                <p className="text-[9px] text-slate-400 mt-0.5 leading-tight">开启后每位成员的气泡使用其私聊气泡主题（AI 侧）；关闭则全员统一。</p>
+                                <p className="text-[9px] text-slate-400 mt-0.5 leading-tight">开启后每位成员完整沿用其私聊气泡主题（AI 侧，包含自定义 CSS 与装饰）；关闭则全员统一。</p>
                             </div>
                             <div
                                 onClick={() => setTempMemberBubbleIndependent(v => !v)}

--- a/apps/Launcher.tsx
+++ b/apps/Launcher.tsx
@@ -1159,15 +1159,19 @@ const Launcher: React.FC = () => {
 
       {/* Page Indicators */}
       <div
-          className="absolute left-0 w-full flex justify-center gap-2 pointer-events-none z-20"
+          className="absolute left-0 w-full flex justify-center gap-1 pointer-events-none z-20"
           style={{ bottom: `calc(${launcherBottomInset} + 5.5rem)` }}
+          aria-hidden="true"
       >
           {Array.from({ length: totalPages }).map((_, i) => (
-              <div 
-                key={i}
-                className={`h-1.5 rounded-full transition-all duration-300 ${activePageIndex === i ? 'w-4 opacity-100' : 'w-1.5 opacity-40'}`} 
-                style={{ backgroundColor: contentColor }}
-              ></div>
+              // 每个页码占固定 16px 槽位，只动画内部圆点。旧版直接动画 flex child 的宽度，
+              // 快速划过多页时 WebKit 会一边改宽一边重算整行居中，几个过渡态就会挤成方块串。
+              <div key={i} className="flex h-1.5 w-4 shrink-0 items-center justify-center">
+                  <div
+                    className={`h-1.5 rounded-full transform-gpu transition-[width,opacity] duration-300 ${activePageIndex === i ? 'w-4 opacity-100' : 'w-1.5 opacity-40'}`}
+                    style={{ backgroundColor: contentColor }}
+                  />
+              </div>
           ))}
       </div>
 

--- a/apps/ThemeMaker.tsx
+++ b/apps/ThemeMaker.tsx
@@ -7,6 +7,7 @@ import { ChatTheme, BubbleStyle } from '../types';
 import { processImage } from '../utils/file';
 import { validateScopedCss, runCssRenderabilityCheck, CssValidationResult } from '../utils/scopedCss';
 import { trackEvent } from '../utils/analytics';
+import { resolveBubbleCornerRadii, shouldHideBubbleTail } from '../utils/bubbleAppearance';
 
 const cloneTheme = (theme: ChatTheme): ChatTheme => {
     if (typeof structuredClone === 'function') {
@@ -19,6 +20,7 @@ const DEFAULT_STYLE: BubbleStyle = {
     textColor: '#334155',
     backgroundColor: '#ffffff',
     borderRadius: 20,
+    tailMode: 'last',
     opacity: 1,
     backgroundImageOpacity: 0.5,
     decorationX: 90,
@@ -264,7 +266,7 @@ type CssSnippet = {
     code: string;
 };
 
-const TARGET_SELECTOR_REGEX = /^\.sully-bubble-(user|ai)\b/;
+const TARGET_SELECTOR_REGEX = /^(?:\.sully-bubble-(?:user|ai)\b|\.sully-voice-bar\b)/;
 
 const isValidHttpImageUrl = (value: string) => {
     try {
@@ -277,7 +279,7 @@ const isValidHttpImageUrl = (value: string) => {
 
 // 校验实现挪去 utils/scopedCss.ts（心象卡片的自定义 CSS 复用同一套），这里只绑定气泡作用域
 const validateCustomCss = (css: string): CssValidationResult =>
-    validateScopedCss(css, TARGET_SELECTOR_REGEX, '.sully-bubble-user / .sully-bubble-ai');
+    validateScopedCss(css, TARGET_SELECTOR_REGEX, '.sully-bubble-user / .sully-bubble-ai / .sully-voice-bar');
 
 const CSS_SCOPE_SNIPPETS: CssSnippet[] = [
     {
@@ -303,6 +305,12 @@ const CSS_SCOPE_SNIPPETS: CssSnippet[] = [
         name: '玻璃',
         description: '毛玻璃 + 高光边框',
         code: `.sully-bubble-user, .sully-bubble-ai {\n  backdrop-filter: blur(10px);\n  border: 1px solid rgba(255, 255, 255, 0.45);\n}\n.sully-bubble-user {\n  background: rgba(99, 102, 241, 0.62) !important;\n}\n.sully-bubble-ai {\n  background: rgba(255, 255, 255, 0.62) !important;\n}`
+    },
+    {
+        id: 'scope-voice-bar',
+        name: '语音条',
+        description: '单独修改语音条、播放键和波形',
+        code: `.sully-voice-bar {\n  min-width: 220px;\n  border-radius: 10px !important;\n  background: rgba(255,255,255,.72) !important;\n}\n.sully-voice-bar-button {\n  transform: rotate(-4deg);\n}\n.sully-voice-bar-wave-segment {\n  border-radius: 0 !important;\n}`
     }
 ];
 
@@ -357,7 +365,7 @@ const STYLE_TEMPLATES: StyleTemplate[] = [
 type PreviewMockMessage = {
     id: string;
     role: 'user' | 'ai';
-    kind: 'text' | 'image' | 'emoji';
+    kind: 'text' | 'image' | 'emoji' | 'voice';
     content: string;
     replyTo?: {
         name: string;
@@ -379,7 +387,8 @@ const PREVIEW_SCENES: PreviewScene[] = [
         name: '日常聊天',
         messages: [
             { id: 'd1', role: 'ai', kind: 'text', content: '今天状态怎么样？要不要一起复盘一下计划。' },
-            { id: 'd2', role: 'user', kind: 'text', content: '挺好！晚点一起把任务过一遍吧。' }
+            { id: 'd2', role: 'ai', kind: 'voice', content: '00:08' },
+            { id: 'd3', role: 'user', kind: 'text', content: '挺好！晚点一起把任务过一遍吧。' }
         ]
     },
     {
@@ -476,6 +485,9 @@ const ThemeMaker: React.FC = () => {
     const cssTextareaRef = useRef<HTMLTextAreaElement>(null);
 
     const activeStyle = editingTheme[activeTab === 'css' ? 'user' : activeTab];
+    // 语音消息只出现在角色侧；无论当前在编辑哪个 tab，语音条控件都写到 ai，
+    // 避免旧版在“用户气泡”页改了颜色却永远不生效的假设置。
+    const voiceBarStyle = editingTheme.ai;
     const CONTRAST_LOW_THRESHOLD = 4.5;
     const CONTRAST_CRITICAL_THRESHOLD = 3;
     const HIGH_BG_IMAGE_OPACITY = 0.75;
@@ -616,6 +628,28 @@ const ThemeMaker: React.FC = () => {
                     }
                 }
                 : {})
+        }));
+    };
+
+    const updateVoiceBarStyle = (key: keyof BubbleStyle, value: any) => {
+        updateTheme(prev => ({
+            ...prev,
+            ai: { ...prev.ai, [key]: value },
+        }));
+    };
+
+    const updateAllCornerRadii = (value: number) => {
+        if (activeTab === 'css') return;
+        updateTheme(prev => ({
+            ...prev,
+            [activeTab]: {
+                ...prev[activeTab],
+                borderRadius: value,
+                borderTopLeftRadius: undefined,
+                borderTopRightRadius: undefined,
+                borderBottomRightRadius: undefined,
+                borderBottomLeftRadius: undefined,
+            },
         }));
     };
 
@@ -868,21 +902,23 @@ const ThemeMaker: React.FC = () => {
         setIsAppliedToPreview(false);
     };
 
-    const renderPreviewBubble = (mock: PreviewMockMessage, theme: ChatTheme, panel: 'A' | 'B') => {
+    const renderPreviewBubble = (mock: PreviewMockMessage, theme: ChatTheme, panel: 'A' | 'B', isLastInGroup: boolean) => {
         const role = mock.role;
         const style = role === 'user' ? theme.user : theme.ai;
         const isUser = role === 'user';
+        const isVoice = mock.kind === 'voice';
         const isActive = panel === 'A' && (activeTab === role || activeTab === 'css');
         
-        // Match core bubble corner strategy in MessageItem.tsx
+        // Match core bubble corner/tail strategy in MessageItem.tsx.
+        const corners = resolveBubbleCornerRadii(style);
+        const hideTail = shouldHideBubbleTail(style.tailMode, isLastInGroup);
         const containerStyle = {
             backgroundColor: style.backgroundColor,
-            borderRadius: `${style.borderRadius}px`,
             opacity: style.opacity,
-            borderBottomLeftRadius: isUser ? `${style.borderRadius}px` : '4px',
-            borderBottomRightRadius: isUser ? '4px' : `${style.borderRadius}px`,
-            borderTopLeftRadius: `${style.borderRadius}px`,
-            borderTopRightRadius: `${style.borderRadius}px`,
+            borderTopLeftRadius: `${corners.topLeft}px`,
+            borderTopRightRadius: `${corners.topRight}px`,
+            borderBottomRightRadius: `${corners.bottomRight}px`,
+            borderBottomLeftRadius: `${corners.bottomLeft}px`,
         };
 
         return (
@@ -925,10 +961,12 @@ const ThemeMaker: React.FC = () => {
                     )}
 
                     <div
-                        className={`relative px-5 py-3 shadow-sm border border-black/5 text-sm overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'} ${isActive ? 'ring-2 ring-primary/70' : ''}`}
-                        style={containerStyle}
+                        className={isVoice
+                            ? `sully-voice-bar-shell relative py-1 text-sm overflow-visible ${isActive ? 'ring-2 ring-primary/70 rounded-2xl' : ''}`
+                            : `relative px-5 py-3 shadow-sm border border-black/5 text-sm overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'} ${isLastInGroup ? 'sully-bubble-group-last' : ''} ${hideTail ? 'sully-bubble-tail-hidden' : 'sully-bubble-tail-visible'} ${isActive ? 'ring-2 ring-primary/70' : ''}`}
+                        style={isVoice ? undefined : containerStyle}
                     >
-                        {showPreviewBgImage && style.backgroundImage && (
+                        {!isVoice && showPreviewBgImage && style.backgroundImage && (
                             <div 
                                 className="absolute inset-0 bg-cover bg-center pointer-events-none z-0"
                                 style={{ 
@@ -945,7 +983,27 @@ const ThemeMaker: React.FC = () => {
                             </div>
                         )}
 
-                        {mock.kind === 'image' ? (
+                        {mock.kind === 'voice' ? (
+                            <div
+                                className="sully-voice-bar relative z-10 flex min-w-[210px] items-center gap-2.5 rounded-2xl border border-black/5 px-3 py-2"
+                                style={{ background: style.voiceBarBg || 'linear-gradient(135deg, rgba(0,0,0,0.03), rgba(0,0,0,0.06))' }}
+                            >
+                                <span
+                                    className="sully-voice-bar-button flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[10px]"
+                                    style={{ color: style.voiceBarBtnColor || '#64748b', background: style.voiceBarBg ? 'rgba(255,255,255,.3)' : 'rgba(148,163,184,.18)' }}
+                                >▶</span>
+                                <span className="sully-voice-bar-wave flex h-5 flex-1 items-center gap-[3px] overflow-hidden">
+                                    {[4, 10, 6, 14, 8, 12, 5, 11, 7, 13, 5, 9].map((height, index) => (
+                                        <i
+                                            key={index}
+                                            className="sully-voice-bar-wave-segment block w-[2.5px] rounded-full"
+                                            style={{ height: Math.max(2, height * 0.4), background: style.voiceBarWaveColor ? `${style.voiceBarWaveColor}99` : 'rgba(148,163,184,.55)' }}
+                                        />
+                                    ))}
+                                </span>
+                                <span className="sully-voice-bar-toggle rounded-lg bg-black/5 px-1.5 py-0.5 text-[9px] font-medium" style={{ color: style.voiceBarTextColor || '#64748b' }}>转文字</span>
+                            </div>
+                        ) : mock.kind === 'image' ? (
                             <div className="relative z-10 w-40 h-28 rounded-xl bg-black/10 border border-black/10 flex items-center justify-center text-xs" style={{ color: style.textColor }}>
                                 🖼️ 图片占位
                             </div>
@@ -1071,6 +1129,10 @@ const ThemeMaker: React.FC = () => {
                 
                 {/* Live CSS Injection for Preview */}
                 {editingTheme.customCss && <style>{editingTheme.customCss}</style>}
+                <style>{`
+                    .sully-bubble-tail-hidden::before,
+                    .sully-bubble-tail-hidden::after { content: none !important; display: none !important; }
+                `}</style>
 
                 <div className="w-full max-w-sm relative z-10 bg-white/70 dark:bg-black/20 backdrop-blur-sm rounded-2xl p-3 border border-white/30 shadow-sm">
                     <div className={`absolute right-3 top-3 px-2.5 py-1 rounded-full text-[11px] font-bold shadow-sm ${overallContrastScore.grade === 'A' ? 'bg-emerald-100 text-emerald-700' : overallContrastScore.grade === 'B' ? 'bg-amber-100 text-amber-700' : 'bg-rose-100 text-rose-700'}`}>
@@ -1128,17 +1190,21 @@ const ThemeMaker: React.FC = () => {
                         {[{ label: 'A 当前编辑', theme: editingTheme, panel: 'A' as const }, { label: 'B 上次保存', theme: lastSavedTheme, panel: 'B' as const }].map(item => (
                             <div key={item.label} className={`space-y-4 p-4 rounded-2xl ${isPreviewDark ? 'bg-slate-950/60 border border-white/10' : 'bg-white/70 border border-white/60'}`}>
                                 <div className="text-[10px] text-slate-500">{item.label}</div>
-                                {currentScene.messages.map(msg => (
-                                    <div key={`${item.panel}-${msg.id}`}>{renderPreviewBubble(msg, item.theme, item.panel)}</div>
-                                ))}
+                                {currentScene.messages.map((msg, index) => {
+                                    const next = currentScene.messages[index + 1];
+                                    const isLastInGroup = !next || next.role !== msg.role;
+                                    return <div key={`${item.panel}-${msg.id}`}>{renderPreviewBubble(msg, item.theme, item.panel, isLastInGroup)}</div>;
+                                })}
                             </div>
                         ))}
                     </div>
                 ) : (
                     <div className={`w-full max-w-sm space-y-4 p-4 rounded-2xl relative z-10 ${isPreviewDark ? 'bg-slate-950/60 border border-white/10' : 'bg-white/70 border border-white/60'}`}>
-                        {currentScene.messages.map(msg => (
-                            <div key={msg.id}>{renderPreviewBubble(msg, previewCompareMode === 'toggle' && previewToggleTarget === 'B' ? lastSavedTheme : editingTheme, previewCompareMode === 'toggle' && previewToggleTarget === 'B' ? 'B' : 'A')}</div>
-                        ))}
+                        {currentScene.messages.map((msg, index) => {
+                            const next = currentScene.messages[index + 1];
+                            const isLastInGroup = !next || next.role !== msg.role;
+                            return <div key={msg.id}>{renderPreviewBubble(msg, previewCompareMode === 'toggle' && previewToggleTarget === 'B' ? lastSavedTheme : editingTheme, previewCompareMode === 'toggle' && previewToggleTarget === 'B' ? 'B' : 'A', isLastInGroup)}</div>;
+                        })}
                     </div>
                 )}
                 
@@ -1178,7 +1244,8 @@ const ThemeMaker: React.FC = () => {
                         <div className="space-y-6 animate-fade-in h-full flex flex-col">
                             <div className="text-[10px] text-slate-500 bg-slate-50 p-3 rounded-xl border border-slate-100 leading-relaxed space-y-2">
                                 <span className="font-bold block mb-1 text-slate-500">CSS 增强模式</span>
-                                可使用CSS类名 <code className="bg-slate-200 px-1 rounded">.sully-bubble-user</code> 和 <code className="bg-slate-200 px-1 rounded">.sully-bubble-ai</code> 来统一定制气泡样式。
+                                可使用 <code className="bg-slate-200 px-1 rounded">.sully-bubble-user</code>、<code className="bg-slate-200 px-1 rounded">.sully-bubble-ai</code> 定制气泡，使用 <code className="bg-slate-200 px-1 rounded">.sully-voice-bar</code>、<code className="bg-slate-200 px-1 rounded">.sully-voice-bar-button</code>、<code className="bg-slate-200 px-1 rounded">.sully-voice-bar-wave-segment</code> 单独定制语音条。
+                                <br/>连续消息可用 <code className="bg-slate-200 px-1 rounded">.sully-bubble-group-last</code> 命中组末气泡；基础样式里的“尾巴出现位置”也会自动隐藏中间气泡的伪元素尾巴。
                                 <br/>支持使用 <code className="text-red-400">!important</code> 覆盖可视化编辑器的设置。
                                 <div className="rounded-lg border border-indigo-100 bg-indigo-50 px-2.5 py-2 text-[10px] text-indigo-700">
                                     <div className="font-semibold">优先级说明：可视化参数 vs CSS 覆盖</div>
@@ -1224,7 +1291,7 @@ const ThemeMaker: React.FC = () => {
                             )}
 
                             <div>
-                                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest block mb-2">限定作用域插入器（仅 .sully-bubble-user/.sully-bubble-ai）</label>
+                                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-widest block mb-2">限定作用域插入器（气泡 / 语音条）</label>
                                 <div className="grid grid-cols-2 gap-2">
                                     {CSS_SCOPE_SNIPPETS.map(snippet => (
                                         <button
@@ -1295,7 +1362,7 @@ const ThemeMaker: React.FC = () => {
                                 </div>
                             </div>
 
-                            {activeTab !== 'css' && (
+                            <>
                                 <div className={`rounded-xl border p-3 ${showLowContrastWarning ? 'border-amber-200 bg-amber-50/80' : 'border-emerald-200 bg-emerald-50/70'}`}>
                                     <div className="flex flex-wrap items-center justify-between gap-2">
                                         <div>
@@ -1316,7 +1383,7 @@ const ThemeMaker: React.FC = () => {
                                         </div>
                                     )}
                                 </div>
-                            )}
+                            </>
 
                             {/* Colors & Opacity */}
                             <div className="grid grid-cols-2 gap-4">
@@ -1370,9 +1437,49 @@ const ThemeMaker: React.FC = () => {
                             </div>
 
                             {/* Border Radius */}
-                            <div>
-                                <div className="flex justify-between mb-2"><label className="text-[10px] font-bold text-slate-400 uppercase">圆角大小</label><span className="text-[9px] px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-600">推荐：16 / 20</span></div>
-                                <input type="range" min="0" max="30" value={activeStyle.borderRadius} onChange={(e) => updateStyle('borderRadius', parseInt(e.target.value))} className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-primary" />
+                            <div className="space-y-3">
+                                <div>
+                                    <div className="flex justify-between mb-2"><label className="text-[10px] font-bold text-slate-400 uppercase">四角一起调</label><span className="text-[9px] px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-600">{activeStyle.borderRadius}px</span></div>
+                                    <input type="range" min="0" max="36" value={activeStyle.borderRadius} onChange={(e) => updateAllCornerRadii(parseInt(e.target.value))} className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-primary" />
+                                </div>
+                                <details className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                                    <summary className="cursor-pointer text-xs font-semibold text-slate-600">独立调整四个角</summary>
+                                    <div className="mt-3 grid grid-cols-2 gap-3">
+                                        {([
+                                            ['borderTopLeftRadius', '左上'],
+                                            ['borderTopRightRadius', '右上'],
+                                            ['borderBottomLeftRadius', '左下'],
+                                            ['borderBottomRightRadius', '右下'],
+                                        ] as const).map(([key, label]) => {
+                                            const corners = resolveBubbleCornerRadii(activeStyle);
+                                            const value = key === 'borderTopLeftRadius' ? corners.topLeft
+                                                : key === 'borderTopRightRadius' ? corners.topRight
+                                                : key === 'borderBottomLeftRadius' ? corners.bottomLeft
+                                                : corners.bottomRight;
+                                            return (
+                                                <label key={key} className="rounded-lg bg-white p-2 text-[10px] text-slate-500">
+                                                    <span className="mb-1 flex justify-between"><span>{label}</span><b>{value}px</b></span>
+                                                    <input type="range" min="0" max="36" value={value} onChange={(e) => updateStyle(key, parseInt(e.target.value))} className="w-full h-1.5 bg-slate-200 rounded-full appearance-none cursor-pointer accent-primary" />
+                                                </label>
+                                            );
+                                        })}
+                                    </div>
+                                    <button type="button" onClick={() => updateAllCornerRadii(activeStyle.borderRadius)} className="mt-3 w-full rounded-lg bg-white py-2 text-[10px] font-semibold text-slate-500">重新统一四角</button>
+                                </details>
+                                <div>
+                                    <div className="mb-2 text-[10px] font-bold uppercase text-slate-400">小尾巴出现位置</div>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        {([
+                                            ['last', '仅组末'],
+                                            ['every', '每一条'],
+                                            ['none', '不显示'],
+                                        ] as const).map(([mode, label]) => {
+                                            const selected = (activeStyle.tailMode || 'every') === mode;
+                                            return <button key={mode} type="button" onClick={() => updateStyle('tailMode', mode)} className={`rounded-xl border py-2 text-[10px] font-semibold transition ${selected ? 'border-primary bg-primary/10 text-primary' : 'border-slate-200 bg-white text-slate-500'}`}>{label}</button>;
+                                        })}
+                                    </div>
+                                    <p className="mt-1.5 text-[9px] leading-relaxed text-slate-400">适用于用 ::before / ::after 画出的 CSS 尾巴；“仅组末”就是 iMessage 那种连续消息只在最后一条保留尾巴。</p>
+                                </div>
                             </div>
 
                             {/* Background Image Logic */}
@@ -1411,45 +1518,55 @@ const ThemeMaker: React.FC = () => {
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4"><path d="M7 4a3 3 0 0 1 6 0v6a3 3 0 1 1-6 0V4Z" /><path d="M5.5 9.643a.75.75 0 0 0-1.5 0V10c0 3.06 2.29 5.585 5.25 5.954V17.5h-1.5a.75.75 0 0 0 0 1.5h4.5a.75.75 0 0 0 0-1.5h-1.5v-1.546A6.001 6.001 0 0 0 16 10v-.357a.75.75 0 0 0-1.5 0V10a4.5 4.5 0 0 1-9 0v-.357Z" /></svg>
                                     语音条样式
                                 </h3>
+                                <p className="mb-3 text-[9px] leading-relaxed text-slate-400">语音只出现在角色侧，因此这里始终写入角色气泡配置；在“用户气泡”页修改也会真实生效。需要改尺寸、圆角或布局，可到“自定义 CSS”使用 .sully-voice-bar。</p>
+                                <div className="sully-bubble-ai mb-4 rounded-2xl bg-slate-50 p-2">
+                                    <div className="sully-voice-bar flex items-center gap-2.5 rounded-2xl border border-black/5 px-3 py-2" style={{ background: voiceBarStyle.voiceBarBg || 'linear-gradient(135deg, rgba(0,0,0,0.03), rgba(0,0,0,0.06))' }}>
+                                        <span className="sully-voice-bar-button flex h-7 w-7 shrink-0 items-center justify-center rounded-full" style={{ color: voiceBarStyle.voiceBarBtnColor || '#64748b', background: 'rgba(255,255,255,.55)' }}>▶</span>
+                                        <span className="sully-voice-bar-wave flex flex-1 items-center gap-[3px]">
+                                            {[5, 11, 7, 14, 8, 12, 6, 10, 5, 9].map((height, index) => <i key={index} className="sully-voice-bar-wave-segment block w-[2.5px] rounded-full" style={{ height, background: voiceBarStyle.voiceBarWaveColor || '#94a3b8' }} />)}
+                                        </span>
+                                        <span className="sully-voice-bar-toggle text-[9px]" style={{ color: voiceBarStyle.voiceBarTextColor || '#475569' }}>转文字</span>
+                                    </div>
+                                </div>
                                 <div className="grid grid-cols-2 gap-3">
                                     <div>
                                         <label className="text-[10px] text-slate-400 block mb-1">背景色</label>
                                         <div className="flex items-center gap-2">
-                                            <input type="color" value={activeStyle.voiceBarBg || '#f1f5f9'} onChange={(e) => updateStyle('voiceBarBg', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
-                                            <span className="text-[10px] text-slate-400 font-mono">{activeStyle.voiceBarBg || '默认'}</span>
-                                            {activeStyle.voiceBarBg && <button onClick={() => updateStyle('voiceBarBg', undefined)} className="text-[9px] text-red-400">重置</button>}
+                                            <input type="color" value={voiceBarStyle.voiceBarBg || '#f1f5f9'} onChange={(e) => updateVoiceBarStyle('voiceBarBg', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
+                                            <span className="text-[10px] text-slate-400 font-mono">{voiceBarStyle.voiceBarBg || '默认'}</span>
+                                            {voiceBarStyle.voiceBarBg && <button onClick={() => updateVoiceBarStyle('voiceBarBg', undefined)} className="text-[9px] text-red-400">重置</button>}
                                         </div>
                                     </div>
                                     <div>
                                         <label className="text-[10px] text-slate-400 block mb-1">播放时背景</label>
                                         <div className="flex items-center gap-2">
-                                            <input type="color" value={activeStyle.voiceBarActiveBg || '#d1fae5'} onChange={(e) => updateStyle('voiceBarActiveBg', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
-                                            <span className="text-[10px] text-slate-400 font-mono">{activeStyle.voiceBarActiveBg || '默认'}</span>
-                                            {activeStyle.voiceBarActiveBg && <button onClick={() => updateStyle('voiceBarActiveBg', undefined)} className="text-[9px] text-red-400">重置</button>}
+                                            <input type="color" value={voiceBarStyle.voiceBarActiveBg || '#d1fae5'} onChange={(e) => updateVoiceBarStyle('voiceBarActiveBg', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
+                                            <span className="text-[10px] text-slate-400 font-mono">{voiceBarStyle.voiceBarActiveBg || '默认'}</span>
+                                            {voiceBarStyle.voiceBarActiveBg && <button onClick={() => updateVoiceBarStyle('voiceBarActiveBg', undefined)} className="text-[9px] text-red-400">重置</button>}
                                         </div>
                                     </div>
                                     <div>
                                         <label className="text-[10px] text-slate-400 block mb-1">按钮颜色</label>
                                         <div className="flex items-center gap-2">
-                                            <input type="color" value={activeStyle.voiceBarBtnColor || '#10b981'} onChange={(e) => updateStyle('voiceBarBtnColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
-                                            <span className="text-[10px] text-slate-400 font-mono">{activeStyle.voiceBarBtnColor || '默认'}</span>
-                                            {activeStyle.voiceBarBtnColor && <button onClick={() => updateStyle('voiceBarBtnColor', undefined)} className="text-[9px] text-red-400">重置</button>}
+                                            <input type="color" value={voiceBarStyle.voiceBarBtnColor || '#10b981'} onChange={(e) => updateVoiceBarStyle('voiceBarBtnColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
+                                            <span className="text-[10px] text-slate-400 font-mono">{voiceBarStyle.voiceBarBtnColor || '默认'}</span>
+                                            {voiceBarStyle.voiceBarBtnColor && <button onClick={() => updateVoiceBarStyle('voiceBarBtnColor', undefined)} className="text-[9px] text-red-400">重置</button>}
                                         </div>
                                     </div>
                                     <div>
                                         <label className="text-[10px] text-slate-400 block mb-1">波形颜色</label>
                                         <div className="flex items-center gap-2">
-                                            <input type="color" value={activeStyle.voiceBarWaveColor || '#10b981'} onChange={(e) => updateStyle('voiceBarWaveColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
-                                            <span className="text-[10px] text-slate-400 font-mono">{activeStyle.voiceBarWaveColor || '默认'}</span>
-                                            {activeStyle.voiceBarWaveColor && <button onClick={() => updateStyle('voiceBarWaveColor', undefined)} className="text-[9px] text-red-400">重置</button>}
+                                            <input type="color" value={voiceBarStyle.voiceBarWaveColor || '#10b981'} onChange={(e) => updateVoiceBarStyle('voiceBarWaveColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
+                                            <span className="text-[10px] text-slate-400 font-mono">{voiceBarStyle.voiceBarWaveColor || '默认'}</span>
+                                            {voiceBarStyle.voiceBarWaveColor && <button onClick={() => updateVoiceBarStyle('voiceBarWaveColor', undefined)} className="text-[9px] text-red-400">重置</button>}
                                         </div>
                                     </div>
                                     <div className="col-span-2">
                                         <label className="text-[10px] text-slate-400 block mb-1">文字颜色</label>
                                         <div className="flex items-center gap-2">
-                                            <input type="color" value={activeStyle.voiceBarTextColor || '#475569'} onChange={(e) => updateStyle('voiceBarTextColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
-                                            <span className="text-[10px] text-slate-400 font-mono">{activeStyle.voiceBarTextColor || '默认'}</span>
-                                            {activeStyle.voiceBarTextColor && <button onClick={() => updateStyle('voiceBarTextColor', undefined)} className="text-[9px] text-red-400">重置</button>}
+                                            <input type="color" value={voiceBarStyle.voiceBarTextColor || '#475569'} onChange={(e) => updateVoiceBarStyle('voiceBarTextColor', e.target.value)} className="w-7 h-7 rounded-lg border-0 cursor-pointer" />
+                                            <span className="text-[10px] text-slate-400 font-mono">{voiceBarStyle.voiceBarTextColor || '默认'}</span>
+                                            {voiceBarStyle.voiceBarTextColor && <button onClick={() => updateVoiceBarStyle('voiceBarTextColor', undefined)} className="text-[9px] text-red-400">重置</button>}
                                         </div>
                                     </div>
                                 </div>

--- a/components/PhoneShell.tsx
+++ b/components/PhoneShell.tsx
@@ -425,18 +425,18 @@ const ImportRecoveryPopup: React.FC<{
 // 刻意「零动画开销」：之前那套呼吸/涟漪/上升微尘的持续动画在 iOS 上会引起卡顿，且预热命中后
 // 这屏几乎不出现 —— 收益小、代价大。现在只一次性淡入一个静态柔光点（无 infinite 动画），
 // 透明底让外壳虚化壁纸透出来。真卡住（>7s）才换成可点的刷新/返回兜底。
-const AppLoadingFallback: React.FC<{ onReturn?: () => void }> = ({ onReturn }) => {
+const AppLoadingFallback: React.FC<{ onReturn?: () => void; animationEnabled?: boolean }> = ({ onReturn, animationEnabled = true }) => {
   const [show, setShow] = useState(false);
   const [stalled, setStalled] = useState(false);
   useEffect(() => {
-    const t = setTimeout(() => setShow(true), 220);
+    const t = animationEnabled ? setTimeout(() => setShow(true), 220) : null;
     // 卡死逃生口：iOS standalone PWA 从后台恢复 / 弱网时，动态 import 可能既不 resolve 也不 reject，
     // Suspense 会永远停在这一屏（不报错 → 错误边界不触发 → 不会自动刷新），用户狂点中心光点却毫无反应。
     // 超过 STALL_MS 仍未加载完 → 把「看着像按钮其实不是」的光点换成真正可点的「刷新/返回」按钮，
     // 既明确告诉用户该点哪里，又把静默卡死变成一键可恢复。只动占位 UI，不碰 import 逻辑。
     const stall = setTimeout(() => { setStalled(true); trackEvent('App 加载卡死超时'); }, 7000);
-    return () => { clearTimeout(t); clearTimeout(stall); };
-  }, []);
+    return () => { if (t) clearTimeout(t); clearTimeout(stall); };
+  }, [animationEnabled]);
   if (stalled) {
     return (
       <div className="w-full h-full flex flex-col items-center justify-center bg-slate-900/95 text-white p-6 text-center space-y-4" style={{ animation: 'appLoadIn 320ms ease-out both' }}>
@@ -495,6 +495,11 @@ const PhoneShell: React.FC = () => {
 
   // 冷启动「世界入场」是否已结束。结束前由 BootSequence 接管整屏（同时取代旧的黑屏 spinner）。
   const [bootDone, setBootDone] = useState(false);
+  const bootAnimationEnabled = theme.bootAnimationEnabled !== false;
+  useEffect(() => {
+    // 本次启动一旦选择跳过，就记为已经完成；用户稍后重新打开开关时不在桌面中途补播。
+    if (!bootAnimationEnabled) setBootDone(true);
+  }, [bootAnimationEnabled]);
 
   // 从根本上消除「每次进 App 都要加载」：数据一就绪就在后台按优先级逐个预热各 App 的代码块。
   // 关键：不等开机动画（bootDone）结束就开始 —— 否则用户在开机那 ~2 秒内点开 Chat 时 chunk 还没热，
@@ -748,7 +753,7 @@ const PhoneShell: React.FC = () => {
 
   // 冷启动：先放「世界入场」cinematic（数据没就绪时它持续呼吸等待，绝不出现 spinner）。
   // BootSequence 在「数据就绪 + 停留够时长」后推进退场，再交还控制权给下方的锁屏/桌面。
-  if (!bootDone) {
+  if (!bootDone && bootAnimationEnabled) {
     return <BootSequence dataReady={isDataLoaded} wallpaper={theme.wallpaper} onDone={() => setBootDone(true)} />;
   }
 
@@ -941,7 +946,7 @@ const PhoneShell: React.FC = () => {
           {/* App Container */}
           <div className="flex-1 relative overflow-hidden" style={{ contain: useIOSStandaloneLayout ? undefined : 'layout style paint' }}>
             <AppErrorBoundary onCloseApp={closeApp} resetKey={`${activeApp}:${activeCharacterId || 'none'}`}>
-              <Suspense fallback={<AppLoadingFallback onReturn={closeApp} />}>
+              <Suspense fallback={<AppLoadingFallback onReturn={closeApp} animationEnabled={theme.appLoadingAnimationEnabled !== false} />}>
                 {/* 统一「淡入」过渡：每次切换 App 时 key 变化 → 重新挂载并淡入，
                     让所有 App 都像个人档案那样「渐变进去」，而非瞬间咚一下。
                     关键：只动 opacity、不做 scale/translate —— 否则会把整棵（常含大量头像图片的）

--- a/components/appearance/ChatAppearanceEditor.tsx
+++ b/components/appearance/ChatAppearanceEditor.tsx
@@ -480,10 +480,10 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
     const previewGap = messageSpacing === 'compact' ? 'gap-1.5' : messageSpacing === 'spacious' ? 'gap-4' : 'gap-2.5';
     const previewPad = headerDensity === 'compact' ? 'px-4 py-3' : headerDensity === 'airy' ? 'px-5 py-[18px]' : 'px-4 py-3.5';
     const previewMessages = [
-        { id: 'ai-1', role: 'assistant', text: '今天这套聊天壳已经比之前像样多了。' },
-        { id: 'ai-2', role: 'assistant', text: '现在还能决定头像是连续共用，还是每条都显示。' },
-        { id: 'user-1', role: 'user', text: '对，我想把头像频率也做成可以 DIY 的。' },
-        { id: 'user-2', role: 'user', text: '这样不同软件的味道会更明显。' },
+        { id: 'ai-1', role: 'assistant', kind: 'text', text: '今天这套聊天壳已经比之前像样多了。' },
+        { id: 'ai-2', role: 'assistant', kind: 'voice', text: '00:08' },
+        { id: 'user-1', role: 'user', kind: 'text', text: '对，我想把头像频率也做成可以 DIY 的。' },
+        { id: 'user-2', role: 'user', kind: 'text', text: '这样不同软件的味道会更明显。' },
     ] as const;
 
     return (
@@ -549,7 +549,17 @@ export const ChatAppearanceEditor: React.FC<Props> = ({ theme, updateTheme, onRe
                             const shouldShowAvatar = avatarMode === 'every_message' || nextRole !== message.role;
                             const avatarTone = isUser ? 'bg-primary/25' : 'bg-pink-200';
                             const avatarHidden = isUser ? hidePreviewUserAvatar : hidePreviewAiAvatar;
-                            const bubbleNode = (
+                            const bubbleNode = message.kind === 'voice' ? (
+                                <div className={`sully-voice-bar flex min-w-[190px] items-center gap-2 rounded-2xl border px-3 py-2 ${headerStyle === 'discord' ? 'border-white/10 bg-white/10' : chromeStyle === 'pixel' ? 'border-2 border-[#8f674a] bg-[#fff7ed]' : 'border-black/5 bg-slate-100/90'}`}>
+                                    <span className={`sully-voice-bar-button flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[9px] ${chromeStyle === 'pixel' ? 'bg-[#c99872] text-[#fff7ed]' : 'bg-primary/15 text-primary'}`}>▶</span>
+                                    <span className="sully-voice-bar-wave flex h-5 flex-1 items-center gap-[3px] overflow-hidden">
+                                        {[4, 10, 6, 14, 8, 12, 5, 11, 7, 13].map((height, waveIndex) => (
+                                            <i key={waveIndex} className={`sully-voice-bar-wave-segment block w-[2.5px] rounded-full ${headerStyle === 'discord' ? 'bg-white/55' : chromeStyle === 'pixel' ? 'bg-[#8f674a]/70' : 'bg-primary/45'}`} style={{ height: Math.max(2, height * 0.42) }} />
+                                        ))}
+                                    </span>
+                                    <span className={`sully-voice-bar-toggle rounded-lg px-1.5 py-0.5 text-[8px] font-medium ${headerStyle === 'discord' ? 'bg-white/10 text-white/65' : chromeStyle === 'pixel' ? 'bg-[#eadfce] text-[#8f674a]' : 'bg-black/5 text-slate-500'}`}>转文字</span>
+                                </div>
+                            ) : (
                                 <div style={{ ...previewBubbleStyle(bubbleStyle, isUser, theme), ...previewFineTextStyle }}>
                                     {message.text}
                                     {showTimestamp === 'always' && nextRole !== message.role && (

--- a/components/call/CallPreferencesSheet.tsx
+++ b/components/call/CallPreferencesSheet.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Gear, Phone, SpeakerHigh, X } from '@phosphor-icons/react';
+import { ChatCircleDots, Gear, Phone, SpeakerHigh, X } from '@phosphor-icons/react';
 import type { CallPreferences } from '../../utils/callPreferences';
 
 interface CallPreferencesSheetProps {
@@ -102,7 +102,7 @@ const CallPreferencesSheet: React.FC<CallPreferencesSheetProps> = ({
             </span>
             <span className="min-w-0 flex-1">
               <span className={`block text-[13px] font-medium ${lightTheme ? 'text-[#262239]/90' : 'text-white/85'}`}>自动播放语音</span>
-              <span className={`mt-0.5 block text-[10px] leading-4 ${lightTheme ? 'text-[#262239]/55' : 'text-white/38'}`}>关掉后，点“播放语音”时才会生成并播放。</span>
+              <span className={`mt-0.5 block text-[10px] leading-4 ${lightTheme ? 'text-[#262239]/55' : 'text-white/38'}`}>默认开启并沿用你的选择。关掉后，语音和视频通话都只在你点“播放语音”时才生成，避免额外消耗额度。</span>
             </span>
             <button
               type="button"
@@ -118,6 +118,35 @@ const CallPreferencesSheet: React.FC<CallPreferencesSheetProps> = ({
               <span
                 className="absolute top-[3px] h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200"
                 style={{ left: 3, transform: preferences.voiceAutoPlay ? 'translateX(20px)' : 'translateX(0)' }}
+              />
+            </button>
+          </div>
+
+          <div className="flex min-h-[4.75rem] items-center gap-3 py-3">
+            <span
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border"
+              style={{ color: preferences.idleNudgeEnabled ? accentColor : lightTheme ? 'rgba(38,34,57,.42)' : 'rgba(255,255,255,.38)', borderColor: preferences.idleNudgeEnabled ? `${accentColor}66` : lightTheme ? 'rgba(38,34,57,.1)' : 'rgba(255,255,255,.1)', background: preferences.idleNudgeEnabled ? `${accentColor}14` : lightTheme ? 'rgba(38,34,57,.025)' : 'rgba(255,255,255,.025)' }}
+            >
+              <ChatCircleDots size={17} weight="fill" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className={`block text-[13px] font-medium ${lightTheme ? 'text-[#262239]/90' : 'text-white/85'}`}>沉默后主动接话</span>
+              <span className={`mt-0.5 block text-[10px] leading-4 ${lightTheme ? 'text-[#262239]/55' : 'text-white/38'}`}>按需开启。通话安静较久时，对方最多主动接话两次；默认关闭，不会自行发起请求。</span>
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={preferences.idleNudgeEnabled}
+              aria-label="沉默后主动接话"
+              onClick={() => onChange({ ...preferences, idleNudgeEnabled: !preferences.idleNudgeEnabled })}
+              className="relative h-7 w-12 shrink-0 rounded-full border transition-all duration-200 active:scale-95"
+              style={preferences.idleNudgeEnabled
+                ? { background: accentColor, borderColor: accentColor, boxShadow: `0 0 14px ${accentColor}44` }
+                : { background: lightTheme ? 'rgba(38,34,57,.07)' : 'rgba(255,255,255,.06)', borderColor: lightTheme ? 'rgba(38,34,57,.14)' : 'rgba(255,255,255,.13)' }}
+            >
+              <span
+                className="absolute top-[3px] h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200"
+                style={{ left: 3, transform: preferences.idleNudgeEnabled ? 'translateX(20px)' : 'translateX(0)' }}
               />
             </button>
           </div>

--- a/components/call/CallUpdateAnnouncement.tsx
+++ b/components/call/CallUpdateAnnouncement.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Gear, Phone, SpeakerHigh, X } from '@phosphor-icons/react';
+import { ChatCircleDots, Gear, Phone, SpeakerHigh, X } from '@phosphor-icons/react';
 
 interface CallUpdateAnnouncementProps {
   accentColor: string;
@@ -50,8 +50,8 @@ const CallUpdateAnnouncement: React.FC<CallUpdateAnnouncementProps> = ({
       </button>
 
       <div className="text-[9px] font-semibold tracking-[0.28em]" style={{ color: `${accentColor}cc` }}>CALL UPDATE</div>
-      <h2 id="call-update-title" className="mt-2 pr-8 text-[1.45rem] font-semibold leading-tight text-white/95">通话有些调整</h2>
-      <p className="mt-2 text-[11px] leading-5 text-white/45">为了让电话更像真的，我们改了几处。聊天里的语音不受影响。</p>
+      <h2 id="call-update-title" className="mt-2 pr-8 text-[1.45rem] font-semibold leading-tight text-white/95">通话偏好现在有三项</h2>
+      <p className="mt-2 text-[11px] leading-5 text-white/45">左下角可以分别控制开场、语音额度和沉默后的主动接话。聊天页的语音设置不受影响。</p>
 
       <div className="mt-5 divide-y divide-white/8 border-y border-white/8">
         <div className="flex gap-3 py-3">
@@ -64,15 +64,15 @@ const CallUpdateAnnouncement: React.FC<CallUpdateAnnouncementProps> = ({
         <div className="flex gap-3 py-3">
           <SpeakerHigh className="mt-0.5 shrink-0" size={17} weight="fill" style={{ color: accentColor }} />
           <div>
-            <div className="text-xs font-medium text-white/85">可以关掉自动语音</div>
-            <div className="mt-0.5 text-[10px] leading-4 text-white/38">关掉后不会提前生成语音。你点“播放语音”时，才会生成并播放。</div>
+            <div className="text-xs font-medium text-white/85">语音与视频共用自动播放偏好</div>
+            <div className="mt-0.5 text-[10px] leading-4 text-white/38">默认开启，并沿用你已经保存的选择；关掉后两种通话都不会提前生成语音。</div>
           </div>
         </div>
         <div className="flex gap-3 py-3">
-          <span className="mt-0.5 flex h-[17px] w-[17px] shrink-0 items-center justify-center text-[10px]" style={{ color: accentColor }}>✦</span>
+          <ChatCircleDots className="mt-0.5 shrink-0" size={17} weight="fill" style={{ color: accentColor }} />
           <div>
-            <div className="text-xs font-medium text-white/85">修了 iPhone 没声音的问题</div>
-            <div className="mt-0.5 text-[10px] leading-4 text-white/38">Safari 和 Firefox 的视频通话、重播语音现在应该都能正常出声。</div>
+            <div className="text-xs font-medium text-white/85">沉默后主动接话改为按需开启</div>
+            <div className="mt-0.5 text-[10px] leading-4 text-white/38">默认关闭。开启后，通话安静较久时对方最多自然接话两次。</div>
           </div>
         </div>
       </div>

--- a/components/chat/ChromeCssEditor.tsx
+++ b/components/chat/ChromeCssEditor.tsx
@@ -33,10 +33,15 @@ const AI_PROMPT = `你是一个 CSS 设计师。我在用一个叫 SullyOS 的�
 - .sully-chat-turn-avatar-slot 每组首条的头像槽（默认 display:none，内部已有正确的双方头像）
 - .sully-chat-turn-avatar      上述头像槽里的头像容器；图片是 .sully-chat-message-avatar-img
 - .sully-bubble-ai / .sully-bubble-user 角色 / 用户气泡
+- .sully-schedule-change      角色修改未来日程后浮出的整张回执
+- .sully-schedule-change-head / -mark / -kicker  回执标题行 / 勾选标记 / 标题文字
+- .sully-schedule-change-list / -row             修改列表 / 单条修改
+- .sully-schedule-change-time / -before / -arrow / -after  时段 / 原计划 / 箭头 / 新计划
+- .sully-schedule-change-shine                    掠过回执的一次性高光
 
 【必须遵守的规范】
 1. 覆盖默认样式必须加 !important（尤其 .sully-chat-buffs button 带内联样式，不加 !important 盖不掉）。
-2. 只允许使用上面的 .sully-chat-* 选择器及其后代/伪元素，禁止写 body、*、div、html 这类全局选择器（会污染其它界面）。
+2. 只允许使用上面的 .sully-chat-* / .sully-bubble-* / .sully-schedule-change* 选择器及其后代/伪元素，禁止写 body、*、div、html 这类全局选择器（会污染其它界面）。
 3. 这是移动端窄屏（宽约 390px），尺寸请克制、用相对单位或小数值。
 4. 顶栏顶部已自动留出状态栏安全区。装饰若要贴最顶部，用 top: calc(var(--safe-top) + 数值)。
 5. 不要 display:none 掉 .sully-chat-back（否则用户无法返回），除非我明确要求。
@@ -453,6 +458,9 @@ const ChromeCssEditor: React.FC<{ value: string; onChange: (css: string) => void
                 />
                 <div className="mt-1.5 text-[10px] leading-relaxed text-slate-400">
                     可用选择器：<code className="rounded bg-slate-100 px-1 text-slate-500">.sully-chat-header / -avatar / -name / -buffs / -token / -trigger / -back / -status / -inputbar / -panel / -root</code>
+                </div>
+                <div className="mt-1 text-[10px] leading-relaxed text-slate-400">
+                    日程修改动效：<code className="rounded bg-slate-100 px-1 text-slate-500">.sully-schedule-change / -head / -mark / -kicker / -list / -row / -time / -before / -arrow / -after / -shine</code>
                 </div>
             </div>
         </div>

--- a/components/chat/MessageItem.tsx
+++ b/components/chat/MessageItem.tsx
@@ -9,6 +9,7 @@ import { VALID_INTERJECTION_TAGS, cleanVoiceMarkupForDisplay } from '../../utils
 import { stripFishCuesForDisplay } from '../../utils/fishAudioTts';
 import { formatStatCount } from '../../utils/videoParser';
 import { trackEvent } from '../../utils/analytics';
+import { resolveBubbleCornerRadii, shouldHideBubbleTail } from '../../utils/bubbleAppearance';
 import McdCard from './McdCard';
 import HtmlCard from './HtmlCard';
 import LuckinCard from './LuckinCard';
@@ -3296,8 +3297,19 @@ const MessageItem = React.memo(({
     }
 
     // --- Dynamic Style Generation for Bubble ---
-    const radius = styleConfig.borderRadius;
-    const borderObj: React.CSSProperties = { borderRadius: `${radius}px` };
+    const cornerRadii = resolveBubbleCornerRadii(styleConfig);
+    const borderObj: React.CSSProperties = {
+        borderTopLeftRadius: `${cornerRadii.topLeft}px`,
+        borderTopRightRadius: `${cornerRadii.topRight}px`,
+        borderBottomRightRadius: `${cornerRadii.bottomRight}px`,
+        borderBottomLeftRadius: `${cornerRadii.bottomLeft}px`,
+    };
+    const hideBubbleTail = shouldHideBubbleTail(styleConfig.tailMode, isLastInGroup);
+    const bubbleGroupClasses = [
+        isFirstInGroup ? 'sully-bubble-group-first' : '',
+        isLastInGroup ? 'sully-bubble-group-last' : '',
+        hideBubbleTail ? 'sully-bubble-tail-hidden' : 'sully-bubble-tail-visible',
+    ].filter(Boolean).join(' ');
 
     // Container style (BackgroundColor + Opacity) with bubble variant
     const containerStyle: React.CSSProperties = {
@@ -3480,7 +3492,7 @@ const MessageItem = React.memo(({
     return commonLayout(
         <div className={isVoiceOnlyMsg
             ? `relative ${suppressEntranceAnimation ? '' : 'animate-fade-in'}`
-            : `relative ${bubbleVariant === 'flat' || bubbleVariant === 'outline' || bubbleVariant === 'wechat' ? '' : 'shadow-sm '}px-5 py-3 ${suppressEntranceAnimation ? '' : 'animate-fade-in'} ${bubbleVariant === 'outline' ? '' : 'border border-black/5 '}active:scale-[0.98] transition-transform overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'}`}
+            : `relative ${bubbleVariant === 'flat' || bubbleVariant === 'outline' || bubbleVariant === 'wechat' ? '' : 'shadow-sm '}px-5 py-3 ${suppressEntranceAnimation ? '' : 'animate-fade-in'} ${bubbleVariant === 'outline' ? '' : 'border border-black/5 '}active:scale-[0.98] transition-transform overflow-visible ${isUser ? 'sully-bubble-user' : 'sully-bubble-ai'} ${bubbleGroupClasses}`}
             style={isVoiceOnlyMsg ? undefined : containerStyle}>
 
             {/* Layer 1: Background Image with Independent Opacity */}
@@ -3562,12 +3574,12 @@ const MessageItem = React.memo(({
                 // 外语语音消息顶部正文已隐藏（交给语音条渲染），同样按纯语音处理，去掉多余上间距。
                 const isVoiceOnly = !!voiceData?.url && (!displayContent || isForeignVoiceMsg);
                 return (
-                <div className={`relative z-10 ${isVoiceOnly ? '' : 'mt-2.5'}`}>
+                <div className={`sully-voice-bar-shell relative z-10 ${isVoiceOnly ? '' : 'mt-2.5'}`}>
                     {voiceData?.url ? (
                         <div className="max-w-[260px]">
                             <button
                                 onClick={(e) => { e.stopPropagation(); e.preventDefault(); onPlayVoice?.(m.id); if (!isVoicePlaying) trackEvent('播放语音条'); }}
-                                className="group flex items-center gap-2.5 w-full px-3 py-2 rounded-2xl transition-all duration-300 active:scale-[0.97] select-none"
+                                className="sully-voice-bar group flex items-center gap-2.5 w-full px-3 py-2 rounded-2xl transition-all duration-300 active:scale-[0.97] select-none"
                                 style={{
                                     background: isVoicePlaying
                                         ? (vbActiveBg || 'linear-gradient(135deg, rgba(16,185,129,0.12) 0%, rgba(52,211,153,0.08) 100%)')
@@ -3578,7 +3590,7 @@ const MessageItem = React.memo(({
                                 }}
                             >
                                 {/* Play/Pause circle */}
-                                <div className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-300"
+                                <div className="sully-voice-bar-button shrink-0 w-7 h-7 rounded-full flex items-center justify-center transition-all duration-300"
                                     style={{
                                         backgroundColor: isVoicePlaying ? (vbBtn || '#10b981') : (vbBg ? 'rgba(255,255,255,0.25)' : 'rgba(148,163,184,0.2)'),
                                         boxShadow: isVoicePlaying ? `0 2px 8px ${vbBtn ? vbBtn + '4D' : 'rgba(16,185,129,0.3)'}` : 'none',
@@ -3591,11 +3603,11 @@ const MessageItem = React.memo(({
                                     )}
                                 </div>
                                 {/* Waveform bars */}
-                                <div className="flex-1 flex items-center gap-[3px] h-5 overflow-hidden">
+                                <div className="sully-voice-bar-wave flex-1 flex items-center gap-[3px] h-5 overflow-hidden">
                                     {[4, 10, 6, 14, 8, 12, 5, 11, 7, 13, 4, 9, 6, 11, 5, 8, 10, 7, 12, 6].map((h, i) => (
                                         <div
                                             key={i}
-                                            className={`w-[2.5px] rounded-full transition-all duration-150 ${isVoicePlaying ? 'animate-pulse' : ''}`}
+                                            className={`sully-voice-bar-wave-segment w-[2.5px] rounded-full transition-all duration-150 ${isVoicePlaying ? 'animate-pulse' : ''}`}
                                             style={{
                                                 height: isVoicePlaying ? `${Math.max(3, h + Math.sin(i * 0.8) * 3)}px` : `${Math.max(2, h * 0.4)}px`,
                                                 backgroundColor: isVoicePlaying
@@ -3609,7 +3621,7 @@ const MessageItem = React.memo(({
                                 </div>
                                 {/* Text toggle button — always available so user can read the text */}
                                 <div
-                                    className={`shrink-0 ml-0.5 px-1.5 py-0.5 rounded-lg text-[9px] font-medium transition-all ${showVoiceText ? 'ring-1 ring-current/20' : ''}`}
+                                    className={`sully-voice-bar-toggle shrink-0 ml-0.5 px-1.5 py-0.5 rounded-lg text-[9px] font-medium transition-all ${showVoiceText ? 'ring-1 ring-current/20' : ''}`}
                                     style={{
                                         color: vbText || 'rgba(100,116,139,0.7)',
                                         backgroundColor: showVoiceText ? 'rgba(0,0,0,0.08)' : 'rgba(0,0,0,0.04)',
@@ -3627,7 +3639,7 @@ const MessageItem = React.memo(({
                             {/* Expandable text area — shows spoken text + Chinese translation */}
                             {showVoiceText && (
                                 <div>
-                                    <div className="mt-1.5 px-3 py-2 rounded-xl text-[11px] leading-relaxed space-y-1"
+                                    <div className="sully-voice-bar-transcript mt-1.5 px-3 py-2 rounded-xl text-[11px] leading-relaxed space-y-1"
                                         style={{
                                             backgroundColor: vbBg || 'rgba(0,0,0,0.02)',
                                             color: vbText || '#475569',
@@ -3668,7 +3680,7 @@ const MessageItem = React.memo(({
                             )}
                         </div>
                     ) : voiceLoading ? (
-                        <div className="flex items-center gap-2 px-3 py-2 max-w-[200px] rounded-2xl" style={{ background: vbBg || 'linear-gradient(135deg, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0.04) 100%)', border: '1px solid rgba(0,0,0,0.04)' }}>
+                        <div className="sully-voice-bar sully-voice-bar-loading flex items-center gap-2 px-3 py-2 max-w-[200px] rounded-2xl" style={{ background: vbBg || 'linear-gradient(135deg, rgba(0,0,0,0.02) 0%, rgba(0,0,0,0.04) 100%)', border: '1px solid rgba(0,0,0,0.04)' }}>
                             <div className="shrink-0 w-7 h-7 rounded-full flex items-center justify-center" style={{ backgroundColor: vbBg ? 'rgba(255,255,255,0.2)' : '#f1f5f9' }}>
                                 <svg className="animate-spin h-3.5 w-3.5" style={{ color: vbBtn || '#94a3b8' }} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3.5"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
                             </div>
@@ -3686,7 +3698,7 @@ const MessageItem = React.memo(({
                            aligning fake voice messages with real ones. */
                         <div className="max-w-[260px]">
                             <div
-                                className="flex items-center gap-2 px-3 py-2 rounded-2xl"
+                                className="sully-voice-bar sully-voice-bar-placeholder flex items-center gap-2 px-3 py-2 rounded-2xl"
                                 style={{ background: vbBg || 'linear-gradient(135deg, rgba(0,0,0,0.03) 0%, rgba(0,0,0,0.06) 100%)', border: '1px solid rgba(0,0,0,0.05)' }}
                             >
                                 <button
@@ -3717,7 +3729,7 @@ const MessageItem = React.memo(({
                                 )}
                             </div>
                             {showVoiceText && (voiceTagText || displayContent) && (
-                                <div className="mt-1.5 px-3 py-2 rounded-xl text-[11px] leading-relaxed whitespace-pre-wrap"
+                                <div className="sully-voice-bar-transcript mt-1.5 px-3 py-2 rounded-xl text-[11px] leading-relaxed whitespace-pre-wrap"
                                     style={{
                                         backgroundColor: vbBg || 'rgba(0,0,0,0.02)',
                                         color: vbText || '#475569',

--- a/components/chat/ScheduleChangeNotice.tsx
+++ b/components/chat/ScheduleChangeNotice.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+import type { ScheduleChangeEventDetail } from '../../utils/scheduleChange';
+
+interface ScheduleChangeNoticeProps {
+    detail: ScheduleChangeEventDetail;
+    onDone: () => void;
+}
+
+/** ChatApp 顶部短暂浮出的日程修订回执；全部零件都有稳定白框 CSS 钩子。 */
+const ScheduleChangeNotice: React.FC<ScheduleChangeNoticeProps> = ({ detail, onDone }) => {
+    useEffect(() => {
+        const timer = window.setTimeout(onDone, 4300);
+        return () => window.clearTimeout(timer);
+    }, [detail.eventId, onDone]);
+
+    return (
+        <>
+            <style>{`
+                @keyframes sullyScheduleChangeInOut {
+                    0% { opacity:0; transform:translate3d(-50%,-14px,0) scale(.96); }
+                    11%,82% { opacity:1; transform:translate3d(-50%,0,0) scale(1); }
+                    100% { opacity:0; transform:translate3d(-50%,-6px,0) scale(.985); }
+                }
+                @keyframes sullyScheduleChangeShine {
+                    0%,14% { transform:translateX(-130%) skewX(-18deg); opacity:0; }
+                    28% { opacity:.7; }
+                    45%,100% { transform:translateX(240%) skewX(-18deg); opacity:0; }
+                }
+                :where(.sully-schedule-change) {
+                    position:absolute; z-index:185; top:calc(var(--safe-top) + 66px); left:50%;
+                    width:min(340px,calc(100% - 28px)); overflow:hidden; pointer-events:none;
+                    padding:11px 13px 12px; border:1px solid rgba(255,255,255,.78); border-radius:18px;
+                    color:#243047; background:rgba(255,255,255,.92);
+                    box-shadow:0 14px 34px -18px rgba(15,23,42,.48),0 0 0 1px hsla(var(--primary-hue),70%,55%,.10);
+                    backdrop-filter:blur(14px); animation:sullyScheduleChangeInOut 4.2s cubic-bezier(.2,.8,.2,1) both;
+                }
+                :where(.sully-schedule-change-head) { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
+                :where(.sully-schedule-change-mark) {
+                    display:grid; place-items:center; width:23px; height:23px; flex:none; border-radius:8px;
+                    color:white; background:hsla(var(--primary-hue),68%,54%,1); font-size:12px; font-weight:900;
+                    box-shadow:0 5px 12px -7px hsla(var(--primary-hue),75%,35%,.8);
+                }
+                :where(.sully-schedule-change-kicker) { font-size:11px; font-weight:750; letter-spacing:.08em; }
+                :where(.sully-schedule-change-count) { margin-left:auto; color:#94a3b8; font-size:9px; }
+                :where(.sully-schedule-change-list) { display:grid; gap:6px; }
+                :where(.sully-schedule-change-row) {
+                    display:grid; grid-template-columns:40px minmax(0,1fr) 15px minmax(0,1.15fr); align-items:center; gap:5px;
+                    min-height:27px; padding:5px 7px; border-radius:11px; background:hsla(var(--primary-hue),72%,55%,.065);
+                }
+                :where(.sully-schedule-change-time) { color:hsla(var(--primary-hue),55%,42%,1); font-size:10px; font-weight:800; }
+                :where(.sully-schedule-change-before), :where(.sully-schedule-change-after) {
+                    overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:11px;
+                }
+                :where(.sully-schedule-change-before) { color:#94a3b8; text-decoration:line-through; text-decoration-thickness:1px; }
+                :where(.sully-schedule-change-arrow) { color:hsla(var(--primary-hue),62%,52%,.72); text-align:center; font-size:11px; }
+                :where(.sully-schedule-change-after) { color:#334155; font-weight:760; }
+                :where(.sully-schedule-change-shine) {
+                    position:absolute; inset:-30% auto -30% -22%; width:18%; pointer-events:none;
+                    background:linear-gradient(90deg,transparent,rgba(255,255,255,.72),transparent);
+                    animation:sullyScheduleChangeShine 2.4s ease-out both;
+                }
+                @media (prefers-reduced-motion: reduce) {
+                    :where(.sully-schedule-change) { animation:none; }
+                    :where(.sully-schedule-change-shine) { display:none; animation:none; }
+                }
+            `}</style>
+            <div className="sully-schedule-change" role="status" aria-live="polite" aria-label="未来日程已调整">
+                <div className="sully-schedule-change-shine" aria-hidden="true" />
+                <div className="sully-schedule-change-head">
+                    <span className="sully-schedule-change-mark" aria-hidden="true">✓</span>
+                    <span className="sully-schedule-change-kicker">未来日程已调整</span>
+                    {detail.changes.length > 1 && (
+                        <span className="sully-schedule-change-count">{detail.changes.length} 项</span>
+                    )}
+                </div>
+                <div className="sully-schedule-change-list">
+                    {detail.changes.slice(0, 3).map((change) => (
+                        <div className="sully-schedule-change-row" key={change.startTime}>
+                            <span className="sully-schedule-change-time">{change.startTime}</span>
+                            <span className="sully-schedule-change-before">{change.before}</span>
+                            <span className="sully-schedule-change-arrow" aria-hidden="true">→</span>
+                            <span className="sully-schedule-change-after">{change.after}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default ScheduleChangeNotice;

--- a/hooks/useChatAI.ts
+++ b/hooks/useChatAI.ts
@@ -52,6 +52,7 @@ import { INSTANT_TOTAL_TIMEOUT_MS } from '../worker/amsg/src/instantChat';
 import { appendInstantTraceEntry } from '../utils/instantTraceLog';
 import { AMSG2_TOOLS, AMSG2_TOOL_NAMES, createAmsg2ToolSession, executeAmsg2Tool, isAmsg2GlobalReady } from '../utils/amsg2ToolBridge';
 import { shouldSendThinkingParams } from '../utils/thinkingGate';
+import { buildClaudeProxyCompatibilityBody, shouldRetryClaudeProxyCompatibility } from '../utils/claudeProxyCompat';
 import { routeMiniAppToolCall } from '../utils/miniAppToolRoute';
 import { applyEmotionEvalRaw, extractAssistantText } from '../utils/emotionApply';
 import { announceChatGen, CHAT_GEN_EVENTS } from '../utils/chatGenEvents';
@@ -1467,12 +1468,38 @@ export const useChatAI = ({
                     body: JSON.stringify({ ...baseReqBody, messages: withAmsg2TaskContext(baseReqBody.messages) })
                 }, 2, 0, { appName: '消息', charId: char.id, charName: char.name, purpose: '聊天回复' }, streamHooks);
             } catch (e) {
+                let requestError: unknown = e;
+                const attemptedBody = {
+                    ...baseReqBody,
+                    messages: withAmsg2TaskContext(baseReqBody.messages),
+                };
+                // 部分第三方 OpenAI→Claude 中转会把请求形状不兼容包装成 502
+                // bad_response_status_code：thinking 三种方言、tools、尾部 system 单独都能收，
+                // 组合在一起却在上游适配层失败。只对这一条高度特征化的 502 降级一次：
+                // tools 和正文完整保留，system 合到开头，thinking 参数让步。普通网络 502、
+                // 非 Claude、没工具的请求一律不重发，避免无依据地重复计费。
+                if (shouldRetryClaudeProxyCompatibility(requestError, attemptedBody)) {
+                    console.warn('🧩 [Claude compat] 中转拒绝 thinking + tools 组合，使用兼容请求体重试一次');
+                    try {
+                        data = await safeFetchJson(`${baseUrl}/chat/completions`, {
+                            method: 'POST', headers,
+                            body: JSON.stringify(buildClaudeProxyCompatibilityBody(attemptedBody)),
+                        }, 0, 0, { appName: '消息', charId: char.id, charName: char.name, purpose: 'Claude 中转兼容重试' }, streamHooks);
+                        requestError = null;
+                    } catch (compatError) {
+                        requestError = compatError;
+                    }
+                }
+
+                if (!requestError) {
+                    // Claude 兼容重试已成功，继续走下方统一后处理。
+                } else {
                 // 仅通用 MCP、且没有和其他工具模式混用时降级。部分 OpenAI 兼容中转
                 // 会对携带 tools 的请求直接回 4xx，而不是忽略参数；去掉 tools 后让
                 // 现有正文假调用容错接手。真实鉴权失败会在这次重试中再次抛出原样错误。
                 const mcpOnly = payload.flags.mcpChatActive
                     && !payload.flags.luckinChatActive && !payload.flags.mcdActive && !payload.flags.luckinActive;
-                if (!mcpOnly || !baseReqBody.tools?.length || !shouldRetryMcpWithoutTools(e)) throw e;
+                if (!mcpOnly || !baseReqBody.tools?.length || !shouldRetryMcpWithoutTools(requestError)) throw requestError;
                 console.warn('🔌 [MCP] 当前中转拒绝 tools 请求，降级为正文工具调用兼容模式');
                 // 这条路把 tools 全删了，角色排不了新任务；排程现状照样要带——它得知道
                 // 自己名下已经有哪些承诺，否则又会在正文里许一遍。
@@ -1484,6 +1511,7 @@ export const useChatAI = ({
                     method: 'POST', headers,
                     body: JSON.stringify(fallbackBody)
                 }, 0, 0, { appName: '消息', charId: char.id, charName: char.name, purpose: 'MCP tools 兼容重试' });
+                }
             }
             console.log(`⏱ [API call] ${Math.round(performance.now() - apiT0)}ms`);
             updateTokenUsage(data, historyMsgCount, 'initial');
@@ -1947,6 +1975,7 @@ export const useChatAI = ({
                 userProfile,
                 emojis,
                 realtimeConfig,
+                groups,
                 contextMsgs,
                 fullMessages,
                 initialData: data,

--- a/types.ts
+++ b/types.ts
@@ -98,6 +98,12 @@ export interface OSTheme {
   lockWallpaper?: string;
   darkMode: boolean;
   contentColor?: string;
+  /** 冷启动时是否播放整机开机过场。默认开启（undefined 视为 true）。 */
+  bootAnimationEnabled?: boolean;
+  /** 进入聊天或切换角色时是否播放角色登场过场。默认开启。 */
+  chatCharacterSwitchAnimationEnabled?: boolean;
+  /** App 代码块加载较慢时是否显示加载柔光动画。默认开启；卡死恢复页不受影响。 */
+  appLoadingAnimationEnabled?: boolean;
   /** 桌面整体皮肤。'animalcrossing' = 动森风格（NookPhone 彩色圆角图标 + 暖色界面）；
    *  'mobilegame' = 二次元手游首页风格（角色卡 + 等级经验条 + 货币栏 + 网格卡 + 罗盘 dock）；
    *  'tamagotchi' = 电子宠物养成机（桌面即角色的小屋舞台 + 四颗糖果实体键）。默认 'default'。 */
@@ -786,6 +792,13 @@ export interface BubbleStyle {
     backgroundImage?: string;
     backgroundImageOpacity?: number;
     borderRadius: number;
+    /** 四角独立圆角；未设置的角继续跟随 borderRadius，兼容旧主题。 */
+    borderTopLeftRadius?: number;
+    borderTopRightRadius?: number;
+    borderBottomRightRadius?: number;
+    borderBottomLeftRadius?: number;
+    /** 自定义 CSS 伪元素尾巴的出现频率。旧主题缺省为 every，新建主题默认 last。 */
+    tailMode?: 'every' | 'last' | 'none';
     opacity: number;
     
     decoration?: string;

--- a/utils/applyAssistantPostProcessing.ts
+++ b/utils/applyAssistantPostProcessing.ts
@@ -25,7 +25,7 @@
  * Phase 2 会让 worker 端把识别出的副作用 (RECALL/SEARCH/...) 结构化传 directives, 这里只重放。
  */
 
-import { CharacterProfile, UserProfile, Message, Emoji, RealtimeConfig } from '../types';
+import { CharacterProfile, UserProfile, Message, Emoji, RealtimeConfig, GroupProfile } from '../types';
 import { DB } from './db';
 import { ChatParser, type FrozenMusicSong } from './chatParser';
 import { resolveCharTimeZone } from './timezone';
@@ -51,6 +51,8 @@ import {
 } from './agenticTools';
 import { getLocalDateKey } from './localDate';
 import { normalizeAssistantActionFormatting } from './assistantActionFormat';
+import { markAmsgStateDirty } from './amsgStateSync';
+import { announceScheduleChanges, applyAssistantScheduleChanges } from './scheduleChange';
 
 // ─── 模块内辅助 ──────────────────────────────────────────────────────────────
 
@@ -197,6 +199,7 @@ export type PostProcessDirective =
     | { type: 'transfer_accept' }
     | { type: 'transfer_return' }
     | { type: 'add_event'; title: string; date: string }
+    | { type: 'change_schedule'; time: string; activity: string }
     | { type: 'schedule_message'; time: string; text: string }
     // song 是主动消息 2.0 的定时路径后补的「角色说的是哪首歌」（见 chatParser 的
     // FrozenMusicSong）；标签里只有歌单名带不动它，所以单独走 directive 字段。
@@ -247,6 +250,9 @@ function reconstructDirectiveTags(directives: PostProcessDirective[] | undefined
                 break;
             case 'add_event':
                 parts.push(`[[ACTION:ADD_EVENT|${d.title}|${d.date}]]`);
+                break;
+            case 'change_schedule':
+                parts.push(`[[ACTION:CHANGE_SCHEDULE|${d.time}|${d.activity}]]`);
                 break;
             case 'schedule_message':
                 parts.push(`[schedule_message | ${d.time} | fixed | ${d.text}]`);
@@ -359,6 +365,8 @@ export interface PostProcessCtx {
     userProfile: UserProfile;
     emojis: Emoji[];
     realtimeConfig?: RealtimeConfig;
+    /** 日程被角色改写后刷新主动消息 fire_pack；旧调用方可不传。 */
+    groups?: GroupProfile[];
     /** 上下文消息窗 — 用来匹配 quote 目标 */
     contextMsgs: Message[];
     /** 发给 API 的完整 messages 数组 — 2nd-pass LLM 调用要带上 */
@@ -438,6 +446,7 @@ export async function applyAssistantPostProcessing(
         userProfile,
         emojis,
         realtimeConfig,
+        groups,
         contextMsgs,
         fullMessages,
         initialData,
@@ -536,9 +545,32 @@ export async function applyAssistantPostProcessing(
     // 局部 data 副本 — 后续 2nd-pass 会覆盖, 模仿旧版的 let data 行为
     let data: any = initialData;
 
+    let scheduleFailureNotified = false;
+    const consumeScheduleChanges = async (content: string): Promise<string> => {
+        const result = await applyAssistantScheduleChanges(content, char);
+        if (result.changes.length > 0 && result.schedule) {
+            if (realtimeConfig) {
+                // 本地聊天直接复用 caller 的 groups；主动消息路径只在真的改了日程时读一次，
+                // 不给每一条普通 push 平添 IndexedDB 查询和新的失败点。
+                const syncGroups = groups ?? await DB.getGroups().catch(() => undefined);
+                if (syncGroups) markAmsgStateDirty({ char, userProfile, groups: syncGroups, realtimeConfig });
+            }
+            announceScheduleChanges(char.id, result.schedule, result.changes);
+        }
+        if (!scheduleFailureNotified
+            && result.changes.length === 0
+            && (result.malformedCount > 0 || result.rejectedCount > 0)) {
+            scheduleFailureNotified = true;
+            addToast('日程修改没有匹配到未来时段，已安全跳过', 'info');
+        }
+        return result.cleanedText;
+    };
+
     // ─── Step 1: 初次粗洗 ───
     let aiContent = replayedTagPrefix ? `${replayedTagPrefix}${rawAiContent}` : rawAiContent;
     aiContent = normalizeAiContent(aiContent);
+    // 先于 lead-in / 二轮渲染消费：否则控制标签会作为普通气泡短暂闪给用户看。
+    aiContent = await consumeScheduleChanges(aiContent);
     // 在任何 lead-in/二轮渲染之前先剥掉仿卡片文本，防止它被 chunkText 拆成灰色普通气泡。
     const mimickedXhsShares = extractMimickedXhsShares(aiContent);
     aiContent = mimickedXhsShares.cleanedContent;
@@ -2005,6 +2037,10 @@ export async function applyAssistantPostProcessing(
         setXhsStatus('');
     }
     aiContent = aiContent.replace(/\[\[XHS_POST:.*?\]\]/gs, '').trim();
+
+    // 二轮 LLM 可能新产生日程标签；在统一动作解析前再消费一次。首次那条已经从 aiContent
+    // 剥掉且写入幂等（同活动不重复），因此普通单轮回复不会重放副作用。
+    aiContent = await consumeScheduleChanges(aiContent);
 
     // ─── Step 3: ChatParser.parseAndExecuteActions ───
     // mcdInheritMeta 一起传下去：戳一戳 / 转账卡 / 音乐卡 / 新闻卡 / 日程系统提示 / 生活记录卡

--- a/utils/bubbleAppearance.test.ts
+++ b/utils/bubbleAppearance.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBubbleCornerRadii, shouldHideBubbleTail } from './bubbleAppearance';
+
+describe('bubble appearance compatibility', () => {
+  it('keeps old themes on one shared radius', () => {
+    expect(resolveBubbleCornerRadii({ borderRadius: 18 })).toEqual({
+      topLeft: 18,
+      topRight: 18,
+      bottomRight: 18,
+      bottomLeft: 18,
+    });
+  });
+
+  it('allows every corner to override the shared radius independently', () => {
+    expect(resolveBubbleCornerRadii({
+      borderRadius: 12,
+      borderTopLeftRadius: 24,
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 6,
+      borderBottomLeftRadius: 2,
+    })).toEqual({ topLeft: 24, topRight: 0, bottomRight: 6, bottomLeft: 2 });
+  });
+
+  it('supports every, group-last and hidden tail modes', () => {
+    expect(shouldHideBubbleTail(undefined, false)).toBe(false);
+    expect(shouldHideBubbleTail('every', false)).toBe(false);
+    expect(shouldHideBubbleTail('last', false)).toBe(true);
+    expect(shouldHideBubbleTail('last', true)).toBe(false);
+    expect(shouldHideBubbleTail('none', true)).toBe(true);
+  });
+});

--- a/utils/bubbleAppearance.ts
+++ b/utils/bubbleAppearance.ts
@@ -1,0 +1,37 @@
+import type { BubbleStyle } from '../types';
+
+export interface BubbleCornerRadii {
+  topLeft: number;
+  topRight: number;
+  bottomRight: number;
+  bottomLeft: number;
+}
+
+const finiteRadius = (value: unknown, fallback: number): number => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, numeric) : fallback;
+};
+
+/** Resolve four-corner values while keeping every pre-existing theme compatible. */
+export const resolveBubbleCornerRadii = (
+  style: Pick<BubbleStyle,
+    'borderRadius' | 'borderTopLeftRadius' | 'borderTopRightRadius' |
+    'borderBottomRightRadius' | 'borderBottomLeftRadius'>,
+): BubbleCornerRadii => {
+  const base = finiteRadius(style.borderRadius, 20);
+  return {
+    topLeft: finiteRadius(style.borderTopLeftRadius, base),
+    topRight: finiteRadius(style.borderTopRightRadius, base),
+    bottomRight: finiteRadius(style.borderBottomRightRadius, base),
+    bottomLeft: finiteRadius(style.borderBottomLeftRadius, base),
+  };
+};
+
+/**
+ * Existing themes had no tail setting, so undefined intentionally keeps the old
+ * "every bubble" behaviour. Newly-created themes explicitly opt into `last`.
+ */
+export const shouldHideBubbleTail = (
+  mode: BubbleStyle['tailMode'],
+  isLastInGroup: boolean,
+): boolean => mode === 'none' || (mode === 'last' && !isLastInGroup);

--- a/utils/callAppRuntimeReferences.test.ts
+++ b/utils/callAppRuntimeReferences.test.ts
@@ -56,7 +56,9 @@ describe('CallApp runtime references', () => {
     expect(source).toContain('idleNudgeCountRef');
     expect(source).toContain('电话刚接通。你先开口');
     expect(source).toContain('callPreferences.characterInitiative');
+    expect(source).toContain('callPreferences.idleNudgeEnabled');
     expect(preferenceSource).toContain('characterInitiative: true');
+    expect(preferenceSource).toContain('idleNudgeEnabled: false');
     expect(preferenceSheetSource).toContain('谁先开口');
     expect(preferenceSheetSource).toContain('对方先说');
     expect(preferenceSheetSource).toContain('我先说');
@@ -78,7 +80,7 @@ describe('CallApp runtime references', () => {
     expect(source).toContain('shouldKeepNativeCallAudio');
     expect(source).not.toContain('<audio');
     expect(preferenceSheetSource).toContain('不改变聊天页的语音设置');
-    expect(preferenceSheetSource).toContain('关掉后，点“播放语音”时才会生成并播放');
+    expect(preferenceSheetSource).toContain('语音和视频通话都只在你点“播放语音”时才生成');
   });
 
   it('announces the call update once and spotlights the lower-left preferences entry', () => {
@@ -89,13 +91,13 @@ describe('CallApp runtime references', () => {
     expect(source).toContain('useState(shouldShowCallUpdateAnnouncement)');
     expect(source).toContain('markCallUpdateAnnouncementSeen()');
     expect(source).toContain('data-testid="call-preferences-entry"');
-    expect(preferenceSource).toContain("CALL_UPDATE_ANNOUNCEMENT_KEY = 'sully-call-update-audio-2026-08-v1'");
+    expect(preferenceSource).toContain("CALL_UPDATE_ANNOUNCEMENT_KEY = 'sully-call-update-preferences-2026-08-v2'");
     expect(announcementSource).toContain('data-testid="call-update-announcement"');
     expect(announcementSource).toContain('data-testid="call-settings-spotlight"');
-    expect(announcementSource).toContain('通话有些调整');
+    expect(announcementSource).toContain('通话偏好现在有三项');
     expect(announcementSource).toContain('可以设置谁先开口');
-    expect(announcementSource).toContain('关掉后不会提前生成语音');
-    expect(announcementSource).toContain('修了 iPhone 没声音的问题');
+    expect(announcementSource).toContain('两种通话都不会提前生成语音');
+    expect(announcementSource).toContain('沉默后主动接话改为按需开启');
   });
 
   it('offers game-like video layouts and a collapsible immersive subtitle', () => {

--- a/utils/callPreferences.test.ts
+++ b/utils/callPreferences.test.ts
@@ -10,19 +10,26 @@ import {
 afterEach(() => vi.unstubAllGlobals());
 
 describe('call preferences', () => {
-  it('defaults both call behaviors on for existing users', () => {
+  it('keeps voice/opening defaults on but makes idle follow-ups opt-in', () => {
     expect(parseCallPreferences(null)).toEqual(DEFAULT_CALL_PREFERENCES);
     expect(parseCallPreferences('{broken')).toEqual(DEFAULT_CALL_PREFERENCES);
   });
 
-  it('persists initiative and autoplay independently', () => {
+  it('persists all three preferences independently and migrates old storage safely', () => {
     expect(parseCallPreferences(JSON.stringify({ characterInitiative: false }))).toEqual({
       characterInitiative: false,
       voiceAutoPlay: true,
+      idleNudgeEnabled: false,
     });
     expect(parseCallPreferences(JSON.stringify({ voiceAutoPlay: false }))).toEqual({
       characterInitiative: true,
       voiceAutoPlay: false,
+      idleNudgeEnabled: false,
+    });
+    expect(parseCallPreferences(JSON.stringify({ idleNudgeEnabled: true }))).toEqual({
+      characterInitiative: true,
+      voiceAutoPlay: true,
+      idleNudgeEnabled: true,
     });
   });
 

--- a/utils/callPreferences.ts
+++ b/utils/callPreferences.ts
@@ -1,14 +1,17 @@
 export interface CallPreferences {
   characterInitiative: boolean;
   voiceAutoPlay: boolean;
+  /** 通话进行中长时间无人说话时，是否允许角色主动接话。显式按需开启。 */
+  idleNudgeEnabled: boolean;
 }
 
 export const CALL_PREFERENCES_KEY = 'sully-call-preferences-v1';
-export const CALL_UPDATE_ANNOUNCEMENT_KEY = 'sully-call-update-audio-2026-08-v1';
+export const CALL_UPDATE_ANNOUNCEMENT_KEY = 'sully-call-update-preferences-2026-08-v2';
 
 export const DEFAULT_CALL_PREFERENCES: CallPreferences = {
   characterInitiative: true,
   voiceAutoPlay: true,
+  idleNudgeEnabled: false,
 };
 
 export const parseCallPreferences = (raw: string | null | undefined): CallPreferences => {
@@ -18,6 +21,7 @@ export const parseCallPreferences = (raw: string | null | undefined): CallPrefer
     return {
       characterInitiative: parsed?.characterInitiative !== false,
       voiceAutoPlay: parsed?.voiceAutoPlay !== false,
+      idleNudgeEnabled: parsed?.idleNudgeEnabled === true,
     };
   } catch {
     return { ...DEFAULT_CALL_PREFERENCES };

--- a/utils/chatModeTransition.test.ts
+++ b/utils/chatModeTransition.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Message } from '../types';
+import { buildChatRequestPayload } from './chatRequestPayload';
+import { detectChatModeTransition } from './chatPrompts';
+
+const message = (
+    id: number,
+    role: Message['role'],
+    source?: string,
+    metadata: Record<string, unknown> = {},
+): Message => ({
+    id,
+    charId: 'char-return',
+    role,
+    type: role === 'system' ? 'system' : 'text',
+    content: `message-${id}`,
+    timestamp: id,
+    metadata: source ? { source, ...metadata } : metadata,
+} as Message);
+
+describe('detectChatModeTransition', () => {
+    it.each([
+        ['call', message(2, 'assistant', 'call'), 'call'],
+        ['video', message(2, 'assistant', 'call', { callMode: 'video' }), 'video'],
+        ['date', message(2, 'assistant', 'date'), 'date'],
+        ['story', message(2, 'assistant', 'story_theater_memory'), 'story'],
+    ] as const)('识别从 %s 回到 ChatApp 的第一轮', (_label, modeMessage, expected) => {
+        expect(detectChatModeTransition([
+            message(1, 'assistant'),
+            modeMessage,
+            message(3, 'user'),
+        ])).toBe(expected);
+    });
+
+    it('用户连续发送多个气泡时仍能越过它们找到刚结束的模式', () => {
+        expect(detectChatModeTransition([
+            message(1, 'assistant'),
+            message(2, 'assistant', 'date'),
+            message(3, 'system'),
+            message(4, 'user'),
+            message(5, 'user'),
+        ])).toBe('date');
+    });
+
+    it('已经产生普通 ChatApp assistant 回复后不再重复提醒', () => {
+        expect(detectChatModeTransition([
+            message(1, 'assistant', 'story_theater_memory'),
+            message(2, 'user'),
+            message(3, 'assistant'),
+            message(4, 'user'),
+        ])).toBeNull();
+    });
+
+    it('特殊模式之后还没有新的 ChatApp 用户输入时不误报', () => {
+        expect(detectChatModeTransition([
+            message(1, 'assistant'),
+            message(2, 'assistant', 'call'),
+            message(3, 'system', 'call-end-popup'),
+        ])).toBeNull();
+    });
+});
+
+describe('buildChatRequestPayload 模式切换接线', () => {
+    it('即使 recentMsgsHint 已过滤通话记录，也按完整 API 历史注入视频转文字提醒', async () => {
+        const historyMsgs = [
+            message(1, 'assistant'),
+            message(2, 'assistant', 'call', { callMode: 'video' }),
+            message(3, 'system', 'call-end-popup', { callMode: 'video' }),
+            message(4, 'user'),
+        ];
+        const payload = await buildChatRequestPayload({
+            char: {
+                id: 'char-return',
+                name: '阿一',
+                timeAwarenessEnabled: false,
+                scheduleFeatureEnabled: false,
+            } as any,
+            userProfile: { name: '小明' } as any,
+            groups: [],
+            emojis: [],
+            categories: [],
+            historyMsgs,
+            // 模拟 Chat.tsx 的可见消息：call / call-end-popup 均不在这份 React state 中。
+            recentMsgsHint: [message(1, 'assistant'), message(4, 'user')],
+            contextLimit: 20,
+            realtimeConfig: { weatherEnabled: false, newsEnabled: false } as any,
+        });
+
+        const joined = payload.fullMessages.map(item => String(item.content || '')).join('\n');
+        expect(joined).toContain('系统提示｜模式切换（最高优先级）');
+        expect(joined).toContain('刚刚结束了视频通话');
+        expect(joined).toContain('现在已经回到 ChatApp 的文字聊天界面');
+        expect(joined).toContain('如果 ChatApp 当前开启了语音消息，仍可遵守它自己的语音消息格式');
+    });
+});

--- a/utils/chatPrompts.ts
+++ b/utils/chatPrompts.ts
@@ -74,6 +74,40 @@ function summarizeGroupMsgContent(m: Message): string {
     }
 }
 
+export type ChatModeTransition = 'call' | 'video' | 'date' | 'story';
+
+const getChatModeTransition = (message: Message): ChatModeTransition | null => {
+    const source = message.metadata?.source;
+    if (source === 'date') return 'date';
+    if (source === 'story_theater' || source === 'story_theater_memory') return 'story';
+    if (source === 'call' || source === 'call-end-popup') {
+        return message.metadata?.callMode === 'video' ? 'video' : 'call';
+    }
+    return null;
+};
+
+/**
+ * 判断当前是不是「从特殊互动模式回到 ChatApp 后，尚未产生普通聊天回复」的第一轮。
+ *
+ * 用户可能连续发送多个气泡再点生成，所以普通 user 消息不会截断搜索；一旦已经出现
+ * 普通 assistant 回复，就说明格式切换已经完成，不应在后续每一轮重复提醒。
+ * 普通 system 日志也不参与判断，避免挂断卡片与其他后台提示把真正的来源隔开。
+ */
+export const detectChatModeTransition = (messages: readonly Message[]): ChatModeTransition | null => {
+    let hasPendingChatInput = false;
+
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
+        const mode = getChatModeTransition(message);
+        if (mode) return hasPendingChatInput ? mode : null;
+
+        if (message.role === 'assistant') return null;
+        if (message.role === 'user') hasPendingChatInput = true;
+    }
+
+    return null;
+};
+
 /**
  * buildSystemPrompt / buildSystemPromptParts 的构建选项。
  *
@@ -93,6 +127,8 @@ function summarizeGroupMsgContent(m: Message): string {
  */
 export interface PromptBuildOptions {
     forFirePack?: boolean;
+    /** 主 API 从完整数据库历史识别出的「刚从哪种模式回到 ChatApp」。 */
+    returningFromMode?: ChatModeTransition;
     /**
      * `timelyByWorker` = 这份 prompt 会交给 amsg worker 在 fire 时刻补时效段
      * （即时对话路径）。与 forFirePack 的区别：只裁「worker 那边有对应槽位」的
@@ -460,11 +496,16 @@ ${groupLogStr}\n`;
         // ── 拼接：易变的进 volatileState，稳定的进 baseSystemPrompt ──
         volatileState += realtimeText;
 
-        // 2a. 日程注入（当前时段 + 意识流独白，每轮都可能变）
+        // 2a. 日程注入（完整今日日程 + 当前时段 + 意识流独白，每轮都可能变）
         //     fire_pack 不烤：改由 worker 到点用 AMSG_SLOT_SCENE 现挑时段（见 amsgFireScene）。
         if (schedule && !forFirePack) {
             try {
-                const scheduleContext = ContextBuilder.buildScheduleInjection(schedule, evolvedNarrative, charNow);
+                const scheduleContext = ContextBuilder.buildScheduleInjection(
+                    schedule,
+                    evolvedNarrative,
+                    charNow,
+                    { includeFullDay: true, includeChangeInstruction: true },
+                );
                 if (scheduleContext) volatileState += `\n${scheduleContext}\n`;
             } catch (e) {
                 console.error('Failed to inject schedule context:', e);
@@ -889,15 +930,23 @@ ${xhsEnabled ? `${[notionEnabled, feishuEnabled, notionNotesEnabled].filter(Bool
 
 `;
 
-        // 「刚结束见面/通话」的切换提示由倒数第二条消息推导，随对话推进而变 → 易变段。
+        // 特殊模式结束后的第一轮必须把输出格式重新锚定到 ChatApp。
+        // 主聊天路径会从完整 DB 历史算好 returningFromMode；直接调用 ChatPrompts 的旧路径
+        // 则用 currentMsgs 兜底。不能再看固定的倒数第二条：用户可能连续发多个气泡，界面
+        // 状态也会隐藏 date/call/story 消息，而 API 历史仍会携带它们。
         // fire_pack 不烤：打包时确实刚挂电话，但那条主动消息可能是第二天凌晨才发出去的，
         // 角色照着这句接一句「刚才电话里说的那个……」就穿帮了。
-        const previousMsg = (currentMsgs.length > 1 && !forFirePack) ? currentMsgs[currentMsgs.length - 2] : null;
-        if (previousMsg && previousMsg.metadata?.source === 'date') {
-            volatileState += `\n\n[System Note: You just finished a face-to-face meeting. You are now back on the phone. Switch back to texting style.]`;
-        }
-        if (previousMsg && (previousMsg.metadata?.source === 'call' || previousMsg.metadata?.source === 'call-end-popup')) {
-            volatileState += `\n\n[系统提示: 你刚刚和对方结束了一通电话，现在回到了文字聊天模式。请切换回打字聊天的风格——不要再用电话口吻说话，不要输出语音标签，回到正常的 IM 短句风格。你可以自然地提一下"刚才电话里说的……"之类的衔接，但不要继续以通话模式回复。]`;
+        const returningFromMode = !forFirePack
+            ? (promptOptions?.returningFromMode || detectChatModeTransition(currentMsgs))
+            : null;
+        if (returningFromMode) {
+            const modeLabel: Record<ChatModeTransition, string> = {
+                call: '语音通话',
+                video: '视频通话',
+                date: '线下见面',
+                story: '剧情模式',
+            };
+            volatileState += `\n\n[系统提示｜模式切换（最高优先级）: 你刚刚结束了${modeLabel[returningFromMode]}，现在已经回到 ChatApp 的文字聊天界面。之前模式中的台词、旁白、动作、场景或转录格式只代表已经发生的历史，绝不是当前回复的格式范例。从这一条开始，只按 ChatApp 当前启用的输出规则回复：使用自然的 IM 短句/气泡，不沿用通话口吻、连续口语转录、动作描写、小说旁白、场景标题或说话人标签；如果 ChatApp 当前开启了语音消息，仍可遵守它自己的语音消息格式。你可以自然承接刚才发生的事，但必须以正在聊天界面发消息的方式表达。]`;
         }
 
         // Voice message prompt injection

--- a/utils/chatRequestPayload.ts
+++ b/utils/chatRequestPayload.ts
@@ -13,7 +13,7 @@
  */
 
 import type { CharacterProfile, UserProfile, GroupProfile, Emoji, EmojiCategory, Message, RealtimeConfig, TranslationConfig, VisionApiConfig } from '../types';
-import { ChatPrompts } from './chatPrompts';
+import { ChatPrompts, detectChatModeTransition } from './chatPrompts';
 import { injectMemoryPalace } from './memoryPalace/pipeline';
 import { buildHtmlPrompt } from './htmlPrompt';
 import { buildThinkingChainPrompt } from './thinkingChainPrompt';
@@ -281,6 +281,10 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
     // volatileTail → 历史消息之后的 system（时间/召回/buff/日程/音乐等实时状态 + 点单类模式块）；
     // recencyTail（总纲+「回到你自己」钢印）最后拼进 volatileTail 末尾，保证它是模型
     // 开口前读到的最后内容 —— 双语/HTML/思考链等格式块都只能拼在 stable 里、排它前面。
+    // UI 为了不把通话/见面/剧情正文画进 ChatApp，会把这些 source 从 React state 过滤掉；
+    // 但主 API 的 historyMsgsForPrompt 来自完整 DB，仍然会看到它们。模式切换必须以 API
+    // 真正要发送的历史为准，否则模型会收到特殊模式正文，却收不到「切回聊天格式」的提示。
+    const returningFromMode = detectChatModeTransition(historyMsgsForPrompt);
     const parts = await ChatPrompts.buildSystemPromptParts(
         char, userProfile, groups, emojis, categories, recentMsgsHint,
         realtimeConfig, innerState || undefined,
@@ -288,7 +292,10 @@ export async function buildChatRequestPayload(input: BuildChatPayloadInput): Pro
         !!isListeningTogether,
         musicCfg,
         recentTrackSwitch,
-        input.timelyByWorker ? { timelyByWorker: true } : undefined,
+        (input.timelyByWorker || returningFromMode) ? {
+            timelyByWorker: input.timelyByWorker === true,
+            returningFromMode: returningFromMode || undefined,
+        } : undefined,
     );
     let systemPrompt = parts.stable;
     let volatileTail = parts.volatileState;

--- a/utils/claudeProxyCompat.test.ts
+++ b/utils/claudeProxyCompat.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildClaudeProxyCompatibilityBody,
+  shouldRetryClaudeProxyCompatibility,
+} from './claudeProxyCompat';
+
+const body = {
+  model: '[千岛-AWS]claude-opus-4-6',
+  messages: [
+    { role: 'system', content: 'stable' },
+    { role: 'user', content: 'hello' },
+    { role: 'system', content: 'timely' },
+  ],
+  tools: [{ type: 'function', function: { name: 'schedule_active_message' } }],
+  thinking: { type: 'enabled', budget_tokens: 4000 },
+  reasoning_effort: 'medium',
+  extra_body: { thinking: { type: 'enabled', budget_tokens: 4000 } },
+};
+
+describe('Claude relay compatibility retry', () => {
+  it('recognizes the opaque Claude + tools + thinking 502', () => {
+    expect(shouldRetryClaudeProxyCompatibility(new Error('API Error 502: 项目1'), body)).toBe(true);
+    expect(shouldRetryClaudeProxyCompatibility(new Error('API Error 401: bad key'), body)).toBe(false);
+    expect(shouldRetryClaudeProxyCompatibility(new Error('API Error 502: upstream'), { ...body, tools: [] })).toBe(false);
+  });
+
+  it('merges system messages and strips thinking dialects without dropping tools', () => {
+    const fallback = buildClaudeProxyCompatibilityBody(body);
+    expect(fallback.messages).toEqual([
+      { role: 'system', content: 'stable\n\ntimely' },
+      { role: 'user', content: 'hello' },
+    ]);
+    expect(fallback.tools).toEqual(body.tools);
+    expect(fallback).not.toHaveProperty('thinking');
+    expect(fallback).not.toHaveProperty('reasoning_effort');
+    expect(fallback).not.toHaveProperty('extra_body');
+  });
+});

--- a/utils/claudeProxyCompat.ts
+++ b/utils/claudeProxyCompat.ts
@@ -1,0 +1,52 @@
+import { mergeSystemMessages } from './systemMessageMerge';
+
+type ChatRequestBody = Record<string, any> & {
+  model?: unknown;
+  messages?: Array<{ role: string; content: unknown }>;
+  tools?: unknown[];
+};
+
+const isClaudeModel = (model: unknown): boolean =>
+  typeof model === 'string' && /claude|anthropic/i.test(model);
+
+const hasThinkingDialect = (body: ChatRequestBody): boolean =>
+  !!(body.thinking || body.reasoning_effort || body.extra_body?.thinking);
+
+/**
+ * Some OpenAI-compatible Claude relays turn upstream request-shape rejection
+ * into an opaque 502 `bad_response_status_code`. Only retry this very narrow
+ * combination: Claude + tools + thinking dialects + a confirmed HTTP 502.
+ */
+export const shouldRetryClaudeProxyCompatibility = (
+  error: unknown,
+  body: ChatRequestBody,
+): boolean => {
+  const message = error instanceof Error ? error.message : String(error || '');
+  return /API Error 502\b/i.test(message)
+    && isClaudeModel(body.model)
+    && Array.isArray(body.tools)
+    && body.tools.length > 0
+    && hasThinkingDialect(body);
+};
+
+/**
+ * Compatibility retry body for strict Claude relays:
+ * - consolidate late system messages at the front;
+ * - remove the three competing thinking dialects;
+ * - keep tools and all user content intact.
+ */
+export const buildClaudeProxyCompatibilityBody = (body: ChatRequestBody): ChatRequestBody => {
+  const next: ChatRequestBody = {
+    ...body,
+    messages: Array.isArray(body.messages) ? mergeSystemMessages(body.messages) : body.messages,
+  };
+  delete next.thinking;
+  delete next.reasoning_effort;
+  if (next.extra_body && typeof next.extra_body === 'object') {
+    const extraBody = { ...next.extra_body };
+    delete extraBody.thinking;
+    if (Object.keys(extraBody).length) next.extra_body = extraBody;
+    else delete next.extra_body;
+  }
+  return next;
+};

--- a/utils/groupChat/theme.test.ts
+++ b/utils/groupChat/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveChatTheme } from './theme';
+import { resolveChatTheme, scopeBubbleThemeCss } from './theme';
 import { ChatTheme } from '../../types';
 
 const presets: Record<string, ChatTheme> = {
@@ -35,5 +35,21 @@ describe('resolveChatTheme', () => {
         const resolved = resolveChatTheme('old', [broken], presets);
         expect(resolved.user.borderRadius).toBe(18);
         expect(resolved.ai.backgroundColor).toBe('#eee');
+    });
+});
+
+describe('scopeBubbleThemeCss', () => {
+    it('给普通、逗号列表和嵌套规则追加群聊消息作用域', () => {
+        const css = `.sully-bubble-user, .sully-bubble-ai::after { box-shadow: none; }
+@media (max-width: 480px) { .sully-voice-bar { gap: 4px; } }`;
+        const scoped = scopeBubbleThemeCss(css, '.group-theme-a');
+
+        expect(scoped).toContain('.group-theme-a .sully-bubble-user, .group-theme-a .sully-bubble-ai::after');
+        expect(scoped).toContain('@media (max-width: 480px) { .group-theme-a .sully-voice-bar');
+    });
+
+    it('空 CSS 不产生样式', () => {
+        expect(scopeBubbleThemeCss('', '.group-theme-a')).toBe('');
+        expect(scopeBubbleThemeCss(undefined, '.group-theme-a')).toBe('');
     });
 });

--- a/utils/groupChat/theme.ts
+++ b/utils/groupChat/theme.ts
@@ -22,3 +22,19 @@ export function resolveChatTheme(
         ai: { ...fallback.ai, ...(found.ai || {}) },
     };
 }
+
+/**
+ * 气泡工坊的 CSS 选择器在私聊里直接作用于整页；群聊允许每个成员使用不同主题，
+ * 因此要给每套主题加上消息级作用域，避免 A 的 `.sully-bubble-ai` 串到 B。
+ *
+ * 编辑器只允许规则以 `.sully-bubble-user` / `.sully-bubble-ai` / `.sully-voice-bar`
+ * 开头；这里同时兼容逗号列表和 @media / @supports 内的规则。
+ */
+export function scopeBubbleThemeCss(css: string | undefined, scopeSelector: string): string {
+    if (!css?.trim() || !scopeSelector.trim()) return '';
+    return css.replace(
+        /(^|[,{])(\s*)(\.sully-(?:bubble-(?:user|ai)|voice-bar)\b)/gmu,
+        (_whole, boundary: string, whitespace: string, selector: string) =>
+            `${boundary}${whitespace}${scopeSelector} ${selector}`,
+    );
+}

--- a/utils/scheduleChange.test.ts
+++ b/utils/scheduleChange.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import type { DailySchedule } from '../types';
+import { applyFutureScheduleChanges, extractScheduleChangeDirectives } from './scheduleChange';
+
+const schedule: DailySchedule = {
+    id: 'char-1_2026-08-15',
+    charId: 'char-1',
+    date: '2026-08-15',
+    generatedAt: new Date(2026, 7, 15, 8).getTime(),
+    slots: [
+        { startTime: '08:00', activity: '起床', location: '家' },
+        { startTime: '14:00', activity: '写稿', description: '完成第三章', innerThought: '别再拖稿了' },
+        { startTime: '18:30', activity: '健身', location: '健身房', theater: { generatedAt: 1, lines: [{ text: '跑步' }] } },
+        { startTime: '22:00', activity: '看电影' },
+    ],
+    flowNarrative: { afternoon: '晚上还得去健身。' },
+};
+
+const at = (hour: number, minute = 0) => new Date(2026, 7, 15, hour, minute);
+
+describe('extractScheduleChangeDirectives', () => {
+    it('识别规范格式并把控制标签从聊天正文隐藏', () => {
+        const result = extractScheduleChangeDirectives('那今晚就不练啦。\n[[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]]');
+        expect(result.cleanedText).toBe('那今晚就不练啦。');
+        expect(result.directives).toEqual([{ startTime: '18:30', activity: '去超市' }]);
+        expect(result.malformedCount).toBe(0);
+    });
+
+    it.each([
+        '【【修改日程：18:30：去超市】】',
+        '[[change schedule: (18:30): 去超市]]',
+        '【change schedue：（18：30）：去超市】',
+        '【【修改日程：18点30分：去超市】】',
+        'change_schedule：18时30分：去超市',
+        '[[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]',
+        '[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]]',
+        '[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]',
+        '[[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市',
+        'ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]]',
+        'ACTION:CHANGE_SCHEDULE | 18:30 | 去超市',
+    ])('容错括号、标点、中文别名与 schedue 拼写：%s', (raw) => {
+        const result = extractScheduleChangeDirectives(raw);
+        expect(result.cleanedText).toBe('');
+        expect(result.directives).toEqual([{ startTime: '18:30', activity: '去超市' }]);
+    });
+
+    it('无法确定时段时只隐藏控制标签并记为 malformed，不猜测目标', () => {
+        const result = extractScheduleChangeDirectives('好。\n[[ACTION:CHANGE_SCHEDULE | 晚一点 | 去超市]]');
+        expect(result.cleanedText).toBe('好。');
+        expect(result.directives).toEqual([]);
+        expect(result.malformedCount).toBe(1);
+    });
+});
+
+describe('applyFutureScheduleChanges', () => {
+    it('只改未来已有时段，并清掉围绕旧活动生成的冲突信息', () => {
+        const result = applyFutureScheduleChanges(
+            schedule,
+            [{ startTime: '18:30', activity: '去超市' }],
+            null,
+            at(14, 5),
+        );
+        expect(result.changes).toEqual([{ startTime: '18:30', before: '健身', after: '去超市' }]);
+        expect(result.schedule.slots[2]).toEqual({ startTime: '18:30', activity: '去超市' });
+        expect(result.schedule.flowNarrative).toBeUndefined();
+        expect(schedule.slots[2].activity).toBe('健身');
+    });
+
+    it('拒绝过去、当前、表里不存在的时段', () => {
+        const result = applyFutureScheduleChanges(schedule, [
+            { startTime: '08:00', activity: '睡懒觉' },
+            { startTime: '14:00', activity: '摸鱼' },
+            { startTime: '19:00', activity: '散步' },
+        ], null, at(14));
+        expect(result.changes).toEqual([]);
+        expect(result.rejectedCount).toBe(3);
+        expect(result.schedule).toBe(schedule);
+    });
+
+    it('同一时段重复输出时折叠为“最初计划 → 最终计划”', () => {
+        const result = applyFutureScheduleChanges(schedule, [
+            { startTime: '22:00', activity: '看书' },
+            { startTime: '22:00', activity: '早点睡' },
+        ], null, at(18));
+        expect(result.changes).toEqual([{ startTime: '22:00', before: '看电影', after: '早点睡' }]);
+        expect(result.schedule.slots[3].activity).toBe('早点睡');
+    });
+});

--- a/utils/scheduleChange.ts
+++ b/utils/scheduleChange.ts
@@ -1,0 +1,225 @@
+import type { CharacterProfile, DailySchedule, ScheduleSlot } from '../types';
+import { DB } from './db';
+import { getDailyScheduleForChar } from './dailySchedule';
+import { getScheduleWallClock } from './scheduleTime';
+
+export const SCHEDULE_CHANGE_EVENT = 'schedule-change-applied';
+
+export interface ScheduleChangeDirective {
+    startTime: string;
+    activity: string;
+}
+
+export interface AppliedScheduleChange {
+    startTime: string;
+    before: string;
+    after: string;
+}
+
+export interface ScheduleChangeEventDetail {
+    charId: string;
+    date: string;
+    changes: AppliedScheduleChange[];
+    schedule: DailySchedule;
+    eventId: string;
+}
+
+export interface ExtractedScheduleChanges {
+    cleanedText: string;
+    directives: ScheduleChangeDirective[];
+    malformedCount: number;
+}
+
+export interface AppliedScheduleChangeResult extends ExtractedScheduleChanges {
+    schedule: DailySchedule | null;
+    changes: AppliedScheduleChange[];
+    rejectedCount: number;
+}
+
+const KEYWORD_RE = /^\s*(?:ACTION\s*[:：]\s*CHANGE_SCHEDULE|change[\s_-]*(?:schedule|schedue)|modify[\s_-]*schedule|修改(?:未来)?日程|更改(?:未来)?日程|改日程)(?=\s|[:：|=→>\-（(]|\d|$)/iu;
+
+type ParsedBody =
+    | { recognized: false }
+    | { recognized: true; directive: ScheduleChangeDirective | null };
+
+const parseDirectiveBody = (input: string): ParsedBody => {
+    const body = input
+        .replace(/^[\s【\[]+|[\s】\]]+$/gu, '')
+        .trim();
+    const keyword = body.match(KEYWORD_RE);
+    if (!keyword) return { recognized: false };
+
+    const rest = body
+        .slice(keyword[0].length)
+        .replace(/^\s*[:：|=→>\-]+\s*/u, '');
+    // canonical: 18:30；同时兜底 18：30 /（18:30）/ 18点30分 / 18时。
+    const time = rest.match(/[（(]?\s*(\d{1,2})\s*(?:[:：点时])\s*(\d{1,2})?\s*(?:分)?\s*[）)]?/u);
+    if (!time || time.index == null) return { recognized: true, directive: null };
+
+    const hour = Number(time[1]);
+    const minute = time[2] == null || time[2] === '' ? 0 : Number(time[2]);
+    if (!Number.isInteger(hour) || !Number.isInteger(minute) || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+        return { recognized: true, directive: null };
+    }
+
+    const activity = rest
+        .slice(time.index + time[0].length)
+        .replace(/^\s*(?:[:：|=→>\-]+)\s*/u, '')
+        .replace(/[】\]]+\s*$/gu, '')
+        .trim();
+    if (!activity) return { recognized: true, directive: null };
+
+    return {
+        recognized: true,
+        directive: {
+            startTime: `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`,
+            // 日程卡本来就是短标题；截断异常长输出，避免一条标签撑坏 UI / prompt。
+            activity: activity.slice(0, 120),
+        },
+    };
+};
+
+/**
+ * 从回复里取出日程修改标签并隐藏标签本身。
+ *
+ * 正式格式跟其它动作一致：`[[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]]`。解析端额外接受：
+ * - 单层 / 中文括号；
+ * - `change schedule`、旧版 `change schedue`、中文「修改日程」；
+ * - 全角冒号、圆括号时段、`18点30分`；
+ * - 忘记闭合括号但整条指令仍独占一行。
+ */
+export const extractScheduleChangeDirectives = (text: string): ExtractedScheduleChanges => {
+    const directives: ScheduleChangeDirective[] = [];
+    let malformedCount = 0;
+
+    const consumeBody = (body: string, original: string): string => {
+        const parsed = parseDirectiveBody(body);
+        if (!parsed.recognized) return original;
+        if (parsed.directive) directives.push(parsed.directive);
+        else malformedCount += 1;
+        return '';
+    };
+
+    // 先吃带括号的块。允许左右各一层或两层，避免少打一枚括号时留下孤立的 `[` / `]`。
+    let cleanedText = (text || '').replace(
+        /(?:【{1,2}|\[{1,2})([^【】\[\]\r\n]{1,360})(?:】{1,2}|\]{1,2})/gu,
+        (whole, body) => consumeBody(body ?? '', whole),
+    );
+
+    // 兜底模型漏掉一侧或全部括号的情况。能力标签要求独占一行，因此只消费到本行末尾。
+    cleanedText = cleanedText.replace(
+        /(?:【【?|\[\[?)?\s*(?:ACTION\s*[:：]\s*CHANGE_SCHEDULE|change[\s_-]*(?:schedule|schedue)|modify[\s_-]*schedule|修改(?:未来)?日程|更改(?:未来)?日程|改日程)\s*[:：|]?[^\r\n]{0,360}/giu,
+        (whole) => consumeBody(whole, whole),
+    );
+
+    return {
+        cleanedText: cleanedText
+            .replace(/[ \t]+\r?\n/gu, '\n')
+            .replace(/\n{3,}/gu, '\n\n')
+            .trim(),
+        directives,
+        malformedCount,
+    };
+};
+
+const minutesOf = (time: string): number | null => {
+    const matched = /^(\d{1,2}):(\d{2})$/u.exec(time.trim());
+    if (!matched) return null;
+    const hour = Number(matched[1]);
+    const minute = Number(matched[2]);
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+    return hour * 60 + minute;
+};
+
+/** 纯数据层：只允许命中已有且尚未开始的时段；无法确定目标时宁可不改。 */
+export const applyFutureScheduleChanges = (
+    schedule: DailySchedule,
+    directives: ScheduleChangeDirective[],
+    char?: Pick<CharacterProfile, 'customTimezoneEnabled' | 'customTimezone'> | null,
+    at: Date = new Date(),
+): { schedule: DailySchedule; changes: AppliedScheduleChange[]; rejectedCount: number } => {
+    const wallNow = getScheduleWallClock(char, at);
+    const currentMinutes = wallNow.getHours() * 60 + wallNow.getMinutes();
+    const slots: ScheduleSlot[] = schedule.slots.map((slot) => ({ ...slot }));
+    const changeByTime = new Map<string, AppliedScheduleChange>();
+    let rejectedCount = 0;
+
+    for (const directive of directives) {
+        const slotIndex = slots.findIndex((slot) => slot.startTime === directive.startTime);
+        const targetMinutes = minutesOf(directive.startTime);
+        if (slotIndex < 0 || targetMinutes == null || targetMinutes <= currentMinutes) {
+            rejectedCount += 1;
+            continue;
+        }
+
+        const slot = slots[slotIndex];
+        if (slot.activity.trim() === directive.activity.trim()) continue;
+        const originalBefore = changeByTime.get(directive.startTime)?.before ?? slot.activity;
+        slots[slotIndex] = {
+            startTime: slot.startTime,
+            activity: directive.activity.trim(),
+            // 原描述、地点、独白和小剧场都围绕旧活动生成，保留会立即穿帮。
+            ...(slot.emoji ? { emoji: slot.emoji } : {}),
+        };
+        changeByTime.set(directive.startTime, {
+            startTime: directive.startTime,
+            before: originalBefore,
+            after: directive.activity.trim(),
+        });
+    }
+
+    const changes = [...changeByTime.values()];
+    if (changes.length === 0) return { schedule, changes, rejectedCount };
+    return {
+        schedule: {
+            ...schedule,
+            slots,
+            // 整日意识流同样基于旧计划生成；清掉后回落到当前 slot 的独白，避免未来安排改了、念头仍旧。
+            flowNarrative: undefined,
+        },
+        changes,
+        rejectedCount,
+    };
+};
+
+/** 解析模型回复、落库成功的未来日程，并返回供聊天 UI 展示的差异。 */
+export const applyAssistantScheduleChanges = async (
+    text: string,
+    char: Pick<CharacterProfile, 'id' | 'customTimezoneEnabled' | 'customTimezone'>,
+    at: Date = new Date(),
+): Promise<AppliedScheduleChangeResult> => {
+    const extracted = extractScheduleChangeDirectives(text);
+    if (extracted.directives.length === 0) {
+        return { ...extracted, schedule: null, changes: [], rejectedCount: 0 };
+    }
+
+    const schedule = await getDailyScheduleForChar(char, at);
+    if (!schedule) {
+        return {
+            ...extracted,
+            schedule: null,
+            changes: [],
+            rejectedCount: extracted.directives.length,
+        };
+    }
+
+    const applied = applyFutureScheduleChanges(schedule, extracted.directives, char, at);
+    if (applied.changes.length > 0) await DB.saveDailySchedule(applied.schedule);
+    return { ...extracted, ...applied };
+};
+
+export const announceScheduleChanges = (
+    charId: string,
+    schedule: DailySchedule,
+    changes: AppliedScheduleChange[],
+): void => {
+    if (changes.length === 0 || typeof window === 'undefined') return;
+    const detail: ScheduleChangeEventDetail = {
+        charId,
+        date: schedule.date,
+        changes,
+        schedule,
+        eventId: `${charId}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    };
+    window.dispatchEvent(new CustomEvent<ScheduleChangeEventDetail>(SCHEDULE_CHANGE_EVENT, { detail }));
+};

--- a/utils/scheduleChangeNotice.test.ts
+++ b/utils/scheduleChangeNotice.test.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import ScheduleChangeNotice from '../components/chat/ScheduleChangeNotice';
+
+describe('ScheduleChangeNotice', () => {
+    it('明确展示时段、原计划与新计划，并暴露白框稳定选择器', () => {
+        const html = renderToStaticMarkup(React.createElement(ScheduleChangeNotice, {
+            detail: {
+                charId: 'char-1',
+                date: '2026-08-15',
+                eventId: 'event-1',
+                schedule: {
+                    id: 'char-1_2026-08-15',
+                    charId: 'char-1',
+                    date: '2026-08-15',
+                    generatedAt: 1,
+                    slots: [],
+                },
+                changes: [{ startTime: '18:30', before: '健身', after: '去超市' }],
+            },
+            onDone: () => {},
+        }));
+
+        expect(html).toContain('未来日程已调整');
+        expect(html).toContain('18:30');
+        expect(html).toContain('健身');
+        expect(html).toContain('去超市');
+        for (const hook of [
+            'sully-schedule-change',
+            'sully-schedule-change-time',
+            'sully-schedule-change-before',
+            'sully-schedule-change-after',
+            'sully-schedule-change-shine',
+        ]) expect(html).toContain(hook);
+    });
+});

--- a/utils/scheduleInjection.test.ts
+++ b/utils/scheduleInjection.test.ts
@@ -52,6 +52,19 @@ describe('凌晨 0-5 点算前一夜的延续', () => {
         expect(out).toContain('稿子卡在第三段');
     });
 
+    it('ChatApp 主请求可注入完整日程，并用一个简单标签教角色修改未来计划', () => {
+        const out = buildScheduleInjection(schedule, undefined, at(14), {
+            includeFullDay: true,
+            includeChangeInstruction: true,
+        });
+        expect(out).toContain('你今天的完整日程：');
+        expect(out).toContain('- 07:00 晨跑');
+        expect(out).toContain('- 13:00 写稿');
+        expect(out).toContain('- 22:00 看剧');
+        expect(out).toContain('[[ACTION:CHANGE_SCHEDULE | 22:00 | 去超市]]');
+        expect(out).toContain('时段必须来自上表且尚未开始');
+    });
+
     it('一天三档的通用取法本身没变（小剧场、桌面小屋还按它取色）', () => {
         expect(getFlowNarrativeKey(1)).toBe('morning');
         expect(getFlowNarrativeKey(9)).toBe('morning');

--- a/utils/scheduleInjection.ts
+++ b/utils/scheduleInjection.ts
@@ -20,6 +20,13 @@ import type { DailySchedule, ScheduleSlot } from '../types';
  */
 export type RenderableSchedule = Pick<DailySchedule, 'slots' | 'flowNarrative'>;
 
+export interface ScheduleInjectionOptions {
+    /** ChatApp 主请求需要让角色看到今天的整张表；主动消息到点场景仍只看当前与下一条。 */
+    includeFullDay?: boolean;
+    /** 仅在能实际接收并执行修改指令的聊天请求里教角色这个能力。 */
+    includeChangeInstruction?: boolean;
+}
+
 /** 意识流独白按一天三档取：早 / 午 / 晚。 */
 export function getFlowNarrativeKey(hour: number): 'morning' | 'afternoon' | 'evening' {
     if (hour < 12) return 'morning';
@@ -62,6 +69,7 @@ export const buildScheduleInjection = (
     schedule: RenderableSchedule | null,
     evolvedNarrative?: string,
     now: Date = new Date(),
+    options: ScheduleInjectionOptions = {},
 ): string => {
     if (!schedule || !schedule.slots || schedule.slots.length === 0) return '';
     const { current: currentSlot, next: nextSlot } = resolveScheduleSlots(schedule, now);
@@ -103,9 +111,23 @@ export const buildScheduleInjection = (
     const preamble = `此刻你的心中盘旋着这些想法……\n`;
     const footnote = `\n（不是台词，不用说出口——让它影响你的语气和情绪就好。）`;
 
-    let out = slotHeader;
+    let out = '';
+    if (options.includeFullDay) {
+        const rows = schedule.slots.map((slot) => {
+            let line = `- ${slot.startTime} ${slot.activity}`;
+            if (slot.location) line += `（${slot.location}）`;
+            if (slot.description) line += `：${slot.description}`;
+            return line;
+        });
+        out += `你今天的完整日程：\n${rows.join('\n')}\n`;
+    }
+    out += slotHeader;
     if (narrative) {
         out += preamble + narrative + footnote;
+    }
+    if (options.includeChangeInstruction && nextSlot) {
+        out += '\n你拥有更改未来日程计划的能力；需要时在回复末尾单独输出：'
+            + `[[ACTION:CHANGE_SCHEDULE | ${nextSlot.startTime} | 去超市]]（时段必须来自上表且尚未开始）。`;
     }
     out += '\n';
     return out;


### PR DESCRIPTION
修复 Claude 模型在开启工具调用与思考模式时可能出现的 502 兼容问题。
通话设置新增“沉默后主动接话”开关，默认关闭，按需启用。
“自动播放语音”默认开启；关闭后语音通话和视频通话都不再自动生成、播放语音，仍可手动播放。
更新通话 App 的功能说明弹窗。
外观 App 新增三个独立动画开关：开机动画、ChatApp 切换角色动画、进入 App 加载动画，默认全部开启。
默认气泡预览加入语音条，可直接预览整体效果。
语音条新增独立颜色与 CSS 美化能力。
气泡四个圆角支持分别调整。
气泡尾巴支持“仅连续消息最后一条显示 / 每条显示 / 完全隐藏”。
群聊补齐白框与气泡美化，并与私聊使用相同的自定义能力。
ChatApp 会把角色当天的完整日程提供给 AI，不再只提供当前时段。
角色可以通过 [[ACTION:CHANGE_SCHEDULE | 18:30 | 去超市]] 修改未来日程。
日程指令支持缺少括号、中文括号、全角冒号及常见拼写错误等兜底识别。
修改日程后，聊天界面会显示带前后变化的提示动效。
修复从通话、视频、见面和剧情模式返回 ChatApp 后，回复格式仍沿用上一模式的问题。
修复桌面底部页面指示器在部分浏览器中挤压、粘连成条的问题。
已补充相关自动化测试，并通过生产构建验证。