### PR TITLE
amsg2 诊断：补上 Service Worker 那一侧的盲区

### DIFF
--- a/components/Amsg2DebugPanel.tsx
+++ b/components/Amsg2DebugPanel.tsx
@@ -11,11 +11,12 @@ import {
     type Amsg2PanelPosition,
 } from '../utils/amsg2DebugView';
 import {
-    formatInstantTraceLog,
+    formatFullTraceLog,
     readAllInstantTraces,
     readRecentInstantTraces,
 } from '../utils/instantTraceLog';
 import { shareOrDownloadBlob } from '../utils/shareExport';
+import { summarizeChannelHealth, type SwChannelHealth } from '../utils/swChannelProbe';
 import {
     describeExpirePolicy,
     describeRecurrence,
@@ -170,6 +171,8 @@ const Amsg2DebugPanel: React.FC = () => {
     const panelRef = useRef<HTMLDivElement | null>(null);
     const dragRef = useRef<{ pointerId: number; startX: number; startY: number; origin: Amsg2PanelPosition } | null>(null);
 
+    const [health, setHealth] = useState<SwChannelHealth | null>(null);
+
     useEffect(() => subscribeDevDebugAvailability(setAvailable), []);
     useEffect(() => subscribeDevDebugFlags((flags) => setEnabled(flags.amsg2Panel)), []);
 
@@ -179,7 +182,10 @@ const Amsg2DebugPanel: React.FC = () => {
         if (!active) return;
         const readTraces = () => {
             setTraces(readRecentInstantTraces(TRACE_SHOWN));
-            setTraceTotal(readAllInstantTraces().length);
+            const all = readAllInstantTraces();
+            setTraceTotal(all.length);
+            // 用全部两百条算，而不是上面显示的那几条：通道断没断要看一段时间的走势。
+            setHealth(summarizeChannelHealth(all));
         };
         readTraces();
         const timer = window.setInterval(readTraces, TRACE_RELOAD_MS);
@@ -238,7 +244,9 @@ const Amsg2DebugPanel: React.FC = () => {
      * 用户会以为文件已经在手上了。
      */
     const exportTraces = async () => {
-        const text = formatInstantTraceLog();
+        // 页面侧 + SW 侧合在一起导：只有页面那半截的话，「推送到没到、SW 有没有喊到
+        // 页面」全看不见，而这类故障的答案恰恰在那一段。
+        const text = await formatFullTraceLog();
         if (!text) return;
         try {
             const result = await shareOrDownloadBlob({
@@ -406,6 +414,27 @@ const Amsg2DebugPanel: React.FC = () => {
                                 : traceTotal === 0 ? '暂无' : `导出全部 (${traceTotal})`}
                     </button>
                 </div>
+                {/* 实时通道的体检结论。放在最显眼处是因为这条腿断了之后功能表面上还是好的——
+                    消息照样到，只是每条都白等最多一分钟，用户多半当成「网络卡」而不会来报。 */}
+                {health && health.status !== 'idle' && (
+                    <div
+                        style={{
+                            fontSize: 11,
+                            marginBottom: 3,
+                            color: health.status === 'ok' ? C.dim : C.red,
+                        }}
+                    >
+                        {health.status === 'ok'
+                            ? `实时通道正常 · 上次收到 SW 消息 ${hhmmss(new Date(health.lastSwMessageAt!).getTime())}`
+                            : '⚠ 没收到过 SW 消息，消息全靠兜底轮询捞（每条最多白等 60 秒）'}
+                        {health.flushByTrigger.length > 0 && (
+                            <span style={{ color: C.dim }}>
+                                {' · 冲刷来源 '}
+                                {health.flushByTrigger.map((item) => `${item.trigger}×${item.count}`).join(' ')}
+                            </span>
+                        )}
+                    </div>
+                )}
                 {traces.length === 0 ? (
                     <div style={{ color: C.dim, fontSize: 11 }}>（暂无）</div>
                 ) : (

--- a/docs/dev-debug.md
+++ b/docs/dev-debug.md
@@ -282,6 +282,23 @@ LLM 日志里的聊天历史动辄几十条，整段塞进 localStorage 很快�
 
 > 折叠是**通用**的——对所有捕获类的 `data` 一视同仁，未来加的捕获类自动享受，不用各自处理。当前规则只有一条：递归遇到 key=`messages` 的数组就整组替换成 metadata，其它字段一律原样。
 
+### 主动消息的 trace 是另一套（无条件记录）
+
+上面那套要先勾选才录。主动消息 / instant push 这条链路另有一套 **不用勾、正式版照录** 的记录，落在 `localStorage` 的 `instant_push_trace_log_v1`（滚动留 200 条，刷新不丢），实现在 [`utils/instantTraceLog.ts`](../utils/instantTraceLog.ts)。Service Worker 那一侧的记录存在独立的 `ActiveMsgSwTrace` 库里（SW 访问不到 localStorage），导出时两边合成一份、按时间排好。
+
+入口在 amsg2 观察窗的 `trace` 那一行，点「导出全部」得到一个 json。因为不用提前开任何开关，**可以先复现、事后再导**。
+
+排「通知都弹了、聊天界面半天不出字」这类问题时，看这几个字段：
+
+| 字段 | 在哪条记录上 | 说明 |
+|---|---|---|
+| `trigger` | `runtime-flush-start` | 这趟冲刷是谁发起的。`SW通知` 是唯一的实时路径，其余（`轮询补收` / `回到前台` / `启动` / `上线补收`…）都是兜底，各自带着几秒到一分钟的固有延迟 |
+| `waitedMs` | `runtime-inbox-message` | 这条消息在收件箱里躺了多久才轮到它。跟正文长短无关，纯粹是「没人来捞」的时间 |
+| `count` / `posted` / `targets` | `notify-clients`（SW 侧） | SW 喊页面时找到几个页面、各自可见性、发成功几个 |
+| `portAck` / `clientsAck` | `runtime-sw-channel-probe` | 启动时的通道体检。两条路分开测：port 通而 clients 不通 = SW 活着但找不到页面 |
+
+面板上还有一行现成的结论：**实时通道正常**（附上次收到 SW 消息的时刻），或者 **没收到过 SW 消息**。后者意味着消息全靠兜底轮询在捞，每条最多白等 60 秒——这种状态下功能表面上是正常的（消息照样会到），所以只能靠主动看，等不到用户来报。
+
 ---
 
 ## 十、容易踩的坑

--- a/utils/activeMsgRuntime.test.ts
+++ b/utils/activeMsgRuntime.test.ts
@@ -481,7 +481,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs('char-ts-main');
     expect(msgs.length).toBeGreaterThan(0);
@@ -522,7 +522,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt: occurrenceMs,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs.length, '循环任务不该被防穿帮闸吞掉').toBeGreaterThan(0);
@@ -571,7 +571,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt: occurrenceMs,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await assistantMsgs(charId), '这条消息该被闸吞掉').toHaveLength(0);
     const char = (await DB.getAllCharacters()).find((c) => c.id === charId);
@@ -613,7 +613,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt: occurrenceMs,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await assistantMsgs(charId), '前提：这条该被吞').toHaveLength(0);
     const decision = readAllInstantTraces()
@@ -662,7 +662,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt: occurrenceMs,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await assistantMsgs(charId), '跨夜的早安不该被锚点规则吞掉').toHaveLength(1);
   }, 20000);
@@ -694,12 +694,38 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt: occurrenceMs,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await assistantMsgs(charId), '前提：这条该放行').toHaveLength(1);
     expect(
       readAllInstantTraces().some((e) => e.event === 'runtime-expire-decision-pass'),
       '放行也要留痕',
+    ).toBe(true);
+  }, 20000);
+
+  /**
+   * 这条守的是「排障能力本身」。收件箱里的消息有七八条路能捞出来，其中只有 SW 实时喊
+   * 页面那条是快的，其余（轮询、回前台、补收）都带着几秒到一分钟的固有延迟。线上出过
+   * 一次实时通道整个断掉、消息全靠 60 秒轮询兜底的故障——功能表面正常，只是每条都白等，
+   * 而当时的记录里没有触发源，只能靠算时间差反推。所以这个字段必须一直在。
+   */
+  it('每趟冲刷都要记下是谁触发的，否则查不出实时通道断没断', async () => {
+    const charId = 'char-flush-trigger';
+    await DB.saveCharacter({ id: charId, name: '触发源角色' } as any);
+    await ActiveMsgStore.saveInboxMessage(inboxMsg({
+      messageId: 'msg-flush-trigger',
+      charId,
+      messageType: 'text',
+      sentAt: Date.now(),
+    }));
+
+    await flushInboxToChat('轮询补收');
+
+    const flushStarts = readAllInstantTraces().filter((e) => e.event === 'runtime-flush-start');
+    expect(flushStarts.length, '前提：这趟冲刷要留痕').toBeGreaterThan(0);
+    expect(
+      flushStarts.some((e) => e.trigger === '轮询补收'),
+      '冲刷记录里必须带上触发源',
     ).toBe(true);
   }, 20000);
 
@@ -714,7 +740,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs.length).toBeGreaterThan(0);
@@ -734,7 +760,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
     }));
 
     const before = Date.now();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs.length).toBeGreaterThan(0);
@@ -763,7 +789,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
     }));
 
     const before = Date.now();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs.length).toBeGreaterThan(0);
@@ -780,7 +806,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs).toHaveLength(1);
@@ -807,7 +833,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         receivedAt,
       }));
       const t0 = Date.now();
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
       return Date.now() - t0;
     };
 
@@ -841,7 +867,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
     notePageBecameVisible(receivedAt + 1_000);
     const t0 = Date.now();
     try {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       notePageBecameVisible(0); // 全局状态，别漏给后面的用例
     }
@@ -861,7 +887,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       messageType: 'text',
       sentAt: Date.now() - 8 * 60_000, // 走补收口径，跳过拟人慢放
     }));
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
     const first = await assistantMsgs(charId);
     expect(first.length).toBeGreaterThan(0);
 
@@ -872,7 +898,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       messageType: 'text',
       sentAt: Date.now() - 8 * 60_000,
     }));
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect((await assistantMsgs(charId)).length, '第二次到达不能再上屏').toBe(first.length);
   }, 20000);
@@ -914,7 +940,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
       }
@@ -942,7 +968,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
       }
@@ -968,7 +994,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
       }
@@ -997,7 +1023,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
         // 收掉这一轮排下的补落定时器，别让它带着生产间隔漂进后面的测试
@@ -1089,7 +1115,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId, amsgEmotionDone: true, amsgEmotionRef: ref },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       expect(readSpy).toHaveBeenCalledWith(amsgStateNamespace(charId), ref);
       const updated = (await DB.getAllCharacters()).find((c) => c.id === charId)!;
@@ -1124,7 +1150,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
       }
@@ -1157,7 +1183,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
 
       const { seen, restore } = captureEvents();
       try {
-        await flushInboxToChat();
+        await flushInboxToChat('SW通知');
       } finally {
         restore();
         // 收掉这一轮排下的补落定时器，别让它带着生产间隔漂进后面的测试
@@ -1192,7 +1218,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId, messageIndex: 1, amsgReasoning: '他这句问得很轻，先接住。' },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       expect(await thinkingChainOf(charId)).toEqual(['他这句问得很轻，先接住。']);
     }, 20000);
@@ -1213,7 +1239,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId, messageIndex: 1, amsgReasoningRef: ref },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       expect(readSpy).toHaveBeenCalledWith(amsgStateNamespace(charId), ref);
       expect(await thinkingChainOf(charId)).toEqual(['想了很久才决定这么说。']);
@@ -1234,7 +1260,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId, messageIndex: 2, amsgReasoning: '这段不该出现在卡片里。' },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       expect((await assistantMsgs(charId)).length).toBeGreaterThan(0);   // 正文照常上屏
       expect(await thinkingChainOf(charId)).toEqual([]);
@@ -1263,7 +1289,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId, amsgToolTrace: TRACE },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       const msgs = await assistantMsgs(charId);
       expect(msgs.length).toBeGreaterThan(0);
@@ -1288,7 +1314,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
         metadata: { charId },
       }));
 
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
 
       const msgs = await assistantMsgs(charId);
       expect(msgs.length).toBeGreaterThan(0);
@@ -1306,7 +1332,7 @@ describe('flushInboxToChat 落库时间戳（走真库）', () => {
       sentAt,
     }));
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs).toHaveLength(1);
@@ -1452,7 +1478,7 @@ describe('认领角色自排任务后广播 amsg2-tasks-adopted', () => {
     await pushWithSelfScheduled(charId, 'msg-adopt-event-1', [selfScheduledTask('amsgself-evt-1', now)]);
 
     const events = captureEvents();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const adopted = events.filter((e) => e.type === AMSG2_TASKS_ADOPTED_EVENT);
     expect(adopted, '修复前只写库不广播，这里拿到 0 条').toHaveLength(1);
@@ -1470,7 +1496,7 @@ describe('认领角色自排任务后广播 amsg2-tasks-adopted', () => {
     await pushWithSelfScheduled(charId, 'msg-adopt-event-2', [selfScheduledTask('amsgself-evt-dup', now)]);
 
     const events = captureEvents();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(events.filter((e) => e.type === AMSG2_TASKS_ADOPTED_EVENT)).toHaveLength(0);
   }, 20000);
@@ -1505,7 +1531,7 @@ describe('认领角色自排任务后广播 amsg2-tasks-adopted', () => {
     } as any);
 
     const events = captureEvents();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const chars = await DB.getAllCharacters();
     const tasks = chars.find((c: any) => c.id === charId)?.activeMsg2Config?.tasks ?? [];
@@ -1538,7 +1564,7 @@ describe('认领角色自排任务后广播 amsg2-tasks-adopted', () => {
     } as any);
 
     const events = captureEvents();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(events.filter((e) => e.type === AMSG2_TASKS_ADOPTED_EVENT)).toHaveLength(0);
   }, 20000);
@@ -1715,7 +1741,7 @@ describe('防穿帮闸吞掉消息后撤销云端自述日志（走真库）', (
       },
     } as any);
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     // 撤销是 best-effort、不拦着 flush，所以等它自己跑完。
     await vi.waitFor(() => {
@@ -1783,7 +1809,7 @@ describe('多段消息跨批到达的等齐守卫（走真库）', () => {
     await DB.saveCharacter({ id: charId, name: '分段角色' } as any);
 
     await chunk(charId, sessionId, 2, 2, '……不然我一个人吃不完');
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await bodies(charId), '修复前后段会直接落库，顺序就此固定').toEqual([]);
     expect(
@@ -1792,7 +1818,7 @@ describe('多段消息跨批到达的等齐守卫（走真库）', () => {
     ).toEqual([`${sessionId}-2`]);
 
     await chunk(charId, sessionId, 1, 2, '晚上一起吃火锅吧');
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await bodies(charId)).toEqual(['晚上一起吃火锅吧', '……不然我一个人吃不完']);
   }, 20000);
@@ -1806,11 +1832,11 @@ describe('多段消息跨批到达的等齐守卫（走真库）', () => {
 
     // 扣满上限的那几次
     for (let i = 0; i < MAX_INBOX_ORDER_HOLDS; i += 1) {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
       expect(await bodies(charId), `第 ${i + 1} 次还该扣着`).toEqual([]);
     }
     // 再来一次：放行
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await bodies(charId)).toEqual(['……你说呢']);
     expect(await ActiveMsgStore.listInboxMessages()).toEqual([]);
@@ -1822,7 +1848,7 @@ describe('多段消息跨批到达的等齐守卫（走真库）', () => {
     await DB.saveCharacter({ id: charId, name: '分段角色' } as any);
 
     await chunk(charId, sessionId, 1, 2, '在吗');
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(await bodies(charId)).toEqual(['在吗']);
   }, 20000);
@@ -1883,7 +1909,7 @@ describe('离线补收落库时间戳与本地历史的先后（走真库）', (
     await backfillPush(charId, 'msg-backfill-after-user', sentAt);
 
     const before = Date.now();
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs).toHaveLength(1);
@@ -1896,7 +1922,7 @@ describe('离线补收落库时间戳与本地历史的先后（走真库）', (
     await DB.saveCharacter({ id: charId, name: '守夜角色' } as any);
     await backfillPush(charId, 'msg-backfill-quiet', sentAt);
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await assistantMsgs(charId);
     expect(msgs).toHaveLength(1);
@@ -1938,7 +1964,7 @@ describe('重试清场时副作用产物不受牵连（走真库）', () => {
       metadata: { directives: [{ type: 'transfer', amount: 5 }] },
     } as any);
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const msgs = await DB.getRecentMessagesByCharId(charId, 200);
     const transfers = msgs.filter((m) => m.type === 'transfer');
@@ -1980,7 +2006,7 @@ describe('重试清场·只留下副作用产物的半成品（走真库）', ()
       metadata: { directives: [{ type: 'transfer', amount: 8 }] },
     } as any);
 
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     const transfers = (await DB.getRecentMessagesByCharId(charId, 200))
       .filter((m) => m.type === 'transfer');
@@ -2058,7 +2084,7 @@ describe('即时对话的待收记录（走真库）', () => {
       sentAt: Date.now(),
       metadata: { charId },
     } as any);
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(getInstantChatPending(charId)).toBeNull();
   }, 20000);
@@ -2085,7 +2111,7 @@ describe('即时对话的待收记录（走真库）', () => {
       sentAt: Date.now(),
       metadata: { charId },
     } as any);
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(marked).toHaveBeenCalledWith(charId, ['expired-1', 'expired-2']);
     expect(getStagedInstantChatExpiredNotices(charId)).toBeNull();
@@ -2110,7 +2136,7 @@ describe('即时对话的待收记录（走真库）', () => {
       sentAt: Date.now(),
       metadata: { charId },
     } as any);
-    await flushInboxToChat();
+    await flushInboxToChat('SW通知');
 
     expect(getInstantChatPending(charId)?.uuid, '别的消息不能替这一轮销账').toBe('uuid-awaited');
   }, 20000);
@@ -2492,7 +2518,7 @@ describe('收件箱处理途中抛错不许吞掉整批（走真库）', () => {
       return ms != null && ms >= 1_000 ? (0 as any) : realSetTimeout(fn, ms, ...rest);
     }) as any);
     try {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       spy.mockRestore();
     }
@@ -2530,7 +2556,7 @@ describe('收件箱处理途中抛错不许吞掉整批（走真库）', () => {
     const track = vi.spyOn(Analytics, 'trackEvent').mockImplementation(() => {});
     const timers = captureInboxRetryTimer();
     try {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       timers.restore();
     }
@@ -2575,7 +2601,7 @@ describe('收件箱处理途中抛错不许吞掉整批（走真库）', () => {
 
     const timers = captureInboxRetryTimer();
     try {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       timers.restore();
       dispatch.mockRestore();
@@ -2625,7 +2651,7 @@ describe('收件箱处理途中抛错不许吞掉整批（走真库）', () => {
 
     const timers = captureInboxRetryTimer();
     try {
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       timers.restore();
     }
@@ -2687,7 +2713,7 @@ describe('云端旁路副本等这条消息处理成功了再删（走真库）'
     try {
       // 第一趟：落库挂了（配额满 / 连接被占那种），这条被压回收件箱等重试。
       const saveSpy = vi.spyOn(DB, 'saveMessage').mockRejectedValue(new Error('QuotaExceededError'));
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
       saveSpy.mockRestore();
 
       expect(clearSpy, '这一趟没成，云端那几份一个都不许删').not.toHaveBeenCalled();
@@ -2697,7 +2723,7 @@ describe('云端旁路副本等这条消息处理成功了再删（走真库）'
       ).toBe(true);
 
       // 第二趟：存储缓过来了，重试把心象卡片补上。
-      await flushInboxToChat();
+      await flushInboxToChat('SW通知');
     } finally {
       timers.restore();
     }

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -2742,12 +2742,29 @@ export const ActiveMsgRuntime = {
 
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', () => {
+        // 切走也记一笔。排「消息在收件箱躺了很久」时要回答的是「那段时间页面在干嘛」，
+        // 而只记「回来了」的话，前面那段空白到底是页面没在跑、还是在跑但没人喊它，
+        // 事后分不出来。
+        activeMsgTrace('runtime-page-visibility', { state: document.visibilityState });
         if (document.visibilityState !== 'visible') return;
         handlePageBecameVisible();
       });
       // 冷启动那一下（点通知才把 App 拉起来）没有 visibilitychange 可听，这里补一次：
       // 不补的话「回到前台的时刻」一直是 0，从通知进来的第一条判不出「送达时人不在」。
       if (document.visibilityState === 'visible') notePageBecameVisible();
+    }
+
+    // 浏览器把后台页面冻起来 / 解冻。冻结期间 JS 完全不跑，SW 喊过来的消息会排队等
+    // 解冻——这跟「SW 压根没喊」在事后看长得一模一样（页面侧都是一段空白），只有这两
+    // 个事件能把它们分开。移动端和 iOS 的 PWA 冻得尤其积极。
+    // 不是所有浏览器都发这两个事件，收不到就当没有，不影响其它判断。
+    if (typeof document !== 'undefined') {
+      document.addEventListener('freeze', () => {
+        activeMsgTrace('runtime-page-freeze');
+      });
+      document.addEventListener('resume', () => {
+        activeMsgTrace('runtime-page-resume');
+      });
     }
 
     // 受理一轮即时对话之后（useChatAI 那边写记录 + 广播），把点名周期排上。

--- a/utils/activeMsgRuntime.ts
+++ b/utils/activeMsgRuntime.ts
@@ -35,6 +35,7 @@ import { describeInstantChatFailure, pruneStaleTasks, type RemoteTaskLastError }
 // 线协议常量的唯一出处是 shared（amsg-sw 只是 re-export 同一份）。
 import { MULTIPART_FAILURE_REASON } from '@rei-standard/amsg-shared';
 import { appendInstantTraceEntry } from './instantTraceLog';
+import { captureSwRegistrationSnapshot, probeSwChannel } from './swChannelProbe';
 import { trackEvent } from './analytics';
 
 // 同一个 category，两个 tag——保持 console 里现有的 [ActiveMsg] / [amsg] 标签，
@@ -1371,7 +1372,7 @@ const scheduleInboxRetry = (attempts: number) => {
   if (inboxRetryTimer != null) return;   // 已经排了就不重复排，一次重试会带上全部积压
   inboxRetryTimer = setTimeout(() => {
     inboxRetryTimer = null;
-    void flushInboxToChat();
+    void flushInboxToChat('重试');
   }, resolveInboxRetryDelay(attempts));
 };
 
@@ -1423,7 +1424,7 @@ const scheduleInboxOrderRecheck = () => {
   if (inboxOrderHoldTimer != null) return;   // 已经排了就不重复排，一次重看会带上全部积压
   inboxOrderHoldTimer = setTimeout(() => {
     inboxOrderHoldTimer = null;
-    void flushInboxToChat();
+    void flushInboxToChat('等齐重看');
   }, INBOX_ORDER_HOLD_DELAY_MS);
 };
 
@@ -1623,11 +1624,33 @@ const handleInboxStageFailure = async (
   notifyInboxProcessFailed(message, 'swallowed', '收发');
 };
 
-const flushInboxToChatImpl = async (): Promise<string[]> => {
+/**
+ * 这一趟冲刷是谁发起的。
+ *
+ * 「SW通知」是唯一的实时路径——推送一到就喊页面。其余全是兜底：轮询、回前台、启动、
+ * 补收，它们都带着几秒到一分钟不等的固有延迟。所以这个字段实际回答的是
+ * 「实时通道还活着吗」：一段时间里的冲刷全由兜底触发，就说明它断了。
+ */
+export type FlushTrigger =
+  | 'SW通知'          // Service Worker 收到推送后喊页面（唯一的实时路径）
+  | 'SW思维链'        // 思维链推送到达
+  | 'SW工具请求'      // 工具调用推送到达
+  | '点通知进入'      // 用户点系统通知把 App 唤到前台
+  | '回到前台'        // 页面重新可见
+  | '启动'            // App 冷启动时的兜底排空
+  | '重试'            // 上一趟处理失败，定时重来
+  | '等齐重看'        // 多段消息扣住后段，隔几秒回头看前段到了没
+  | '上线补收'        // 开 App 自动去云端账本捞后台期间漏掉的
+  | '手动补收'        // 用户点「找回没收到的消息」
+  | '轮询补收'        // 即时对话 60 秒点名顺手把账本上的捞回来
+  | '原生收件箱'      // 原生壳把消息塞进收件箱后触发
+  | '原生推送';       // 原生壳收到推送后触发
+
+const flushInboxToChatImpl = async (trigger: FlushTrigger): Promise<string[]> => {
   const pendingMessages = await ActiveMsgStore.consumeInboxMessages();
   // 这一趟真正落进聊天流的那几条（见 flushInboxToChat 的返回值说明）。
   const landedMessageIds: string[] = [];
-  activeMsgTrace('runtime-flush-start', { count: pendingMessages.length });
+  activeMsgTrace('runtime-flush-start', { count: pendingMessages.length, trigger });
   // 这一趟处理谁「还没着落」的记账从空开始（见 retainedInboxMessageIds）。
   retainedInboxMessageIds.clear();
   // ─── 落库前的 messageId 去重 ───
@@ -1675,6 +1698,18 @@ const flushInboxToChatImpl = async (): Promise<string[]> => {
         charId: message.charId,
         messageType: message.messageType,
         bodyChars: typeof message.body === 'string' ? message.body.length : undefined,
+        // 这条推送落到设备上的时刻（SW 写收件箱时打的），以及从那一刻起在收件箱里
+        // 躺了多久才轮到它。用户抱怨的「通知都看到了，界面半天没字」量的就是这个数：
+        // 它跟正文长短无关，纯粹是「没人来捞」的时间。
+        receivedAt: message.receivedAt,
+        waitedMs: typeof message.receivedAt === 'number' && message.receivedAt > 0
+          ? Date.now() - message.receivedAt
+          : undefined,
+        // 第几段 / 共几段：多段回复的延迟要按段看才有意义。
+        chunk: (message.metadata as any)?.messageIndex,
+        total: (message.metadata as any)?.totalMessages,
+        // 重试过几次（0 = 第一次处理）。
+        attempts: message.processAttempts ?? 0,
       });
 
       // 见上面 isAlreadyPersisted 的注释：这条已经在聊天记录里了（补收先到、真推送迟到，
@@ -2042,7 +2077,7 @@ const flushInboxToChatImpl = async (): Promise<string[]> => {
  * 插回正确位置）。尽力而为：失败就算了，正常路径什么都扫不到。
  */
 const sweepSettledInstantRound = async (charId: string, uuid: string): Promise<void> => {
-  const entries = await drainOutboxAndFlush();
+  const entries = await drainOutboxAndFlush('轮询补收');
   if (entries === null) {
     log.warn('即时对话销账后补扫没读成（缺段只能等下一轮顺带）', { charId, uuid });
   }
@@ -2066,13 +2101,18 @@ let flushChain: Promise<unknown> = Promise.resolve();
  *
  * （导出仅为让 activeMsgRuntime.test.ts 走真库钉「主路径 / 降级路径落库时间戳同口径」，
  *   运行时入口仍是 ActiveMsgRuntime.init 挂的监听器。）
+ *
+ * trigger 是**必填**的：收件箱里的消息可能被七八条路捞出来，光看「冲刷跑了」分不清是
+ * 推送实时喊醒的、还是等满 60 秒被兜底轮询捞的——而这两件事对用户是天壤之别（前者
+ * 立刻，后者最坏差一分钟）。设成必填而不是给个默认值，是为了让新加的调用点漏传时
+ * 编译就报错，而不是静默记成一个查不出所以然的「未知」。
  */
-export const flushInboxToChat = (): Promise<string[]> => {
+export const flushInboxToChat = (trigger: FlushTrigger): Promise<string[]> => {
   const next = flushChain.then(async () => {
     try {
-      return await flushInboxToChatImpl();
+      return await flushInboxToChatImpl(trigger);
     } catch (e) {
-      log.warn('flushInboxToChat failed', { error: e });
+      log.warn('flushInboxToChat failed', { trigger, error: e });
       return [];
     }
   });
@@ -2176,8 +2216,11 @@ const notifyOutboxStaleDropped = (count: number): void => {
  *
  * 返回这一趟读到的全部条目；**读失败返回 null**。两者不能混：「没读成」不构成任何
  * 结论，调用方要拿它下「回复取不回」的判决时只能认前者（docs/instant-push-dual-channel.md）。
+ *
+ * trigger 由调用方给：这个函数被上线补收、手动补收、60 秒点名三条路共用，而排障时
+ * 要分的正是「是谁把消息捞回来的」——记成同一个就白记了。
  */
-const drainOutboxAndFlush = async (): Promise<AmsgOutboxEntry[] | null> => {
+const drainOutboxAndFlush = async (trigger: FlushTrigger): Promise<AmsgOutboxEntry[] | null> => {
   lastOutboxDrainAt = Date.now();
   try {
     const { written, ackNow, entries, staleDropped } = await drainOutbox();
@@ -2191,7 +2234,7 @@ const drainOutboxAndFlush = async (): Promise<AmsgOutboxEntry[] | null> => {
     // 用户后来去点「找回没收到的消息」，看到的是一句「账本上没有漏收的消息，这条链路是
     // 通的」——他刚丢了消息，界面却在告诉他一切正常。这一句是那件事唯一的出口。
     if (staleDropped > 0) notifyOutboxStaleDropped(staleDropped);
-    if (written > 0) await flushInboxToChat();
+    if (written > 0) await flushInboxToChat(trigger);
     return entries;
   } catch (e) {
     log.warn('补收失败（等下一次时机再试）', { error: e });
@@ -2234,7 +2277,7 @@ export const catchUpMissedPushes = async (
     return 'failed';
   }
 
-  const entries = await drainOutboxAndFlush();
+  const entries = await drainOutboxAndFlush(trigger === 'manual' ? '手动补收' : '上线补收');
   return entries === null ? 'failed' : 'drained';
 };
 
@@ -2276,7 +2319,7 @@ export const catchUpMissedPushesManually = async (): Promise<{
   // 报给用户的是「上了屏几条」，所以要等冲刷跑完、再拿这一趟落库的名单跟自己写进收件箱
   // 的名单对一次。只认自己那几条：同一趟冲刷可能顺手把收件箱里别人（推送刚写的）留下的
   // 也带走了，那些不是这次补收的功劳。
-  const landed = written > 0 ? new Set(await flushInboxToChat()) : new Set<string>();
+  const landed = written > 0 ? new Set(await flushInboxToChat('手动补收')) : new Set<string>();
   const persisted = writtenIds.filter((id) => landed.has(id)).length;
   return { written: persisted, scanned: entries.length, stale: staleDropped };
 };
@@ -2313,7 +2356,7 @@ export const handlePageBecameVisible = (): void => {
   notePageBecameVisible();
   // 先 await flush 落库 round-1 旁白, 再跑 runner 触发 round-2, 避免 "B+A".
   void (async () => {
-    await flushInboxToChat();
+    await flushInboxToChat('回到前台');
     void catchUpMissedPushes('foreground');
     void runInstantChatStatusCheck();
     void drainPendingDiaries(loadRealtimeConfigFromLocalStorage(), (charId) => {
@@ -2372,7 +2415,7 @@ export const runInstantChatStatusCheck = async (): Promise<void> => {
   // 这趟不走上线补收那个节流：点名的语义是「下结论之前必须拿最新的账本」，为省一次
   // 往返而跳过，就可能拿着几十秒前的旧结论去判「回复取不回」。冷启动那一刻可能跟
   // 上线补收撞上一次，那是「用户正等着回复」才有的场景，多一次往返换判断可靠，值。
-  if (pendings.length > 0) await drainOutboxAndFlush();
+  if (pendings.length > 0) await drainOutboxAndFlush('轮询补收');
   for (const pending of pendings) {
     // 补收那一步如果把回复放进来了，flush 里已经销账了——这一轮就此结束。
     if (getInstantChatPending(pending.charId)?.uuid !== pending.uuid) continue;
@@ -2432,7 +2475,7 @@ export const runInstantChatStatusCheck = async (): Promise<void> => {
     }
 
     // completed / gone：再兜一次账本（落账与删行之间有窗口），仍没有才下结论。
-    const entries = await drainOutboxAndFlush();
+    const entries = await drainOutboxAndFlush('轮询补收');
     if (getInstantChatPending(pending.charId)?.uuid !== pending.uuid) continue;
 
     // 上游的 completed = 行还在、但已经出了 pending 队列（sent / failed 都算这个码）。
@@ -2623,13 +2666,13 @@ export const ActiveMsgRuntime = {
           });
         }
         if (type === 'active-msg-received') {
-          void flushInboxToChat();
+          void flushInboxToChat('SW通知');
           return;
         }
 
         if (type === 'active-msg-reasoning') {
           // 先确保已到的 content 落库 (flush 链串行), 再尝试把思维链回填到首条回复上.
-          void flushInboxToChat().then(() =>
+          void flushInboxToChat('SW思维链').then(() =>
             backfillReasoningSafely(event.data?.sessionId, event.data?.charId),
           );
           return;
@@ -2679,7 +2722,7 @@ export const ActiveMsgRuntime = {
         // 先 flush 再跑 runner: 同一轮的旁白 (round-1 prefix) 是单独的 content push, 必须保证
         // 它先入库, 再让 runner 触发 round-2, 否则 round-2 回复可能抢在旁白前面 ("B+A").
         if (type === 'instant-tool-request') {
-          void flushInboxToChat().then(() => runPendingToolCallsSafely());
+          void flushInboxToChat('SW工具请求').then(() => runPendingToolCallsSafely());
           return;
         }
 
@@ -2687,7 +2730,7 @@ export const ActiveMsgRuntime = {
           // 严格串行: 先把 inbox 里的 round-1 旁白落库, 再跑 tool runner (它会触发 round-2),
           // 保证用户回到界面时先看到旁白, 且 round-2 回复排在旁白之后.
           void (async () => {
-            await flushInboxToChat();
+            await flushInboxToChat('点通知进入');
             window.dispatchEvent(new CustomEvent('active-msg-open', {
               detail: { charId: event.data?.charId },
             }));
@@ -2717,9 +2760,24 @@ export const ActiveMsgRuntime = {
     // 不能拦着下面的 inbox flush。
     void refreshPushSubscriptionIfMarked();
 
+    // SW→页面通道体检：拍一张注册关系的快照，再用推送真正走的那条路探一次通不通。
+    // 这条通道断了之后主动消息不会消失、只会慢几十秒（兜底轮询还在捞），表面上一切
+    // 正常，所以必须主动去测——等用户来报的时候，它可能已经坏了好几天。
+    // fire-and-forget：探测要等回信，不能拦着下面的冲刷。
+    void (async () => {
+      try {
+        const registration = await captureSwRegistrationSnapshot();
+        activeMsgTrace('runtime-sw-registration', { ...registration });
+        const probe = await probeSwChannel();
+        activeMsgTrace('runtime-sw-channel-probe', { ...probe });
+      } catch (e) {
+        log.warn('SW 通道体检没做成（不影响功能）', { error: e });
+      }
+    })();
+
     // 启动兜底: 先 flush 落库 (含上次被杀进程时卡在 inbox 的 round-1 旁白), 再跑 runner
     // 触发 round-2, 保证冷启动恢复时旁白也排在 round-2 回复之前.
-    await flushInboxToChat();
+    await flushInboxToChat('启动');
     await runPendingToolCallsSafely();
     // 上次不在线时丢掉的推送去账本上捞回来。**这一趟无条件跑**：定时主动消息的推送
     // 丢了之后，本地不会留下任何「有条消息没到」的痕迹，账本是唯一的线索来源

--- a/utils/instantTraceLog.ts
+++ b/utils/instantTraceLog.ts
@@ -69,3 +69,95 @@ export const formatInstantTraceLog = (): string => {
     entries,
   }, null, 2);
 };
+
+// ─── Service Worker 那一侧的日志 ───
+//
+// SW 里 console.log 出来的东西，在远端用户手上等于不存在（手机没有 DevTools，装成
+// PWA 更没有），于是「推送到没到 SW、SW 有没有喊到页面」整段都看不见——而页面这边
+// 的第一条记录已经是「开始处理」了，中间那截空白恰恰是最要命的地方。
+// SW 把它写进一个独立的小库（见 worker/sw-keep-alive.ts），这里把它读出来一起导出。
+const SW_TRACE_DB_NAME = 'ActiveMsgSwTrace';
+const SW_TRACE_STORE = 'entries';
+
+/**
+ * 读 SW 写下的日志。**不带版本号打开**：库归 SW 建，页面这边只是来读，
+ * 带版本号会在库还没被建过时触发一次建库、甚至跟 SW 抢升级。
+ * 读不到就返回空数组——SW 还没装新版、或者浏览器不给开，都不该让导出整个失败。
+ */
+export const readSwTraces = async (): Promise<InstantTraceEntry[]> => {
+  if (typeof indexedDB === 'undefined') return [];
+  try {
+    const db = await new Promise<IDBDatabase | null>((resolve) => {
+      const request = indexedDB.open(SW_TRACE_DB_NAME);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => resolve(null);
+      request.onblocked = () => resolve(null);
+    });
+    if (!db) return [];
+    try {
+      if (!db.objectStoreNames.contains(SW_TRACE_STORE)) return [];
+      const rows = await new Promise<InstantTraceEntry[]>((resolve) => {
+        const tx = db.transaction(SW_TRACE_STORE, 'readonly');
+        const request = tx.objectStore(SW_TRACE_STORE).getAll();
+        request.onsuccess = () => resolve((request.result || []) as InstantTraceEntry[]);
+        request.onerror = () => resolve([]);
+        tx.onabort = () => resolve([]);
+      });
+      return rows;
+    } finally {
+      // 页面只是来读一趟，读完就还回去：连接开着会挡住 SW 后续的版本升级。
+      try { db.close(); } catch { /* ignore */ }
+    }
+  } catch {
+    return [];
+  }
+};
+
+/** 导出文件里那段「这台设备当时是什么状况」。都是环境信息，不含任何聊天内容。 */
+const captureEnvSnapshot = (): Record<string, unknown> => {
+  const snapshot: Record<string, unknown> = {};
+  try {
+    snapshot.userAgent = navigator.userAgent;
+    snapshot.language = navigator.language;
+    // 装成 PWA 独立窗口跑的，行为跟浏览器标签页不一样（尤其 iOS）。
+    snapshot.standalone = window.matchMedia?.('(display-mode: standalone)').matches
+      || (navigator as any)?.standalone === true;
+    snapshot.swSupported = 'serviceWorker' in navigator;
+    snapshot.swControlled = 'serviceWorker' in navigator && !!navigator.serviceWorker.controller;
+    snapshot.visibility = typeof document !== 'undefined' ? document.visibilityState : undefined;
+    snapshot.online = navigator.onLine;
+    // 导出这一刻设备的钟。跟条目里的时间戳对照能看出设备时钟有没有跑偏。
+    snapshot.now = new Date().toISOString();
+    snapshot.timezoneOffsetMin = new Date().getTimezoneOffset();
+  } catch { /* 拿不到的就不记 */ }
+  return snapshot;
+};
+
+/**
+ * 导出「页面 + SW 两侧合在一起」的完整现场。
+ *
+ * 两侧的记录都带 ISO 时间戳，合并后按时间排一次，读的人就能直接看出
+ * 「推送几点到的 SW、SW 几点喊的页面、页面几点才动手」——这三个时刻之间的空档，
+ * 正是排这类故障唯一要看的东西。
+ */
+export const formatFullTraceLog = async (): Promise<string> => {
+  const pageEntries = readAllInstantTraces();
+  const swEntries = await readSwTraces();
+  if (pageEntries.length === 0 && swEntries.length === 0) return '';
+
+  const merged = [
+    ...pageEntries.map((entry) => ({ side: 'page', ...entry })),
+    ...swEntries.map((entry) => ({ side: 'sw', ...entry })),
+  ].sort((a, b) => String(b.ts ?? '').localeCompare(String(a.ts ?? '')));
+
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    appVersion: APP_VERSION,
+    build: BUILD_LABEL,
+    env: captureEnvSnapshot(),
+    count: merged.length,
+    pageCount: pageEntries.length,
+    swCount: swEntries.length,
+    entries: merged,
+  }, null, 2);
+};

--- a/utils/instantTraceLog.ts
+++ b/utils/instantTraceLog.ts
@@ -12,7 +12,14 @@
 import { APP_VERSION, BUILD_LABEL } from './buildInfo';
 
 const TRACE_LOG_KEY = 'instant_push_trace_log_v1';
-const TRACE_LOG_LIMIT = 200;
+/**
+ * 留多少条。
+ *
+ * 一轮多段回复本身就能打三四十条，再加上 SW 每喊一次页面也记一条，200 条只够翻回
+ * 三四轮——而排障要的往往是「上午那次」。实测每条约 280 字节，400 条也就一百来 KB，
+ * localStorage 装得下，导出的文件也还是能直接发给人的大小。
+ */
+const TRACE_LOG_LIMIT = 400;
 
 export interface InstantTraceEntry {
   ts?: string;

--- a/utils/nativeAmsgInbox.ts
+++ b/utils/nativeAmsgInbox.ts
@@ -69,6 +69,6 @@ export const ingestNativeAmsgPayload = async (
 
   await ActiveMsgStore.saveInboxMessage(inbox);
   rememberReceivedId(messageId);
-  await flushInboxToChat();
+  await flushInboxToChat('原生收件箱');
   return { charId, messageId };
 };

--- a/utils/nativeAmsgPush.ts
+++ b/utils/nativeAmsgPush.ts
@@ -70,7 +70,7 @@ const ingestNotification = async (notification: PushNotificationSchema): Promise
   };
   await ActiveMsgStore.saveInboxMessage(inbox);
   rememberReceivedId(messageId);
-  await flushInboxToChat();
+  await flushInboxToChat('原生推送');
 };
 
 const registerToken = async (token: Token) => {

--- a/utils/swChannelProbe.test.ts
+++ b/utils/swChannelProbe.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeChannelHealth } from './swChannelProbe';
+
+/**
+ * 这组测试守的是一件很容易被忽略的事：主动消息有实时和兜底两条腿，实时那条断了之后
+ * **功能表面上仍然是好的**——消息照样会到，只是每条都要白等最多一分钟。所以判定不能
+ * 看「消息到没到」，只能看「有没有过 SW 喊页面这件事」。
+ */
+describe('summarizeChannelHealth（实时通道还活着没有）', () => {
+  it('收到过 SW 消息 → 判定正常，并给出最近那次的时刻', () => {
+    const health = summarizeChannelHealth([
+      { event: 'runtime-flush-start', ts: '2026-09-04T02:50:30.000Z', trigger: 'SW通知' },
+      { event: 'runtime-sw-message', ts: '2026-09-04T02:50:29.000Z' },
+    ]);
+
+    expect(health.status).toBe('ok');
+    expect(health.lastSwMessageAt).toBe('2026-09-04T02:50:29.000Z');
+  });
+
+  it('消息一直在到、但没有一次是 SW 喊的 → 判定为只剩兜底', () => {
+    // 这正是线上那台设备的形态：冲刷在跑、消息也上屏了，就是没人实时喊过它。
+    // 只看「有没有冲刷」会把这种情况判成正常，那就永远发现不了。
+    const health = summarizeChannelHealth([
+      { event: 'runtime-flush-start', ts: '2026-09-04T02:50:30.000Z', trigger: '轮询补收' },
+      { event: 'runtime-flush-start', ts: '2026-09-04T02:53:35.000Z', trigger: '轮询补收' },
+      { event: 'runtime-inbox-message', ts: '2026-09-04T02:53:36.000Z' },
+    ]);
+
+    expect(health.status).toBe('fallback-only');
+    expect(health.lastSwMessageAt).toBeUndefined();
+  });
+
+  it('一次冲刷都没有 → 不下结论（刚装好、或这段时间根本没消息）', () => {
+    expect(summarizeChannelHealth([]).status).toBe('idle');
+    expect(summarizeChannelHealth([{ event: 'runtime-emotion-done' }]).status).toBe('idle');
+  });
+
+  it('记录乱序时取最新的那条 SW 消息，不是最后遇到的那条', () => {
+    const health = summarizeChannelHealth([
+      { event: 'runtime-sw-message', ts: '2026-09-04T02:50:29.000Z' },
+      { event: 'runtime-sw-message', ts: '2026-09-04T01:00:00.000Z' },
+    ]);
+
+    expect(health.lastSwMessageAt).toBe('2026-09-04T02:50:29.000Z');
+  });
+
+  it('按触发源分类计数，多的排前面', () => {
+    const health = summarizeChannelHealth([
+      { event: 'runtime-flush-start', trigger: '轮询补收' },
+      { event: 'runtime-flush-start', trigger: '轮询补收' },
+      { event: 'runtime-flush-start', trigger: '轮询补收' },
+      { event: 'runtime-flush-start', trigger: '回到前台' },
+    ]);
+
+    expect(health.flushByTrigger).toEqual([
+      { trigger: '轮询补收', count: 3 },
+      { trigger: '回到前台', count: 1 },
+    ]);
+  });
+
+  it('没带触发源的冲刷不计数，免得凑出一个查不出所以然的分组', () => {
+    const health = summarizeChannelHealth([
+      { event: 'runtime-flush-start' },
+      { event: 'runtime-flush-start', trigger: 'SW通知' },
+    ]);
+
+    expect(health.flushByTrigger).toEqual([{ trigger: 'SW通知', count: 1 }]);
+  });
+});

--- a/utils/swChannelProbe.ts
+++ b/utils/swChannelProbe.ts
@@ -1,0 +1,207 @@
+/**
+ * Service Worker → 页面这条通道的体检。
+ *
+ * 主动消息有两条腿：推送到达时 SW 立刻喊页面（实时），以及页面自己每 60 秒去云端账本
+ * 捞一次（兜底）。前者断了之后功能表面上还是好的——消息照样会到，只是慢上几十秒，
+ * 用户多半会当成「网络有点卡」而不会来报，于是它可以坏很久没人发现。
+ *
+ * 这里做两件事：把「页面和 SW 是什么关系」拍个快照，以及**用推送真正走的那条路**
+ * 探一次通不通。两者都只读、不改任何状态。
+ */
+
+/** 页面与 Service Worker 的注册关系。字段都取自浏览器，取不到就留空。 */
+export interface SwRegistrationSnapshot {
+  /** 这个环境有没有 Service Worker（隐私模式 / 老浏览器可能没有）。 */
+  supported: boolean;
+  /**
+   * 页面**受不受**当前 SW 控制。
+   * 为 false 时 SW 仍可能通过 includeUncontrolled 找到页面，所以它不等于「一定收不到」，
+   * 但配合探测结果一起看就能说明问题。
+   */
+  controlled: boolean;
+  /** SW 的作用域，和页面路径对不上的话 SW 根本管不到这个页面。 */
+  scope?: string;
+  /** 页面自己的路径（不带查询串和 hash，那上面可能有不该进日志的东西）。 */
+  pagePath?: string;
+  /** 三种状态各自的 state，用来看是不是卡在等待激活。 */
+  activeState?: string;
+  waitingState?: string;
+  installingState?: string;
+  /** 已激活 SW 的脚本路径，用来确认跑的是不是当前这份。 */
+  activeScriptPath?: string;
+  /** 装成 PWA 独立窗口打开的（iOS 上这种壳的行为跟浏览器标签页不一样）。 */
+  standalone?: boolean;
+}
+
+/** 一次通道探测的结果。两条路分别记，为的是把「SW 没在跑」和「SW 找不到页面」分开。 */
+export interface SwChannelProbeResult {
+  /** 页面递了回信地址的那条路（MessageChannel）。它通 = SW 在跑、收得到页面的消息。 */
+  portAck: boolean;
+  portMs?: number;
+  /**
+   * SW 自己把页面找出来的那条路（clients.matchAll + postMessage）。
+   * **推送通知页面走的就是它**，所以只有这条的结果能代表真实链路。
+   */
+  clientsAck: boolean;
+  clientsMs?: number;
+  /** 等了多久放弃。 */
+  waitedMs: number;
+}
+
+/** 从已有记录看这条通道最近的状态。 */
+export interface SwChannelHealth {
+  /**
+   * - 'ok'：最近确实收到过 SW 喊的消息，实时这条腿是活的
+   * - 'fallback-only'：有冲刷发生过，但没有一次是 SW 喊的——全靠兜底在捞
+   * - 'idle'：这段记录里根本没有冲刷，无从判断（刚装好、或一直没收到消息）
+   */
+  status: 'ok' | 'fallback-only' | 'idle';
+  /** 最近一次收到 SW 消息的时刻（ISO），从来没有就是 undefined。 */
+  lastSwMessageAt?: string;
+  /** 各触发源分别冲刷了几次，按次数从多到少。 */
+  flushByTrigger: Array<{ trigger: string; count: number }>;
+}
+
+/**
+ * 判断实时通道还活着没有。
+ *
+ * 判据是「有没有过 SW 喊页面这件事」，而不是「消息到没到」——消息最终总会到（兜底
+ * 轮询在捞），所以拿它当判据永远看不出问题。反过来，一段时间里冲刷全由兜底触发，
+ * 就说明实时那条腿断了：功能看着正常，只是每条消息都白等最多一分钟。
+ */
+export const summarizeChannelHealth = (
+  entries: Array<{ event?: string; ts?: string; trigger?: unknown }>,
+): SwChannelHealth => {
+  const counts = new Map<string, number>();
+  let lastSwMessageAt: string | undefined;
+
+  for (const entry of entries) {
+    if (entry.event === 'runtime-sw-message') {
+      // 记录不保证有序，取时间戳最大的那条。
+      if (!lastSwMessageAt || String(entry.ts ?? '') > lastSwMessageAt) {
+        lastSwMessageAt = entry.ts;
+      }
+    }
+    if (entry.event === 'runtime-flush-start' && typeof entry.trigger === 'string') {
+      counts.set(entry.trigger, (counts.get(entry.trigger) ?? 0) + 1);
+    }
+  }
+
+  const flushByTrigger = [...counts.entries()]
+    .map(([trigger, count]) => ({ trigger, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const status: SwChannelHealth['status'] = lastSwMessageAt
+    ? 'ok'
+    : (flushByTrigger.length > 0 ? 'fallback-only' : 'idle');
+
+  return { status, lastSwMessageAt, flushByTrigger };
+};
+
+/** 只留路径：查询串和 hash 上可能挂着不该进日志的东西。 */
+const pathOf = (url: string): string => {
+  try {
+    return new URL(url, location.href).pathname;
+  } catch {
+    return '?';
+  }
+};
+
+export const captureSwRegistrationSnapshot = async (): Promise<SwRegistrationSnapshot> => {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) {
+    return { supported: false, controlled: false };
+  }
+
+  const snapshot: SwRegistrationSnapshot = {
+    supported: true,
+    controlled: !!navigator.serviceWorker.controller,
+    pagePath: typeof location !== 'undefined' ? pathOf(location.href) : undefined,
+  };
+
+  try {
+    snapshot.standalone = typeof window !== 'undefined'
+      && (window.matchMedia?.('(display-mode: standalone)').matches
+        || (window.navigator as any)?.standalone === true);
+  } catch { /* 拿不到就不记 */ }
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (registration) {
+      snapshot.scope = pathOf(registration.scope);
+      snapshot.activeState = registration.active?.state;
+      snapshot.waitingState = registration.waiting?.state;
+      snapshot.installingState = registration.installing?.state;
+      if (registration.active?.scriptURL) {
+        snapshot.activeScriptPath = pathOf(registration.active.scriptURL);
+      }
+    }
+  } catch { /* 取不到注册信息就只回上面那几项 */ }
+
+  return snapshot;
+};
+
+/**
+ * 探一次 SW 能不能喊到这个页面。
+ *
+ * 发一条带随机串的探测给 SW，SW 会**分别**用两条路回信；这里等到两条都回来、
+ * 或者等够 waitMs 为止。之所以要等而不是发完就走：没回信才是要抓的现象，
+ * 而「没回信」只能靠等出来。
+ *
+ * 探测本身不改任何状态，失败也只是返回一份「都没通」的结果。
+ */
+export const probeSwChannel = async (waitMs = 3_000): Promise<SwChannelProbeResult> => {
+  const result: SwChannelProbeResult = { portAck: false, clientsAck: false, waitedMs: waitMs };
+
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return result;
+
+  let target: ServiceWorker | null = null;
+  try {
+    target = navigator.serviceWorker.controller
+      || (await navigator.serviceWorker.getRegistration())?.active
+      || null;
+  } catch { /* 下面按拿不到处理 */ }
+  if (!target) return result;
+
+  const nonce = `probe_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  const startedAt = Date.now();
+
+  return await new Promise<SwChannelProbeResult>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      result.waitedMs = Date.now() - startedAt;
+      try { navigator.serviceWorker.removeEventListener('message', onClientsMessage); } catch { /* ignore */ }
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    // clients 这条路的回信会走页面全局的 SW message 事件——跟真实推送落到同一个入口。
+    const onClientsMessage = (event: MessageEvent) => {
+      if (event.data?.type !== 'sw-channel-probe-ack' || event.data?.nonce !== nonce) return;
+      result.clientsAck = true;
+      result.clientsMs = Date.now() - startedAt;
+      if (result.portAck) finish();
+    };
+
+    try {
+      navigator.serviceWorker.addEventListener('message', onClientsMessage);
+    } catch { /* 加不上监听就只能靠超时收尾 */ }
+
+    const timer = setTimeout(finish, waitMs);
+
+    try {
+      const channel = new MessageChannel();
+      channel.port1.onmessage = (event: MessageEvent) => {
+        if (event.data?.type !== 'sw-channel-probe-port-ack' || event.data?.nonce !== nonce) return;
+        result.portAck = true;
+        result.portMs = Date.now() - startedAt;
+        if (result.clientsAck) finish();
+      };
+      target.postMessage({ type: 'SW_CHANNEL_PROBE', nonce }, [channel.port2]);
+    } catch {
+      // 连消息都发不出去：两条路都算不通，不用干等满。
+      finish();
+    }
+  });
+};

--- a/worker/sw-keep-alive.ts
+++ b/worker/sw-keep-alive.ts
@@ -71,8 +71,12 @@ import { installReiSW } from '@rei-standard/amsg-sw';
  *  - 1.17.0: 升级 amsg-sw，通知的 silent 认 'when-visible' 这一档：静不静音改由 SW 按
  *            收到推送那一刻的窗口可见性算，用户看着页面时安静、切后台照常响铃震动。
  *            老 SW 把这个字符串当真值，会一律静音。
+ *  - 1.18.0: SW 侧 trace 落到独立的 ActiveMsgSwTrace 库（原来只写 console.log，远端用户
+ *            手上等于没有），并把 notifyClients 记细：找到几个页面、各自可见性、
+ *            postMessage 成没成。排「推送到了、通知也弹了、界面半天不动」这类故障时，
+ *            SW 到底有没有喊到页面是第一个要回答的问题。
  */
-const SW_VERSION = '1.17.0';
+const SW_VERSION = '1.18.0';
 
 const PING_INTERVAL = 15_000;
 const MAX_MANUAL_ALIVE_MS = 5 * 60_000;
@@ -114,15 +118,101 @@ function summarizeAmsgPayload(payload: any): Record<string, any> {
   };
 }
 
+// ─── SW 侧 trace 的持久化 ───
+//
+// traceSw 原本只写 console.log。SW 的 console 在远端用户那儿等于不存在（手机上没有
+// DevTools，装成 PWA 更没有），于是「SW 到底有没有收到推送、有没有喊到页面」这一整段
+// 全是盲区——排障时只能看到页面侧的记录，而页面侧的第一条记录已经是「开始处理」了。
+//
+// 存在**独立的小库**里，不往 ActiveMsg 库塞：那个库一升版本就要走 onupgradeneeded，
+// 主线程正开着旧版本连接的话会 blocked（openInboxDb 里就为此写了 onblocked 分支），
+// 排障用的日志不值得给收件箱这条关键路径带上这种风险。
+const SW_TRACE_DB_NAME = 'ActiveMsgSwTrace';
+const SW_TRACE_DB_VERSION = 1;
+const SW_TRACE_STORE = 'entries';
+/** 留多少条。一轮多段回复能打十几条，留够翻几轮的量。 */
+const SW_TRACE_LIMIT = 300;
+
+let swTraceDbPromise: Promise<IDBDatabase> | null = null;
+
+function openSwTraceDb(): Promise<IDBDatabase> {
+  if (swTraceDbPromise) return swTraceDbPromise;
+
+  const promise = new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(SW_TRACE_DB_NAME, SW_TRACE_DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(SW_TRACE_STORE)) {
+        db.createObjectStore(SW_TRACE_STORE, { keyPath: 'seq', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      // 跟另外两个库同款的失效自愈：被强关 / 别处升版本时清缓存，下次重开。
+      db.onversionchange = () => {
+        db.close();
+        if (swTraceDbPromise === promise) swTraceDbPromise = null;
+      };
+      db.onclose = () => {
+        if (swTraceDbPromise === promise) swTraceDbPromise = null;
+      };
+      resolve(db);
+    };
+    request.onerror = () => {
+      if (swTraceDbPromise === promise) swTraceDbPromise = null;
+      reject(request.error);
+    };
+    request.onblocked = () => {
+      if (swTraceDbPromise === promise) swTraceDbPromise = null;
+      reject(new Error('sw trace db blocked'));
+    };
+  });
+
+  swTraceDbPromise = promise;
+  return promise;
+}
+
+/** 追加一条并把超出上限的最老记录删掉。整个函数的失败都被调用方吞掉。 */
+async function appendSwTrace(entry: Record<string, any>): Promise<void> {
+  const db = await openSwTraceDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(SW_TRACE_STORE, 'readwrite');
+    const store = tx.objectStore(SW_TRACE_STORE);
+    store.add(entry);
+    // 同一个事务里 count 能看到刚 add 的那条，多出来的从最老的一头删。
+    const countRequest = store.count();
+    countRequest.onsuccess = () => {
+      const excess = countRequest.result - SW_TRACE_LIMIT;
+      if (excess <= 0) return;
+      let removed = 0;
+      const cursorRequest = store.openCursor();
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result;
+        if (!cursor || removed >= excess) return;
+        cursor.delete();
+        removed += 1;
+        cursor.continue();
+      };
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
 function traceSw(event: string, payload?: any, extra: Record<string, any> = {}) {
+  const entry = {
+    ts: new Date().toISOString(),
+    event,
+    swVersion: SW_VERSION,
+    ...(payload !== undefined ? summarizeAmsgPayload(payload) : {}),
+    ...extra,
+  };
   try {
-    console.log('[InstantTrace:SW]', {
-      ts: new Date().toISOString(),
-      event,
-      ...(payload !== undefined ? summarizeAmsgPayload(payload) : {}),
-      ...extra,
-    });
+    console.log('[InstantTrace:SW]', entry);
   } catch { /* ignore */ }
+  // 不 await：trace 是旁路，写库慢了 / 挂了都不能拖住推送处理本身。
+  void appendSwTrace(entry).catch(() => { /* trace 写不进去就算了 */ });
 }
 
 installReiSW(sw, {
@@ -193,17 +283,64 @@ function stopKeepAlive() {
   refreshKeepAlive();
 }
 
+/**
+ * 页面地址里只留路径，不带查询串和 hash——排障要认的是「这是哪个页面」，
+ * 而查询串/hash 上可能挂着不该进日志的东西。
+ */
+function tracePathOf(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return '?';
+  }
+}
+
+/**
+ * 把消息喊给所有打开着的页面。
+ *
+ * 这里的 trace 记得比别处细，因为「推送到了、通知也弹了，页面却毫无反应」这类故障
+ * 全卡在这一步，而它三种坏法长得一模一样（都是页面那边什么都没发生）：
+ *   1. matchAll 压根没找到页面 → count 为 0
+ *   2. 找到了但 postMessage 抛错 → posted 少于 count，failures 里有原因
+ *   3. 都成了，是页面自己没处理 → 这里全绿，页面侧却没有对应的收到记录
+ * 不把这三样分开记，就只能靠猜。
+ */
 async function notifyClients(data: Record<string, any>) {
-  const clients = await sw.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  let clients: readonly Client[] = [];
+  let matchError: string | undefined;
+  try {
+    clients = await sw.clients.matchAll({ type: 'window', includeUncontrolled: true });
+  } catch (e) {
+    matchError = e instanceof Error ? e.name : String(e);
+  }
+
+  let posted = 0;
+  const failures: string[] = [];
+  for (const client of clients) {
+    try {
+      client.postMessage(data);
+      posted += 1;
+    } catch (e) {
+      failures.push(e instanceof Error ? e.name : String(e));
+    }
+  }
+
   traceSw('notify-clients', undefined, {
     type: data.type,
     charId: data.charId,
     sessionId: data.sessionId,
     count: clients.length,
+    posted,
+    targets: clients.map((client) => ({
+      path: tracePathOf(client.url),
+      visibility: (client as WindowClient).visibilityState,
+      focused: (client as WindowClient).focused,
+      // 冻结的页面收得下 postMessage，但要等解冻才会处理——只有部分浏览器报这个字段。
+      frozen: (client as any).frozen,
+    })),
+    ...(failures.length > 0 ? { failures } : {}),
+    ...(matchError ? { matchError } : {}),
   });
-  for (const client of clients) {
-    client.postMessage(data);
-  }
 }
 
 function fireProactiveTrigger(charId: string) {
@@ -760,6 +897,20 @@ sw.addEventListener('message', (event: ExtendableMessageEvent) => {
       // BuildBadge 通过 MessageChannel + port 协议查询；不响应时 BuildBadge 显示 sw@?
       event.ports[0]?.postMessage({ version: SW_VERSION });
       break;
+    case 'SW_CHANNEL_PROBE': {
+      // 页面主动探一次「SW 还能不能喊到我」。两条路各回一次，为的是把故障分开：
+      //   - port 这条是「谁问谁答」，页面把回信地址一起递过来（BuildBadge 查版本走它）；
+      //   - clients 这条要 SW 自己去把页面找出来，**推送通知页面走的正是它**。
+      // 只有后者不通，说明 SW 活得好好的、只是找不到页面——这两种坏法在用户那儿
+      // 长得一模一样（界面就是不动），不分开测就只能靠猜。
+      const nonce = event.data?.nonce;
+      traceSw('channel-probe-received', undefined, { nonce });
+      event.ports[0]?.postMessage({ type: 'sw-channel-probe-port-ack', nonce, swVersion: SW_VERSION });
+      // 故意复用 notifyClients：探测必须跟真实推送走同一条路才作数，
+      // 顺带还留下一条 notify-clients 记录（找到几个页面、各自什么状态）。
+      event.waitUntil(notifyClients({ type: 'sw-channel-probe-ack', nonce, swVersion: SW_VERSION }));
+      break;
+    }
     case 'keepalive-start':
       startKeepAlive();
       break;


### PR DESCRIPTION
## 为什么

有用户反馈「系统通知都弹出来了，聊天界面还要等几十秒才出字」。从他导出的记录里查到：

- 11 条推送**早就全到齐了**，躺在收件箱里等人来捞
- 两轮的延迟分别是 61.9 秒和 62.8 秒——这种稳定性不是网络或负载能造成的，是定时器
- 记录里 200 条覆盖 13 小时，**没有一条**「收到 Service Worker 消息」

也就是说：推送到了、通知也弹了，但 Service Worker 喊页面那一声页面一次都没听见，消息全靠 60 秒的兜底轮询在捞。

麻烦的地方在于**这条腿断了之后功能表面上仍然是好的**——消息照样会到，只是每条都白等最多一分钟，用户多半当成「网络有点卡」而不会来报。而当时的记录里既没有「这趟冲刷是谁触发的」，Service Worker 那一侧更是一行持久化日志都没有（只写 `console.log`，手机上等于不存在），只能靠算时间差反推。

**通道为什么断还没查出来**，这个 PR 不修问题，只补上查它需要的东西——一次加全，不用让用户反复复现。

## 加了什么

| 收集什么 | 用来回答 |
|---|---|
| Service Worker 日志落进独立小库，导出时与页面侧合并按时间排序 | 推送几点到的、SW 几点喊的、页面几点才动手 |
| 每趟冲刷记下触发源 | 实时通道有没有在工作（`SW通知` 是唯一的实时路径） |
| 每条消息记下在收件箱躺了多久 | 白等了多久（跟正文长短无关） |
| SW 喊页面时记下找到几个页面、各自状态、发成功几个 | 是找不到页面，还是找到了发不出去 |
| 启动时通道体检，两条路分开测 | 分辨「SW 没在跑」和「SW 活着但找不到页面」 |
| 页面冻结 / 解冻 / 前后台切换 | 那段空白里页面到底在不在跑 |
| 注册关系快照、环境快照 | 作用域对不对、是不是 PWA 独立窗口、设备时钟有没有跑偏 |

观察窗上还直接给结论：**实时通道正常**（附上次收到消息的时刻），或者 **没收到过 SW 消息，全靠兜底轮询在捞**。

## 几个设计取舍

- **Service Worker 日志用独立的库**，不往收件箱库里塞——后者升版本会有被占用阻塞的风险，排障用的日志不值得给收件箱这条关键路径带上它
- **通道探测复用真实推送走的那条路**（`clients.matchAll` + `postMessage`），而不是查版本用的 MessageChannel。这两条是不同的通道，测错了就白测
- **触发源设成必填**，漏传的调用点编译就报错，不会静默记成查不出所以然的「未知」
- **记录上限 200 → 400**：新增的事件会更快填满，而排障要看的往往是几小时前那次

## 隐私

导出内容只有 ID、状态和字数，**不含任何聊天正文**；页面地址只留路径，不带查询串和 hash。

## 测试

新增 7 个守卫，全量 4583 个测试通过。两个关键守卫都验证过「在错误行为下会挂」：

- 把触发源从记录里去掉 → 挂
- 把健康判定改成「有冲刷就算正常」（正是线上漏判的那种写法）→ 挂

版本号没动，等这一轮查清楚、真正的修复落地时一起改。

https://claude.ai/code/session_01JdHz25ZY4KjbrJwh1Hf7d8