### PR TITLE
fix(彼方): 调不通模型就自己停下，空转也不再是静默的

### DIFF
--- a/apps/VRWorldApp.tsx
+++ b/apps/VRWorldApp.tsx
@@ -11,7 +11,7 @@ import { CreatorIframe, type ChibiResult } from '../components/Like520Event';
 import { useMusic, type Song } from '../context/MusicContext';
 import { DB } from '../utils/db';
 import { useResilientAssetUrl, attachAudioMirrorFallback } from '../utils/assetUrl';
-import { VRScheduler } from '../utils/vrWorld/scheduler';
+import { VRScheduler, VR_FAIL_LIMIT } from '../utils/vrWorld/scheduler';
 import { VR_ROOMS, getRoom, VR_DEFAULT_INTERVAL_MIN, SIGNAL_EPIGRAPH, signalActFor, signalActRanges, SIGNAL_POEMS_PER_BOOKLET, SIGNAL_EVENT_ENDED, SIGNAL_MEMORIAL_CLOSING } from '../utils/vrWorld/constants';
 import { buildNovelAsync, groupAnnotationsBySeg, getBookmark } from '../utils/vrWorld/novel';
 import { decodeBytes } from '../utils/vrWorld/decodeText';
@@ -3373,6 +3373,7 @@ const SettingsView: React.FC<{
         <div className="space-y-3">
             <p className="text-[11px] text-indigo-300/60 leading-relaxed">
                 启用后，角色会按设定的间隔自己登入「彼方」，在图书馆读你上传的小说、写批注。每次活动会在 ta 的聊天里留下动态卡片，也会被记忆总结捕捉。
+                连着 {VR_FAIL_LIMIT} 次调不通模型（比如 API 令牌失效了）会自动暂停这个角色，不会一直空跑下去。
                 {novelCount === 0 && <span className="text-amber-300/80"> 书库还空着，先去「书库」上传一本。</span>}
             </p>
             {characters.length === 0 && <p className="text-[11px] text-indigo-300/50 py-4 text-center">还没有角色。</p>}
@@ -3386,6 +3387,7 @@ const SettingsView: React.FC<{
                 const enabled = !!st?.enabled;
                 const interval = st?.intervalMinutes || VR_DEFAULT_INTERVAL_MIN;
                 const chibi = getChibi(char);
+                const failStreak = VRScheduler.getFailStreak(char.id);
                 return (
                     <div key={char.id} className="rounded-2xl p-3.5 backdrop-blur-sm" style={{ background: 'rgba(255,255,255,0.045)', border: '1px solid rgba(255,255,255,0.07)' }}>
                         <div className="flex items-center gap-2.5">
@@ -3396,8 +3398,13 @@ const SettingsView: React.FC<{
                             </button>
                             <div className="flex-1 min-w-0">
                                 <div className="text-[13px] font-bold truncate">{char.name}</div>
-                                {enabled ? <div className="text-[10px] text-indigo-300/60">每 {interval >= 60 ? `${interval / 60} 小时` : `${interval} 分`}登入一次</div>
-                                    : <div className="text-[10px] text-indigo-300/40">{chibi.isFallback ? '未设形象 · 未接入' : '未接入'}</div>}
+                                {enabled ? (
+                                    <div className="text-[10px] text-indigo-300/60">
+                                        每 {interval >= 60 ? `${interval / 60} 小时` : `${interval} 分`}登入一次
+                                        {/* 后台失败本来一点声响都没有，攒到熔断前先让用户看见 */}
+                                        {failStreak > 0 && <span className="text-amber-300/80"> · 已连续 {failStreak} 次没调通</span>}
+                                    </div>
+                                ) : <div className="text-[10px] text-indigo-300/40">{chibi.isFallback ? '未设形象 · 未接入' : '未接入'}</div>}
                             </div>
                             <button onClick={() => enabled ? disable(char) : onRequestEnable(char)}
                                 className={`relative w-11 h-6 rounded-full transition-colors ${enabled ? 'bg-indigo-400' : 'bg-white/15'}`}>
@@ -3479,7 +3486,10 @@ const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; add
         } catch (e: any) { setTestResult(`连接失败: ${e.message}`); } finally { setTesting(false); }
     };
 
-    const okCount = log.filter(l => l.ok).length;
+    // 日志里混着两种行：真实的模型调用，和「调度动了但没走到模型」的诊断行。
+    // 对账只该看前者，把诊断行算进分母会让「成功几次」失真。
+    const calls = log.filter(l => !l.kind);
+    const okCount = calls.filter(l => l.ok).length;
 
     return (
         <div className="space-y-3">
@@ -3549,22 +3559,33 @@ const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; add
             <div className="rounded-2xl p-3" style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.07)' }}>
                 <div className="flex items-center gap-1.5 mb-2">
                     <span className="text-[10px] tracking-[0.2em] text-indigo-200/60" style={{ fontFamily: `'Noto Serif SC',serif` }}>调用记录</span>
-                    <span className="text-[9.5px] text-white/40 rounded-full px-1.5 leading-tight" style={{ background: 'rgba(255,255,255,.08)' }}>{log.length}{log.length ? ` · 成功${okCount}` : ''}</span>
+                    <span className="text-[9.5px] text-white/40 rounded-full px-1.5 leading-tight" style={{ background: 'rgba(255,255,255,.08)' }}>{calls.length}{calls.length ? ` · 成功${okCount}` : ''}</span>
                     {log.length > 0 && <button onClick={() => { void clearVRApiLog(); setLog([]); }} className="ml-auto text-[10px] text-white/40 hover:text-rose-300/80">清空</button>}
                 </div>
                 {log.length === 0 ? (
                     <p className="text-[10.5px] text-white/35 py-2 text-center">还没有调用。角色每次登入彼方触发的模型调用都会记在这里，方便你对账。</p>
                 ) : (
                     <div className="space-y-1">
-                        {log.slice(0, 60).map((l, i) => (
-                            <div key={i} className="flex items-center gap-2 text-[10.5px] py-1 border-b border-white/5 last:border-0">
-                                <span className={`shrink-0 ${l.ok ? 'text-emerald-400/80' : 'text-rose-400/80'}`}>{l.ok ? '●' : '○'}</span>
-                                <span className="text-white/75 truncate">{l.charName || '—'}</span>
-                                <span className="text-indigo-300/40 shrink-0">{l.room ? getRoom(l.room as VRRoomId).name : ''}</span>
-                                <span className="ml-auto text-white/30 shrink-0 tabular-nums">{(l.ms / 1000).toFixed(1)}s</span>
-                                <span className="text-white/35 shrink-0 tabular-nums w-[68px] text-right">{new Date(l.ts).toLocaleString('zh-CN', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
-                            </div>
-                        ))}
+                        {log.slice(0, 60).map((l, i) => {
+                            const diag = !!l.kind;   // 诊断行：调度到点了，但这一轮没走到模型
+                            return (
+                                <div key={i} className="flex items-start gap-2 text-[10.5px] py-1 border-b border-white/5 last:border-0">
+                                    <span className={`shrink-0 ${diag ? 'text-amber-400/70' : l.ok ? 'text-emerald-400/80' : 'text-rose-400/80'}`}>{diag ? '◌' : l.ok ? '●' : '○'}</span>
+                                    <span className="text-white/75 truncate shrink-0">{l.charName || l.charId?.slice(-4) || '—'}</span>
+                                    {diag ? (
+                                        <span className="flex-1 min-w-0 text-amber-200/55 leading-snug">{l.note}</span>
+                                    ) : (
+                                        <>
+                                            <span className="text-indigo-300/40 shrink-0">{l.room ? getRoom(l.room as VRRoomId).name : ''}</span>
+                                            {/* 接入明明是关的却还是发了请求 —— 这就是「关不掉」的现场，标出来别让它混在红点里 */}
+                                            {l.charEnabled === false && <span className="text-rose-300/75 shrink-0">未接入却发了</span>}
+                                            <span className="ml-auto text-white/30 shrink-0 tabular-nums">{(l.ms / 1000).toFixed(1)}s</span>
+                                        </>
+                                    )}
+                                    <span className="text-white/35 shrink-0 tabular-nums w-[68px] text-right">{new Date(l.ts).toLocaleString('zh-CN', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
             </div>

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -15,8 +15,9 @@ import { exportStoryTheaterAppearanceSetting, restoreStoryTheaterAppearanceSetti
 import { createV2ArrayFieldWriter, writeV2Backup, assembleV2Backup, type BackupManifest, type ZipFileWriter, type ZipFileReader } from '../utils/backupFormat';
 import { encodeVectorsForBackup, encodeVectorsForBackupChunked } from '../utils/memoryPalace/db';
 import { ProactiveChat } from '../utils/proactiveChat';
-import { VRScheduler } from '../utils/vrWorld/scheduler';
+import { VRScheduler, type VRSessionOutcome } from '../utils/vrWorld/scheduler';
 import { runVRSession } from '../utils/vrWorld/runSession';
+import { logVRApiCall } from '../utils/vrWorld/vrApi';
 import { VR_DEFAULT_INTERVAL_MIN } from '../utils/vrWorld/constants';
 import { WorldScheduler, toTickEntries } from '../utils/worldHome/scheduler';
 import { runWorldEpisode, rerollWorldCharBeat } from '../utils/worldHome/engine';
@@ -2510,10 +2511,22 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       // 「彼方」自主登入 —— 独立调度，复用同一批 refs 拿最新状态
       const runVR = async (charId: string, room?: string, letterId?: string) => {
           const char = charactersRef.current.find(c => c.id === charId);
-          if (!char || !char.vrState?.enabled) return;
+          // 调度表里还排着队，角色却已经不接入了（或者压根被删了）：这条调度不该继续存在。
+          // 就地撤掉并留一行记录 —— 不撤的话它会一直空转，而空转是完全静默的，
+          // 用户那边只看得到「明明全关了，调用记录还在涨」，谁也说不清是哪一边错了。
+          if (!char || !char.vrState?.enabled) {
+              VRScheduler.stop(charId);
+              void logVRApiCall({
+                  ts: Date.now(), charId, charName: char?.name, ok: false, ms: 0,
+                  kind: 'skipped', charEnabled: !!char?.vrState?.enabled,
+                  note: char ? '角色未接入彼方，已撤掉这条残留调度' : '角色已不存在，已撤掉这条残留调度',
+              });
+              return;
+          }
           if (!userProfileRef.current) return;
+          let outcome: VRSessionOutcome = 'skipped';
           try {
-              await runVRSession({
+              const result = await runVRSession({
                   char,
                   characters: charactersRef.current,
                   apiConfig: apiConfigRef.current,
@@ -2525,9 +2538,27 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   forcedRoom: room as any,
                   forcedLetterId: letterId,
               });
+              // 没书没歌、房间被别人占着这些都不算账，只有真的没调通模型才记一笔失败
+              outcome = result.ok ? 'ok' : (result.reason === 'api-error' ? 'failed' : 'skipped');
           } catch (e) {
               console.error('[VRWorld] runVR error', e);
+              outcome = 'failed';
           }
+
+          const { tripped, streak } = VRScheduler.report(charId, outcome);
+          if (!tripped) return;
+          // 熔断了：调度已经被掐掉，这里把角色一并落回未接入，让界面和实际跑的东西对上，
+          // 免得又变成「显示未接入、后台还在动」。用函数式更新拿最新的 vrState，
+          // 别拿会话开头那份快照写回去，那会把这一轮刚记下的房间和时间抹掉。
+          void updateCharacter(charId, prev => ({
+              vrState: { ...(prev.vrState || { intervalMinutes: VR_DEFAULT_INTERVAL_MIN }), enabled: false } as any,
+          }));
+          void logVRApiCall({
+              ts: Date.now(), charId, charName: char.name, ok: false, ms: 0,
+              kind: 'tripped',
+              note: `连续 ${streak} 次没能调通模型，已暂停 ${char.name} 的自主登入`,
+          });
+          addToast(`${char.name} 连续 ${streak} 次没能调通模型，已暂停 ta 在彼方的自主登入`, 'error');
       };
       VRScheduler.onTrigger((charId: string, room?: string, letterId?: string) => { void runVR(charId, room, letterId); });
 

--- a/utils/memoryPalace/roomPlatesCloudFallback.test.ts
+++ b/utils/memoryPalace/roomPlatesCloudFallback.test.ts
@@ -103,6 +103,23 @@ describe('交云端整理之后往哪走', () => {
     expect(result.cloudPending, '一块门牌没动 + 不说在路上 = 日志报「整理未跑成」').toBe(true);
   });
 
+  // 回归守卫：**没更新 Worker 的用户**走的就是这条。老 bundle 的 /config-check 里没有
+  // backgroundJobs 这个字段，探测得到「不支持」→ 这一轮压根不碰云端，原地在本地把整理
+  // 跑完，跟上云之前一模一样。这条断了的话，那批用户的门牌会彻底停止更新，而界面上
+  // 一片正常——最难发现的那种坏法。副 API 没配、没填 Worker 地址、没开主动消息 2.0
+  // 也都落在这个出口。
+  it('这台 Worker 不认识后台任务（老 bundle）→ 本地照常跑完，不建云端任务', async () => {
+    plateCloudGate.mockResolvedValue('local');
+
+    const result = await run();
+
+    expect(submitPlateConsolidation, '老 worker 会把它当聊天任务跑然后终态失败').not.toHaveBeenCalled();
+    expect(safeFetchJson, '不在本地跑的话，这批用户的门牌就永远不更新了').toHaveBeenCalled();
+    expect(result.cloudPending, '云端根本没接手，别让日志说结果在路上').toBeFalsy();
+    // 本地这条路的老规矩照旧：LLM 没给出有效条目时，本轮候选机械兜底并入，不许蒸发。
+    expect(result.updated).toContain('user_room');
+  });
+
   it('服务端答复了「不行」→ 退回本地跑，已经保底并入的房间照样报出来', async () => {
     submitPlateConsolidation.mockRejectedValueOnce(new Error('worker 说不行'));
 

--- a/utils/vrWorld/runSession.ts
+++ b/utils/vrWorld/runSession.ts
@@ -157,6 +157,9 @@ export async function runVRSession(deps: VRSessionDeps): Promise<VRSessionResult
     running.add(char.id);
     // 信号坠落处的写诗会话锁 token（抢到才有值）；finally 里兜底放锁
     let signalLockToken: string | null = null;
+    // 这一轮是不是折在「调模型」这一步上。调度器只对这种失败记账做熔断——
+    // 解析出错、落库出错都是本机自己的事，重试有意义，不该算到 API 头上。
+    let modelCallFailed = false;
     try {
         window.dispatchEvent(new CustomEvent('vr-session-start', {
             detail: { charId: char.id, charName: char.name, room: room.id },
@@ -375,9 +378,10 @@ export async function runVRSession(deps: VRSessionDeps): Promise<VRSessionResult
                     temperature: 0.9, stream: false,
                 }),
             }, 2, 0, { appName: '彼方', charId: char.id, charName: char.name, purpose: '自由活动' });
-            logVRApiCall({ ts: callStart, charName: char.name, room: room.id, model: vrApi.model, baseUrl, ok: true, ms: Date.now() - callStart });
+            logVRApiCall({ ts: callStart, charId: char.id, charName: char.name, charEnabled: !!char.vrState?.enabled, room: room.id, model: vrApi.model, baseUrl, ok: true, ms: Date.now() - callStart });
         } catch (e: any) {
-            logVRApiCall({ ts: callStart, charName: char.name, room: room.id, model: vrApi.model, baseUrl, ok: false, ms: Date.now() - callStart, error: (e?.message || String(e)).slice(0, 160) });
+            modelCallFailed = true;
+            logVRApiCall({ ts: callStart, charId: char.id, charName: char.name, charEnabled: !!char.vrState?.enabled, room: room.id, model: vrApi.model, baseUrl, ok: false, ms: Date.now() - callStart, error: (e?.message || String(e)).slice(0, 160) });
             throw e;
         }
         let aiContent: string = data.choices?.[0]?.message?.content || '';
@@ -657,7 +661,7 @@ export async function runVRSession(deps: VRSessionDeps): Promise<VRSessionResult
         return { ok: true, room: room.id, activity };
     } catch (err) {
         console.error('[VRWorld] session error:', err);
-        return { ok: false, room: room.id, reason: 'error' };
+        return { ok: false, room: room.id, reason: modelCallFailed ? 'api-error' : 'error' };
     } finally {
         running.delete(char.id);
         // 兜底放锁：任何提前 return / 异常路径漏放，这里补放（漏了也有 TTL 自动回收）

--- a/utils/vrWorld/scheduler.ts
+++ b/utils/vrWorld/scheduler.ts
@@ -21,9 +21,23 @@ export interface VRSchedule {
 
 type ScheduleMap = Record<string, VRSchedule>;
 type LastFireMap = Record<string, number>;
+type FailStreakMap = Record<string, number>;
+
+/** 一轮活动的结局。`skipped` = 压根没调模型（没书没歌、房间被占、角色没接入），不算账。 */
+export type VRSessionOutcome = 'ok' | 'failed' | 'skipped';
 
 const STORAGE_KEY = 'vr_schedules';
 const LAST_FIRE_KEY = 'vr_last_fire';
+const FAIL_STREAK_KEY = 'vr_fail_streak';
+
+/**
+ * 连着失败这么多次，就掐掉这个角色的自主登入。
+ *
+ * 彼方整个跑在后台：令牌被停用、余额耗尽这类「再试也不会好」的故障，用户在界面上
+ * 一点都看不见，只会在几小时后翻调用记录时发现全是红的。攒够这个数就停调度、把角色
+ * 落回未接入，让它自己收手，而不是通宵一轮轮撞下去。
+ */
+export const VR_FAIL_LIMIT = 3;
 
 function load<T>(key: string): T {
     try {
@@ -44,6 +58,15 @@ const loadSchedules = () => load<ScheduleMap>(STORAGE_KEY);
 const saveSchedules = (s: ScheduleMap) => save(STORAGE_KEY, s);
 const loadLastFire = () => load<LastFireMap>(LAST_FIRE_KEY);
 const saveLastFire = (m: LastFireMap) => save(LAST_FIRE_KEY, m);
+const loadFailStreak = () => load<FailStreakMap>(FAIL_STREAK_KEY);
+const saveFailStreak = (m: FailStreakMap) => save(FAIL_STREAK_KEY, m);
+
+function removeFailStreak(charId: string) {
+    const m = loadFailStreak();
+    if (m[charId] === undefined) return;
+    delete m[charId];
+    saveFailStreak(m);
+}
 
 function getLastFire(charId: string): number {
     return loadLastFire()[charId] || 0;
@@ -107,6 +130,17 @@ function schedulePreciseTimer() {
     }, delay);
 }
 
+/** 撤掉一个角色的自主登入，连带清掉它的首火时刻和失败计数。 */
+function stopSchedule(charId: string) {
+    const schedules = loadSchedules();
+    delete schedules[charId];
+    saveSchedules(schedules);
+    removeLastFire(charId);
+    removeFailStreak(charId);
+    if (Object.keys(schedules).length === 0) detachListeners();
+    else schedulePreciseTimer();
+}
+
 function handleVisibility() {
     if (document.visibilityState !== 'visible') return;
     checkOverdue();
@@ -157,19 +191,45 @@ export const VRScheduler = {
         schedules[charId] = { charId, intervalMs };
         saveSchedules(schedules);
         setLastFire(charId, Date.now());
+        // 重新启用 = 用户已经去处理过（换了 API / 充了值），旧的失败账一笔勾销，
+        // 否则熔断过一次的角色刚开回来就会被上一轮的余额一脚踢停。
+        removeFailStreak(charId);
         attachListeners();
         console.log(`[VRScheduler] Started: ${charId}, every ${clamped}min`);
     },
 
     /** 停止某角色。 */
     stop(charId: string) {
-        const schedules = loadSchedules();
-        delete schedules[charId];
-        saveSchedules(schedules);
-        removeLastFire(charId);
-        if (Object.keys(schedules).length === 0) detachListeners();
-        else schedulePreciseTimer();
+        stopSchedule(charId);
         console.log(`[VRScheduler] Stopped: ${charId}`);
+    },
+
+    /**
+     * 回报一轮活动的结局，用来判断要不要熔断。
+     *
+     * `failed` 累计到 {@link VR_FAIL_LIMIT} 就把调度掐掉并返回 `tripped: true`；
+     * 中间只要成功一次，计数就归零。调用方拿到 `tripped` 后负责把角色落回未接入、
+     * 并告诉用户——调度器只管自己这张表，不碰角色数据。
+     */
+    report(charId: string, outcome: VRSessionOutcome): { tripped: boolean; streak: number } {
+        if (outcome === 'skipped') return { tripped: false, streak: loadFailStreak()[charId] || 0 };
+        if (outcome === 'ok') {
+            removeFailStreak(charId);
+            return { tripped: false, streak: 0 };
+        }
+        const m = loadFailStreak();
+        const streak = (m[charId] || 0) + 1;
+        m[charId] = streak;
+        saveFailStreak(m);
+        if (streak < VR_FAIL_LIMIT) return { tripped: false, streak };
+        stopSchedule(charId);
+        console.warn(`[VRScheduler] 连续 ${streak} 次失败，已停掉自主登入: ${charId}`);
+        return { tripped: true, streak };
+    },
+
+    /** 当前累计的连续失败次数（面板展示用）。 */
+    getFailStreak(charId: string): number {
+        return loadFailStreak()[charId] || 0;
     },
 
     /** 重载后恢复所有计划。 */
@@ -215,6 +275,7 @@ export const VRScheduler = {
             if (!activeIds.has(id)) {
                 delete schedules[id];
                 removeLastFire(id);
+                removeFailStreak(id);
                 changed = true;
             }
         }

--- a/utils/vrWorld/vrApi.ts
+++ b/utils/vrWorld/vrApi.ts
@@ -18,6 +18,24 @@ export interface VRApiCall {
     ok: boolean;
     ms: number;
     error?: string;
+    /** 角色 id。角色被删掉后名字就没了，靠它还能认出是谁的调度在动。 */
+    charId?: string;
+    /**
+     * 这条记的是什么。省略 = 一次真实的模型调用。
+     *   - `skipped`：调度到点了，但这一轮没走到模型（角色没接入、角色已删）
+     *   - `tripped`：连续失败攒够，自主登入被停掉
+     */
+    kind?: 'skipped' | 'tripped';
+    /** kind 非空时的一句话说明，直接显示给用户。 */
+    note?: string;
+    /**
+     * 发起这次调用的**那一刻**读到的接入状态。
+     *
+     * 「界面上明明全关了，调用记录还在涨」这类反馈，光看请求本身分不清是谁的锅：
+     * 是这一轮绕过了接入判断，还是界面和实际跑的是两份数据。把当时读到的值一起记下来，
+     * 一眼就能分开。
+     */
+    charEnabled?: boolean;
 }
 
 // 旧版本曾把数据放在 localStorage，这里做一次性迁移到 IndexedDB。

--- a/utils/vrWorld/vrWorld.test.ts
+++ b/utils/vrWorld/vrWorld.test.ts
@@ -4,7 +4,7 @@ import { parseVROutput, parseMusicOutput, parseGuestbookOutput, parseGymOutput, 
 import { rollPoemLines, SIGNAL_LINES_MIN, SIGNAL_LINES_MAX, signalActFor } from './constants';
 import { maskPen } from './postOffice';
 import { decodeBytes } from './decodeText';
-import { VRScheduler } from './scheduler';
+import { VRScheduler, VR_FAIL_LIMIT } from './scheduler';
 import { rollRoom } from './runSession';
 
 // scheduler 的 attachListeners 会访问 document/window（node 环境下没有），补最简 stub。
@@ -43,6 +43,62 @@ describe('VRScheduler.reconcile', () => {
         VRScheduler.reconcile([{ charId: 'c1', intervalMinutes: 240 }]);
         expect(VRScheduler.getIntervalMinutes('c1')).toBe(240);
         expect(JSON.parse(localStorage.getItem('vr_last_fire')!).c1).toBe(fireBefore);
+    });
+});
+
+describe('VRScheduler 熔断', () => {
+    beforeEach(() => {
+        localStorage.removeItem('vr_schedules');
+        localStorage.removeItem('vr_last_fire');
+        localStorage.removeItem('vr_fail_streak');
+    });
+
+    it('连续调不通模型就掐掉自主登入（令牌失效时别通宵一轮轮撞下去）', () => {
+        VRScheduler.start('c1', 120);
+        for (let i = 1; i < VR_FAIL_LIMIT; i++) {
+            expect(VRScheduler.report('c1', 'failed').tripped).toBe(false);
+            expect(VRScheduler.isActiveFor('c1')).toBe(true);
+        }
+        const last = VRScheduler.report('c1', 'failed');
+        expect(last.tripped).toBe(true);
+        expect(last.streak).toBe(VR_FAIL_LIMIT);
+        expect(VRScheduler.isActiveFor('c1')).toBe(false);
+    });
+
+    it('中间成功一次，失败计数归零', () => {
+        VRScheduler.start('c1', 120);
+        VRScheduler.report('c1', 'failed');
+        VRScheduler.report('c1', 'failed');
+        VRScheduler.report('c1', 'ok');
+        expect(VRScheduler.getFailStreak('c1')).toBe(0);
+        expect(VRScheduler.report('c1', 'failed').tripped).toBe(false);
+        expect(VRScheduler.isActiveFor('c1')).toBe(true);
+    });
+
+    it('压根没走到模型的轮次不算账（没书没歌、房间被别人占着）', () => {
+        VRScheduler.start('c1', 120);
+        for (let i = 0; i < VR_FAIL_LIMIT + 2; i++) VRScheduler.report('c1', 'skipped');
+        expect(VRScheduler.getFailStreak('c1')).toBe(0);
+        expect(VRScheduler.isActiveFor('c1')).toBe(true);
+    });
+
+    it('重新启用会把上一轮的失败账清掉', () => {
+        VRScheduler.start('c1', 120);
+        for (let i = 0; i < VR_FAIL_LIMIT; i++) VRScheduler.report('c1', 'failed');
+        expect(VRScheduler.isActiveFor('c1')).toBe(false);
+
+        VRScheduler.start('c1', 120);   // 用户换了 API 重新开
+        expect(VRScheduler.getFailStreak('c1')).toBe(0);
+        expect(VRScheduler.report('c1', 'failed').tripped).toBe(false);
+        expect(VRScheduler.isActiveFor('c1')).toBe(true);
+    });
+
+    it('熔断只掐当事角色，不连累别人', () => {
+        VRScheduler.start('c1', 120);
+        VRScheduler.start('c2', 120);
+        for (let i = 0; i < VR_FAIL_LIMIT; i++) VRScheduler.report('c1', 'failed');
+        expect(VRScheduler.isActiveFor('c1')).toBe(false);
+        expect(VRScheduler.isActiveFor('c2')).toBe(true);
     });
 });
 


### PR DESCRIPTION
## 起因

有用户反馈彼方整夜都在调 API，早上起来把主动消息关了、角色接入也退了，调用记录还是几秒一条地刷，全是 401。

查下来是这么回事：彼方的角色在后台按间隔自主登入，**一轮活动失败在界面上没有任何反馈**。API 令牌被上游停用之后，调度照旧一轮轮往下跑，用户只能在几小时后翻调用记录才发现整晚全是红的；期间做的那些「关掉」也看不出到底有没有生效，最后连是哪一边的问题都说不清。

## 改了什么

| | 改前 | 改后 |
|---|---|---|
| 连续调不通模型 | 一直撞下去，撞到用户自己发现 | 连着 3 次就停掉这个角色的自主登入，并把它落回「未接入」 |
| 失败的可见度 | 完全静默 | 接入列表里显示「已连续 N 次没调通」，暂停时弹提示 |
| 调度表和角色状态脱钩 | 调度到点、角色其实没接入 → 静默空转 | 就地撤掉这条残留调度，并在调用记录里留一行 |
| 调用记录 | 只有成功/失败 | 每条都记下发起那一刻读到的接入状态 |

几个边界：

- 中间成功一次，失败计数就归零
- 没书没歌、房间被别人占着这类**压根没走到模型**的轮次不算账
- 重新启用会把上一轮的失败账清掉，换完 API 开回来不会被旧账一脚踢停
- 暂停只掐当事角色，不连累别人

最后一条是为下一次排障准备的：这次卡了很久，就是因为「界面显示全关了，记录却还在涨」这两件事按代码不该同时成立，而没有任何运行时痕迹能分清是谁错了。以后这种反馈截个图就能定位。

## 没做的事

`Bearer ${apiKey || 'sk-none'}` 这个写法**没动**。它在项目里有 21 处（`useChatAI`、通话、家园、小红书自由活动、情绪评估…），是个全局惯例，本意应该是照顾不需要 key 的本地端点。只在彼方一处改会造成不一致，要清得单独开一个改动统一处理。

真正让人难受的也不是「拿占位符当钥匙」，是撞了一整晚没人喊停 —— 那个由熔断解决。

## 测试

`utils/vrWorld/vrWorld.test.ts` 加了 5 条，都当回归守卫用，验证过在坏行为下会挂：

- 把 `skipped` 也算成失败 → 「压根没走到模型的轮次不算账」挂
- 去掉熔断动作 → 另外 3 条挂

全量 3652 个测试通过，改动涉及的文件类型检查干净。

## 附带

`227f478` 是分支基点上已有的 amsg2 测试提交，跟这次改动无关，一并带过来了。