### PR TITLE
chore: publish Android v3.5.0 manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
-  "versionCode": 30409,
-  "versionName": "3.4.9",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.4.9/SullyOS-Android-v3.4.9.apk",
-  "sha256": "a9d3842325688c2657a5a00e4a5c5a8010d7a335a38c312fe2c6a32bd0c97257",
-  "sizeBytes": 37110087,
-  "publishedAt": "2026-08-30T05:31:52Z",
+  "versionCode": 30500,
+  "versionName": "3.5.0",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.5.0/SullyOS-Android-v3.5.0.apk",
+  "sha256": "8ecb3e07b3d620db617976e614084d61b0b3eb2358d478e327390b269eda06e3",
+  "sizeBytes": 45870874,
+  "publishedAt": "2026-09-12T03:51:14Z",
   "releaseNotes": [
-    "修复更新缓存目录已存在时出现 DirectoryExists、无法继续下载的问题",
-    "重复更新会清理旧 APK、重新下载并校验摘要、包名、签名与版本",
-    "只忽略目录已存在状态，真实权限或文件系统错误仍会正常提示",
-    "3.4.8 用户若仍遇到旧错误，请从 Release 手动覆盖安装 3.4.9 一次",
-    "延续固定签名、UnifiedPush / ntfy、Android PDF 导入、Umami 与应用内更新"
+    "同步 SullyOS v3.9.2：新增 SAR 活动空间、恐龙花园、钓鱼、剧情、收藏与经济系统",
+    "修正恐龙模型部署路径，补充艾文钓鱼售卖与按星期问候逻辑",
+    "增强主动消息 2.0 收件箱自检、通道体检、任务暂停恢复与落库重试",
+    "加入协同上下文、聊天清理、收藏搜索、PNG 分享卡与记忆事件箱更新",
+    "延续固定签名、UnifiedPush / ntfy、Android PDF 导入、Umami、应用内更新与 DirectoryExists 修复"
   ]
 }


### PR DESCRIPTION
Updates the public Android update manifest for the signed v3.5.0 release built from master commit 7d065116e4f3ee58b7ea277bf26ffeb7321be12f. The APK asset size and SHA-256 were verified against the local signed artifact before publishing.