### PR TITLE
fix(amsg2): 设备时钟改过之后，云端状态不再被永久锁死

### DIFF
--- a/components/settings/ActiveMsgGlobalSettingsModal.tsx
+++ b/components/settings/ActiveMsgGlobalSettingsModal.tsx
@@ -107,8 +107,16 @@ const REQUIRED_WORKER_FEATURES = [
 //            `silent: 'when-visible'`（静音改由 Service Worker 按窗口可见性算）。
 //            server 侧没有行为变化，单升这一档不解决任何问题；这批真正要用户去点
 //            一次「更新 Worker」的是通知策略本身，见 utils/amsgBundleVersion.ts。
+//   next.26 — client_state 的条件写不再被「来自未来」的时间戳锁死。设备时钟只要
+//            领先过真实时间，那一刻同步上去的行就带着一个还没到的时刻，之后这台
+//            设备发什么都被判成「旧的」，云端那行要等真实时间追上来才解得开；用户
+//            侧的表现是某个角色的即时对话一直发不出去，删消息、重装、重填地址全都
+//            不管用。这一档两件事：库里那种行不再有拦人的资格（存量能被覆盖回来），
+//            以及新写入的护栏值钳到服务端当前时刻（不再产生新的脏行）。旧部署上前端
+//            的水位（utils/amsgStateClock.ts）能兜住发不出去这一半，但云端那行会一直
+//            停在未来，只有升上来才会第一次写入就回到现实。
 // 不比版本的话，旧粘贴部署会被误判为最新，问题全在 worker 侧静默发生。
-const REQUIRED_WORKER_VERSION = '2.6.0-next.23';
+const REQUIRED_WORKER_VERSION = '2.6.0-next.26';
 
 /** 装着打包好的 worker 代码的部署仓库：fork 它 → 在 Cloudflare 连上 → 以后点 Sync fork 更新。 */
 const WORKERS_REPO_URL = 'https://github.com/Tosd0/sullyos-workers';

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^6.0.0",
-    "@rei-standard/amsg-server": "2.6.0-next.23",
+    "@rei-standard/amsg-server": "2.6.0-next.26",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",

--- a/plans/amsg2-instant-chat-contract.md
+++ b/plans/amsg2-instant-chat-contract.md
@@ -43,8 +43,12 @@
 - 处理步骤（严格顺序，两个 await 失败即向客户端返回明确错误，不落任务）：
   1. 内部 `upstream.fetch` 转发 `PUT /client-state`（statePayload）→ 必须成功。
      HTTP ok 还不够：上游按 updatedAt 条件写（旧不盖新），成功体 `data.skippedEntries`
-     里点名了 `fire_pack` 条目（典型成因：设备时钟被回拨过）时同样打回——
-     `409 INSTANT_CHAT_STATE_STALE`，绝不落任务（否则 fire 拿旧 chat 段答话）。
+     里点名了 `fire_pack` 条目时同样打回——`409 INSTANT_CHAT_STATE_STALE`，绝不落任务
+     （否则 fire 拿旧 chat 段答话）。
+     客户端拿到这个码会自愈一次：读回云端那几行的 `updatedAt`、把本地水位抬过去
+     （`utils/amsgStateClock.ts`）、重新盖戳再发一次。设备时钟只要领先过真实时间，云端
+     那一行就带着一个还没到的时刻，本地墙钟从此跨不过去，那个角色发一句挂一句，把系统
+     时间调回来也没用；水位是这条路的唯一出路。对齐不动才是真被别人写了新的，那时不重发。
   2. 内部转发 `POST /schedule-message`（taskPayload）→ 必须成功，拿到 uuid
      （顶替在上游事务内完成）。
   3. 返回 `202 { status: 'accepted', uuid }`。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.1
       '@rei-standard/amsg-server':
-        specifier: 2.6.0-next.23
-        version: 2.6.0-next.23(@neondatabase/serverless@1.1.0)(pg@8.22.0)
+        specifier: 2.6.0-next.26
+        version: 2.6.0-next.26(@neondatabase/serverless@1.1.0)(pg@8.22.0)
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -1069,8 +1069,8 @@ packages:
     resolution: {integrity: sha512-GsLzRvSXsp5cbJ/vNwQP+yHoZ4LJiilOvws0LemrzaFoG45ApQ7WW3YHux58DXdXOSN36prT5CsmipA3wUAmQQ==}
     engines: {node: '>=18'}
 
-  '@rei-standard/amsg-server@2.6.0-next.23':
-    resolution: {integrity: sha512-2VDkC2ljVCS5JA7fK127qSW0cHf0v02okUBB2ZFdxdGo7AhNyGKCnR5V+zWr2tU9MaNjWZMJEA51Jv5OgFH38Q==}
+  '@rei-standard/amsg-server@2.6.0-next.26':
+    resolution: {integrity: sha512-1arQovTz4nbZOrNaKNfdjyZTwA341WhsRUa2NiNLlX4FI0dVoWFrNdZaw4DQvGCs8RfVpbH00xwnsUx4N6WPAA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@neondatabase/serverless': '>=0.9.0'
@@ -1091,6 +1091,10 @@ packages:
 
   '@rei-standard/amsg-shared@0.4.0-next.8':
     resolution: {integrity: sha512-jyxIbrNR8XPvVLEu7pAyiDnfECKByOhO0zu3zMtxbN7Jf5Ui1rKpX3qQbWRL6WidOTyXYO8jLjkzrCib4wDkgg==}
+    engines: {node: '>=20'}
+
+  '@rei-standard/amsg-shared@0.4.0-next.9':
+    resolution: {integrity: sha512-Jo3TROPfYoAM4KgV0zcZQkvpvtApA4kj70e9M0TXhgRcn3rsWwbv3nEY+8QM76KsmePrrOY0K5VCKTtxwuWU/w==}
     engines: {node: '>=20'}
 
   '@rei-standard/amsg-sw@2.4.0-next.6':
@@ -3516,10 +3520,10 @@ snapshots:
     dependencies:
       '@rei-standard/amsg-shared': 0.2.0
 
-  '@rei-standard/amsg-server@2.6.0-next.23(@neondatabase/serverless@1.1.0)(pg@8.22.0)':
+  '@rei-standard/amsg-server@2.6.0-next.26(@neondatabase/serverless@1.1.0)(pg@8.22.0)':
     dependencies:
       '@netlify/blobs': 8.2.0
-      '@rei-standard/amsg-shared': 0.4.0-next.8
+      '@rei-standard/amsg-shared': 0.4.0-next.9
       web-push: 3.6.7
     optionalDependencies:
       '@neondatabase/serverless': 1.1.0
@@ -3532,6 +3536,8 @@ snapshots:
   '@rei-standard/amsg-shared@0.4.0-next.7': {}
 
   '@rei-standard/amsg-shared@0.4.0-next.8': {}
+
+  '@rei-standard/amsg-shared@0.4.0-next.9': {}
 
   '@rei-standard/amsg-sw@2.4.0-next.6':
     dependencies:

--- a/utils/activeMsgClient.stateClock.test.ts
+++ b/utils/activeMsgClient.stateClock.test.ts
@@ -1,0 +1,241 @@
+// utils/activeMsgClient.stateClock.test.ts
+//
+// 回归守卫（云端拒收这一轮状态时怎么办）：
+//   1. 设备时钟领先过真实时间的话，云端 client_state 那一行会带着一个还没到的时刻，
+//      之后每次上传都被条件写判成「旧的」——即时对话表现为每发一句都 409，用户把系统
+//      时间调回来也没用（那一行在云端，本地删消息 / 重装 / 重填 Worker 地址都碰不到）。
+//      2026-09-01 有用户真的这么卡住了，这里钉住自愈：读回云端那行的时间戳、对齐水位、
+//      重新盖戳发第二次。
+//   2. 但不能见 409 就重发：云端确实有更新的一份时（多设备竞写）重发也是白发，得先看
+//      水位有没有真的抬动。
+//   3. 常规批量同步撞上同一道闸只有一行 log，比即时对话那条还难发现，所以它也要对齐
+//      水位——只是不在这一轮重传（下一轮打脏同步带着更新的内容盖过去更有道理）。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { reiClient } = vi.hoisted(() => ({
+  reiClient: {
+    init: vi.fn(),
+    putClientState: vi.fn(),
+    getClientState: vi.fn(),
+    getCapabilities: vi.fn(),
+    putLlmCredentials: vi.fn(),
+    deleteLlmCredentials: vi.fn(),
+    _encrypt: vi.fn(),
+  },
+}));
+vi.mock('@rei-standard/amsg-client', () => ({ ReiClient: vi.fn(() => reiClient) }));
+vi.mock('./keepAlive', () => ({
+  KeepAlive: { init: vi.fn().mockResolvedValue(undefined), reregister: vi.fn().mockResolvedValue(undefined) },
+}));
+
+const TEST_USER_ID = '3f2b1c8a-9d4e-4a1b-8c2d-000000000043';
+const globalConfig: Record<string, unknown> = {
+  userId: TEST_USER_ID,
+  workerUrl: 'https://amsg.example.workers.dev',
+  serverToken: '',
+  llmCredentialsSupported: true,
+};
+vi.mock('./activeMsgStore', () => ({
+  ActiveMsgStore: {
+    ensureUserId: async () => TEST_USER_ID,
+    getGlobalConfig: async () => ({ ...globalConfig }),
+    saveGlobalConfig: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { ActiveMsgClient } from './activeMsgClient';
+import { amsgStateNamespace } from './amsgFirePack';
+import { clearInstantChatPending } from './amsgInstantChat';
+import { forgetAllCredIds } from './amsgLlmCredentials';
+import { readStateClockWatermark, resetStateClock } from './amsgStateClock';
+import { ChatPrompts } from './chatPrompts';
+import { DB } from './db';
+
+const CHAR_ID = 'char-state-clock';
+const CHAR = {
+  id: CHAR_ID,
+  name: '小满',
+  memories: [],
+  activeMsg2Config: { enabled: true, tasks: [] },
+} as any;
+const NAMESPACE = amsgStateNamespace(CHAR_ID);
+
+/** 云端那一行记着的时刻：比本机的钟晚一小时（当初设备时钟领先时写进去的）。 */
+const FUTURE = Date.now() + 3_600_000;
+
+/** 这一轮 POST 出去的载荷（加密前）。 */
+const capturedPayloads: any[] = [];
+/** 每次 POST 的返回，按顺序取；用完了就一直回最后一个。 */
+let postResponses: Array<{ status: number; body: unknown }> = [];
+let postedPaths: string[] = [];
+
+const respond = () => {
+  const next = postResponses.length > 1 ? postResponses.shift()! : postResponses[0];
+  return {
+    status: next.status,
+    text: async () => JSON.stringify(next.body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  };
+};
+
+const STATE_STALE = {
+  status: 409,
+  body: { success: false, error: { code: 'INSTANT_CHAT_STATE_STALE', message: '云端拒收了这轮的最新状态', step: 'client-state' } },
+};
+const ACCEPTED = { status: 202, body: { status: 'accepted', uuid: 'instant-retried' } };
+
+beforeEach(() => {
+  resetStateClock();
+  capturedPayloads.length = 0;
+  postedPaths = [];
+  postResponses = [ACCEPTED];
+  forgetAllCredIds();
+  reiClient.init.mockReset().mockResolvedValue(undefined);
+  reiClient.putClientState.mockReset().mockResolvedValue({ success: true });
+  reiClient.getClientState.mockReset().mockResolvedValue({ success: true, data: { entries: [] } });
+  reiClient.putLlmCredentials.mockReset().mockResolvedValue({ success: true, data: { upserted: 1 } });
+  reiClient.deleteLlmCredentials.mockReset().mockResolvedValue({ success: true, data: { deleted: 0 } });
+  reiClient.getCapabilities.mockReset().mockResolvedValue({ serverVersion: '2.6.0-next.23', features: [] });
+  reiClient._encrypt.mockReset().mockImplementation(async (json: string) => {
+    capturedPayloads.push(JSON.parse(json));
+    return { iv: 'iv', authTag: 'tag', encryptedData: 'enc' };
+  });
+  vi.spyOn(DB, 'getRecentMessagesByCharId').mockResolvedValue([] as any);
+  vi.spyOn(DB, 'getEmojis').mockResolvedValue([] as any);
+  vi.spyOn(DB, 'getEmojiCategories').mockResolvedValue([] as any);
+  vi.spyOn(ChatPrompts, 'buildSystemPrompt').mockResolvedValue('SYS');
+  vi.spyOn(ChatPrompts, 'buildMessageHistory').mockReturnValue({ apiMessages: [] } as any);
+  vi.spyOn(ChatPrompts, 'filterVisibleEmojis').mockReturnValue({ emojis: [], categories: [] } as any);
+  vi.spyOn(ActiveMsgClient, 'registerPushSubscription').mockResolvedValue(undefined);
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    const target = String(url);
+    postedPaths.push(target);
+    // 只有即时对话那条路吃这条响应队列。首次调用还会捎带握手/探测那几个请求，
+    // 让它们也去队列里取的话，队首那个 409 会被别人吃掉。
+    if (target.includes('instant-chat')) return respond();
+    return {
+      status: 200,
+      text: async () => JSON.stringify({ success: true, data: {} }),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    };
+  }));
+  clearInstantChatPending(CHAR_ID);
+});
+
+afterEach(() => {
+  clearInstantChatPending(CHAR_ID);
+  resetStateClock();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+/** 云端 GET 回来的那一份：fire_pack 那行记着一个还没到的时刻。 */
+const remoteHasFuturePack = () => {
+  reiClient.getClientState.mockResolvedValue({
+    success: true,
+    data: { entries: [{ namespace: NAMESPACE, key: 'fire_pack', value: 'gz1:...', updatedAt: FUTURE }] },
+  });
+};
+
+const send = () => ActiveMsgClient.sendInstantChat({
+  char: CHAR,
+  chatMessages: [{ role: 'user', content: '在吗' }],
+  api: { baseUrl: 'https://api.example.dev/v1', apiKey: 'sk-global', model: 'gpt-global' },
+  userProfile: { name: '小明' } as any,
+  groups: [],
+  realtimeConfig: {} as any,
+} as any);
+
+/** POST 出去的云端状态载荷（任务那份有 messageType，据此分开）。 */
+const statePayloads = () => capturedPayloads.filter((p) => p && Array.isArray(p.entries));
+const firePackStampOf = (payload: any) => payload.entries.find((e: any) => e.key === 'fire_pack').updatedAt;
+const instantChatPosts = () => postedPaths.filter((p) => p.includes('instant-chat'));
+
+describe('即时对话撞上「云端拒收这轮状态」', () => {
+  it('云端那行落在未来 → 读回来对齐、重新盖戳、重发一次，这一轮发得出去', async () => {
+    postResponses = [STATE_STALE, ACCEPTED];
+    remoteHasFuturePack();
+
+    const result = await send();
+
+    expect(result.uuid).toBe('instant-retried');
+    expect(instantChatPosts(), '第一次被拒之后要再发一次').toHaveLength(2);
+    expect(reiClient.getClientState).toHaveBeenCalledWith(NAMESPACE);
+
+    // 重发那一份的戳必须跨过云端那行，否则条件写还是拦下它。
+    const [first, second] = statePayloads();
+    expect(firePackStampOf(first)).toBeLessThan(FUTURE);
+    expect(firePackStampOf(second)).toBeGreaterThan(FUTURE);
+  });
+
+  it('重发只换戳，不重打包（value 原样复用）', async () => {
+    postResponses = [STATE_STALE, ACCEPTED];
+    remoteHasFuturePack();
+
+    await send();
+
+    const [first, second] = statePayloads();
+    expect(second.entries.map((e: any) => e.value)).toEqual(first.entries.map((e: any) => e.value));
+  });
+
+  it('云端读回来的都不比本地新 → 不重发，原样报错（重发也是白发）', async () => {
+    postResponses = [STATE_STALE, ACCEPTED];
+    reiClient.getClientState.mockResolvedValue({
+      success: true,
+      data: { entries: [{ namespace: NAMESPACE, key: 'fire_pack', value: 'gz1:...', updatedAt: 1 }] },
+    });
+
+    await expect(send()).rejects.toThrow('即时对话没发出去');
+    expect(instantChatPosts()).toHaveLength(1);
+  });
+
+  it('云端状态读不回来 → 不重发也不改口，原来的失败原样报出去', async () => {
+    postResponses = [STATE_STALE, ACCEPTED];
+    reiClient.getClientState.mockRejectedValue(new Error('网络断了'));
+
+    await expect(send()).rejects.toThrow('即时对话没发出去');
+    expect(instantChatPosts()).toHaveLength(1);
+  });
+
+  it('对齐过一次之后，别的上传路径也跟着跨过去了（水位是共用的）', async () => {
+    postResponses = [STATE_STALE, ACCEPTED];
+    remoteHasFuturePack();
+    await send();
+
+    reiClient.putClientState.mockClear();
+    await ActiveMsgClient.syncToolConfig({} as any);
+
+    const [entries] = reiClient.putClientState.mock.calls.at(-1)!;
+    expect(entries[0].updatedAt).toBeGreaterThan(FUTURE);
+  });
+});
+
+describe('常规批量同步撞上同一道闸', () => {
+  const sync = () => ActiveMsgClient.syncCharFirePacks([{
+    char: CHAR,
+    config: { enabled: true, tasks: [] } as any,
+    userProfile: { name: '小明' } as any,
+    groups: [],
+    realtimeConfig: {} as any,
+  }]);
+
+  it('被拦下 → 读回云端时间戳对齐水位（这一轮不重传）', async () => {
+    reiClient.putClientState.mockResolvedValue({
+      success: true,
+      data: { upserted: 1, skippedEntries: [{ namespace: NAMESPACE, key: 'fire_pack' }] },
+    });
+    remoteHasFuturePack();
+
+    await sync();
+
+    expect(reiClient.getClientState).toHaveBeenCalledWith(NAMESPACE);
+    expect(reiClient.putClientState, '对齐就够了，这一轮不重传').toHaveBeenCalledTimes(1);
+    expect(readStateClockWatermark()).toBe(FUTURE);
+  });
+
+  it('一条都没被拦 → 不白读一次云端', async () => {
+    await sync();
+
+    expect(reiClient.getClientState).not.toHaveBeenCalled();
+  });
+});

--- a/utils/activeMsgClient.ts
+++ b/utils/activeMsgClient.ts
@@ -44,6 +44,7 @@ import {
   supportsLlmCredentials,
   type LlmCredentialRow,
 } from './amsgLlmCredentials';
+import { observeRemoteStateUpdatedAt, stampStateUpdatedAt } from './amsgStateClock';
 import { flattenContentPartsToText } from './promptMessageCleanup';
 import { resolveBlobRefsDeep } from './blobRef';
 import {
@@ -1049,6 +1050,13 @@ export const describeInstantChatFailure = (status: number, body: any): string =>
     return '即时对话没发出去：没赶上服务端的时间校验——网络太慢，或设备时钟偏慢。'
       + '重试一次通常就好；每次都这样的话，检查一下设备的「自动设置时间」开没开。';
   }
+  // 走到这里说明连自愈那一轮（读回云端时间戳对齐再发一次）都没盖上去：要么云端状态
+  // 读不回来，要么真的有另一台设备/另一个标签页在同时写同一个角色。
+  if (code === 'INSTANT_CHAT_STATE_STALE') {
+    return '即时对话没发出去：云端那份状态比这台设备的新，对齐之后重发也没能盖上去。'
+      + '另一台设备或另一个标签页开着同一个角色的话，先关掉再发；只有这一台的话，'
+      + '检查一下设备的「自动设置时间」开没开。';
+  }
   return `即时对话没发出去（HTTP ${status}${code ? ` / ${code}` : ''}）${detail ? `：${detail}` : '。'}`;
 };
 
@@ -1061,6 +1069,15 @@ export const describeInstantChatFailure = (status: number, body: any): string =>
 export const isCredentialNotFound = (body: any): boolean =>
   body?.error?.code === 'CREDENTIAL_NOT_FOUND'
   || body?.error?.upstream?.error?.code === 'CREDENTIAL_NOT_FOUND';
+
+/**
+ * 这个错误体是不是「云端拒收了这一轮的状态」——条件写把 fire_pack 拦下了。
+ *
+ * 这个码由包装层判出来（`worker/amsg/src/instantChat.ts`），所以只在顶层，不用像
+ * 凭据那个一样再往 `error.upstream` 里剥一层。
+ */
+export const isInstantChatStateStale = (body: any): boolean =>
+  body?.error?.code === 'INSTANT_CHAT_STATE_STALE';
 
 /** client_state 上传每次尝试前等多久：数组长度即总尝试次数（首次不等）。 */
 const CLIENT_STATE_BACKOFF_MS = [0, 400, 1200];
@@ -1116,6 +1133,35 @@ export const putClientStateOrThrow = async (
 };
 
 /**
+ * 被条件写拦下之后，照云端那几行的时间戳把本地水位抬上去；返回水位有没有真的动。
+ *
+ * 为什么非得读一遍：拦下只说明「你盖的戳不够新」，没说云端那行是几点。不读回来就只能
+ * 猜偏移多少，而这个偏移取决于当初设备时钟跑偏了多少，猜不出来。对齐之后下一次盖的戳
+ * 自然就跨得过去了（见 amsgStateClock）。
+ *
+ * 读失败不抛：调用方拿 false 当「没对齐上」处理，该报的错照报——自愈是加分项，不该
+ * 把原本清清楚楚的失败盖成一句「读云端状态失败」。
+ */
+const alignStateClockWithRemote = async (
+  client: ReiClient,
+  namespaces: string[],
+): Promise<boolean> => {
+  let aligned = false;
+  for (const namespace of namespaces) {
+    try {
+      const response = await client.getClientState(namespace) as
+        { data?: { entries?: Array<{ updatedAt?: unknown }> } } | undefined;
+      for (const entry of response?.data?.entries ?? []) {
+        if (observeRemoteStateUpdatedAt(entry?.updatedAt)) aligned = true;
+      }
+    } catch (error) {
+      console.warn(`${ACTIVE_MSG_RUNTIME_HEADER} 读云端状态时间戳失败，这一轮不对齐`, error);
+    }
+  }
+  return aligned;
+};
+
+/**
  * 把一个 namespace 下还有内容的条目全部清空，返回被清掉的键名。
  *
  * 先读一遍再逐条写空，而不是照着已知键名盲写，有两个原因：
@@ -1146,10 +1192,10 @@ export const clearNamespaceValuesOrThrow = async (
   const keys = entries.filter((e) => e?.key && e?.value).map((e) => e.key as string);
   if (keys.length === 0) return [];
 
-  const now = Date.now();
+  const updatedAt = stampStateUpdatedAt();
   await putClientStateOrThrow(
     client,
-    keys.map((key) => ({ namespace, key, value: '', updatedAt: now })),
+    keys.map((key) => ({ namespace, key, value: '', updatedAt })),
     '清空云端状态',
   );
   return keys;
@@ -2287,7 +2333,7 @@ export const ActiveMsgClient = {
     // 到点只能硬失败。tool_pack / tool_config 里没有 chat，照传。抽掉的那份不会就此作废：
     // 排完任务紧跟着的落库会打脏，等回复销账后由状态同步把最新的包补上去。
     if (firePack) {
-      const now = Date.now();
+      const now = stampStateUpdatedAt();
       const owesChat = owesInstantChatReply(char.id);
       if (owesChat) {
         console.warn(`${ACTIVE_MSG_RUNTIME_HEADER} 该角色还欠着一条即时对话回复，这次排程不覆盖云端 fire_pack（等回复销账后由状态同步补传）`);
@@ -2459,7 +2505,7 @@ export const ActiveMsgClient = {
       throw new Error('这台 Worker 还不支持凭据存表，后台任务跑不了（去设置页重新部署一次）。');
     }
 
-    const now = Date.now();
+    const now = stampStateUpdatedAt();
     await putClientStateOrThrow(client, [{
       namespace: AMSG_JOB_NAMESPACE,
       key: params.jobKey,
@@ -2698,16 +2744,24 @@ export const ActiveMsgClient = {
       },
     };
 
-    const stateEntries = {
-      entries: [
-        ...(await buildCharStateEntries(char, firePack, now)),
-        buildToolConfigEntry(realtimeConfig, now),
-      ],
-    };
-    const [statePayload, encryptedTask] = await Promise.all([
-      encryptPayload(client, stateEntries),
+    // 云端那一行的版本号走水位而不是墙钟（见 amsgStateClock）：设备时钟领先过真实时间
+    // 的话，云端会留着一个还没到的时刻，之后每次上传都被条件写判成「旧的」，这条路上
+    // 的表现就是每发一句都 409。
+    const stampedAt = stampStateUpdatedAt();
+    const stateEntries = [
+      ...(await buildCharStateEntries(char, firePack, stampedAt)),
+      buildToolConfigEntry(realtimeConfig, stampedAt),
+    ];
+    // 自愈那一轮只换戳、不重打包：value 里那份压好的 fire_pack 原样复用。
+    const encryptStateEntries = (updatedAt: number) => encryptPayload(client, {
+      entries: stateEntries.map((entry) => ({ ...entry, updatedAt })),
+    });
+    const [encryptedTask, initialState] = await Promise.all([
       encryptPayload(client, taskPayload),
+      encryptStateEntries(stampedAt),
     ]);
+    // 重发那一轮要换成新盖的戳，所以这份是可变的。
+    let statePayload = initialState;
 
     // 凭据行先落地再建任务（上游建任务前会挨个查引用）。只有值变过才真的发请求，
     // 所以常态下这一步是零请求——不给「用户正等着回复」这条路白加一次往返。
@@ -2729,6 +2783,16 @@ export const ActiveMsgClient = {
       await putLlmCredentialRows(credRows, { force: true });
       ({ status, body } = await postInstantChat());
     }
+    // 云端拒收了这一轮的状态：不是内容有问题，是这台设备盖的时间戳跨不过云端那一行
+    // （设备时钟被改过之后，云端会一直留着一个还没到的时刻）。读回云端那份对齐水位、
+    // 重新盖戳再发一次。对齐不动就不重发——那说明拦下它的不是时间戳，重发也是白发。
+    if (status !== 202 && isInstantChatStateStale(body)) {
+      if (await alignStateClockWithRemote(client, [amsgStateNamespace(char.id)])) {
+        console.warn(`${ACTIVE_MSG_RUNTIME_HEADER} 云端状态的时间戳比本机的钟新，对齐后重发这一轮`);
+        statePayload = await encryptStateEntries(stampStateUpdatedAt());
+        ({ status, body } = await postInstantChat());
+      }
+    }
 
     if (status !== 202 || typeof body?.uuid !== 'string' || !body.uuid) {
       throw new Error(describeInstantChatFailure(status, body));
@@ -2746,7 +2810,9 @@ export const ActiveMsgClient = {
       namespace: amsgStateNamespace(charId),
       key: AMSG_CHAT_PRESENCE_KEY,
       value: JSON.stringify(presence),
-      updatedAt: presence.activeAt,
+      // 行的版本号走水位，而不是 presence.activeAt：worker 读的是 value 里那个
+      // activeAt（45s TTL 判活跃），版本号只管「这一行能不能盖上去」，两者不是一回事。
+      updatedAt: stampStateUpdatedAt(),
     }]);
     if (!response?.success) {
       throw new Error(response?.error?.message || '上传活跃会话租约失败。');
@@ -2766,7 +2832,7 @@ export const ActiveMsgClient = {
     if (!items.length) return;
     const globalConfig = await ensureWorkerReady();
     const client = await initializeClient(globalConfig);
-    const now = Date.now();
+    const now = stampStateUpdatedAt();
     // 表情包全库与角色无关，整批读一次就够——放在循环里的话 N 个角色要跑 2N 次全表
     // getAll（表情记录带图片数据），拿回来的还是同一份。
     const emojiLibrary = await readEmojiLibrary();
@@ -2794,23 +2860,29 @@ export const ActiveMsgClient = {
         rejected.map((r) => `${r.namespace}/${r.key}: ${r.message || 'rejected'}`),
       );
     }
-    // amsg-server 2.6.0-next.15 起服务端按 updatedAt 做条件写（旧不盖新）。被拦 = 云端
-    // 已有**更新**的一份（多设备 / 多标签页竞写时晚到的旧包），是保护生效而不是错误，
-    // log 一句留个排障线索就好。
+    // amsg-server 2.6.0-next.15 起服务端按 updatedAt 做条件写（旧不盖新）。被拦有两种
+    // 成因，长得一模一样：云端确实有更新的一份（多设备 / 多标签页竞写），或者云端那行
+    // 的时间戳落在了未来（设备时钟被改过，见 amsgStateClock）。后者不管的话，这个角色
+    // 的云端上下文会一直停在旧版本、主动消息一直拿旧上下文说话，而这条路上除了这行 log
+    // 没有任何动静——比即时对话那条明着报 409 的还难发现。
+    //
+    // 对齐水位就够了，这一轮不重传：fire_pack 每轮聊天都是全量重建的，下一次打脏同步
+    // 带着更新的内容盖过去，比现在拿这份已经被判成「旧」的包硬挤进去更有道理。
     const skipped = (response as { data?: { skippedEntries?: Array<{ namespace: string; key: string }> } })
       .data?.skippedEntries;
     if (skipped && skipped.length > 0) {
-      console.log(
-        `${ACTIVE_MSG_RUNTIME_HEADER} 云端已有更新的一份，这批旧条目被拦下（条件写保护）`,
+      console.warn(
+        `${ACTIVE_MSG_RUNTIME_HEADER} 云端已有更新的一份，这批条目被条件写拦下`,
         skipped.map((s) => `${s.namespace}/${s.key}`),
       );
+      await alignStateClockWithRemote(client, [...new Set(skipped.map((s) => s.namespace))]);
     }
   },
 
   async syncToolConfig(realtimeConfig: RealtimeConfig | undefined): Promise<void> {
     const globalConfig = await ensureWorkerReady();
     const client = await initializeClient(globalConfig);
-    const response = await client.putClientState([buildToolConfigEntry(realtimeConfig, Date.now())]);
+    const response = await client.putClientState([buildToolConfigEntry(realtimeConfig, stampStateUpdatedAt())]);
     if (!response?.success) {
       throw new Error(response?.error?.message || '上传工具凭据失败。');
     }
@@ -3214,7 +3286,7 @@ export const ActiveMsgClient = {
     const client = await initializeClient(config);
     await putClientStateOrThrow(
       client,
-      [{ namespace, key, value, updatedAt: Date.now() }],
+      [{ namespace, key, value, updatedAt: stampStateUpdatedAt() }],
       '写入云端状态',
     );
   },
@@ -3230,7 +3302,7 @@ export const ActiveMsgClient = {
   async clearClientStateValue(namespace: string, key: string): Promise<void> {
     const config = await ensureWorkerReady();
     const client = await initializeClient(config);
-    await client.putClientState([{ namespace, key, value: '', updatedAt: Date.now() }]);
+    await client.putClientState([{ namespace, key, value: '', updatedAt: stampStateUpdatedAt() }]);
   },
 
   /**
@@ -3279,7 +3351,7 @@ export const ActiveMsgClient = {
       const authed = await initializeClient(config);
       await putClientStateOrThrow(
         authed,
-        [buildToolConfigEntry(realtimeConfig, Date.now())],
+        [buildToolConfigEntry(realtimeConfig, stampStateUpdatedAt())],
         '重新上传工具凭据',
       );
     } catch (error) {

--- a/utils/amsgBundleVersion.ts
+++ b/utils/amsgBundleVersion.ts
@@ -12,4 +12,4 @@
 //   - utils/amsgWorkerVersion.ts 比的是**上游库** @rei-standard/amsg-server 的 semver；
 //   - utils/buildInfo.ts 的 APP_VERSION 是整个 SullyOS App 的版本。
 //   这里管的只有一样：用户自己那台 Worker 上跑的这份 bundle 是哪天的。
-export const AMSG_BUNDLE_VERSION = '2026-08-19';
+export const AMSG_BUNDLE_VERSION = '2026-09-01';

--- a/utils/amsgStateClock.test.ts
+++ b/utils/amsgStateClock.test.ts
@@ -1,0 +1,93 @@
+// utils/amsgStateClock.test.ts
+//
+// 回归守卫（云端 client_state 那一行的版本号该盖几点）：
+//   1. 时钟正常走的时候盖的戳就是墙钟本身。这一层绝不能给正常路径引入偏移——云端那行
+//      一旦莫名其妙领先真实时间，换台设备（水位是空的）就写不进去了。
+//   2. 设备时钟被回拨之后，盖出去的戳仍然往前走。这是这个模块存在的全部理由：云端是
+//      条件写（旧不盖新），戳只要回头，那台设备就再也写不进去。
+//   3. 云端那行落在未来时，照它对齐一次就能跨过去——这是已经卡住的人唯一的出路。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AMSG_STATE_CLOCK_LS_KEY,
+  observeRemoteStateUpdatedAt,
+  readStateClockWatermark,
+  resetStateClock,
+  stampStateUpdatedAt,
+} from './amsgStateClock';
+
+/** 让 Date.now 按给定的序列往外吐（用完停在最后一个）。 */
+const mockClock = (values: number[]) => {
+  let i = 0;
+  vi.spyOn(Date, 'now').mockImplementation(() => values[Math.min(i++, values.length - 1)]);
+};
+
+beforeEach(() => {
+  resetStateClock();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetStateClock();
+});
+
+describe('盖戳', () => {
+  it('时钟正常往前走时，盖的就是墙钟本身（不引入任何偏移）', () => {
+    mockClock([1_000, 2_000, 3_000]);
+
+    expect(stampStateUpdatedAt()).toBe(1_000);
+    expect(stampStateUpdatedAt()).toBe(2_000);
+    expect(stampStateUpdatedAt()).toBe(3_000);
+  });
+
+  it('同一毫秒内连写两次也严格递增（条件写用的是 >=，相等能过，但递增更稳）', () => {
+    mockClock([1_000]);
+
+    expect(stampStateUpdatedAt()).toBe(1_000);
+    expect(stampStateUpdatedAt()).toBe(1_001);
+  });
+
+  it('时钟被回拨之后，戳不跟着回头', () => {
+    // 5 秒处写过一次，然后用户把钟往回拨了 1 秒。
+    mockClock([5_000, 4_000, 4_001]);
+
+    expect(stampStateUpdatedAt()).toBe(5_000);
+    expect(stampStateUpdatedAt()).toBe(5_001);
+    expect(stampStateUpdatedAt()).toBe(5_002);
+  });
+
+  it('水位落盘，重新读得回来（关掉页面再回来，云端那行还在原地）', () => {
+    mockClock([7_000]);
+
+    stampStateUpdatedAt();
+    expect(localStorage.getItem(AMSG_STATE_CLOCK_LS_KEY)).toBe('7000');
+  });
+});
+
+describe('照云端对齐', () => {
+  it('云端那行落在未来 → 对齐一次，之后盖的戳就跨过去了', () => {
+    // 本机的钟停在 5 秒处，云端那行却记着 9 秒（当初设备时钟领先时写进去的）。
+    mockClock([5_000]);
+
+    expect(observeRemoteStateUpdatedAt(9_000)).toBe(true);
+    expect(stampStateUpdatedAt()).toBe(9_001);
+  });
+
+  it('云端那行比水位旧 → 不动水位，也不谎报对齐过（重发是白发）', () => {
+    mockClock([5_000]);
+    stampStateUpdatedAt();
+
+    expect(observeRemoteStateUpdatedAt(3_000)).toBe(false);
+    expect(readStateClockWatermark()).toBe(5_000);
+  });
+
+  it('云端回的不是个正经时间戳 → 一律不动水位', () => {
+    mockClock([5_000]);
+    stampStateUpdatedAt();
+
+    for (const bad of [undefined, null, 'a', NaN, 1.5, Number.MAX_VALUE]) {
+      expect(observeRemoteStateUpdatedAt(bad)).toBe(false);
+    }
+    expect(readStateClockWatermark()).toBe(5_000);
+  });
+});

--- a/utils/amsgStateClock.ts
+++ b/utils/amsgStateClock.ts
@@ -1,0 +1,104 @@
+// utils/amsgStateClock.ts
+//
+// 云端 client_state 那一行该盖几点的版本号（`updatedAt`）。
+//
+// 云端的写入是条件写：新来的 `updatedAt` 不比库里那行晚，整条就跳过（旧不盖新，
+// 见 worker 的 `WHERE excluded.updated_at >= client_state.updated_at`）。这道闸护的是
+// 「慢包后到别盖掉新包」，判据却是客户端自己报的时间——于是它护不住设备时钟本身跑偏：
+// 手机的钟只要领先过真实时间，那一刻同步上去的行就带着一个**还没到的时刻**，之后每
+// 次上传都比它「旧」，云端从此一直拒收。
+//
+// 这不是理论上的坑。2026-09-01 有用户改过一次系统时间，之后那个角色的即时对话一直
+// 报 409，删消息、重启、重装小手机、重填 Worker 地址全都不管用——那一行在云端 D1 里，
+// 本地做什么都碰不到它；而常规的批量同步撞上同一道闸只打一行 log，那个角色的云端上
+// 下文就一直停在旧版本，界面上什么都看不出来。
+//
+// 所以本地记一道水位：盖出去的时间戳只会往前走，绝不回头。正常情况下（时钟没跑偏）
+// 水位就是上次写入的时刻，`Date.now()` 每次都比它大，行为与直接用墙钟完全一致；
+// 只有在时钟被回拨、或云端那行已经落在未来时，水位才接管，保证这一次写得进去。
+//
+// 水位有两个抬升来源：自己每次盖戳（同一毫秒内连写两次也能严格递增），以及
+// `observeRemoteStateUpdatedAt` —— 云端明说了它那份更新时，照它的数对齐。
+
+const HEADER = '[AmsgStateClock]';
+
+/** 水位的落盘位置。存 localStorage 而不是内存：关掉页面再回来，云端那行还在原地。 */
+export const AMSG_STATE_CLOCK_LS_KEY = 'amsg2_state_clock_watermark';
+
+/** 水位领先本机时钟超过这么久就喊一声——正常状态下两者只差几毫秒。 */
+const CLOCK_SKEW_WARN_MS = 60_000;
+
+/** 内存里的当前水位；null = 还没从 localStorage 读回来。 */
+let watermark: number | null = null;
+
+const readWatermark = (): number => {
+  if (watermark !== null) return watermark;
+  try {
+    const raw = Number(localStorage.getItem(AMSG_STATE_CLOCK_LS_KEY));
+    watermark = Number.isSafeInteger(raw) && raw > 0 ? raw : 0;
+  } catch {
+    // 隐私模式 / 没有 localStorage 的环境：退回纯内存，本次会话内仍然单调。
+    watermark = 0;
+  }
+  return watermark;
+};
+
+const writeWatermark = (value: number) => {
+  watermark = value;
+  try {
+    localStorage.setItem(AMSG_STATE_CLOCK_LS_KEY, String(value));
+  } catch {
+    // 存储满 / 写不进去：这一轮盖的戳仍然是对的，只是重启后退回本地时钟。
+  }
+};
+
+const warnIfAhead = (value: number, now: number, reason: string) => {
+  const skew = value - now;
+  if (skew <= CLOCK_SKEW_WARN_MS) return;
+  console.warn(
+    `${HEADER} 云端状态的时间戳领先本机时钟 ${Math.round(skew / 1000)} 秒（${reason}）。`
+    + '设备时钟大概被改过，云端那行要等真实时间追上来才会回到正常节奏。',
+  );
+};
+
+/**
+ * 给这一次 client_state 写入盖一个时间戳：本机时钟与水位取大的那个，且严格递增。
+ *
+ * 凡是往云端写状态的地方都该用它，别再各自 `Date.now()` —— 只要有一条路漏了，
+ * 那条路就会在时钟跑偏后一直被云端拒收。
+ */
+export const stampStateUpdatedAt = (): number => {
+  const now = Date.now();
+  const at = Math.max(now, readWatermark() + 1);
+  writeWatermark(at);
+  warnIfAhead(at, now, '本地水位');
+  return at;
+};
+
+/**
+ * 云端那份的时间戳比本地水位还新时，照它对齐（返回是否真的抬动了）。
+ *
+ * 用在「被条件写拦下」之后：拦下就说明云端那行的时间戳我们跨不过去，读回来对齐一次，
+ * 下一次写入自然就盖得上。返回 false 表示水位没动——那这次被拦不是时间戳的事，
+ * 重发也是白发。
+ */
+export const observeRemoteStateUpdatedAt = (remoteUpdatedAt: unknown): boolean => {
+  if (typeof remoteUpdatedAt !== 'number' || !Number.isSafeInteger(remoteUpdatedAt)) return false;
+  if (remoteUpdatedAt <= readWatermark()) return false;
+  writeWatermark(remoteUpdatedAt);
+  warnIfAhead(remoteUpdatedAt, Date.now(), '云端那行');
+  return true;
+};
+
+/** 当前水位（排障与单测用；日常代码不需要看它）。 */
+export const readStateClockWatermark = (): number => readWatermark();
+
+/** 把水位清零（单测用：各条用例之间不互相污染）。 */
+export const resetStateClock = () => {
+  watermark = null;
+  try {
+    localStorage.removeItem(AMSG_STATE_CLOCK_LS_KEY);
+  } catch {
+    // 同上，读不到就当没有。
+  }
+};

--- a/worker/amsg/worker.bundle.js
+++ b/worker/amsg/worker.bundle.js
@@ -3,7 +3,7 @@
 // worker/amsg/src/index.ts
 import { DurableObject } from "cloudflare:workers";
 
-// node_modules/.pnpm/@rei-standard+amsg-server@2_c57770165a8a2256e4acaa4bae2ba803/node_modules/@rei-standard/amsg-server/dist/chunk-GN44PST5.mjs
+// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.26_@neondatabase+serverless@1.1.0_pg@8.22.0/node_modules/@rei-standard/amsg-server/dist/chunk-GN44PST5.mjs
 var UPDATABLE_COLUMNS = /* @__PURE__ */ new Set([
   "user_id",
   "uuid",
@@ -22,7 +22,7 @@ var UPDATABLE_COLUMNS = /* @__PURE__ */ new Set([
 var TASK_DELIVERY_COLUMNS = "id, user_id, uuid, encrypted_payload, message_type, next_send_at, retry_after, status, retry_count";
 var TASK_DETAIL_COLUMNS = "id, user_id, uuid, encrypted_payload, message_type, next_send_at, status, retry_count, last_error, created_at, updated_at";
 
-// node_modules/.pnpm/@rei-standard+amsg-shared@0.4.0-next.8/node_modules/@rei-standard/amsg-shared/dist/index.mjs
+// node_modules/.pnpm/@rei-standard+amsg-shared@0.4.0-next.9/node_modules/@rei-standard/amsg-shared/dist/index.mjs
 var TEXT_ENCODER = new TextEncoder();
 var TEXT_DECODER = new TextDecoder("utf-8", { fatal: false });
 function toUint8(buf) {
@@ -349,7 +349,10 @@ function looksLikeJson(raw) {
 function salvageJsonStringFields(raw) {
   const found = {};
   for (const match of raw.matchAll(JSON_STRING_FIELD)) {
-    if (found[match[1]] === void 0) found[match[1]] = unescapeJsonString(match[2]);
+    if (found[match[1]] !== void 0) continue;
+    const value = unescapeJsonString(match[2]);
+    if (match[1] === "type" && value === "error") continue;
+    found[match[1]] = value;
   }
   return {
     message: firstNonEmptyString(found.message, found.detail),
@@ -396,15 +399,27 @@ var UUID_SHAPE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
 function alternationCount(segment) {
   return (segment.match(/[a-z]+|[0-9]+/g) || []).length;
 }
+var MOE_SIZE_SEGMENT = /^\d+x\d+b$/;
+var HEX_SEGMENT = /^[0-9a-f]+$/;
+var HEX_RUN_MAX_CHARS = 15;
 function looksLikeModelId(token) {
   if (token.length > MODEL_ID_MAX_CHARS) return false;
   if (!MODEL_ID_LIKE.test(token)) return false;
   if (UUID_SHAPE.test(token)) return false;
   const segments = token.split(/[.-]/);
   if (CREDENTIAL_PREFIX_SEGMENTS.has(segments[0])) return false;
-  const randomLooking = segments.filter((segment) => alternationCount(segment) >= 3);
-  if (randomLooking.length === 0) return true;
-  return randomLooking.length === 1 && randomLooking[0].length <= 5;
+  let hexRunChars = 0;
+  for (const segment of segments) {
+    if (HEX_SEGMENT.test(segment)) {
+      hexRunChars += segment.length;
+      if (hexRunChars > HEX_RUN_MAX_CHARS) return false;
+    } else {
+      hexRunChars = 0;
+    }
+  }
+  return segments.every(
+    (segment) => alternationCount(segment) < 3 || MOE_SIZE_SEGMENT.test(segment)
+  );
 }
 function redactCredentials(text) {
   let s = text;
@@ -1121,7 +1136,7 @@ function stringifyDecisionForError(value) {
   }
 }
 
-// node_modules/.pnpm/@rei-standard+amsg-server@2_c57770165a8a2256e4acaa4bae2ba803/node_modules/@rei-standard/amsg-server/dist/chunk-3JEWYDM4.mjs
+// node_modules/.pnpm/@rei-standard+amsg-server@2.6.0-next.26_@neondatabase+serverless@1.1.0_pg@8.22.0/node_modules/@rei-standard/amsg-server/dist/chunk-4YH3TS4W.mjs
 var DAY_MS = 24 * 60 * 60 * 1e3;
 var MAX_LISTED_SKIPPED_OCCURRENCES = 32;
 var MAX_ADJUST_STEPS = 32;
@@ -2111,14 +2126,17 @@ function planClientStateCleanup(ttl, now) {
   }
   return targets;
 }
-async function writeClientStateEntries({ db, userId, userKey, entries }) {
+async function writeClientStateEntries({ db, userId, userKey, entries, now }) {
+  const nowFn = typeof now === "function" ? now : Date.now;
+  const at = nowFn();
   const physicalRows = [];
   const cleanups = [];
   const rootRowIndexes = [];
   const rootRowEntries = [];
   let deleted = 0;
   for (const entry of entries) {
-    const guardAt = Number.isInteger(entry.version) && entry.version > 0 ? entry.version : entry.updatedAt;
+    const rawGuardAt = Number.isInteger(entry.version) && entry.version > 0 ? entry.version : entry.updatedAt;
+    const guardAt = Math.min(rawGuardAt, at);
     cleanups.push({
       namespace: chunkNamespaceFor(entry.namespace),
       keyPrefix: chunkKeyPrefixFor(entry.key),
@@ -2164,7 +2182,7 @@ async function writeClientStateEntries({ db, userId, userKey, entries }) {
   if (physicalRows.length === 0 && cleanups.length === 0) {
     return { upserted: 0, skipped: 0, deleted: 0, skippedEntries: [] };
   }
-  const result = await db.upsertClientState(userId, physicalRows, cleanups);
+  const result = await db.upsertClientState(userId, physicalRows, cleanups, at);
   let upserted = 0;
   let skipped = 0;
   const skippedEntries = [];
@@ -2255,7 +2273,7 @@ function createStateAccessors({ db, userId, userKey, maxStateValueBytes, now }) 
         ...entry.version !== void 0 ? { version: entry.version } : {}
       };
     });
-    return writeClientStateEntries({ db, userId, userKey, entries: normalized });
+    return writeClientStateEntries({ db, userId, userKey, entries: normalized, now: nowFn });
   };
   return { readState, writeState };
 }
@@ -2311,15 +2329,27 @@ async function discardUndeliveredPushes({ db, userId, pushes, sentIds }) {
 var OUTBOX_SCAN_PAGE_SIZE = 100;
 var OUTBOX_SCAN_MAX_ROWS = 5e3;
 async function discardUndeliveredPushesForTask({ db, userId, taskUuid }) {
-  if (!db || typeof db.listUnackedOutbox !== "function" || typeof db.discardOutboxMessages !== "function") return;
-  if (!taskUuid) return;
+  if (!db || !taskUuid) return;
+  if (typeof db.discardUndeliveredOutboxForTask === "function") {
+    try {
+      await db.discardUndeliveredOutboxForTask(userId, taskUuid);
+    } catch (error) {
+      console.warn("[amsg-server] outbox \u6309\u4EFB\u52A1\u64A4\u56DE\u672A\u6295\u9012\u7684\u884C\u5931\u8D25\uFF08\u5DF2\u5FFD\u7565\uFF09:", error && error.message);
+    }
+    return;
+  }
+  if (typeof db.listUnackedOutbox !== "function" || typeof db.discardOutboxMessages !== "function") return;
   const messageIds = [];
+  let exhausted = false;
   try {
     let cursor = 0;
     let scanned = 0;
     while (scanned < OUTBOX_SCAN_MAX_ROWS) {
       const rows = await db.listUnackedOutbox(userId, cursor, OUTBOX_SCAN_PAGE_SIZE);
-      if (!rows || rows.length === 0) break;
+      if (!rows || rows.length === 0) {
+        exhausted = true;
+        break;
+      }
       scanned += rows.length;
       let nextCursor = cursor;
       for (const row of rows) {
@@ -2330,11 +2360,19 @@ async function discardUndeliveredPushesForTask({ db, userId, taskUuid }) {
       }
       if (nextCursor <= cursor) break;
       cursor = nextCursor;
-      if (rows.length < OUTBOX_SCAN_PAGE_SIZE) break;
+      if (rows.length < OUTBOX_SCAN_PAGE_SIZE) {
+        exhausted = true;
+        break;
+      }
     }
   } catch (error) {
     console.warn("[amsg-server] outbox \u67E5\u672A\u6295\u9012\u7684\u884C\u5931\u8D25\uFF08\u5DF2\u5FFD\u7565\uFF09:", error && error.message);
     return;
+  }
+  if (!exhausted) {
+    console.warn(
+      `[amsg-server] outbox \u626B\u63CF\u5230 ${OUTBOX_SCAN_MAX_ROWS} \u884C\u4E0A\u9650\u4ECD\u672A\u626B\u5B8C\uFF0C\u4EFB\u52A1 ${taskUuid} \u53EF\u80FD\u8FD8\u6709\u672A\u6295\u9012\u7684\u884C\u6CA1\u64A4\u6389\uFF08\u88AB\u53D6\u6D88\u4EFB\u52A1\u7684\u884C\u901A\u5E38\u662F\u6700\u65B0\u7684\uFF0C\u6B63\u597D\u5728\u4E0A\u9650\u4E4B\u5916\uFF09\u3002\u7ED9\u9002\u914D\u5668\u5B9E\u73B0 discardUndeliveredOutboxForTask \u53EF\u7ED5\u5F00\u8FD9\u4E2A\u4E0A\u9650\u3002`
+    );
   }
   await discardPushesFromOutbox({ db, userId, messageIds });
 }
@@ -2391,10 +2429,17 @@ function createResultEmitter({
   sessionId,
   occurrenceMs,
   webpush,
-  now
+  now,
+  isCancelled
 }) {
   const nowFn = typeof now === "function" ? now : Date.now;
   let emitted = 0;
+  const assertNotCancelled = () => {
+    if (typeof isCancelled !== "function" || !isCancelled()) return;
+    const error = new Error("\u4EFB\u52A1\u5728\u6295\u9012\u671F\u95F4\u88AB\u53D6\u6D88\u6216\u9876\u66FF\uFF0C\u7ED3\u679C\u5DF2\u4E2D\u6B62");
+    error.code = TASK_CANCELLED_CODE;
+    throw error;
+  };
   const emitResult = async (payload) => {
     if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
       throw new TypeError("emitResult(payload) \u9700\u8981\u4E00\u4E2A\u666E\u901A\u5BF9\u8C61");
@@ -2406,9 +2451,10 @@ function createResultEmitter({
       );
     }
     const seq = emitted++;
+    const messageType = decryptedPayload.messageType || "auto";
     const push = buildResultPush({
-      messageType: decryptedPayload.messageType || "auto",
-      source: "scheduled",
+      messageType,
+      source: messageType === "instant" ? "instant" : "scheduled",
       messageId: `${messageIdBase}_result_${seq}`,
       sessionId,
       ...payload,
@@ -2422,9 +2468,11 @@ function createResultEmitter({
       recurrenceType: decryptedPayload.recurrenceType || "none",
       occurrenceMs
     });
+    assertNotCancelled();
     await db.appendOutboxMessages(task.user_id, await toOutboxRows([push], userKey, nowFn()));
     let pushed;
     try {
+      assertNotCancelled();
       pushed = shouldSendPush(push, { outboxed: true }) ? await sendResultPush({ db, task, userKey, decryptedPayload, webpush, push }) : false;
     } catch (error) {
       await discardUndeliveredPushes({ db, userId: task.user_id, pushes: [push], sentIds: [] });
@@ -2620,7 +2668,10 @@ async function runAgenticFire({ task, decryptedPayload, userKey, ctx }) {
     sessionId,
     occurrenceMs,
     webpush: ctx.webpush,
-    now: nowFn
+    now: nowFn,
+    // run-tick 在投递 ctx 上挂的取消信号（与 guardWebpushWithLease 读的是同一
+    // 个租约状态），emitResult 不发推送的那条路要靠它拦下已取消任务的落行。
+    isCancelled: typeof ctx.isTaskCancelled === "function" ? ctx.isTaskCancelled : null
   });
   const maxScheduledTasksPerFire = Number.isInteger(ctx.maxScheduledTasksPerFire) && ctx.maxScheduledTasksPerFire >= 0 ? ctx.maxScheduledTasksPerFire : DEFAULT_MAX_SCHEDULED_TASKS_PER_FIRE;
   let scheduledTaskCount = 0;
@@ -2806,6 +2857,9 @@ async function runAgenticFire({ task, decryptedPayload, userKey, ctx }) {
       );
     }
     const cancelled = await ctx.db.deleteTaskByUuid(uuid, task.user_id);
+    if (cancelled) {
+      await discardUndeliveredPushesForTask({ db: ctx.db, userId: task.user_id, taskUuid: uuid });
+    }
     return { cancelled: !!cancelled };
   };
   const renewTask = async (uuid, nextSendAt) => {
@@ -3262,12 +3316,36 @@ function sleepFor(ctx, ms) {
 }
 function resolveMultipartOptions(ctx) {
   const configured = ctx && ctx.multipart && typeof ctx.multipart === "object" ? ctx.multipart : {};
-  return {
+  const resolved = {
     maxChunkBytes: positiveIntegerOr(configured.maxChunkBytes, DEFAULT_MULTIPART_CHUNK_BYTES),
     maxChunks: positiveIntegerOr(configured.maxChunks, DEFAULT_MULTIPART_MAX_CHUNKS),
     maxTotalBytes: positiveIntegerOr(configured.maxTotalBytes, DEFAULT_MULTIPART_MAX_TOTAL_BYTES),
     ttlMs: positiveIntegerOr(configured.ttlMs, DEFAULT_MULTIPART_TTL_MS)
   };
+  assertChunkBytesFitPushLimit(resolved);
+  return resolved;
+}
+function assertChunkBytesFitPushLimit({ maxChunkBytes, maxChunks, ttlMs }) {
+  const PROBE_CHUNK_BYTES = 3;
+  const [probe] = buildMultipartPushPayloads(
+    { messageKind: "reasoning" },
+    { serializedPayload: "x".repeat(PROBE_CHUNK_BYTES), maxChunkBytes: PROBE_CHUNK_BYTES, ttlMs }
+  );
+  const digitHeadroom = 2 * (String(maxChunks).length - 1);
+  const envelopeOverhead = measurePushPayload(JSON.stringify(probe)).bytes - base64UrlLength(PROBE_CHUNK_BYTES) + digitHeadroom;
+  const worstEnvelopeBytes = envelopeOverhead + base64UrlLength(maxChunkBytes);
+  if (worstEnvelopeBytes <= MAX_PUSH_PAYLOAD_BYTES) return;
+  let maxAllowed = Math.floor((MAX_PUSH_PAYLOAD_BYTES - envelopeOverhead) * 3 / 4);
+  while (maxAllowed > 0 && envelopeOverhead + base64UrlLength(maxAllowed) > MAX_PUSH_PAYLOAD_BYTES) {
+    maxAllowed--;
+  }
+  throw new DeploymentConfigError(
+    `MULTIPART_CHUNK_BYTES_TOO_LARGE: multipart.maxChunkBytes = ${maxChunkBytes} \u5207\u51FA\u7684\u5206\u7247\u4FE1\u5C01\u6700\u574F ${worstEnvelopeBytes} \u5B57\u8282\uFF0C\u8D85\u8FC7\u5355\u6761 push \u660E\u6587\u4E0A\u9650 ${MAX_PUSH_PAYLOAD_BYTES} \u5B57\u8282\uFF0C\u6BCF\u4E00\u7247\u90FD\u4F1A\u88AB\u63A8\u9001\u670D\u52A1\u62D2\u6536\u3002\u8FD9\u4E2A\u65CB\u94AE\u53EA\u7528\u4E8E\u6536\u7A84\uFF0C\u5F53\u524D\u914D\u7F6E\u4E0B\u6700\u5927 ${maxAllowed}`,
+    { code: "MULTIPART_CHUNK_BYTES_TOO_LARGE" }
+  );
+}
+function base64UrlLength(n) {
+  return Math.ceil(n * 4 / 3);
 }
 function positiveIntegerOr(value, fallback) {
   return Number.isInteger(value) && /** @type {number} */
@@ -4021,13 +4099,14 @@ async function deliverTasks(ctx, tasks) {
     groupsTakenThisTick.add(scopedKey);
     return { taken: false, rawKey };
   }
-  function recordCancelled(task, status) {
+  async function recordCancelled(task, status) {
     results.cancelledTasks.push({
       taskId: task.id,
       reason: "\u4EFB\u52A1\u5728\u6295\u9012\u671F\u95F4\u88AB\u53D6\u6D88\u6216\u9876\u66FF",
       status
     });
     console.warn(`[amsg-server] \u4EFB\u52A1 ${task.id} \u5728\u6295\u9012\u671F\u95F4\u88AB\u53D6\u6D88\u6216\u9876\u66FF\uFF08${status}\uFF09`);
+    await discardUndeliveredPushesForTask({ db, userId: task.user_id, taskUuid: task.uuid });
   }
   async function payloadStillFresh(task) {
     if (typeof db.getTaskByUuid !== "function" || !task.uuid) return true;
@@ -4209,7 +4288,8 @@ async function deliverTasks(ctx, tasks) {
           messageIdBase: task.id != null ? `msg_task_${task.id}${occurrenceSuffix(task)}` : `msg_stale_${task.uuid || ""}`,
           sessionId: task.id != null ? `sess_task_${task.id}${occurrenceSuffix(task)}` : `sess_stale_${task.uuid || ""}`,
           occurrenceMs,
-          webpush: ctx.webpush
+          webpush: ctx.webpush,
+          isCancelled: () => lease.lost
         });
         const recurring = isRecurringType(recurrenceType);
         const plan = recurring ? planNextOccurrence(occurrenceMs, recurrenceType, Date.now(), tzId) : null;
@@ -4258,13 +4338,19 @@ async function deliverTasks(ctx, tasks) {
     try {
       sendResult = await processSingleMessage(
         task,
-        { ...ctx, db, masterKey, webpush: guardWebpushWithLease(ctx.webpush, lease) },
+        {
+          ...ctx,
+          db,
+          masterKey,
+          webpush: guardWebpushWithLease(ctx.webpush, lease),
+          isTaskCancelled: () => lease.lost
+        },
         masterKey,
         { userKey, payload: decryptedPayload }
       );
     } catch (error) {
       if (lease.lost) {
-        recordCancelled(task, "cancelled_mid_delivery");
+        await recordCancelled(task, "cancelled_mid_delivery");
         return;
       }
       await handleDeliveryFailure(
@@ -4279,7 +4365,7 @@ async function deliverTasks(ctx, tasks) {
     }
     if (!sendResult.success) {
       if (lease.lost) {
-        recordCancelled(task, "cancelled_mid_delivery");
+        await recordCancelled(task, "cancelled_mid_delivery");
         return;
       }
       await handleDeliveryFailure(
@@ -4302,7 +4388,7 @@ async function deliverTasks(ctx, tasks) {
       if (recurrenceType === "none") {
         markLeaseReleased(task.id);
         if (rowVanished(await db.deleteTaskById(task.id))) {
-          recordCancelled(task, "cancelled_after_delivery");
+          await recordCancelled(task, "cancelled_after_delivery");
           return;
         }
         results.deletedOnceOffTasks++;
@@ -4316,7 +4402,7 @@ async function deliverTasks(ctx, tasks) {
           ...clearedPayload ? { encrypted_payload: clearedPayload } : {}
         });
         if (rowVanished(updated)) {
-          recordCancelled(task, "cancelled_after_delivery");
+          await recordCancelled(task, "cancelled_after_delivery");
           return;
         }
         results.updatedRecurringTasks++;
@@ -4500,6 +4586,13 @@ function createUpdateMessageHandler(ctx) {
       return { status: 409, body: { success: false, error: { code: "TASK_ALREADY_COMPLETED", message: "\u4EFB\u52A1\u5DF2\u5B8C\u6210\u6216\u5DF2\u5931\u8D25\uFF0C\u65E0\u6CD5\u66F4\u65B0" } } };
     }
     const existingData = JSON.parse(await decryptFromStorage(existingTask.encrypted_payload, userKey));
+    if ((updates.apiUrl || updates.apiKey || updates.primaryModel) && hasChatCredRef(existingData)) {
+      return { status: 409, body: { success: false, error: {
+        code: "TASK_USES_CRED_REFS",
+        message: "\u4EFB\u52A1\u5DF2\u901A\u8FC7 credRefs.chat \u5F15\u7528\u51ED\u636E\uFF0C\u89E6\u53D1\u65F6\u4EE5\u51ED\u636E\u8868\u4E3A\u51C6\uFF0C\u5185\u8054 apiUrl / apiKey / primaryModel \u7684\u66F4\u65B0\u4E0D\u4F1A\u751F\u6548\u3002\u6362 Key \u8BF7\u7528 PUT /llm-credentials \u8986\u76D6\u5BF9\u5E94\u51ED\u636E\uFF0C\u6216\u5728\u672C\u6B21\u8BF7\u6C42\u91CC\u6539\u7528 credRefs \u6307\u5411\u65B0\u51ED\u636E",
+        details: { invalidFields: ["apiUrl", "apiKey", "primaryModel"].filter((name) => updates[name]) }
+      } } };
+    }
     const promptUpdates = {};
     if (updates.completePrompt) {
       promptUpdates.completePrompt = updates.completePrompt;
@@ -5576,8 +5669,17 @@ var D1Adapter = class {
    * than the stored row (updatedAt strictly lower) is skipped; equal or
    * newer overwrites. Values arrive pre-encrypted (the handler encrypts).
    *
+   * 例外是「来自未来」的行：`updated_at` 晚于服务端当前时间的行一律放行覆盖。
+   * 比较值是客户端自己报的时间戳，设备时钟只要领先过真实时间（用户改过系统
+   * 时间、时区或日期误操作），那一刻同步上来的行就带着一个还没到的时刻；之后
+   * 这台设备发什么都比它「旧」，条件写全被无声跳过，云端那行要等真实时间追上
+   * 去才解得开——客户端删本地数据、重装都碰不到它。合法写入不可能来自未来，
+   * 所以这种行按脏数据处理：服务端的钟是可信的那一个，拿它当判据放行。一次
+   * 正常写入就把 `updated_at` 拉回现实，之后旧不盖新照常生效。
+   *
    * `cleanups` 是删除项：在同一 batch 里先于 upsert 执行，`updated_at <= ?`
-   * 条件保证陈旧批次删不动更新写入的行。两种形态——
+   * 条件保证陈旧批次删不动更新写入的行（同样对未来时间戳的行放行，否则删一条
+   * 状态时切片行留在库里成孤儿）。两种形态——
    *   - `{ namespace, keyPrefix, updatedAt }` 删 key 前缀下的所有行，用来清掉
    *     大值旧写入留下的切片行（见 lib/state-chunks.js）；
    *   - `{ namespace, key, updatedAt }` 删这一个 key，用来删整条状态（前缀会
@@ -5595,24 +5697,30 @@ var D1Adapter = class {
    * @param {string} userId
    * @param {Array<{ namespace: string, key: string, value: string, updatedAt: number }>} entries
    * @param {Array<{ namespace: string, key?: string, keyPrefix?: string, updatedAt: number }>} [cleanups]
+   * @param {number} [now] - 服务端当前时刻（epoch 毫秒），判定「这行来自未来」用的
+   *   就是它。调用方（lib/client-state-store.js）传下来，测试可以钉住一个假时钟；
+   *   自定义调用方不传时退回本机时钟。
    * @returns {Promise<{ upserted: number, skipped: number, outcomes: boolean[] }>}
    *   `outcomes[i]` 对应 entries[i] 是否真的写入（changes > 0）。
    */
-  async upsertClientState(userId, entries, cleanups = []) {
+  async upsertClientState(userId, entries, cleanups = [], now = Date.now()) {
     const UPSERT_SQL = `INSERT INTO client_state (user_id, namespace, key, value, updated_at)
        VALUES (?, ?, ?, ?, ?)
        ON CONFLICT (user_id, namespace, key) DO UPDATE SET
          value = excluded.value,
          updated_at = excluded.updated_at
-       WHERE excluded.updated_at >= client_state.updated_at`;
+       WHERE excluded.updated_at >= client_state.updated_at
+          OR client_state.updated_at > ?`;
     const CLEANUP_PREFIX_SQL = `DELETE FROM client_state
-       WHERE user_id = ? AND namespace = ? AND key >= ? AND key < ? AND updated_at <= ?`;
+       WHERE user_id = ? AND namespace = ? AND key >= ? AND key < ?
+         AND (updated_at <= ? OR updated_at > ?)`;
     const CLEANUP_KEY_SQL = `DELETE FROM client_state
-       WHERE user_id = ? AND namespace = ? AND key = ? AND updated_at <= ?`;
+       WHERE user_id = ? AND namespace = ? AND key = ?
+         AND (updated_at <= ? OR updated_at > ?)`;
     const buildStatements = () => [
-      ...cleanups.map((c) => typeof c.key === "string" ? this._db.prepare(CLEANUP_KEY_SQL).bind(userId, c.namespace, c.key, c.updatedAt) : this._db.prepare(CLEANUP_PREFIX_SQL).bind(userId, c.namespace, c.keyPrefix, prefixRangeEnd(c.keyPrefix), c.updatedAt)),
+      ...cleanups.map((c) => typeof c.key === "string" ? this._db.prepare(CLEANUP_KEY_SQL).bind(userId, c.namespace, c.key, c.updatedAt, now) : this._db.prepare(CLEANUP_PREFIX_SQL).bind(userId, c.namespace, c.keyPrefix, prefixRangeEnd(c.keyPrefix), c.updatedAt, now)),
       ...entries.map(
-        (entry) => this._db.prepare(UPSERT_SQL).bind(userId, entry.namespace, entry.key, entry.value, entry.updatedAt)
+        (entry) => this._db.prepare(UPSERT_SQL).bind(userId, entry.namespace, entry.key, entry.value, entry.updatedAt, now)
       )
     ];
     let results;
@@ -5897,6 +6005,25 @@ var D1Adapter = class {
       [userId],
       messageIds
     );
+  }
+  /**
+   * 把某条任务名下还没发出去的行一次删掉（取消 / 顶替时的 outbox 清理）。
+   *
+   * 判据与 discardOutboxMessages 相同：只删 delivered_at 与 acked_at 均为
+   * NULL 的行——已经推给设备 / 已 ack 的照旧留着。按 task_uuid 直删是为了不
+   * 受未 ack 积压量的影响：靠翻页扫描挑行的话，积压一大这条任务的行就落在
+   * 扫描上限之外（见 lib/outbox-store.js 的 discardUndeliveredPushesForTask）。
+   *
+   * @param {string} userId
+   * @param {string} taskUuid
+   * @returns {Promise<number>} 删掉的行数
+   */
+  async discardUndeliveredOutboxForTask(userId, taskUuid) {
+    const res = await this._db.prepare(
+      `DELETE FROM message_outbox
+       WHERE user_id = ? AND task_uuid = ? AND delivered_at IS NULL AND acked_at IS NULL`
+    ).bind(userId, taskUuid).run();
+    return res.meta.changes || 0;
   }
   /**
    * 未 ack 的行（id 升序，游标翻页）。payload 仍是密文，解密在 handler。
@@ -6203,7 +6330,7 @@ function createClientStateHandler(ctx) {
   }
   return { PUT, GET, DELETE };
 }
-var SERVER_VERSION = true ? "2.6.0-next.23" : "0.0.0-dev";
+var SERVER_VERSION = true ? "2.6.0-next.26" : "0.0.0-dev";
 var SERVER_FEATURES = Object.freeze([
   "client-state",
   "client-state-chunking",
@@ -6769,8 +6896,101 @@ function createSingleUserCloudflareWorker(buildConfig, options = {}) {
   return { fetch: fetch2, scheduled, runTask: runTask2, getSchemaVersion: getSchemaVersion2, ensureSchema: ensureSchema2 };
 }
 
+// node_modules/.pnpm/@rei-standard+amsg-shared@0.4.0-next.8/node_modules/@rei-standard/amsg-shared/dist/index.mjs
+var TEXT_ENCODER2 = new TextEncoder();
+var TEXT_DECODER2 = new TextDecoder("utf-8", { fatal: false });
+function utf83(str) {
+  return TEXT_ENCODER2.encode(String(str));
+}
+var LLM_MESSAGES_ERROR2 = Object.freeze({
+  MESSAGES_NOT_ARRAY: "MESSAGES_NOT_ARRAY",
+  MESSAGE_NOT_OBJECT: "MESSAGE_NOT_OBJECT",
+  INVALID_ROLE: "INVALID_ROLE",
+  TOOL_CALL_MALFORMED: "TOOL_CALL_MALFORMED",
+  TOOL_CONTENT_INVALID: "TOOL_CONTENT_INVALID",
+  TOOL_CALL_ID_MISSING: "TOOL_CALL_ID_MISSING",
+  CONTENT_EMPTY_STRING: "CONTENT_EMPTY_STRING",
+  CONTENT_EMPTY_ARRAY: "CONTENT_EMPTY_ARRAY",
+  CONTENT_INVALID_TYPE: "CONTENT_INVALID_TYPE"
+});
+var UPSTREAM_ERROR_BODY_MAX_BYTES2 = 16 * 1024;
+var KEY_INFO_PREFIX2 = utf83("WebPush: info\0");
+var CEK_INFO2 = utf83("Content-Encoding: aes128gcm\0");
+var NONCE_INFO2 = utf83("Content-Encoding: nonce\0");
+var VAPID_TOKEN_LIFETIME2 = 12 * 3600;
+var REI_SW_EVENT2 = Object.freeze({
+  CONTENT_RECEIVED: "rei-amsg-content-received",
+  REASONING_RECEIVED: "rei-amsg-reasoning-received",
+  TOOL_REQUEST_RECEIVED: "rei-amsg-tool-request-received",
+  ERROR_RECEIVED: "rei-amsg-error-received",
+  /** 宿主自定义的一条结果（`messageKind: 'result'`），不是聊天内容。 */
+  RESULT_RECEIVED: "rei-amsg-result-received",
+  MULTIPART_EXPIRED: "rei-amsg-multipart-expired",
+  UNKNOWN_RECEIVED: "rei-amsg-unknown-received"
+});
+var MULTIPART_FAILURE_REASON2 = Object.freeze({
+  /** TTL 到期仍未收齐，或收到的分片本身已经过期。 */
+  TTL_EXPIRED: "ttl-expired",
+  /** 分片信封不合规：version / encoding 对不上、index 越界、chunk 不是合法 base64url。 */
+  INVALID_CHUNK: "invalid-chunk",
+  /** 同一个 id 的分片报了不一样的 total / encoding，已收的部分拼不回去。 */
+  CHUNK_CONFLICT: "chunk-conflict",
+  /** 累计字节数超过 maxTotalBytes。 */
+  SIZE_LIMIT_EXCEEDED: "size-limit-exceeded",
+  /** 收齐了但拼不回原 payload（缺片、超限、JSON 解不开）。 */
+  RESTORE_FAILED: "restore-failed",
+  /** 分片仓库（IndexedDB）读写失败。 */
+  STORAGE_FAILED: "storage-failed",
+  /** 接收端把 multipart 关了（`multipart.enabled === false`），分片没法重组。 */
+  DISABLED: "disabled"
+});
+var REI_SW_MESSAGE_TYPE2 = Object.freeze({
+  ENQUEUE_REQUEST: "REI_ENQUEUE_REQUEST",
+  DELIVER: "REI_AMSG_DELIVER",
+  FLUSH_QUEUE: "REI_FLUSH_QUEUE",
+  /**
+   * 入队的点对点回执：谁发的 ENQUEUE_REQUEST 就回给谁一条，一次一条。
+   * 没转 MessagePort 过来时会落到全局的 `navigator.serviceWorker` message
+   * 监听器上。
+   */
+  QUEUE_RESULT: "REI_QUEUE_RESULT",
+  /**
+   * 队列请求被永久拒绝、即将从队列里删掉时广播给所有窗口的一条。
+   *
+   * 跟 QUEUE_RESULT 分开是因为两者的收信人不是一回事：这条是广播，可能来自后台
+   * `sync` 冲刷、说的也可能是另一条八竿子打不着的旧请求。共用一个 type 的话，
+   * 页面等自己那条入队回执时会先收到这一条、当成自己的结果处理。
+   */
+  QUEUE_DROPPED: "REI_QUEUE_DROPPED"
+});
+var REI_AMSG_DELIVER_MESSAGE_TYPE2 = REI_SW_MESSAGE_TYPE2.DELIVER;
+var MESSAGE_KIND2 = Object.freeze({
+  CONTENT: "content",
+  REASONING: "reasoning",
+  TOOL_REQUEST: "tool_request",
+  ERROR: "error",
+  RESULT: "result"
+});
+var MESSAGE_TYPE2 = Object.freeze({
+  INSTANT: "instant",
+  FIXED: "fixed",
+  PROMPTED: "prompted",
+  AUTO: "auto"
+});
+var PUSH_SOURCE2 = Object.freeze({
+  INSTANT: "instant",
+  SCHEDULED: "scheduled"
+});
+var REASONING_CHUNK_ENCODER2 = new TextEncoder();
+var REASONING_CHUNK_DECODER2 = new TextDecoder("utf-8", { fatal: true });
+var REASONING_TAG_RE_G2 = /<(think|thinking|thought)>[\s\S]*?<\/\1>/gi;
+function stripReasoningTags2(content) {
+  if (typeof content !== "string" || !content.includes("<")) return content;
+  return content.replace(REASONING_TAG_RE_G2, "").trim();
+}
+
 // utils/amsgBundleVersion.ts
-var AMSG_BUNDLE_VERSION = "2026-08-19";
+var AMSG_BUNDLE_VERSION = "2026-09-01";
 
 // utils/amsgTaskKinds.ts
 var AMSG_TASK_KIND_KEY = "amsgKind";
@@ -12384,13 +12604,13 @@ function buildScheduleChangeResult(args) {
 
 // worker/amsg/src/nativeFcm.ts
 var accessTokenCache = null;
-var utf83 = new TextEncoder();
+var utf84 = new TextEncoder();
 var bytesToB64u = (bytes) => {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 };
-var textToB64u = (value) => bytesToB64u(utf83.encode(value));
+var textToB64u = (value) => bytesToB64u(utf84.encode(value));
 var pemToPkcs8 = (raw) => {
   const base64 = raw.replace(/\\n/g, "\n").replace(/-----BEGIN PRIVATE KEY-----/g, "").replace(/-----END PRIVATE KEY-----/g, "").replace(/\s+/g, "");
   if (!base64) throw new Error("FCM_SERVICE_ACCOUNT_PRIVATE_KEY \u4E0D\u662F\u6709\u6548\u7684 PKCS#8 PEM");
@@ -12427,7 +12647,7 @@ var fetchFcmAccessToken = async (env) => {
     false,
     ["sign"]
   );
-  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, utf83.encode(unsigned));
+  const signature = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, utf84.encode(unsigned));
   const assertion = `${unsigned}.${bytesToB64u(new Uint8Array(signature))}`;
   const response = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",
@@ -12480,7 +12700,7 @@ var buildFcmMessage = (token, rawPayload) => {
       }
     }
   };
-  const bytes = utf83.encode(JSON.stringify(result)).byteLength;
+  const bytes = utf84.encode(JSON.stringify(result)).byteLength;
   if (bytes > 4e3) throw new Error(`FCM_PAYLOAD_TOO_LARGE: ${bytes} bytes\uFF08\u5B89\u5168\u4E0A\u9650 4000\uFF09`);
   return result;
 };
@@ -13383,7 +13603,7 @@ var amsgHooks = {
       }
       return handler.llmOutput({ ctx, state: kindFire.state });
     }
-    const content = stripReasoningTags(ctx.llmOutputText || "").trim();
+    const content = stripReasoningTags2(ctx.llmOutputText || "").trim();
     const taskId = ctx.taskId != null ? String(ctx.taskId) : null;
     if (taskId == null) {
       console.warn("[amsg:agentic] ctx \u4E0A\u6CA1\u6709 taskId\uFF0C\u9001\u8FBE\u5F52\u5C5E\u4F1A\u5931\u6548", ctx.sessionId);


### PR DESCRIPTION
## 问题

有用户反馈：跟某个角色聊天期间改过一次系统时间，之后那个角色的即时对话**每发一句都失败**（`409 / INSTANT_CHAT_STATE_STALE`），把系统时间调回来也没用；删掉那期间的消息、重启手机、删了小手机重装、把 Worker 地址删掉重填，全都不管用。同账号的其它角色一切正常。

根因是云端 `client_state` 的条件写（旧不盖新）拿客户端本地墙钟当判据。设备时钟只要**领先过**真实时间，那一刻同步上去的行就带着一个还没到的时刻，之后这台设备发什么都比它「旧」，云端一直拒收——那一行在云端 D1 里，本地做什么都碰不到它，只能等真实时间追上去。

查了那位用户的库坐实了：那个角色的四行状态记着一个领先真实时间 **6 小时 33 分**的时刻。而且写坏它的不是用户手动发消息——即时对话是一次请求同时写 `fire_pack`、`tool_pack`、`tool_config` 三样，她的 `tool_config` 是正常的，只有前两样超前，那是**后台批量同步**的签名动作。也就是说聊天内容一变就自动传，用户全程无感。

## 改动

分两层，各管一头：

**客户端记一道水位**（`utils/amsgStateClock.ts`）。盖出去的戳取「本机时钟与水位的较大者」，只会往前走。时钟正常时水位就是上次写入的时刻、墙钟每次都更大，行为与直接用墙钟完全一致，**不给正常路径引入任何偏移**（有测试专门盯这条，不然换台设备就轮到新设备写不进去）。即时对话被拒时再自愈一次：读回云端那行的时间戳、对齐水位、重新盖戳发第二次；对齐不动就不重发。

**worker 升到 `amsg-server 2.6.0-next.26`**。上游两档配套：库里来自未来的行按脏数据处理、条件写对它放行（存量能被覆盖回来），新写入的护栏值钳到服务端当前时刻（不再产生新的脏行）。

顺带把常规批量同步那条也接上了。它撞上同一道闸原先只打一行 log，那个角色的云端上下文会一直停在旧版本、主动消息一直拿旧上下文说话，比即时对话那条明着报错的还难发现。现在它也对齐水位，但这一轮不重传——`fire_pack` 每轮聊天都是全量重建的，下次打脏同步带着更新的内容盖过去，比拿这份已经被判成「旧」的包硬挤进去更有道理。

## 版本门槛

设置页的 `REQUIRED_WORKER_VERSION` 与 `AMSG_BUNDLE_VERSION` 跟着一起动了，所有人会看到一次「更新 Worker」。客户端那道水位只兜得住「发不出去」那一半，云端那行仍会一直停在未来，升上来才会第一次写入就回到现实。

## 测试

新增 14 条。两条守卫都验证过在旧行为下会挂：把自愈那两段临时退回旧逻辑，即时对话 3 条 + 批量同步 1 条准确挂掉，改回来全过。

全量 360 文件 / 4503 条通过。

https://claude.ai/code/session_01KuZwacfFRfvsfu9aJJB9HJ