### PR TITLE
fix: reuse Android update cache directory

### DIFF
--- a/utils/androidAppUpdate.test.ts
+++ b/utils/androidAppUpdate.test.ts
@@ -95,10 +95,34 @@ describe('downloadAndVerifyAndroidUpdate', () => {
       url: validManifest.apkUrl,
       path: 'updates/SullyOS-update.apk',
       directory: 'CACHE',
-      recursive: true,
     }));
+    expect(filesystemMocks.downloadFile.mock.calls[0]?.[0]).not.toHaveProperty('recursive');
     expect(filesystemMocks.mkdir.mock.invocationCallOrder[0]).toBeLessThan(
       filesystemMocks.downloadFile.mock.invocationCallOrder[0],
     );
+  });
+
+  it('continues when a previous update already created the cache directory', async () => {
+    filesystemMocks.mkdir.mockRejectedValueOnce(Object.assign(
+      new Error('Directory exists'),
+      { code: 'DirectoryExists' },
+    ));
+
+    await expect(downloadAndVerifyAndroidUpdate(validManifest)).resolves.toBe(
+      'file:///cache/updates/SullyOS-update.apk',
+    );
+
+    expect(filesystemMocks.deleteFile).toHaveBeenCalledWith({
+      path: 'updates/SullyOS-update.apk',
+      directory: 'CACHE',
+    });
+    expect(filesystemMocks.downloadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hide real cache directory creation failures', async () => {
+    filesystemMocks.mkdir.mockRejectedValueOnce(new Error('Permission denied'));
+
+    await expect(downloadAndVerifyAndroidUpdate(validManifest)).rejects.toThrow('Permission denied');
+    expect(filesystemMocks.downloadFile).not.toHaveBeenCalled();
   });
 });

--- a/utils/androidAppUpdate.ts
+++ b/utils/androidAppUpdate.ts
@@ -39,6 +39,29 @@ const ApkInstaller = registerPlugin<ApkInstallerPlugin>('ApkInstaller');
 const UPDATE_DIRECTORY = 'updates';
 const UPDATE_PATH = 'updates/SullyOS-update.apk';
 
+const isDirectoryExistsError = (error: unknown): boolean => {
+  const record = error && typeof error === 'object' ? error as Record<string, unknown> : null;
+  const detail = [record?.code, record?.message, error instanceof Error ? error.message : error]
+    .filter(value => typeof value === 'string')
+    .join(' ');
+  return /directory\s*(?:does\s+already\s*)?exists|directoryexists|\beexist\b/i.test(detail);
+};
+
+const ensureUpdateDirectory = async (): Promise<void> => {
+  try {
+    await Filesystem.mkdir({
+      path: UPDATE_DIRECTORY,
+      directory: Directory.Cache,
+      recursive: true,
+    });
+  } catch (error) {
+    // Capacitor Filesystem rejects mkdir even with recursive=true when the
+    // directory already exists. A previous update attempt leaving this cache
+    // directory behind is the normal repeat-download path, not a failure.
+    if (!isDirectoryExistsError(error)) throw error;
+  }
+};
+
 export const getAndroidUpdateManifestUrl = (): string =>
   String(import.meta.env.VITE_APK_UPDATE_MANIFEST_URL || '').trim();
 
@@ -93,11 +116,7 @@ export const downloadAndVerifyAndroidUpdate = async (
   manifest: AndroidUpdateManifest,
   onProgress?: (fraction: number) => void,
 ): Promise<string> => {
-  await Filesystem.mkdir({
-    path: UPDATE_DIRECTORY,
-    directory: Directory.Cache,
-    recursive: true,
-  });
+  await ensureUpdateDirectory();
 
   try {
     await Filesystem.deleteFile({ path: UPDATE_PATH, directory: Directory.Cache });
@@ -117,7 +136,6 @@ export const downloadAndVerifyAndroidUpdate = async (
       url: manifest.apkUrl,
       path: UPDATE_PATH,
       directory: Directory.Cache,
-      recursive: true,
       progress: Boolean(onProgress),
     });
   } finally {


### PR DESCRIPTION
修复 Android 应用内更新在缓存 updates 目录已存在时抛 DirectoryExists 的问题。仅忽略目录已存在错误，其他文件系统错误继续上报；同时避免下载阶段重复递归建目录。新增重复下载与真实错误回归测试。全量 357 个测试文件、4465 项通过。