### PR TITLE
feat(彼方): 加一道跟成败无关的最小间隔闸，外加一键排障快照

### DIFF
--- a/apps/VRWorldApp.tsx
+++ b/apps/VRWorldApp.tsx
@@ -12,6 +12,7 @@ import { useMusic, type Song } from '../context/MusicContext';
 import { DB } from '../utils/db';
 import { useResilientAssetUrl, attachAudioMirrorFallback } from '../utils/assetUrl';
 import { VRScheduler, VR_FAIL_LIMIT } from '../utils/vrWorld/scheduler';
+import { collectVRDiagnostics } from '../utils/vrWorld/diagnostics';
 import { VR_ROOMS, getRoom, VR_DEFAULT_INTERVAL_MIN, SIGNAL_EPIGRAPH, signalActFor, signalActRanges, SIGNAL_POEMS_PER_BOOKLET, SIGNAL_EVENT_ENDED, SIGNAL_MEMORIAL_CLOSING } from '../utils/vrWorld/constants';
 import { buildNovelAsync, groupAnnotationsBySeg, getBookmark } from '../utils/vrWorld/novel';
 import { decodeBytes } from '../utils/vrWorld/decodeText';
@@ -383,7 +384,7 @@ const VRWorldApp: React.FC = () => {
                             onRequestEnable={requestEnable} onEditChibi={setChibiEditChar} />
                     </div>
                 ) : (
-                    <VRApiSettings apiPresets={apiPresets} chatApi={apiConfig} addToast={addToast} />
+                    <VRApiSettings apiPresets={apiPresets} chatApi={apiConfig} addToast={addToast} characters={characters} />
                 )}
             </div>
 
@@ -3446,12 +3447,14 @@ const SettingsView: React.FC<{
 };
 
 // ============ 彼方 · API 设置 + 调用记录 ============
-const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; addToast?: (m: string, t?: any) => void }> = ({ apiPresets, chatApi, addToast }) => {
+const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; addToast?: (m: string, t?: any) => void; characters: CharacterProfile[] }> = ({ apiPresets, chatApi, addToast, characters }) => {
     const [vrApi, setVr] = useState<APIConfig | null>(null);
     const [log, setLog] = useState<VRApiCall[]>([]);
     const [testing, setTesting] = useState(false);
     const [testResult, setTestResult] = useState<string | null>(null);
     const [presetsOpen, setPresetsOpen] = useState(false);   // 折叠「保存的预设」长列表
+    const [snapshot, setSnapshot] = useState<string | null>(null);   // 排障快照正文
+    const [collecting, setCollecting] = useState(false);
 
     useEffect(() => {
         void getVRApi().then(setVr);
@@ -3484,6 +3487,25 @@ const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; add
             if (res.ok) { const d = await safeResponseJson(res); const r = d.choices?.[0]?.message?.content || ''; setTestResult(`连接成功 — 模型回复:"${r.slice(0, 24)}"`); }
             else { const t = await res.text().catch(() => ''); setTestResult(`HTTP ${res.status}: ${t.slice(0, 80)}`); }
         } catch (e: any) { setTestResult(`连接失败: ${e.message}`); } finally { setTesting(false); }
+    };
+
+    // 手机上没有控制台，「界面全关了记录还在涨」这类问题光靠截图说不清。
+    // 一次把该看的都收齐，复制走即可；收的全是状态，不含名字、聊天和 key。
+    const exportSnapshot = async () => {
+        setCollecting(true);
+        try {
+            const text = await collectVRDiagnostics(characters, chatApi);
+            setSnapshot(text);
+            try {
+                await navigator.clipboard.writeText(text);
+                addToast?.('排障快照已复制，可以直接粘给开发者', 'success');
+            } catch {
+                // 剪贴板被浏览器挡住也不算失败——下面把正文摊开，截图一样能用
+                addToast?.('快照已生成（这台设备不让自动复制，长按下面的文字选中即可）', 'info');
+            }
+        } catch (e: any) {
+            addToast?.(`收集失败: ${e?.message || e}`, 'error');
+        } finally { setCollecting(false); }
     };
 
     // 日志里混着两种行：真实的模型调用，和「调度动了但没走到模型」的诊断行。
@@ -3587,6 +3609,27 @@ const VRApiSettings: React.FC<{ apiPresets: ApiPreset[]; chatApi: APIConfig; add
                             );
                         })}
                     </div>
+                )}
+            </div>
+
+            {/* 排障快照 */}
+            <div className="rounded-2xl p-3" style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.07)' }}>
+                <div className="flex items-center gap-1.5 mb-1.5">
+                    <span className="text-[10px] tracking-[0.2em] text-indigo-200/60" style={{ fontFamily: `'Noto Serif SC',serif` }}>排障快照</span>
+                    {snapshot && <button onClick={() => setSnapshot(null)} className="ml-auto text-[10px] text-white/40 hover:text-rose-300/80">收起</button>}
+                </div>
+                <p className="text-[10.5px] text-white/40 leading-relaxed mb-2">
+                    角色明明没接入却还在调用、或者设置改完过一阵又退回去 —— 遇到这类说不清的情况，点一下把当前状态收成一段文字发给开发者。
+                    里面只有开关、时间和用量，<b className="text-indigo-200/70">不含角色名字、聊天记录和 API key</b>。
+                </p>
+                <button onClick={exportSnapshot} disabled={collecting}
+                    className="text-[11px] px-3 py-1.5 rounded-full font-semibold disabled:opacity-50"
+                    style={{ background: 'rgba(120,180,255,.16)', color: '#bcd4ff', border: '1px solid rgba(140,180,255,.3)' }}>
+                    {collecting ? '收集中…' : '生成并复制'}
+                </button>
+                {snapshot && (
+                    <pre className="mt-2.5 max-h-64 overflow-auto text-[9.5px] leading-relaxed text-white/55 whitespace-pre-wrap break-all select-all p-2 rounded-lg"
+                        style={{ background: 'rgba(0,0,0,.3)' }}>{snapshot}</pre>
                 )}
             </div>
         </div>

--- a/context/OSContext.tsx
+++ b/context/OSContext.tsx
@@ -2509,7 +2509,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
       });
 
       // 「彼方」自主登入 —— 独立调度，复用同一批 refs 拿最新状态
-      const runVR = async (charId: string, room?: string, letterId?: string) => {
+      const runVR = async (charId: string, room?: string, letterId?: string, manual?: boolean) => {
           const char = charactersRef.current.find(c => c.id === charId);
           // 调度表里还排着队，角色却已经不接入了（或者压根被删了）：这条调度不该继续存在。
           // 就地撤掉并留一行记录 —— 不撤的话它会一直空转，而空转是完全静默的，
@@ -2537,6 +2537,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
                   updateCharacter,
                   forcedRoom: room as any,
                   forcedLetterId: letterId,
+                  manual,
               });
               // 没书没歌、房间被别人占着这些都不算账，只有真的没调通模型才记一笔失败
               outcome = result.ok ? 'ok' : (result.reason === 'api-error' ? 'failed' : 'skipped');
@@ -2560,7 +2561,7 @@ export const OSProvider: React.FC<{ children: React.ReactNode }> = ({ children }
           });
           addToast(`${char.name} 连续 ${streak} 次没能调通模型，已暂停 ta 在彼方的自主登入`, 'error');
       };
-      VRScheduler.onTrigger((charId: string, room?: string, letterId?: string) => { void runVR(charId, room, letterId); });
+      VRScheduler.onTrigger((charId: string, room?: string, letterId?: string, manual?: boolean) => { void runVR(charId, room, letterId, manual); });
 
       // 以角色 vrState 为准对账调度表：调度表存 localStorage、不随备份迁移，
       // 导入备份后角色虽 enabled 但调度表为空，这里补建/清理使其按时触发。

--- a/utils/vrWorld/diagnostics.ts
+++ b/utils/vrWorld/diagnostics.ts
@@ -1,0 +1,226 @@
+/**
+ * 一键收集排障快照。
+ *
+ * 起因：彼方出过一次「界面上角色全都显示未接入，调用记录却还在一条条往上涨」的故障。
+ * 按代码这两件事不该同时成立，可手机上——尤其是装到主屏的那种——没有控制台，
+ * 拿不到任何运行时痕迹，只能靠用户截图猜。
+ *
+ * 这个函数把判断需要的东西一次凑齐：调度表当前长什么样、内存里的角色状态和落在库里的
+ * 那份对不对得上、浏览器还剩多少存储、最近几十轮各自是什么结局。用户点一下复制走即可。
+ *
+ * **只收状态，不收内容**：角色 id 截成后 6 位，名字、人设、聊天记录、提示词、API key
+ * 一概不进快照。API 只记 host、模型名和「key 填没填、多长」。
+ */
+import type { CharacterProfile, APIConfig } from '../../types';
+import { DB } from '../db';
+import { getVRApi, getVRApiLog } from './vrApi';
+import { getVRThrottleCounts } from './runSession';
+import { VRScheduler } from './scheduler';
+
+/** 页面这次是什么时候起来的——用来看「跑了多久攒出这些记录」。 */
+const PAGE_STARTED_AT = Date.now();
+
+/** 调度相关的 localStorage 键，一次全捞出来（彼方 / 主动发消息 / 家园各一套）。 */
+const SCHEDULE_KEYS = [
+    'vr_schedules', 'vr_last_fire', 'vr_fail_streak',
+    'proactive_schedules', 'proactive_last_fire',
+    'world_schedules', 'world_last_fire',
+];
+
+const tail = (id?: string) => (id ? `…${id.slice(-6)}` : '—');
+const at = (ts?: number) => (ts ? new Date(ts).toLocaleString('zh-CN', { hour12: false }) : '—');
+const mins = (ms: number) => `${Math.round(ms / 60000)} 分钟`;
+
+function hostOf(url?: string): string {
+    if (!url) return '—';
+    try { return new URL(url).host; } catch { return url.slice(0, 40); }
+}
+
+/** API 只留「连的是哪儿、用什么模型、key 填没填」，key 本身绝不出现。 */
+function apiSummary(label: string, cfg?: APIConfig | null): string {
+    if (!cfg?.baseUrl) return `${label}：未配置`;
+    const key = cfg.apiKey || '';
+    const keyNote = key ? `key 已填（${key.length} 位）` : 'key 是空的';
+    return `${label}：${hostOf(cfg.baseUrl)} · ${cfg.model || '未选模型'} · ${keyNote}`;
+}
+
+/** localStorage 当场写读删一遍。写不进去或读回来不一样，下面所有调度状态都不可信。 */
+function probeLocalStorage(): string {
+    const probeKey = '__sullyos_probe__';
+    const expected = String(Date.now());
+    try {
+        localStorage.setItem(probeKey, expected);
+        const back = localStorage.getItem(probeKey);
+        localStorage.removeItem(probeKey);
+        if (back !== expected) return `异常：写进去 ${expected}，读回来是 ${back}`;
+        return '正常（写读删都通过）';
+    } catch (e: any) {
+        return `写不进去：${e?.name || ''} ${e?.message || String(e)}`.trim();
+    }
+}
+
+/**
+ * 浏览器给了多少存储、用了多少、有没有拿到「别清我」的许可。
+ *
+ * 没拿到持久化许可的站点，在手机存储吃紧时会被系统连数据一起清掉——「一觉醒来设置退回
+ * 昨天」多半就是这么来的，所以这两个数值要一起看。
+ */
+async function probeStorageQuota(): Promise<string> {
+    const st = (navigator as any)?.storage;
+    if (!st?.estimate) return '这个浏览器不提供存储用量信息';
+    try {
+        const { usage = 0, quota = 0 } = await st.estimate();
+        const mb = (n: number) => `${(n / 1048576).toFixed(1)} MB`;
+        const pct = quota ? `${((usage / quota) * 100).toFixed(1)}%` : '—';
+        let persisted = '未知';
+        if (st.persisted) persisted = (await st.persisted()) ? '已获得（系统不会随手清）' : '**没有**（存储吃紧时可能被清掉）';
+        return `已用 ${mb(usage)} / 上限 ${mb(quota)}（${pct}）· 持久化许可：${persisted}`;
+    } catch (e: any) {
+        return `读不到：${e?.message || String(e)}`;
+    }
+}
+
+/**
+ * 内存里的角色状态 vs 落在库里的那份。
+ *
+ * 这一段是冲着那个矛盾去的：界面读的是内存，后台调度判断读的也是内存，两边理应一致；
+ * 而库里那份要是和内存对不上，就说明用户改的东西压根没写进去（或者被谁写回了旧值）。
+ */
+async function compareMemoryAgainstDb(memChars: CharacterProfile[]): Promise<string[]> {
+    const lines: string[] = [];
+    let dbChars: CharacterProfile[] = [];
+    try {
+        dbChars = await DB.getAllCharacters();
+    } catch (e: any) {
+        return [`读不出库里的角色：${e?.message || String(e)}`];
+    }
+    const dbById = new Map(dbChars.map(c => [c.id, c]));
+    const related = memChars.filter(c => c.vrState || dbById.get(c.id)?.vrState);
+    if (related.length === 0) return ['没有任何角色配过彼方'];
+
+    for (const mem of related) {
+        const db = dbById.get(mem.id);
+        const memOn = !!mem.vrState?.enabled;
+        const dbOn = !!db?.vrState?.enabled;
+        const flag = memOn === dbOn ? '' : '  ← **对不上**';
+        lines.push(
+            `${tail(mem.id)} 内存=${memOn ? '已接入' : '未接入'} 库里=${db ? (dbOn ? '已接入' : '未接入') : '库里没这个角色'}`
+            + ` 间隔=${mem.vrState?.intervalMinutes ?? '—'}分 上次活动=${at(mem.vrState?.lastActiveAt)}`
+            + `${mem.vrState?.api?.baseUrl ? ' 角色自带API' : ''}${flag}`
+        );
+    }
+    return lines;
+}
+
+/** 调度表里每一条：间隔多久、上次什么时候触发、按理这会儿该不该动。 */
+function describeSchedules(): string[] {
+    let schedules: Record<string, { charId: string; intervalMs: number }> = {};
+    let lastFire: Record<string, number> = {};
+    try {
+        schedules = JSON.parse(localStorage.getItem('vr_schedules') || '{}');
+        lastFire = JSON.parse(localStorage.getItem('vr_last_fire') || '{}');
+    } catch { return ['调度表解析失败（内容不是合法 JSON）']; }
+
+    const ids = Object.keys(schedules);
+    if (ids.length === 0) return ['调度表是空的'];
+    const now = Date.now();
+    return ids.map(id => {
+        const s = schedules[id];
+        const fired = lastFire[id] || 0;
+        const since = fired ? now - fired : 0;
+        const due = fired > 0 && since >= s.intervalMs;
+        return `${tail(id)} 间隔=${mins(s.intervalMs)} 上次触发=${at(fired)}`
+            + `（${fired ? `${mins(since)}前` : '没记录'}）→ 这会儿${due ? '**判定该触发**' : '不该触发'}`;
+    });
+}
+
+/** 最近几十轮各自是什么结局。诊断行（拦下 / 跳过 / 暂停）也在里面。 */
+function describeRecentLog(log: Awaited<ReturnType<typeof getVRApiLog>>): string[] {
+    if (log.length === 0) return ['还没有任何记录'];
+    return log.slice(0, 40).map(l => {
+        const when = at(l.ts);
+        if (l.kind) return `${when} [${l.kind}] ${tail(l.charId)} ${l.note || ''}`;
+        const enabled = l.charEnabled === undefined ? '' : ` 发起时=${l.charEnabled ? '已接入' : '**未接入**'}`;
+        const err = l.error ? ` err=${l.error.slice(0, 60)}` : '';
+        return `${when} [调用] ${tail(l.charId)} ${l.room || '—'} ${l.ok ? '成功' : '失败'} ${(l.ms / 1000).toFixed(1)}s${enabled}${err}`;
+    });
+}
+
+/** 主动消息 2.0 排着的任务。只记类型和时刻，内容一个字都不带。 */
+function describeAmsgTasks(memChars: CharacterProfile[]): string[] {
+    const lines: string[] = [];
+    for (const c of memChars) {
+        const tasks = c.activeMsg2Config?.tasks || [];
+        if (tasks.length === 0) continue;
+        lines.push(`${tail(c.id)} 共 ${tasks.length} 条：`);
+        for (const t of tasks.slice(0, 8)) {
+            lines.push(`  · ${t.mode}/${t.recurrenceType} ${t.status} 下次=${t.nextSendAt || t.firstSendTime || '—'}`
+                + ` 来源=${t.source}${t.lastError ? ` err=${t.lastError.slice(0, 40)}` : ''}`);
+        }
+    }
+    return lines.length ? lines : ['没有角色排着主动消息任务'];
+}
+
+/** 收一份快照，返回可以直接粘出去的纯文本。 */
+export async function collectVRDiagnostics(memChars: CharacterProfile[], chatApi?: APIConfig | null): Promise<string> {
+    const [vrApi, log, quota] = await Promise.all([
+        getVRApi().catch(() => null),
+        getVRApiLog().catch(() => []),
+        probeStorageQuota(),
+    ]);
+    const memVsDb = await compareMemoryAgainstDb(memChars);
+    const standalone = (window.matchMedia?.('(display-mode: standalone)').matches || (navigator as any).standalone) ? '是（主屏图标打开）' : '否（浏览器标签里）';
+    const throttles = getVRThrottleCounts();
+    const throttleLines = Object.keys(throttles).length
+        ? Object.entries(throttles).map(([id, n]) => `${tail(id)} 被拦下 ${n} 次`)
+        : ['没有被拦下过（正常）'];
+
+    const storageDump = SCHEDULE_KEYS.map(k => {
+        const v = localStorage.getItem(k);
+        return `${k} = ${v === null ? '（没有这个键）' : v}`;
+    });
+
+    const failStreaks = memChars
+        .filter(c => VRScheduler.getFailStreak(c.id) > 0)
+        .map(c => `${tail(c.id)} 连续失败 ${VRScheduler.getFailStreak(c.id)} 次`);
+
+    return [
+        '===== SullyOS 彼方排障快照 =====',
+        `收集时间：${new Date().toLocaleString('zh-CN', { hour12: false })}`,
+        `时区：${Intl.DateTimeFormat().resolvedOptions().timeZone}`,
+        `独立窗口：${standalone}`,
+        `本次页面已运行：${mins(Date.now() - PAGE_STARTED_AT)}`,
+        `浏览器：${navigator.userAgent.slice(0, 120)}`,
+        '',
+        '--- 存储健康 ---',
+        `localStorage 自检：${probeLocalStorage()}`,
+        `存储用量：${quota}`,
+        '',
+        '--- 内存 vs 库里（对不上 = 改的东西没写进去） ---',
+        ...memVsDb,
+        '',
+        '--- 调度表 ---',
+        ...describeSchedules(),
+        '',
+        '--- 最小间隔闸 ---',
+        ...throttleLines,
+        '',
+        '--- 连续失败计数 ---',
+        ...(failStreaks.length ? failStreaks : ['都是 0']),
+        '',
+        '--- API（不含 key 本身） ---',
+        apiSummary('彼方独立', vrApi),
+        apiSummary('聊天默认', chatApi),
+        `角色自带 API 的：${memChars.filter(c => c.vrState?.api?.baseUrl).length} 个`,
+        '',
+        '--- 主动消息任务 ---',
+        ...describeAmsgTasks(memChars),
+        '',
+        '--- 调度相关的本地存储原文 ---',
+        ...storageDump,
+        '',
+        `--- 最近 ${Math.min(log.length, 40)} 条记录 ---`,
+        ...describeRecentLog(log),
+        '===== 快照结束 =====',
+    ].join('\n');
+}

--- a/utils/vrWorld/runSession.ts
+++ b/utils/vrWorld/runSession.ts
@@ -61,6 +61,8 @@ export interface VRSessionDeps {
     forcedRoom?: VRRoomId;
     /** 用户在邮局指定要让该角色回复的来信 id（forcedRoom 应为 postoffice）。 */
     forcedLetterId?: string;
+    /** 用户亲手点的（「让 ta 现在去逛一次」这类），不受自动登入的最小间隔闸限制。 */
+    manual?: boolean;
 }
 
 export interface VRSessionResult {
@@ -72,6 +74,42 @@ export interface VRSessionResult {
 
 const genId = (p: string) => `${p}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 7)}`;
 const running = new Set<string>();
+
+/**
+ * 自动登入的最小间隔闸 —— 一个角色两次真实的模型调用之间，至少要隔够设定间隔的一半。
+ *
+ * 为什么要有它：熔断只认「一直失败」，可要是调用一直成功、只是被谁催着一分钟跑两趟，
+ * 那是安安静静地烧钱，没有任何东西会喊停。这道闸跟成败无关，只看「上一次是什么时候」。
+ *
+ * 为什么记在内存里而不落存储：它兜的正是「调度状态本身出了问题」——上游的首火时刻写丢了、
+ * 或者哪条路绕过了到期判断，靠的都是存储；把闸也存进去，就会跟着一起失效。页面一刷新
+ * 计数就归零，而失控循环本来就活在单个页面实例里，内存态足够拦住。
+ *
+ * 用户手动点「让 ta 现在去逛一次」不受这道闸限制。
+ */
+const lastAutoCallAt = new Map<string, number>();
+/** 被闸拦下的次数（成功跑一轮就归零）。正常调度永远是 0，非 0 本身就是「上游在失控」的证据。 */
+const throttledCount = new Map<string, number>();
+/** 间隔再怎么短、设定值再怎么脏，两轮之间也不该少于这个数。 */
+const MIN_AUTO_GAP_FLOOR_MS = 5 * 60_000;
+
+/**
+ * 按角色的设定间隔算出「这一轮最早什么时候才允许再来」。
+ *
+ * 取设定间隔的一半，是想留出余量：调度本身会被后台节流推迟，掐得跟设定值一样紧
+ * 会把正常的补火也误伤掉。设定值缺失或是脏数据（NaN、0、负数）时退回默认间隔，
+ * 再由下限兜一道——不这么写的话 NaN 会让所有比较恒为 false，整道闸静悄悄失效。
+ */
+export function vrAutoGapMs(intervalMinutes?: number): number {
+    const raw = Number(intervalMinutes);
+    const minutes = Number.isFinite(raw) && raw > 0 ? raw : VR_DEFAULT_INTERVAL_MIN;
+    return Math.max((minutes * 60_000) / 2, MIN_AUTO_GAP_FLOOR_MS);
+}
+
+/** 各角色当前被最小间隔闸拦下的累计次数，给诊断导出用。 */
+export function getVRThrottleCounts(): Record<string, number> {
+    return Object.fromEntries(throttledCount);
+}
 
 /**
  * 串行化共享房间状态（留言墙等）的 read-modify-write。
@@ -139,9 +177,29 @@ export function rollRoom(char: CharacterProfile, novels: VRWorldNovel[], musicSt
 }
 
 export async function runVRSession(deps: VRSessionDeps): Promise<VRSessionResult> {
-    const { char, characters, apiConfig, userProfile, groups, realtimeConfig, memoryPalaceConfig, updateCharacter, forcedRoom, forcedLetterId } = deps;
+    const { char, characters, apiConfig, userProfile, groups, realtimeConfig, memoryPalaceConfig, updateCharacter, forcedRoom, forcedLetterId, manual } = deps;
 
     if (running.has(char.id)) return { ok: false, reason: 'busy' };
+
+    // 最小间隔闸（见 lastAutoCallAt）。走到这里说明有东西在催，正常调度不会这么密。
+    if (!manual) {
+        const minGap = vrAutoGapMs(char.vrState?.intervalMinutes);
+        const since = Date.now() - (lastAutoCallAt.get(char.id) || 0);
+        if (since < minGap) {
+            const times = (throttledCount.get(char.id) || 0) + 1;
+            throttledCount.set(char.id, times);
+            // 被拦这件事本身就是线索，但真拦起来会几十秒一次，全记下来会把真实调用挤出日志。
+            // 只在第一次和之后每 20 次留一行，把累计次数写进去。
+            if (times === 1 || times % 20 === 0) {
+                void logVRApiCall({
+                    ts: Date.now(), charId: char.id, charName: char.name, ok: false, ms: 0,
+                    kind: 'throttled', charEnabled: !!char.vrState?.enabled,
+                    note: `距上次登入才 ${Math.round(since / 1000)} 秒，不到下限 ${Math.round(minGap / 60000)} 分钟，已拦下（累计 ${times} 次）`,
+                });
+            }
+            return { ok: false, reason: 'too-soon' };
+        }
+    }
 
     // API 优先级：角色自带覆盖 > 彼方独立 API > 聊天默认
     const vrGlobalApi = await getVRApi();
@@ -367,6 +425,9 @@ export async function runVRSession(deps: VRSessionDeps): Promise<VRSessionResult
         // 调 LLM（记录一次调用，供"调用记录"对账）
         const baseUrl = vrApi.baseUrl.replace(/\/+$/, '');
         const callStart = Date.now();
+        // 闸的基准点是「真的发出去了」，而不是「被调度触发了」——没书没歌那些早退的轮次
+        // 一个 token 都没花，不该占掉下一次的额度。
+        if (!manual) { lastAutoCallAt.set(char.id, callStart); throttledCount.delete(char.id); }
         let data: any;
         try {
             data = await safeFetchJson(`${baseUrl}/chat/completions`, {

--- a/utils/vrWorld/scheduler.ts
+++ b/utils/vrWorld/scheduler.ts
@@ -82,7 +82,7 @@ function removeLastFire(charId: string) {
     saveLastFire(m);
 }
 
-let triggerCallback: ((charId: string, room?: string, letterId?: string) => void | Promise<void>) | null = null;
+let triggerCallback: ((charId: string, room?: string, letterId?: string, manual?: boolean) => void | Promise<void>) | null = null;
 let visibilityListener: (() => void) | null = null;
 let focusListener: (() => void) | null = null;
 let mainThreadTimer: ReturnType<typeof setInterval> | null = null;
@@ -177,7 +177,7 @@ function detachListeners() {
 
 export const VRScheduler = {
     /** 注册触发回调（应用启动时调一次）。 */
-    onTrigger(callback: (charId: string, room?: string, letterId?: string) => void | Promise<void>) {
+    onTrigger(callback: (charId: string, room?: string, letterId?: string, manual?: boolean) => void | Promise<void>) {
         triggerCallback = callback;
         attachListeners();
         checkOverdue();
@@ -298,6 +298,6 @@ export const VRScheduler = {
     triggerNow(charId: string, room?: string, letterId?: string) {
         setLastFire(charId, Date.now());
         schedulePreciseTimer();
-        if (triggerCallback) void triggerCallback(charId, room, letterId);
+        if (triggerCallback) void triggerCallback(charId, room, letterId, true);
     },
 };

--- a/utils/vrWorld/vrApi.ts
+++ b/utils/vrWorld/vrApi.ts
@@ -23,9 +23,10 @@ export interface VRApiCall {
     /**
      * 这条记的是什么。省略 = 一次真实的模型调用。
      *   - `skipped`：调度到点了，但这一轮没走到模型（角色没接入、角色已删）
+     *   - `throttled`：来得太密，被最小间隔闸拦下。出现这一行就说明有东西在催调度
      *   - `tripped`：连续失败攒够，自主登入被停掉
      */
-    kind?: 'skipped' | 'tripped';
+    kind?: 'skipped' | 'throttled' | 'tripped';
     /** kind 非空时的一句话说明，直接显示给用户。 */
     note?: string;
     /**

--- a/utils/vrWorld/vrWorld.test.ts
+++ b/utils/vrWorld/vrWorld.test.ts
@@ -5,7 +5,7 @@ import { rollPoemLines, SIGNAL_LINES_MIN, SIGNAL_LINES_MAX, signalActFor } from 
 import { maskPen } from './postOffice';
 import { decodeBytes } from './decodeText';
 import { VRScheduler, VR_FAIL_LIMIT } from './scheduler';
-import { rollRoom } from './runSession';
+import { rollRoom, vrAutoGapMs } from './runSession';
 
 // scheduler 的 attachListeners 会访问 document/window（node 环境下没有），补最简 stub。
 const g = globalThis as any;
@@ -99,6 +99,29 @@ describe('VRScheduler 熔断', () => {
         for (let i = 0; i < VR_FAIL_LIMIT; i++) VRScheduler.report('c1', 'failed');
         expect(VRScheduler.isActiveFor('c1')).toBe(false);
         expect(VRScheduler.isActiveFor('c2')).toBe(true);
+    });
+});
+
+describe('自动登入的最小间隔闸', () => {
+    const MINUTE = 60_000;
+
+    it('取设定间隔的一半，给后台节流留余量', () => {
+        expect(vrAutoGapMs(120)).toBe(60 * MINUTE);
+        expect(vrAutoGapMs(30)).toBe(15 * MINUTE);
+    });
+
+    it('间隔是脏数据时不能让闸失效 —— NaN 会让所有比较恒为 false', () => {
+        // 这几个值以前会算出 NaN 或 0，闸形同虚设：真正失控时一次都拦不住
+        for (const dirty of [NaN, 0, -5, undefined, Infinity]) {
+            const gap = vrAutoGapMs(dirty as any);
+            expect(Number.isFinite(gap)).toBe(true);
+            expect(gap).toBeGreaterThanOrEqual(5 * MINUTE);
+        }
+    });
+
+    it('间隔被写成极小值时由下限兜底', () => {
+        expect(vrAutoGapMs(1)).toBe(5 * MINUTE);
+        expect(vrAutoGapMs(4)).toBe(5 * MINUTE);
     });
 });
 


### PR DESCRIPTION
接着 #584 往下走。那个 PR 装的熔断只认「连着失败」—— 可要是调用一直**成功**，只是被谁催着一分钟跑两趟，那是安安静静地烧钱，没有任何东西会喊停。

## 最小间隔闸

同一个角色两次自动登入之间，至少要隔够设定间隔的一半（下限 5 分钟）。来得太密就直接拦下，不看这一轮是成是败。用户手点「让 ta 现在去逛一次」不受限。

两个刻意的选择：

**闸记在内存里，不落存储。** 它兜的正是「调度状态本身出了问题」这种情况 —— 上游的首火时刻写丢了、或者哪条路绕过了到期判断，靠的都是存储；把闸也存进去，就会跟着一起失效。页面一刷新计数归零，而失控循环本来就活在单个页面实例里，内存态足够拦住。

**被拦下会在调用记录里留一行**（带累计次数，每 20 次记一条免得刷屏）。正常调度永远走不到这里，所以这一行出现本身就是「有东西在催调度」的证据 —— 这正是上一轮排查缺的东西。

顺手补了个洞：设定间隔是脏数据时，原先 `Math.max(30, NaN)` 会算出 `NaN`，让所有比较恒为 `false`，**整道闸静悄悄失效**。现在退回默认值再由下限兜一道。

## 排障快照

彼方「API」标签新增一个按钮，点一下把这些收成一段文字复制走：

- **内存里的角色状态 vs 库里那份** —— 对不上就说明改的东西没写进去
- **存储用量和持久化许可** —— 没拿到许可的站点，系统在存储吃紧时会连数据一起清掉
- localStorage 当场写读删自检
- 调度表每一条：间隔多久、上次何时触发、这会儿按理该不该动
- 间隔闸计数、连续失败计数
- 最近 40 条记录（含每条发起时读到的接入状态）
- 主动消息任务清单（只有类型和时刻）

**只收状态，不收内容**：角色 id 截成后 6 位，名字、人设、聊天记录、提示词一概不进快照；API 只记 host、模型名和「key 填没填、多长」。

为什么要有它：手机上——尤其装到主屏那种——没有控制台，PWA 和 Safari 存储还是分开的两份，普通用户没法配合取证。上一轮排查就卡在这儿，只能靠截图猜。

## 测试

`vrWorld.test.ts` 加了 3 条，验证过在坏行为下会挂（把 NaN 处理换回旧写法，其中 2 条立刻红）。全量 3655 个测试通过，改动涉及的文件类型检查干净。