### PR TITLE
chore: publish Android v3.5.1 manifest

### DIFF
--- a/public/sullyos-update.json
+++ b/public/sullyos-update.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
-  "versionCode": 30500,
-  "versionName": "3.5.0",
-  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.5.0/SullyOS-Android-v3.5.0.apk",
-  "sha256": "8ecb3e07b3d620db617976e614084d61b0b3eb2358d478e327390b269eda06e3",
-  "sizeBytes": 45870874,
-  "publishedAt": "2026-09-12T03:51:14Z",
+  "versionCode": 30501,
+  "versionName": "3.5.1",
+  "apkUrl": "https://github.com/qegj567-cloud/SullyOS/releases/download/android-v3.5.1/SullyOS-Android-v3.5.1.apk",
+  "sha256": "e7053d4d3a88dd440142d191c7905425a601fe28e55df9c77b0a36d2712432d2",
+  "sizeBytes": 45878814,
+  "publishedAt": "2026-09-12T10:35:17Z",
   "releaseNotes": [
-    "同步 SullyOS v3.9.2：新增 SAR 活动空间、恐龙花园、钓鱼、剧情、收藏与经济系统",
-    "修正恐龙模型部署路径，补充艾文钓鱼售卖与按星期问候逻辑",
-    "增强主动消息 2.0 收件箱自检、通道体检、任务暂停恢复与落库重试",
-    "加入协同上下文、聊天清理、收藏搜索、PNG 分享卡与记忆事件箱更新",
-    "延续固定签名、UnifiedPush / ntfy、Android PDF 导入、Umami、应用内更新与 DirectoryExists 修复"
+    "群聊接入输入偏好与表情建议，并保留自定义编辑器样式",
+    "Kanata 活动重新分组，支持自动排除配置",
+    "Kanata 图书馆支持分类整理与按分类阅读",
+    "修正 SAR 子页面在 iOS 与移动端安全区的布局",
+    "延续主动消息 2.0、UnifiedPush / ntfy、Android PDF 导入、Umami、应用内更新与 DirectoryExists 修复"
   ]
 }


### PR DESCRIPTION
Updates the public Android update manifest for the signed v3.5.1 release built from master commit fa4af061ce6cb5c07b2810e7cd2d4f59fdf3d0d5. GitHub's uploaded asset digest and size exactly match the locally verified APK.