### PR TITLE
fix(隐私审计): 线上产物核对扫全站，不再只看入口那一个文件

### DIFF
--- a/.github/workflows/privacy-audit.yml
+++ b/.github/workflows/privacy-audit.yml
@@ -115,8 +115,12 @@ jobs:
           # 1b. 线上产物核对：CI 审计的实例，就是用户浏览器真正在请求的那个
           #
           # 上面那两条只证明「文档 == Variables」，而 Variables 只是构建的输入。
-          # 用户实际加载的是 GitHub Pages 上那个 bundle —— 中间隔着一次构建。
+          # 用户实际加载的是 GitHub Pages 上那些文件 —— 中间隔着一次构建。
           # 所以这里直接把线上产物抓下来，在里面找这两个值。
+          #
+          # 具体怎么抓、为什么要抓全站而不是只看入口那一个文件，见脚本里的说明。
+          # 判定逻辑放在 scripts/ 下有测试守着（scripts/audit-online-bundle.test.ts），
+          # 省得它哪天悄悄退化成「只看一个文件、看不见就报没有」。
           #
           # 只在 Variables 读得到时跑：读不到就说明这是 fork 或没配统计的仓库，
           # 它的 Pages 上本来就不该有这些值，没有可核对的对象。
@@ -126,55 +130,28 @@ jobs:
             owner=${GITHUB_REPOSITORY%%/*}
             repo=${GITHUB_REPOSITORY##*/}
             PAGES="https://${owner}.github.io/${repo}/"
-            echo "  Pages: $PAGES"
+            echo "  Pages: $PAGES ｜ node $(node --version)"
 
-            tmp=$(mktemp -d)
-            entry=""
-            code=""
+            # 人看的进度走 stderr（直接落进日志），stdout 是给这里解析的 JSON。
+            bundle_json=$(node scripts/audit-online-bundle.mjs \
+              --base "$PAGES" \
+              --public-dir public \
+              --website-id "$WID" \
+              --script-url "$VAR_SCRIPT_URL") || true
 
-            # 改这个 workflow 的 push 会同时触发 deploy-pages（那条没有 paths 限制），
-            # 两边撞车时，index.html 指向的 chunk 可能正在被换掉，抓下来是 404。
-            # 所以「读 index → 抓 chunk」整个重试，每轮都重新读 index —— 部署一次
-            # chunk 名就变一次，只重试下载是没用的。
-            for attempt in 1 2 3; do
-              curl -sSL --max-time 20 "$PAGES" -o "$tmp/index.html" || true
-              entry=$(grep -oE 'assets/index-[A-Za-z0-9_-]+\.js' "$tmp/index.html" 2>/dev/null | head -1 || true)
-              if [[ -z "$entry" ]]; then
-                echo "  第 $attempt 次没能从 index.html 定位入口 chunk，等 20 秒重试"
-                sleep 20
-                continue
+            before=${#rows[@]}
+            while IFS=$'\t' read -r name expected actual; do
+              if [[ -n "$name" ]]; then
+                check "$name" "$expected" "$actual"
               fi
-              code=$(curl -sSL --max-time 60 -w '%{http_code}' "${PAGES}${entry}" -o "$tmp/bundle.js" || echo 000)
-              [[ "$code" == "200" ]] && break
-              echo "  第 $attempt 次抓 $entry 得到 $code，等 20 秒重试（多半是正撞上部署）"
-              sleep 20
-            done
+            done < <(printf '%s' "$bundle_json" | jq -r '.checks[]? | [.name, .expected, .actual] | @tsv' 2>/dev/null || true)
 
-            check "线上产物入口 chunk 可下载" "200" "${code:-（没定位到 chunk）}"
-
-            if [[ "$code" == "200" ]]; then
-              echo "  入口 chunk: $entry（$(wc -c < "$tmp/bundle.js") 字节）"
-
-              # ⚠️ 必须 grep 文件，不能写成 `printf '%s' "$bundle" | grep -qF ...`。
-              # grep -q 一匹配上就立刻退出，printf 随即被 SIGPIPE 打死，pipefail
-              # 把整个管道的退出码抬成 141 —— 于是「找到了」被判成「没找到」。
-              # 而真没找到时 grep 会读完全部输入、正常返回 1，同样是 no。
-              # 两条路都通向 no：那种写法下这条断言恒为假，一次都绿不了。
-              # （第一次上线就是这么红的，日志里那句 `printf: write error:
-              #   Broken pipe` 就是 grep 提前退出的证据 —— 换句话说，
-              #   那行报错本身证明了它其实找到了。）
-              hits=$(grep -cF "$WID" "$tmp/bundle.js" || true)
-              check "线上产物内含该站点 id" "yes" "$( (( ${hits:-0} > 0 )) && echo yes || echo no )"
-
-              # 产物里出现的 tracker 脚本地址去重后必须只有一个，且就是配的那个。
-              # 多出一个 = 页面上还挂着第二个上报端点，这必须被发现。
-              # （这条的管道是安全的：grep -oE 不会提前退出，会读完整个文件。）
-              got=$(grep -oE 'https://[A-Za-z0-9.-]+/script\.js' "$tmp/bundle.js" \
-                    | sort -u | paste -sd',' - || true)
-              check "线上产物内 tracker 地址唯一且相符" "$VAR_SCRIPT_URL" "${got:-（没找到）}"
+            # 脚本自己崩了 / 输出解析不出来时，上面那个循环一条都读不到，
+            # 于是「线上产物」这一整块悄无声息地消失，整份审计照样绿。
+            # 这种时候必须留下一条红的。
+            if (( ${#rows[@]} == before )); then
+              check "线上产物核对脚本跑通" "yes" "no（没有可解析的输出，看上面的报错）"
             fi
-
-            rm -rf "$tmp"
             echo
           fi
 

--- a/scripts/audit-online-bundle.mjs
+++ b/scripts/audit-online-bundle.mjs
@@ -1,0 +1,337 @@
+/**
+ * 线上产物核对：把用户浏览器真正会加载到的 js 全部抓下来，
+ * 在里面找统计站点 id 和 tracker 地址。
+ *
+ * 为什么要抓全站而不是只看入口那一个文件：
+ * 统计配置落在哪个 chunk 里，是打包器按依赖图自行决定的，跟隐私承诺无关。
+ * 依赖图一变它就换个地方待着（2026-08-16 起连红两天就是这么来的：某个模块
+ * 在「记忆宫殿」和「amsg 运行时」之间架了条依赖边，analytics 那一片被划进了
+ * memory-palace 包，入口包里从此不含这两个值）。
+ * 更要紧的是反方向：多出来的第二个上报端点只要待在懒加载 chunk 里，
+ * 「只看入口」的查法就永远发现不了 —— 假红只是难看，这个是真会漏。
+ *
+ * 所以这里从 index.html 出发，顺着各个 chunk 之间的引用一路跟下去，
+ * 扫完再下结论；中途撞上限就直接判失败，不按「已经扫到的那部分」报通过。
+ *
+ * 用法：
+ *   node scripts/audit-online-bundle.mjs --base https://例子.github.io/仓库/ \
+ *        --website-id <uuid> --script-url https://统计实例/script.js
+ *   node scripts/audit-online-bundle.mjs --dir dist --website-id ... --script-url ...
+ *
+ * stdout 是给机器看的 JSON（workflow 用 jq 取里面的 checks），
+ * 人看的日志走 stderr。
+ */
+
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+/** 一轮扫描最多抓多少个 js / 多少字节。撞上就停，并且判失败。 */
+const DEFAULT_LIMITS = { maxFiles: 300, maxBytes: 120 * 1024 * 1024 };
+
+/**
+ * 产物里出现的 tracker 脚本地址长这样。跟 assert-privacy.sh 的判定保持一致。
+ * 每次现造一个：带 g 的正则自带 lastIndex，共享一份迟早要在这上面翻车。
+ */
+const trackerPattern = () => /https:\/\/[A-Za-z0-9.-]+\/script\.js/g;
+
+/**
+ * 从一份文本（index.html 或某个 chunk）里找出它引用的、本站内的 js 地址。
+ *
+ * 几种写法都要认：
+ *   · `"./memory-palace-abc.js"`  chunk 之间的 import，相对当前文件
+ *   · `"assets/Chat-abc.js"`      懒加载用的 __vite__mapDeps 数组，相对站点根
+ *   · `"/assets/Chat-abc.js"`     根路径写法，取决于构建时的 base 配置
+ *
+ * 「算不算本站」按同源判定，跟浏览器一个标准：同源的它都会去加载，
+ * 那审计就都得跟。用「地址以站点根开头」来判会漏 —— base 配置一改，
+ * 根路径写法就整批跳出前缀，从审计视野里消失，而浏览器照加载不误。
+ *
+ * @param {string} text 文件内容
+ * @param {string} fromUrl 这份内容自己的地址
+ * @param {string} baseUrl 站点根，必须以 / 结尾
+ * @returns {string[]} 去重后的绝对地址
+ */
+export function extractScriptRefs(text, fromUrl, baseUrl) {
+  const refs = new Set();
+  const pattern = /["'`]([^"'`\s<>]{1,300}\.js)["'`]/g;
+  const siteOrigin = new URL(baseUrl).origin;
+
+  for (const match of text.matchAll(pattern)) {
+    const raw = match[1];
+    let resolved;
+    try {
+      // 以 . 或 / 开头的是相对/根路径写法，按当前文件解析；
+      // 裸路径（mapDeps 数组里那种）按站点根解析。
+      const anchor = raw.startsWith('.') || raw.startsWith('/') ? fromUrl : baseUrl;
+      resolved = new URL(raw, anchor);
+    } catch {
+      continue;
+    }
+    if (resolved.origin !== siteOrigin) continue;
+    refs.add(resolved.href);
+  }
+
+  return [...refs];
+}
+
+/**
+ * 从 index.html 出发，把站内所有能引用到的 js 抓下来。
+ *
+ * 有几个文件是 import 链上找不到的：public/ 下原样复制上线的那些，
+ * 其中一部分由运行时拼出地址来加载（MediaPipe 的 wasm glue 就是这样）。
+ * 浏览器照样会加载它们，所以调用方可以用 extraPaths 把这些路径直接补进起点。
+ *
+ * @param {object} options
+ * @param {string} options.baseUrl 站点根，必须以 / 结尾
+ * @param {(url: string) => Promise<string | null>} options.fetchText 取文本；取不到返回 null
+ * @param {string[]} [options.extraPaths] 额外起点，相对站点根
+ * @param {{ maxFiles?: number, maxBytes?: number }} [options.limits]
+ * @returns {Promise<{ files: {url: string, text: string, bytes: number}[],
+ *                     stats: { fetched: number, missing: number, bytes: number, indexReadable: boolean },
+ *                     truncated: null | { reason: string, limit: number } }>}
+ */
+export async function collectSiteScripts({ baseUrl, fetchText, extraPaths = [], limits = {} }) {
+  const { maxFiles, maxBytes } = { ...DEFAULT_LIMITS, ...limits };
+
+  const files = [];
+  const stats = { fetched: 0, missing: 0, unreachable: 0, bytes: 0, indexReadable: false };
+  let truncated = null;
+
+  const indexText = await fetchText(baseUrl);
+  const queue = [];
+  const seen = new Set();
+
+  const enqueue = (url) => {
+    if (seen.has(url)) return;
+    seen.add(url);
+    queue.push(url);
+  };
+
+  if (indexText !== null) {
+    stats.indexReadable = true;
+    for (const ref of extractScriptRefs(indexText, baseUrl, baseUrl)) enqueue(ref);
+  }
+
+  for (const extra of extraPaths) {
+    try {
+      enqueue(new URL(extra, baseUrl).href);
+    } catch {
+      // 给了个解析不了的路径，跳过就行 —— 抓不到的引用本来也只记数。
+    }
+  }
+
+  while (queue.length > 0) {
+    if (files.length >= maxFiles) {
+      truncated = { reason: 'maxFiles', limit: maxFiles };
+      break;
+    }
+    if (stats.bytes >= maxBytes) {
+      truncated = { reason: 'maxBytes', limit: maxBytes };
+      break;
+    }
+
+    const url = queue.shift();
+    let text;
+    try {
+      text = await fetchText(url);
+    } catch (error) {
+      // 取不到 ≠ 不存在。这个文件没被审计过，结论就有个缺口，
+      // 不能跟「认错文件名」一样放过去。
+      stats.unreachable += 1;
+      console.error(`  ⚠️  取不到 ${url}：${error?.message || error}`);
+      continue;
+    }
+    if (text === null) {
+      // 从压缩过的代码里认文件名难免认错，认错的地址一取就是 404。
+      // 这些不算失败，但要记数：数字太大就说明上面那个正则该收紧了。
+      stats.missing += 1;
+      continue;
+    }
+
+    const bytes = Buffer.byteLength(text);
+    files.push({ url, text, bytes });
+    stats.fetched += 1;
+    stats.bytes += bytes;
+
+    for (const ref of extractScriptRefs(text, url, baseUrl)) enqueue(ref);
+  }
+
+  return { files, stats, truncated };
+}
+
+/**
+ * 对扫到的产物做断言。
+ *
+ * @param {object} options
+ * @param {{ files: {url: string, text: string}[], truncated: any }} options.scan
+ * @param {string} options.websiteId
+ * @param {string} options.scriptUrl
+ * @returns {{ checks: {name: string, expected: string, actual: string, ok: boolean, note?: string}[],
+ *             failed: {name: string, expected: string, actual: string}[] }}
+ */
+export function auditTrackerFootprint({ scan, websiteId, scriptUrl }) {
+  const checks = [];
+  const add = (name, expected, actual, note) => {
+    checks.push({ name, expected, actual, ok: expected === actual, ...(note ? { note } : {}) });
+  };
+
+  // 这几条是「结论有没有依据」的前提，放最前面。
+  // 探测这一侧自己坏掉的时候（站点拿不到、入口包 404、爬了一半撞上限、
+  // 有文件取不到），「什么都没查出来」和「查完没问题」长得一模一样，而且是绿的。
+  add('抓到了可供审计的产物', 'yes', scan.files.length > 0 ? 'yes' : 'no');
+  add(
+    '扫描覆盖完整（没撞上限）',
+    'yes',
+    scan.truncated ? `no（撞上 ${scan.truncated.reason}=${scan.truncated.limit}）` : 'yes',
+  );
+  add('引用到的文件都取到了', '0 个取不到', `${scan.stats.unreachable} 个取不到`);
+
+  const idHit = scan.files.find((file) => file.text.includes(websiteId));
+  add(
+    '线上产物内含该站点 id',
+    'yes',
+    idHit ? 'yes' : 'no',
+    idHit ? `出现在 ${idHit.url.split('/').pop()}` : undefined,
+  );
+
+  // 产物里出现的 tracker 地址去重后必须只有一个，且就是配的那个。
+  // 多出一个 = 页面上还挂着第二个上报端点。
+  const found = new Set();
+  for (const file of scan.files) {
+    for (const match of file.text.matchAll(trackerPattern())) found.add(match[0]);
+  }
+  const got = [...found].sort().join(',');
+  add('线上产物内 tracker 地址唯一且相符', scriptUrl, got || '（没找到）');
+
+  return { checks, failed: checks.filter((check) => !check.ok) };
+}
+
+// ───────────────────────── 以下是命令行入口 ─────────────────────────
+
+/** `--a b --c d` → { a: 'b', c: 'd' } */
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (!argv[i].startsWith('--')) continue;
+    out[argv[i].slice(2)] = argv[i + 1]?.startsWith('--') ? '' : (argv[i + 1] ?? '');
+  }
+  return out;
+}
+
+/**
+ * 走网络取文本。404 当「这个地址本来就没有」（多半是从压缩代码里认错了文件名），
+ * 其余的失败先重试，重试完还不行就抛 —— 那意味着这个文件没被审计到，
+ * 是结论上的缺口，不能跟认错文件名一样默默放过。
+ */
+function httpFetcher(timeoutMs = 60_000, retries = 2) {
+  return async (url) => {
+    let lastError;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      try {
+        const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+        if (response.status === 404) return null;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return await response.text();
+      } catch (error) {
+        lastError = error;
+        if (attempt < retries) await new Promise((resolve) => setTimeout(resolve, 2_000));
+      }
+    }
+    throw lastError;
+  };
+}
+
+/** 从本地构建产物里取，用来自查（node scripts/audit-online-bundle.mjs --dir dist）。 */
+function directoryFetcher(dir, baseUrl) {
+  return async (url) => {
+    const relative = url.slice(baseUrl.length) || 'index.html';
+    try {
+      return await readFile(path.join(dir, decodeURIComponent(relative)), 'utf8');
+    } catch {
+      return null;
+    }
+  };
+}
+
+/**
+ * 列出 public/ 下所有 js 的相对路径。这个目录是原样复制上线的，
+ * 站点上的地址就是「站点根 + 这里的相对路径」。
+ */
+async function listPublicScripts(dir) {
+  const found = [];
+  async function walk(current, prefix) {
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) await walk(path.join(current, entry.name), relative);
+      else if (entry.name.endsWith('.js')) found.push(relative);
+    }
+  }
+  await walk(dir, '');
+  return found;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const websiteId = args['website-id'] || process.env.AUDIT_WEBSITE_ID || '';
+  const scriptUrl = args['script-url'] || process.env.AUDIT_SCRIPT_URL || '';
+  const dir = args.dir || '';
+  // 本地目录模式借一个 http 假地址当站点根：同源判定要有 origin，
+  // 而 file:// 的 origin 是 null，判不了。
+  const baseUrl = dir ? 'http://local/' : (args.base || process.env.AUDIT_BASE_URL || '');
+
+  if (!websiteId || !scriptUrl || (!dir && !args.base && !process.env.AUDIT_BASE_URL)) {
+    console.error('用法：--base <站点根 URL> | --dir <本地目录>，外加 --website-id 与 --script-url');
+    process.exit(2);
+  }
+
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const fetchText = dir ? directoryFetcher(dir, base) : httpFetcher();
+
+  // 改 workflow 的 push 会顺带触发一次部署，两边撞车时 index.html 指向的 chunk
+  // 可能正在被换掉，抓下来是 404。整轮重试 —— 部署一次 chunk 名就变一次，
+  // 只重试下载单个文件是没用的。
+  const extraPaths = args['public-dir'] ? await listPublicScripts(args['public-dir']) : [];
+
+  let scan = null;
+  const attempts = dir ? 1 : 3;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    scan = await collectSiteScripts({ baseUrl: base, fetchText, extraPaths });
+    if (scan.files.length > 0) break;
+    if (attempt < attempts) {
+      console.error(`  第 ${attempt} 次一个 js 都没抓到，等 20 秒重试（多半是正撞上部署）`);
+      await new Promise((resolve) => setTimeout(resolve, 20_000));
+    }
+  }
+
+  const result = auditTrackerFootprint({ scan, websiteId, scriptUrl });
+
+  console.error(`  扫描起点 ${base}${extraPaths.length ? `，外加 public/ 里的 ${extraPaths.length} 个静态 js` : ''}`);
+  console.error(
+    `  抓到 ${scan.stats.fetched} 个 js（${scan.stats.bytes} 字节）；` +
+      `${scan.stats.missing} 个地址是 404（认错文件名，正常）；` +
+      `${scan.stats.unreachable} 个取不到`,
+  );
+  for (const check of result.checks) {
+    const suffix = check.note ? `  ${check.note}` : '';
+    if (check.ok) console.error(`  ✅ ${check.name.padEnd(38)} ${check.actual}${suffix}`);
+    else console.error(`  ❌ ${check.name.padEnd(38)} 期望 ${check.expected}，实际 ${check.actual}`);
+  }
+
+  process.stdout.write(`${JSON.stringify({ checks: result.checks, stats: scan.stats }, null, 2)}\n`);
+  process.exit(result.failed.length === 0 ? 0 : 1);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`审计脚本自己出错了：${error?.stack || error}`);
+    process.exit(2);
+  });
+}

--- a/scripts/audit-online-bundle.test.ts
+++ b/scripts/audit-online-bundle.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error JavaScript helper has no type declarations.
+import { collectSiteScripts, auditTrackerFootprint } from './audit-online-bundle.mjs';
+
+const SITE = 'https://example.test/SullyOS/';
+const WEBSITE_ID = '11111111-2222-3333-4444-555555555555';
+const SCRIPT_URL = 'https://stats.example.test/script.js';
+
+/** 把 { 完整 URL: 内容 } 当成一个静态站点；没列出的地址一律当 404。 */
+function fakeSite(pages: Record<string, string>) {
+  return async (url: string) => (url in pages ? pages[url] : null);
+}
+
+/** 只列出失败项的名字，断言时读起来清楚些。 */
+function failedNames(result: { failed: { name: string }[] }) {
+  return result.failed.map((f) => f.name);
+}
+
+describe('线上产物审计 · 抓取范围', () => {
+  it('统计配置被打包进非入口 chunk 时照样找得到', async () => {
+    // 这正是 2026-08-16 起连红两天的场景：「门牌整理上云」让打包器把
+    // analytics 那一片划进了 memory-palace 包，入口包里就此不含这两个值。
+    const pages = {
+      [SITE]: '<script type="module" crossorigin src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]: 'import"./memory-palace-bbb.js";console.log(1);',
+      [`${SITE}assets/memory-palace-bbb.js`]: `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";`,
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(failedNames(result)).toEqual([]);
+    expect(scan.stats.fetched).toBe(2);
+  });
+
+  it('跟得进只在 mapDeps 数组里出现的懒加载 chunk', async () => {
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]:
+        'const __vite__mapDeps=(i,m,d=(m.f||(m.f=["assets/Chat-ccc.js","assets/Chat-ddd.css"])))=>i.map(i=>d[i]);',
+      [`${SITE}assets/Chat-ccc.js`]: `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";`,
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+
+    expect(scan.files.map((f: { url: string }) => f.url)).toContain(`${SITE}assets/Chat-ccc.js`);
+    expect(failedNames(auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL }))).toEqual([]);
+  });
+
+  it('根路径写法 /assets/xxx.js 也跟得到', async () => {
+    // 产物用相对路径（./assets/…）还是根路径（/assets/…），取决于构建时的 base 配置。
+    // 判定标准得跟浏览器一致：同源的它都会去加载，审计就都得跟，
+    // 不然换个 base 配置就有一批文件从审计视野里消失了。
+    const pages = {
+      [SITE]: '<script type="module" src="/assets/index-aaa.js"></script>',
+      'https://example.test/assets/index-aaa.js': `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";`,
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+
+    expect(scan.stats.fetched).toBe(1);
+    expect(failedNames(auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL }))).toEqual([]);
+  });
+
+  it('没人 import 的静态 js（public/ 那些）给了路径就照样审计', async () => {
+    // public/ 下的文件是原样复制上线的，有几个由运行时拼出地址来加载
+    // （MediaPipe 的 wasm glue 就是），import 链上找不到它们。
+    // 浏览器该加载还是会加载，所以得把这些路径直接喂进来。
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]: `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";`,
+      [`${SITE}mediapipe/wasm/vision-internal.js`]: 'const extra="https://tracker.evil.test/script.js";',
+    };
+
+    const scan = await collectSiteScripts({
+      baseUrl: SITE,
+      fetchText: fakeSite(pages),
+      extraPaths: ['mediapipe/wasm/vision-internal.js'],
+    });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(scan.stats.fetched).toBe(2);
+    expect(failedNames(result)).toContain('线上产物内 tracker 地址唯一且相符');
+  });
+
+  it('不跟去站外的地址', async () => {
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]:
+        `const cdn="https://cdn.other.test/lib-eee.js",w="${WEBSITE_ID}",s="${SCRIPT_URL}";`,
+      'https://cdn.other.test/lib-eee.js': 'const x=1;',
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+
+    expect(scan.files.map((f: { url: string }) => f.url)).toEqual([`${SITE}assets/index-aaa.js`]);
+  });
+});
+
+describe('线上产物审计 · 断言', () => {
+  it('多出来的上报端点藏在懒加载 chunk 里也要被抓出来', async () => {
+    // 旧写法只 grep 入口包，这种「入口一切正常、第二个端点躲在懒加载包里」
+    // 的情况会一路绿灯 —— 恰恰是这条断言本来要防的事。
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]: `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";import"./lazy-fff.js";`,
+      [`${SITE}assets/lazy-fff.js`]: 'const extra="https://tracker.evil.test/script.js";',
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(failedNames(result)).toContain('线上产物内 tracker 地址唯一且相符');
+    const failure = result.failed.find((f) => f.name === '线上产物内 tracker 地址唯一且相符')!;
+    expect(failure.actual).toContain('https://tracker.evil.test/script.js');
+    expect(failure.actual).toContain(SCRIPT_URL);
+  });
+
+  it('站点 id 一处都不出现时判失败', async () => {
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]: `const s="${SCRIPT_URL}";`,
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(failedNames(result)).toContain('线上产物内含该站点 id');
+  });
+
+  it('一个 js 都没抓到时判失败，而不是「没找到问题」', async () => {
+    // 探测机制自己坏掉（index.html 拿不到、入口包 404、站点整个挂了）时，
+    // 「没扫到东西」和「扫完没问题」长得一模一样。必须红。
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite({}) });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(failedNames(result)).toContain('抓到了可供审计的产物');
+  });
+
+  it('扫描撞到上限被截断时判失败，不给出「唯一」的结论', async () => {
+    // 截断之后「tracker 地址唯一」这句话就没有依据了 —— 没扫到的那部分里
+    // 有没有第二个端点，谁也不知道。这种时候必须红，不能悄悄按扫到的部分报通过。
+    const pages: Record<string, string> = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]:
+        `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";import"./a-111.js";import"./b-222.js";`,
+      [`${SITE}assets/a-111.js`]: 'const a=1;',
+      [`${SITE}assets/b-222.js`]: 'const b=2;',
+    };
+
+    const scan = await collectSiteScripts({
+      baseUrl: SITE,
+      fetchText: fakeSite(pages),
+      limits: { maxFiles: 2 },
+    });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(scan.truncated).not.toBeNull();
+    expect(failedNames(result)).toContain('扫描覆盖完整（没撞上限）');
+  });
+
+  it('文件取不到（网络抽风）时判失败，不跟「认错文件名」混为一谈', async () => {
+    // 404 是认错了文件名，无所谓；取不到是这个文件没被审计过。
+    // 两者都当 missing 放过的话，网络抖一下就少扫几个文件，而结论照样是绿的。
+    const fetchText = async (url: string) => {
+      if (url === SITE) return '<script type="module" src="./assets/index-aaa.js"></script>';
+      if (url.endsWith('index-aaa.js')) return `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";import"./lazy-bbb.js";`;
+      throw new Error('502 Bad Gateway');
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(scan.stats.unreachable).toBe(1);
+    expect(failedNames(result)).toContain('引用到的文件都取到了');
+  });
+
+  it('抓不到的引用只记数，不算失败', async () => {
+    // 从压缩后的代码里认文件名难免有认错的，这些地址一取就是 404。
+    // 它们不该把审计判红，但要出现在统计里，好判断正则是不是太松了。
+    const pages = {
+      [SITE]: '<script type="module" src="./assets/index-aaa.js"></script>',
+      [`${SITE}assets/index-aaa.js`]: `const w="${WEBSITE_ID}",s="${SCRIPT_URL}";const nope="./ghost-999.js";`,
+    };
+
+    const scan = await collectSiteScripts({ baseUrl: SITE, fetchText: fakeSite(pages) });
+    const result = auditTrackerFootprint({ scan, websiteId: WEBSITE_ID, scriptUrl: SCRIPT_URL });
+
+    expect(scan.stats.missing).toBe(1);
+    expect(failedNames(result)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 起因

「隐私审计 · 外部检查」这个定时任务 8-16、8-17 连红两天，两次都挂在同样两条：

```
❌ 线上产物内含该站点 id               期望 yes，实际 no
❌ 线上产物内 tracker 地址唯一且相符    期望 https://…/script.js，实际（没找到）
```

统计配置其实一直好好在线上，只是从入口 chunk 挪到了 `memory-palace-*.js` 里——
8-15 那批改动在「记忆宫殿」和 amsg 运行时之间多了条依赖边，打包器顺势把 analytics
那一片划了过去。埋点代码一行没改，只是住址变了。

而审计只 grep 入口那一个文件，于是报「没找到」。

## 真正的问题

假红只是表症。这条断言写的是「tracker 地址**唯一**且相符」，用途是抓「页面上还挂着
第二个上报端点」——可它只看整站 74 个 js 里的 1 个。真有个多余的端点藏在懒加载包里，
**它会照样给绿灯**。反向漏检才是会咬人的那个。

## 改成什么样

| | 改之前 | 改之后 |
|---|---|---|
| 审计范围 | 入口 1 个文件 | 顺着引用爬完整站，线上实测 74 个 |
| 配置换个包待着 | 报「没找到」 | 照样找到，并指出在哪个包 |
| 多余端点藏在懒加载包 | 看不见，放行 | 抓出来，两个地址都列出 |

同时补上几处「探测这侧自己坏掉、结果却是绿的」：

- 一个文件都没抓到 → 判红（之前站点整个挂掉也能报「没发现问题」）
- 爬到一半撞上限 → 判红（扫不全时「唯一」这个结论就没依据了）
- 文件取不到 → 判红；404 属于从压缩代码里认错文件名，只记数
- 脚本自己崩了 → workflow 强制留一条失败，不让这一整块无声消失

另外两处会漏的也一并修了：产物用 `/assets/xxx.js` 根路径写法时（构建 base 配置一变
就是这形态），旧的「地址以站点根开头」判定会把它整批当站外丢掉，而浏览器照加载不误，
现改为按同源判定；`public/` 下那几个由运行时拼地址加载的文件（MediaPipe 的 wasm glue）
import 链上找不到，现把该目录的文件名直接补进爬取起点。本地构建实测 75 个 js 一个不漏。

## 怎么保证不再退化

判定逻辑抽到 `scripts/audit-online-bundle.mjs`，配 11 个测试。把实现临时退化成旧那套
「只看入口」跑过一遍，**5 个测试当场挂**，包括「配置漂到别的包」和「多余端点藏在懒加载包」
这两条最关键的。workflow 那段 bash 也用同样的 `bash -e -o pipefail` 把正常和崩溃两条路都走过。

脚本还能对着本地构建自查：

```
node scripts/audit-online-bundle.mjs --dir dist --public-dir public \
  --website-id <id> --script-url <url>
```

## 验证

- 单测 11 项通过；全量 3666 项通过
- 对着真实线上 Pages 跑通，五条断言全绿，站点 id 确认在 `memory-palace-DbRfcthW.js`

审计跑在 master 上，合进去之后下一轮（次日 03:40 UTC）生效。

https://claude.ai/code/session_01M768gCu8S4LC5jckuq7SNb